### PR TITLE
fix(client): Use paging to fetch all notes

### DIFF
--- a/nextcloud_mcp_server/client/notes.py
+++ b/nextcloud_mcp_server/client/notes.py
@@ -18,8 +18,21 @@ class NotesClient(BaseNextcloudClient):
 
     async def get_all_notes(self) -> List[Dict[str, Any]]:
         """Get all notes."""
-        response = await self._make_request("GET", "/apps/notes/api/v1/notes")
-        return response.json()
+        notes = []
+        cursor = ""
+
+        while True:
+            response = await self._make_request(
+                "GET",
+                "/apps/notes/api/v1/notes",
+                params={"chunkSize": 50, "chunkCursor": cursor},
+            )
+            notes.extend(response.json())
+            if "X-Notes-Chunk-Cursor" not in response.headers:
+                break
+            cursor = response.headers["X-Notes-Chunk-Cursor"]
+
+        return notes
 
     async def get_note(self, note_id: int) -> Dict[str, Any]:
         """Get a specific note by ID."""


### PR DESCRIPTION
Use paging to fetch all notes to avoid hitting http client timeout with large notes repositories