### PR TITLE
fix(observability): isolate metrics endpoint to dedicated port

### DIFF
--- a/nextcloud_mcp_server/observability/__init__.py
+++ b/nextcloud_mcp_server/observability/__init__.py
@@ -18,10 +18,7 @@ from nextcloud_mcp_server.observability.logging_config import (
     get_uvicorn_logging_config,
     setup_logging,
 )
-from nextcloud_mcp_server.observability.metrics import (
-    get_metrics_handler,
-    setup_metrics,
-)
+from nextcloud_mcp_server.observability.metrics import setup_metrics
 from nextcloud_mcp_server.observability.middleware import ObservabilityMiddleware
 from nextcloud_mcp_server.observability.tracing import setup_tracing
 
@@ -30,6 +27,5 @@ __all__ = [
     "get_uvicorn_logging_config",
     "setup_metrics",
     "setup_tracing",
-    "get_metrics_handler",
     "ObservabilityMiddleware",
 ]


### PR DESCRIPTION
Security fix: Move Prometheus metrics endpoint from main HTTP port to
dedicated port 9090 to prevent external exposure of metrics data.

Changes:
- Use prometheus_client.start_http_server() for dedicated metrics server
- Remove /metrics route from main application routes
- Metrics now only accessible on port 9090 (configurable via METRICS_PORT)
- Main application port no longer serves /metrics endpoint

This follows security best practice of isolating monitoring endpoints
from application traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
