### PR TITLE
fix(astrolabe): update Vue component bindings for Vue 3 compatibility

### DIFF
--- a/third_party/astrolabe/src/App.vue
+++ b/third_party/astrolabe/src/App.vue
@@ -443,7 +443,7 @@ export default {
 			algorithm: 'hybrid',
 			showAdvanced: false,
 			selectedDocTypes: [],
-			limit: '20',
+			limit: 20,
 			scoreThreshold: 0,
 			loading: false,
 			error: null,

--- a/third_party/astrolabe/src/components/admin/AdminSettings.vue
+++ b/third_party/astrolabe/src/components/admin/AdminSettings.vue
@@ -152,19 +152,21 @@
 
 				<div class="settings-form">
 					<NcSelect
-						v-model="settings.algorithm"
+						:model-value="selectedAlgorithmOption"
 						:options="algorithmOptions"
 						:label="t('astrolabe', 'Search Algorithm')"
-						class="form-field" />
+						class="form-field"
+						@update:model-value="settings.algorithm = $event ? $event.id : 'hybrid'" />
 					<p class="help-text">
 						{{ t('astrolabe', 'Hybrid combines semantic understanding with keyword matching. Semantic finds conceptually similar content. BM25 matches exact keywords.') }}
 					</p>
 
 					<NcSelect
-						v-model="settings.fusion"
+						:model-value="selectedFusionOption"
 						:options="fusionOptions"
 						:label="t('astrolabe', 'Fusion Method')"
-						class="form-field" />
+						class="form-field"
+						@update:model-value="settings.fusion = $event ? $event.id : 'rrf'" />
 					<p class="help-text">
 						{{ t('astrolabe', 'Only applies to hybrid search. RRF balances results well for most queries. DBSF may work better when keyword matches are over/under-weighted.') }}
 					</p>
@@ -184,14 +186,13 @@
 					</div>
 
 					<NcTextField
-						:value="settings.limit"
+						v-model="settings.limit"
 						:label="t('astrolabe', 'Maximum Results')"
 						type="number"
 						:min="5"
 						:max="100"
 						:step="5"
-						class="form-field"
-						@update:value="settings.limit = Number($event)" />
+						class="form-field" />
 					<p class="help-text">
 						{{ t('astrolabe', 'Maximum number of results to return per search query (5-100).') }}
 					</p>
@@ -275,6 +276,15 @@ const fusionOptions = computed(() => [
 	{ id: 'rrf', label: t('astrolabe', 'RRF - Reciprocal Rank Fusion (Recommended)') },
 	{ id: 'dbsf', label: t('astrolabe', 'DBSF - Distribution-Based Score Fusion') },
 ])
+
+// Computed properties for NcSelect (converts between stored ID and option object)
+const selectedAlgorithmOption = computed(() =>
+	algorithmOptions.value.find(opt => opt.id === settings.value.algorithm) || algorithmOptions.value[0],
+)
+
+const selectedFusionOption = computed(() =>
+	fusionOptions.value.find(opt => opt.id === settings.value.fusion) || fusionOptions.value[0],
+)
 
 // Methods
 async function loadServerStatus() {


### PR DESCRIPTION
## Summary

- Fix NcTextField bindings to use `v-model` instead of legacy `:value/@update:value`
- Fix NcSelect bindings to use `:model-value/@update:model-value` instead of `v-model` with computed property
- Resolves search button being permanently greyed out and algorithm dropdown being unresponsive

## Root Cause

The astrolabe app was using Vue 2 style bindings (`:value`/`@update:value`) but @nextcloud/vue 9.x with Vue 3 uses `modelValue`/`update:modelValue`. The legacy props were being ignored, breaking Vue reactivity.

## Test plan

- [x] Navigate to Astrolabe app in Nextcloud
- [x] Type in the search query field - search button should become enabled
- [x] Click the algorithm dropdown - should show Hybrid/Semantic/BM25 options
- [x] Select a different algorithm - should update the displayed value
- [x] Click Search - should trigger the search API call

---

_This PR was generated with the help of AI, and reviewed by a Human_