### PR TITLE
fix(news): revert get_item() to use get_items() + filter

### DIFF
--- a/nextcloud_mcp_server/client/news.py
+++ b/nextcloud_mcp_server/client/news.py
@@ -228,6 +228,10 @@ class NewsClient(BaseNextcloudClient):
     async def get_item(self, item_id: int) -> dict[str, Any]:
         """Get a specific item by ID.
 
+        Note: The News API doesn't have a direct single-item endpoint,
+        so we fetch all items and filter. For efficiency, consider
+        caching or using get_items with specific feed if known.
+
         Args:
             item_id: Item ID
 
@@ -235,10 +239,15 @@ class NewsClient(BaseNextcloudClient):
             Item data
 
         Raises:
-            HTTPStatusError: 404 if item not found
+            ValueError: If item not found
         """
-        response = await self._make_request("GET", f"{self.API_BASE}/items/{item_id}")
-        return response.json()
+        # Fetch all items and find the one we need
+        # This is inefficient but the API doesn't provide a direct endpoint
+        items = await self.get_items(batch_size=-1, get_read=True)
+        for item in items:
+            if item.get("id") == item_id:
+                return item
+        raise ValueError(f"Item {item_id} not found")
 
     async def get_updated_items(
         self,


### PR DESCRIPTION
## Summary

Fixes vector processor 405 errors when indexing news items by reverting an incorrect "performance optimization" that assumed the News API provides a `GET /items/{itemId}` endpoint.

## Root Cause

Commit 92c4bf3 (2 weeks ago) changed `get_item()` to use a direct API call to `/apps/news/api/v1-3/items/{itemId}`, but this endpoint **does not exist** in any version of the News API (v1-2, v1-3, or v2).

The only `/items/{itemId}` routes in the News API are POST operations for:
- `POST /items/{itemId}/read`
- `POST /items/{itemId}/unread`
- `POST /items/{itemId}/star`
- `POST /items/{itemId}/unstar`

There is no GET endpoint to retrieve individual items.

## Impact

The vector processor has been failing to index news items with:
```
Client error '405 Method Not Allowed' for url 'https://cloud.coutinho.io/apps/news/api/v1-3/items/{item_id}'
```

This broke semantic search for news items across all deployments.

## Changes

- ✅ Restore original `get_item()` implementation that fetches all items and filters in Python
- ✅ Update exception from `HTTPStatusError` to `ValueError` (matches original behavior)
- ✅ Restore documentation explaining the API limitation
- ✅ Update unit tests to mock `get_items()` instead of `_make_request()`
- ✅ Add test for `ValueError` when item not found

## Testing

```bash
✓ 27/27 news API unit tests pass
✓ Ruff checks pass
✓ Type checks pass
```

## Performance Note

The current implementation fetches all items (`batch_size=-1`) to find one item, which is inefficient. However, this matches what the scanner already does and is the only way to work with the News API.

**Future optimization**: Pass full item data from scanner to processor instead of just the `doc_id`, avoiding the need to re-fetch items during indexing.

## References

- News API docs: `~/Software/news/docs/api/api-v1-3.md`
- News app routes: `~/Software/news/appinfo/routes.php`
- Original issue discovered via Grafana analytics agent analyzing k8s logs

---

_This PR was generated with the help of AI, and reviewed by a Human_