### PR TITLE
fix: point caldav to fork with async search href fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ extend-select = ["I", "PLC0415"]
 "tests/**" = ["PLC0415"]
 
 [tool.uv.sources]
-caldav = { git = "https://github.com/cbcoutinho/caldav", branch = "feature/httpx" }
+caldav = { git = "https://github.com/nickallevato/caldav", branch = "fix/async-search-href" }
 qdrant-client = { git = "https://github.com/cbcoutinho/qdrant-client", branch = "fix/fusion-score-threshold" }
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -290,8 +290,8 @@ wheels = [
 
 [[package]]
 name = "caldav"
-version = "2.0.2.dev47+g3e44cf827"
-source = { git = "https://github.com/cbcoutinho/caldav?branch=feature%2Fhttpx#3e44cf827e392a0073a16a6b01e299ecef02404b" }
+version = "2.0.2.dev48+ged212a8db"
+source = { git = "https://github.com/nickallevato/caldav?branch=fix%2Fasync-search-href#ed212a8dbb642f9616836ff6c10aab5375074d90" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "icalendar" },
@@ -2048,7 +2048,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.42.0" },
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "boto3", specifier = ">=1.35.0" },
-    { name = "caldav", git = "https://github.com/cbcoutinho/caldav?branch=feature%2Fhttpx" },
+    { name = "caldav", git = "https://github.com/nickallevato/caldav?branch=fix%2Fasync-search-href" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "fastembed", specifier = ">=0.7.3" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },


### PR DESCRIPTION
The caldav async_collection.py search() method was generating object URLs from the iCal UID instead of using the server-provided href. Nextcloud uses different filenames than the UID, causing update and delete operations to silently fail (PUT/DELETE to wrong URLs).

Points to nickallevato/caldav#fix/async-search-href which resolves the href correctly from the REPORT response.