### PR TITLE
fix: pin Renovate Nextcloud updates to matching major version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,12 @@ jobs:
           - "oauth"
           - "login-flow"
         include:
-          # Version-specific image pins — Renovate updates these via customManagers
-          # renovate: datasource=docker depName=docker.io/library/nextcloud
+          # Version-specific image pins — Renovate updates these via customManagers in renovate.json
+          # Each entry is pinned to its major version (e.g., NC 31 only gets 31.x updates)
           - nextcloud_version: "31"
             nextcloud_image: "docker.io/library/nextcloud:31.0.14@sha256:9bf3fae91aad4dca3eff02c1f71df8d5c6705a349065fb537aa5c5ef578f1013"
-          # renovate: datasource=docker depName=docker.io/library/nextcloud
           - nextcloud_version: "32"
             nextcloud_image: "docker.io/library/nextcloud:32.0.6@sha256:5c4e09f72f096cd68379a8ae69f71e61d13da5a07430fc4a17c702a14e6a4267"
-          # renovate: datasource=docker depName=docker.io/library/nextcloud
           # Disabled until all upstream apps support NC 33
           # - nextcloud_version: "33"
           #   nextcloud_image: "docker.io/library/nextcloud:33.0.0@sha256:d53f6cb35b0712aa890a5e4a8ca21043d6fcd390f38c55b710816dd7cbc2edc0"

--- a/renovate.json
+++ b/renovate.json
@@ -11,18 +11,41 @@
         "pillow"
       ],
       "allowedVersions": "<12.0.0"
+    },
+    {
+      "description": "Pin each Nextcloud matrix entry to its own major version",
+      "matchDepNames": ["nextcloud-31"],
+      "allowedVersions": "/^31\\./"
+    },
+    {
+      "matchDepNames": ["nextcloud-32"],
+      "allowedVersions": "/^32\\./"
+    },
+    {
+      "matchDepNames": ["nextcloud-33"],
+      "allowedVersions": "/^33\\./"
+    },
+    {
+      "description": "Pin docker-compose.yml Nextcloud image to 32.x",
+      "matchPackageNames": ["docker.io/library/nextcloud"],
+      "matchFileNames": ["docker-compose.yml"],
+      "allowedVersions": "/^32\\./"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Nextcloud version matrix pins in CI — each entry gets a version-specific dep name",
       "managerFilePatterns": [
         "/^\\.github/workflows/test\\.yml$/"
       ],
       "matchStrings": [
-        "nextcloud_image:\\s*\"(?<depName>[^:]+):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+        "nextcloud_version:\\s*\"(?<major>\\d+)\"\\s*\\n\\s*#?\\s*nextcloud_image:\\s*\"(?<packageName>[^:]+):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
       ],
-      "datasourceTemplate": "docker"
+      "depNameTemplate": "nextcloud-{{{major}}}",
+      "packageNameTemplate": "docker.io/library/nextcloud",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Custom regex manager now captures `nextcloud_version` to create version-specific dep names (`nextcloud-31`, `nextcloud-32`, `nextcloud-33`) via `depNameTemplate`
- Added `packageRules` with `allowedVersions` constraining each dep to its own major version (e.g., NC 31 only gets 31.x updates)
- Pinned `docker-compose.yml` Nextcloud image to 32.x
- Removed redundant inline `# renovate:` comments that could cause duplicate matching via Renovate's built-in annotation manager

## Test plan

- [ ] Verify Renovate dependency dashboard shows three separate deps (`nextcloud-31`, `nextcloud-32`, `nextcloud-33`)
- [ ] Verify each dep is constrained to its own major version
- [ ] Verify `docker-compose.yml` nextcloud is listed as constrained to 32.x
- [ ] Confirm the commented-out NC 33 entry is still matched by the multiline regex

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)