### PR TITLE
fix(ci): bump helm chart version when MCP appVersion changes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -87,20 +87,31 @@ jobs:
           mcp_commit_count=$(git log "$commit_range" --oneline --grep="^(feat|fix|docs|refactor|perf|test|build|ci|chore)" -E | \
             { grep -v "(helm)" || true; } | { grep -v "(astrolabe)" || true; } | wc -l)
 
+          MCP_BUMPED=false
           if [ "$mcp_commit_count" -gt 0 ]; then
             echo "Found $mcp_commit_count commits for MCP server since $last_mcp_tag"
             echo "Bumping MCP server version..."
             ./scripts/bump-mcp.sh
             BUMPED_COMPONENTS="$BUMPED_COMPONENTS mcp"
+            MCP_BUMPED=true
           else
             echo "No commits found for MCP server since $last_mcp_tag"
           fi
 
-          # Bump Helm chart (scope: helm)
+          # Bump Helm chart (scope: helm OR when MCP appVersion changes)
           echo "Checking Helm chart for version bump..."
+          HELM_HAS_COMMITS=false
           if has_commits_since_tag "nextcloud-mcp-server-" "(feat|fix|docs|refactor|perf|test|build|ci|chore)\(helm\)(!)?:"; then
-            echo "Bumping Helm chart version..."
+            HELM_HAS_COMMITS=true
+          fi
+
+          if [ "$HELM_HAS_COMMITS" = true ]; then
+            echo "Bumping Helm chart version (helm-scoped commits)..."
             ./scripts/bump-helm.sh
+            BUMPED_COMPONENTS="$BUMPED_COMPONENTS helm"
+          elif [ "$MCP_BUMPED" = true ]; then
+            echo "Bumping Helm chart version (appVersion changed)..."
+            ./scripts/bump-helm.sh --increment PATCH
             BUMPED_COMPONENTS="$BUMPED_COMPONENTS helm"
           fi
 


### PR DESCRIPTION
## Summary

- Helm chart version is now bumped (PATCH) whenever the MCP server version changes
- Previously, Helm chart only bumped when there were `(helm)` scoped commits
- This ensures users see new chart releases when the app version changes

## Problem

When the MCP server version was bumped (e.g., v0.61.0 → v0.61.1):
- `Chart.yaml:appVersion` was updated ✅
- `Chart.yaml:version` stayed the same ❌

This meant Helm users wouldn't see new releases even though the deployed app version changed.

## Solution

Modified `bump-version.yml` to also bump the Helm chart when MCP is bumped:

```yaml
if [ "$HELM_HAS_COMMITS" = true ]; then
  # Existing: bump based on helm-scoped commits
  ./scripts/bump-helm.sh
elif [ "$MCP_BUMPED" = true ]; then
  # New: bump PATCH when appVersion changes
  ./scripts/bump-helm.sh --increment PATCH
fi
```

## Test plan

- [ ] Merge a PR with MCP changes (no `(helm)` scope)
- [ ] Verify both MCP and Helm versions are bumped
- [ ] Verify Helm chart release is created with new appVersion

---

_This PR was generated with the help of AI, and reviewed by a Human_