### PR TITLE
fix: pin starlette<1.0 to prevent startup crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "prometheus-client>=0.21.0", # Prometheus metrics
     "opentelemetry-api>=1.28.2", # OpenTelemetry API
     "opentelemetry-sdk>=1.28.2", # OpenTelemetry SDK
+    "starlette<1.0", # Pin until we address starlette 1.0 breaking changes (#648)
     "opentelemetry-instrumentation-asgi>=0.49b2", # Auto-instrument ASGI/Starlette
     "opentelemetry-instrumentation-httpx>=0.49b2", # Auto-instrument httpx client
     "opentelemetry-instrumentation-logging>=0.49b2", # Logging integration

--- a/uv.lock
+++ b/uv.lock
@@ -2120,6 +2120,7 @@ dependencies = [
     { name = "python-json-logger" },
     { name = "pythonvcard4" },
     { name = "qdrant-client" },
+    { name = "starlette" },
 ]
 
 [package.dev-dependencies]
@@ -2171,6 +2172,7 @@ requires-dist = [
     { name = "python-json-logger", specifier = ">=3.2.0" },
     { name = "pythonvcard4", specifier = ">=0.2.0" },
     { name = "qdrant-client", specifier = ">=1.17.0" },
+    { name = "starlette", specifier = "<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Pins `starlette<1.0` in `pyproject.toml` to prevent fresh installs from pulling Starlette 1.0.0, which removed `@app.middleware()` and crashes the server on startup

Closes #648

## Test plan

- [x] `uv lock` resolves starlette 0.50.0
- [x] `uv run ruff check` passes
- [x] 384 unit tests pass
- [x] Smoke tests pass in CI

---

_This PR was generated with the help of AI, and reviewed by a Human_