### PR TITLE
fix: Move grafana_folder from labels to annotations

### DIFF
--- a/charts/nextcloud-mcp-server/dashboards/README.md
+++ b/charts/nextcloud-mcp-server/dashboards/README.md
@@ -123,6 +123,10 @@ kubectl create configmap nextcloud-mcp-dashboard \
 # Add sidecar discovery label
 kubectl label configmap nextcloud-mcp-dashboard \
   grafana_dashboard=1 \
+  -n monitoring
+
+# Add folder annotation (annotations support spaces, unlike labels)
+kubectl annotate configmap nextcloud-mcp-dashboard \
   grafana_folder="Nextcloud MCP" \
   -n monitoring
 ```

--- a/charts/nextcloud-mcp-server/templates/dashboard-configmap.yaml
+++ b/charts/nextcloud-mcp-server/templates/dashboard-configmap.yaml
@@ -9,14 +9,15 @@ metadata:
     {{- with .Values.dashboards.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    # Grafana sidecar discovery labels
+    # Grafana sidecar discovery label
     grafana_dashboard: "1"
-    {{- if .Values.dashboards.grafanaFolder }}
-    grafana_folder: {{ .Values.dashboards.grafanaFolder | quote }}
-    {{- end }}
   annotations:
     {{- with .Values.dashboards.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    # Grafana folder name (annotations support spaces, unlike labels)
+    {{- if .Values.dashboards.grafanaFolder }}
+    grafana_folder: {{ .Values.dashboards.grafanaFolder | quote }}
     {{- end }}
 data:
   nextcloud-mcp-server.json: |-

--- a/charts/nextcloud-mcp-server/values.yaml
+++ b/charts/nextcloud-mcp-server/values.yaml
@@ -210,7 +210,8 @@ dashboards:
   # Enable automatic dashboard provisioning via ConfigMap
   enabled: false
   # Grafana folder name where dashboards will be imported
-  # The grafana-sidecar looks for ConfigMaps with label "grafana_folder"
+  # The grafana-sidecar looks for ConfigMaps with label "grafana_dashboard: 1"
+  # and reads the folder name from annotation "grafana_folder" (supports spaces)
   grafanaFolder: "Nextcloud MCP"
   # Additional labels for dashboard ConfigMap
   # These will be added alongside the required "grafana_dashboard: 1" label


### PR DESCRIPTION
## Problem

PR #292 introduced a Grafana dashboard ConfigMap that fails to deploy to Kubernetes with the following error:

```
ConfigMap "nextcloud-nextcloud-mcp-server-dashboard" is invalid: 
metadata.labels: Invalid value: "Nextcloud MCP": a valid label must be 
an empty string or consist of alphanumeric characters, '-', '_' or '.', 
and must start and end with an alphanumeric character
```

**Root Cause**: Kubernetes labels have strict validation that does not allow spaces. The dashboard ConfigMap was setting `grafana_folder: "Nextcloud MCP"` as a **label**, which violates the validation rule: `[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]`

## Solution

Move `grafana_folder` from labels to annotations, following the standard kube-prometheus-stack pattern:

- **Labels** (strict validation): Used for ConfigMap discovery → `grafana_dashboard: "1"`
- **Annotations** (relaxed validation): Used for folder names → `grafana_folder: "Nextcloud MCP"` ✅

This is the standard approach used by Grafana sidecar:
- Discovery label: identifies ConfigMaps containing dashboards
- Folder annotation: specifies the Grafana folder name (supports spaces)

## Changes

### `templates/dashboard-configmap.yaml`
- Moved `grafana_folder` from `labels:` to `annotations:` section
- Added clarifying comment about annotation support for spaces
- Kept `grafana_dashboard: "1"` as label for discovery

### `dashboards/README.md`
- Fixed kubectl commands to use `kubectl annotate` instead of `kubectl label`
- Added explanatory comment about spaces in folder names

### `values.yaml`
- Updated comments to clarify that folder names are set via annotations

## Verification

Tested Helm template rendering confirms correct structure:
```yaml
labels:
  grafana_dashboard: "1"
annotations:
  grafana_folder: "Nextcloud MCP"
```

## Impact

- ✅ Fixes Kubernetes deployment error
- ✅ Maintains desired folder name "Nextcloud MCP" with space
- ✅ Follows kube-prometheus-stack standard pattern
- ✅ No breaking changes (annotations work with existing Grafana sidecar configs)

---

_This PR was generated with the help of AI, and reviewed by a Human_