### PR TITLE
fix(smithery): Enable JSON response format for scanner compatibility

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1072,7 +1072,11 @@ def get_app(transport: str = "sse", enabled_apps: list[str] | None = None):
         # ADR-016: Use Smithery lifespan for stateless mode, BasicAuth otherwise
         if deployment_mode == DeploymentMode.SMITHERY_STATELESS:
             logger.info("Configuring MCP server for Smithery stateless mode")
-            mcp = FastMCP("Nextcloud MCP", lifespan=app_lifespan_smithery)
+            # json_response=True returns plain JSON-RPC instead of SSE format,
+            # required for Smithery scanner compatibility
+            mcp = FastMCP(
+                "Nextcloud MCP", lifespan=app_lifespan_smithery, json_response=True
+            )
         else:
             logger.info("Configuring MCP server for BasicAuth mode")
             mcp = FastMCP("Nextcloud MCP", lifespan=app_lifespan_basic)

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -335,27 +335,6 @@ def configure_semantic_tools(mcp: FastMCP):
         Note: Requires MCP client to support sampling. If sampling is unavailable,
         the tool gracefully degrades to returning documents with an explanation.
         The client may prompt the user to approve the sampling request.
-
-        Examples:
-            >>> # Query about objectives across multiple apps
-            >>> result = await nc_semantic_search_answer(
-            ...     query="What are my Q1 2025 project goals?",
-            ...     ctx=ctx
-            ... )
-            >>> print(result.generated_answer)
-            "Based on Document 1 (note: Project Kickoff), Document 2 (calendar event:
-            Q1 Planning Meeting), and Document 3 (deck card: Implement semantic search),
-            your main goals are: 1) Improve semantic search accuracy by 20%,
-            2) Deploy new embedding model, 3) Reduce indexing latency..."
-
-            >>> # Query about appointments
-            >>> result = await nc_semantic_search_answer(
-            ...     query="When is my next dentist appointment?",
-            ...     ctx=ctx,
-            ...     limit=10
-            ... )
-            >>> len(result.sources)  # Calendar events and related notes
-            3
         """
         # 1. Retrieve relevant documents via existing semantic search
         search_response = await nc_semantic_search(

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -64,20 +64,6 @@ def configure_webdav_tools(mcp: FastMCP):
             - Text files are decoded to UTF-8
             - Documents (PDF, DOCX, etc.) are parsed and text is extracted
             - Other binary files are base64 encoded
-
-        Examples:
-            # Read a text file
-            result = await nc_webdav_read_file("Documents/readme.txt")
-            logger.info(result['content'])  # Decoded text content
-
-            # Read a PDF document (automatically parsed)
-            result = await nc_webdav_read_file("Documents/report.pdf")
-            logger.info(result['content'])  # Extracted text from PDF
-            logger.info(result['parsing_metadata'])  # Document parsing info
-
-            # Read a binary file
-            result = await nc_webdav_read_file("Images/photo.jpg")
-            logger.info(result['encoding'])  # 'base64'
         """
         client = await get_client(ctx)
         content, content_type = await client.webdav.read_file(path)


### PR DESCRIPTION
## Summary

- Fix Smithery scanner reporting "0 tools" despite valid tool definitions in response
- Root cause: Server returned SSE-formatted responses (`event: message\ndata: {...}`) which the scanner couldn't parse
- Add `json_response=True` to FastMCP for Smithery stateless mode
- Clean up verbose docstring examples in semantic.py and webdav.py

## Technical Details

The MCP spec allows both SSE and plain JSON responses for HTTP transport. Setting `json_response=True` returns `Content-Type: application/json` with plain JSON-RPC instead of `text/event-stream` with SSE format.

**Before (SSE format):**
```
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"tools":[...]}}
```

**After (plain JSON):**
```json
{"jsonrpc":"2.0","id":1,"result":{"tools":[...]}}
```

## Test plan

- [x] Unit tests pass (164 tests)
- [x] Type checking passes
- [x] Linting passes
- [ ] Redeploy to Smithery and verify scanner detects tools

---

_This PR was generated with the help of AI, and reviewed by a Human_