### PR TITLE
test: stagger parallel OAuth fetches for login-flow users

### DIFF
--- a/tests/server/login_flow/conftest.py
+++ b/tests/server/login_flow/conftest.py
@@ -667,7 +667,14 @@ async def all_login_flow_user_tokens(
 
     results: dict[str, str | Exception] = {}
 
-    async def _fetch(username: str, config: dict) -> None:
+    # Stagger per-user starts so parallel Playwright OAuth flows don't all hit
+    # Nextcloud's OIDC consent rendering at once — CI under load needs a wider
+    # gap (see tests/conftest.py:all_oauth_tokens).
+    scale = 0.5 if "GITHUB_ACTIONS" not in os.environ else 10
+
+    async def _fetch(username: str, config: dict, delay: float) -> None:
+        if delay > 0:
+            await anyio.sleep(delay)
         try:
             token = await _get_login_flow_token_for_user(
                 browser,
@@ -682,8 +689,8 @@ async def all_login_flow_user_tokens(
 
     user_list = list(test_users_setup.items())
     async with anyio.create_task_group() as tg:
-        for username, config in user_list:
-            tg.start_soon(_fetch, username, config)
+        for idx, (username, config) in enumerate(user_list):
+            tg.start_soon(_fetch, username, config, idx * scale)
 
     for username, result in results.items():
         if isinstance(result, Exception):


### PR DESCRIPTION
## Summary

- Ports the per-user delay stagger from `tests/conftest.py:all_oauth_tokens` (commit 963a504) into `tests/server/login_flow/conftest.py:all_login_flow_user_tokens`.
- Uses the same `scale = 0.5 if "GITHUB_ACTIONS" not in os.environ else 10` pattern so local runs stay fast but CI gets a wide gap.

## Why

The login-flow integration job has been flakey on master and on every recent PR (including #715, where the change is unrelated to OAuth). Debug artifacts show the last two users in iteration order (`charlie`, `diana`) stuck on the OIDC "Application Authorization Request" consent screen when the 30s callback wait expires.

When `all_login_flow_user_tokens` was added in `aeddc28` (refactor: remove oauth profile, migrate MCP/OAuth tests to login-flow), the parallel-fetch pattern was copied from `all_oauth_tokens` but the staggering that had previously been added to fix this exact flakiness (`963a504 ci: Replace 0.5 stagger with 10s in CI`) wasn't carried across. All four Playwright contexts therefore race into Nextcloud's OIDC authorize endpoint simultaneously and the Vue-rendered consent page occasionally doesn't click through in time under CI load.

Single-user / multi-user-basic / keycloak jobs aren't affected because they don't exercise `all_login_flow_user_tokens`.

## Test plan

- [ ] CI `integration (login-flow / nc31)` passes
- [ ] CI `integration (login-flow / nc32)` passes
- [ ] No regression in other integration matrix jobs

---

_This PR was generated with the help of AI, and reviewed by a Human_