### PR TITLE
feat(vector-viz): add news_item support for links and chunk expansion

### DIFF
--- a/nextcloud_mcp_server/auth/static/vector-viz.js
+++ b/nextcloud_mcp_server/auth/static/vector-viz.js
@@ -203,6 +203,8 @@ function vizApp() {
                     return `${baseUrl}/apps/contacts`;
                 case 'deck':
                     return `${baseUrl}/apps/deck`;
+                case 'news_item':
+                    return `${baseUrl}/apps/news/item/${result.id}`;
                 default:
                     return `${baseUrl}`;
             }

--- a/nextcloud_mcp_server/auth/templates/vector_viz.html
+++ b/nextcloud_mcp_server/auth/templates/vector_viz.html
@@ -68,6 +68,10 @@
                                     <input type="checkbox" x-model="docTypes" value="deck" style="margin-right: 4px;">
                                     <span>Deck</span>
                                 </label>
+                                <label style="display: flex; align-items: center; cursor: pointer; font-weight: normal;">
+                                    <input type="checkbox" x-model="docTypes" value="news_item" style="margin-right: 4px;">
+                                    <span>News</span>
+                                </label>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- Add "News" checkbox to document type filter options in vector visualization page
- Add URL handler to link news items to `/apps/news/item/{id}` in Nextcloud
- Add content fetching for news items in chunk context expansion to enable "Show Chunk" toggle

## Test plan
- [ ] Navigate to vector visualization page
- [ ] Enable "News" filter checkbox and perform a search
- [ ] Verify news items appear in search results
- [ ] Click on a news item link and verify it navigates to the correct Nextcloud News URL
- [ ] Click "Show Chunk" on a news item and verify the chunk context expands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_This PR was generated with the help of AI, and reviewed by a Human_