### PR TITLE
perf: Optimize vector viz search performance

### DIFF
--- a/nextcloud_mcp_server/embedding/bm25_provider.py
+++ b/nextcloud_mcp_server/embedding/bm25_provider.py
@@ -37,7 +37,9 @@ class BM25SparseEmbeddingProvider:
 
     def encode(self, text: str) -> dict[str, Any]:
         """
-        Generate BM25 sparse embedding for a single text.
+        Generate BM25 sparse embedding for a single text (synchronous).
+
+        Note: For async contexts, prefer encode_async() to avoid blocking the event loop.
 
         Args:
             text: Input text to encode
@@ -52,6 +54,23 @@ class BM25SparseEmbeddingProvider:
             "indices": sparse_embedding.indices.tolist(),
             "values": sparse_embedding.values.tolist(),
         }
+
+    async def encode_async(self, text: str) -> dict[str, Any]:
+        """
+        Generate BM25 sparse embedding for a single text (async).
+
+        Runs CPU-bound BM25 encoding in thread pool to avoid blocking the event loop.
+
+        Args:
+            text: Input text to encode
+
+        Returns:
+            Dictionary with 'indices' and 'values' keys for Qdrant sparse vector
+        """
+        import anyio
+
+        # Run CPU-bound BM25 encoding in thread pool
+        return await anyio.to_thread.run_sync(lambda: self.encode(text))  # type: ignore[attr-defined]
 
     async def encode_batch(self, texts: list[str]) -> list[dict[str, Any]]:
         """

--- a/nextcloud_mcp_server/search/algorithms.py
+++ b/nextcloud_mcp_server/search/algorithms.py
@@ -140,6 +140,7 @@ class SearchResult:
         page_number: Page number for PDF documents (None for other doc types)
         chunk_index: Zero-based index of this chunk in the document
         total_chunks: Total number of chunks in the document
+        point_id: Qdrant point ID for batch vector retrieval (None if not from Qdrant)
     """
 
     id: int
@@ -153,6 +154,7 @@ class SearchResult:
     page_number: int | None = None
     chunk_index: int = 0
     total_chunks: int = 1
+    point_id: str | None = None
 
     def __post_init__(self):
         """Validate score is non-negative.
@@ -172,7 +174,14 @@ class SearchAlgorithm(ABC):
 
     All search algorithms must implement the search() method with consistent
     interface, allowing them to be used interchangeably.
+
+    Attributes:
+        query_embedding: The query embedding generated during the last search.
+            Available after search() completes for algorithms that use embeddings.
+            Can be reused by callers to avoid redundant embedding generation.
     """
+
+    query_embedding: list[float] | None = None
 
     @abstractmethod
     async def search(

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -101,11 +101,13 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         # Generate dense embedding for semantic search
         embedding_service = get_embedding_service()
         dense_embedding = await embedding_service.embed(query)
+        # Store for reuse by callers (e.g., viz_routes PCA visualization)
+        self.query_embedding = dense_embedding
         logger.debug(f"Generated dense embedding (dimension={len(dense_embedding)})")
 
         # Generate sparse embedding for BM25 keyword search
         bm25_service = get_bm25_service()
-        sparse_embedding = bm25_service.encode(query)
+        sparse_embedding = await bm25_service.encode_async(query)
         logger.debug(
             f"Generated sparse embedding "
             f"({len(sparse_embedding['indices'])} non-zero terms)"
@@ -218,6 +220,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
                     page_number=result.payload.get("page_number"),
                     chunk_index=result.payload.get("chunk_index", 0),
                     total_chunks=result.payload.get("total_chunks", 1),
+                    point_id=str(result.id),  # Qdrant point ID for batch retrieval
                 )
             )
 

--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -78,6 +78,8 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
         # Generate embedding for query
         embedding_service = get_embedding_service()
         query_embedding = await embedding_service.embed(query)
+        # Store for reuse by callers (e.g., viz_routes PCA visualization)
+        self.query_embedding = query_embedding
         logger.debug(
             f"Generated embedding for query (dimension={len(query_embedding)})"
         )
@@ -164,6 +166,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
                     page_number=result.payload.get("page_number"),
                     chunk_index=result.payload.get("chunk_index", 0),
                     total_chunks=result.payload.get("total_chunks", 1),
+                    point_id=str(result.id),  # Qdrant point ID for batch retrieval
                 )
             )
 


### PR DESCRIPTION
## Summary

- Replace sequential Qdrant scroll calls with batch retrieve (50 HTTP requests → 1 request, ~50x faster vector fetch)
- Add `point_id` to `SearchResult` to enable batch retrieval by Qdrant point ID
- Reuse query embedding from search algorithm in viz_routes (eliminates redundant embedding call)
- Make BM25 `encode()` async with thread pool to avoid blocking event loop
- Run PCA computation in thread pool to avoid blocking event loop

## Performance Impact

| Fix | Before | After | Savings |
|-----|--------|-------|---------|
| Sequential scroll → Batch retrieve | 50 HTTP requests | 1 HTTP request | ~2.5-5s |
| Duplicate query embedding | 2 calls | 1 call | ~30ms |
| BM25 blocking event loop | Sync (blocking) | Async (thread pool) | ~4.4s unblocked |
| PCA blocking event loop | Sync (blocking) | Async (thread pool) | ~1.2s unblocked |

## Test plan

- [x] Unit tests pass (164 tests)
- [x] Search integration tests pass (7 tests)
- [x] Ruff check passes
- [x] Type check passes
- [x] Manual testing with vector viz UI

---

_This PR was generated with the help of AI, and reviewed by a Human_