### PR TITLE
docs: add contributor license agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -4,10 +4,11 @@
 
 The Nextcloud MCP Server project (the "Project") is offered to the public under
 the GNU Affero General Public License version 3 (AGPL-3.0). To allow the
-Project's maintainer ("We" or "Us"), a company established in The Netherlands,
-to sustain the Project's development — including through dual licensing or
-other commercial offerings — and to keep the Project's licensing flexible into
-the future, We ask each contributor to agree to the terms below.
+Project's maintainer, **Astrolabe Cloud** ("We" or "Us"), a company established
+in The Netherlands, to sustain the Project's development — including through
+dual licensing or other commercial offerings — and to keep the Project's
+licensing flexible into the future, We ask each contributor to agree to the
+terms below.
 
 You retain ownership of the copyright in Your Contributions. This Agreement
 grants Us a license that is broad enough to (a) continue distributing Your
@@ -137,7 +138,7 @@ Contributions and for any applicable limitation periods thereafter. Signatures
 collected through cla-assistant.io are processed by SAP SE on Our behalf in
 accordance with their privacy notice. You may exercise Your rights as a data
 subject (access, rectification, erasure where applicable, restriction,
-objection, portability) by contacting Us at [CONTACT EMAIL TO BE ADDED].
+objection, portability) by contacting Us at info@astrolabecloud.com.
 
 ## 10. Governing Law and Jurisdiction
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,169 @@
+# Contributor License Agreement
+
+## Background
+
+The Nextcloud MCP Server project (the "Project") is offered to the public under
+the GNU Affero General Public License version 3 (AGPL-3.0). To allow the
+Project's maintainer ("We" or "Us"), a company established in The Netherlands,
+to sustain the Project's development — including through dual licensing or
+other commercial offerings — and to keep the Project's licensing flexible into
+the future, We ask each contributor to agree to the terms below.
+
+You retain ownership of the copyright in Your Contributions. This Agreement
+grants Us a license that is broad enough to (a) continue distributing Your
+Contributions as part of the Project under AGPL-3.0, and (b) license the
+Project (including Your Contributions) under additional or alternative terms
+in the future.
+
+This Agreement is adapted from the
+[Apache Software Foundation Individual Contributor License Agreement v2.0](https://www.apache.org/licenses/icla.pdf),
+with modifications for use under Dutch law.
+
+---
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with Us. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+a single Contributor.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to Us for inclusion in, or documentation of, any of the products owned
+or managed by Us (the "Work"). For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to Us or
+our representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, Us for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+**sublicense, and distribute Your Contributions and such derivative works under
+any license terms, including without limitation the AGPL-3.0 license, other
+open-source licenses, or proprietary commercial licenses.**
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work to
+which You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work shall terminate as of the date such
+litigation is filed.
+
+## 4. Moral Rights
+
+To the maximum extent permitted by applicable law, including Article 25 of
+the Dutch Copyright Act (*Auteurswet*), You waive — and agree not to assert
+against Us, our licensees, or our successors — any moral rights
+(*persoonlijkheidsrechten*) You may have in Your Contributions, including
+without limitation the right to be identified as the author and the right to
+object to non-derogatory modifications. Moral rights that cannot be waived
+under applicable mandatory law remain unaffected by this Agreement, and We
+will respect such rights in good faith — including by preserving authorship
+attribution in the Project's source control history.
+
+## 5. Representations
+
+You represent that:
+
+a. You are legally entitled to grant the above license. If your employer(s)
+   have rights to intellectual property that you create that includes your
+   Contributions, you represent that you have received permission to make
+   Contributions on behalf of that employer, that your employer has waived
+   such rights for your Contributions to Us, or that your employer has
+   executed a separate Corporate CLA with Us.
+
+b. Each of Your Contributions is Your original creation (see Section 7 for
+   submissions on behalf of others).
+
+c. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related
+   patents and trademarks) of which You are personally aware and which are
+   associated with any part of Your Contributions.
+
+## 6. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notification of Changes
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.
+
+## 8. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to Us separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+You are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+## 9. Personal Data
+
+When You sign this Agreement, We process a limited set of personal data —
+typically Your name, email address, and GitHub account identifier — for the
+purpose of recording Your acceptance of this Agreement and identifying Your
+Contributions. The legal basis for this processing under the EU General Data
+Protection Regulation (Regulation 2016/679, "GDPR") is the performance of this
+Agreement (Article 6(1)(b) GDPR) and our legitimate interest in maintaining a
+verifiable record of contributor consents (Article 6(1)(f) GDPR).
+
+Signature records are retained for as long as the Project distributes
+Contributions and for any applicable limitation periods thereafter. Signatures
+collected through cla-assistant.io are processed by SAP SE on Our behalf in
+accordance with their privacy notice. You may exercise Your rights as a data
+subject (access, rectification, erasure where applicable, restriction,
+objection, portability) by contacting Us at [CONTACT EMAIL TO BE ADDED].
+
+## 10. Governing Law and Jurisdiction
+
+This Agreement and any non-contractual obligations arising out of or in
+connection with it are governed by the laws of The Netherlands, excluding its
+conflict-of-law rules and the United Nations Convention on Contracts for the
+International Sale of Goods (CISG). Any dispute arising out of or in connection
+with this Agreement shall be submitted to the exclusive jurisdiction of the
+competent court in Amsterdam, The Netherlands, without prejudice to any
+mandatory consumer-protection rules that may apply.
+
+The English-language version of this Agreement is the authoritative version.
+Any translations are provided for convenience only.
+
+---
+
+## How to Sign
+
+This Agreement is administered through [cla-assistant.io](https://cla-assistant.io).
+When You open a pull request to a participating repository, the CLA Assistant
+bot will comment with a link inviting You to sign. Clicking the link takes You
+to cla-assistant.io, where You can review the Agreement and sign in with Your
+GitHub account. Your signature is recorded once and applies to subsequent
+Contributions.
+
+The authoritative text reviewed and accepted by signatories is the version
+hosted as a GitHub Gist and referenced by cla-assistant.io. This file
+([`CLA.md`](./CLA.md)) is the version-controlled source of truth and is kept
+in sync with the Gist; any changes are made here first and then propagated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,35 @@
 # Contributing to Nextcloud MCP Server
 
+Thank you for your interest in contributing! This project is licensed under
+AGPL-3.0 and welcomes contributions from the community.
+
+## Contributor License Agreement (CLA)
+
+> **DRAFT — NOT YET IN EFFECT.** The CLA process described below is a planned
+> change. Until the [CLA](./CLA.md) is finalized and the CLA Assistant workflow
+> is enabled on this repository, no signature is required.
+
+To keep the project's licensing flexible — including the ability to offer
+commercial licensing alongside AGPL-3.0 in the future — we ask all contributors
+to sign our [Contributor License Agreement](./CLA.md). The CLA gives the
+project maintainer the rights needed to relicense or dual-license the project
+while letting you retain copyright in your contributions.
+
+**How signing works:**
+
+1. Open a pull request as you normally would.
+2. The CLA Assistant bot ([cla-assistant.io](https://cla-assistant.io)) will
+   comment on your PR with a link inviting you to sign.
+3. Click the link, review the agreement, and sign in with your GitHub account
+   to record your signature.
+4. Your signature is recorded once per GitHub account. Subsequent PRs are
+   covered automatically.
+
+If you contribute on behalf of an employer, please confirm with your employer
+that you are permitted to contribute under the CLA. For larger organizations,
+a separate Corporate CLA may be required — open an issue if this applies to
+you.
+
 ## Version Management
 
 This project uses [commitizen](https://commitizen-tools.github.io/commitizen/) for version management following PEP 440 (`major_version_zero = true`, 0.x.x for pre-1.0).


### PR DESCRIPTION
## Summary

- Adds `CLA.md` — a Contributor License Agreement for **Astrolabe Cloud**, adapted from the Apache 2.0 ICLA with Dutch-law modifications. Future contributions can be relicensed if the project later offers commercial terms alongside AGPL-3.0.
- Updates `CONTRIBUTING.md` with a CLA section describing the cla-assistant.io signing flow.
- Companion Gist (cla-assistant.io's authoritative copy) is published and linked in the cla-assistant.io configuration for this repository.

## What's in the CLA

- **§2 broad copyright grant** including the right to sublicense under any license terms (AGPL-3.0, other open-source, or proprietary commercial) — the language that unlocks dual-licensing.
- **§4 Moral Rights** — waiver under Article 25 _Auteurswet_ with carve-out for non-waivable rights and good-faith commitment to preserve attribution in git history.
- **§9 Personal Data** — GDPR Article 6(1)(b) and 6(1)(f) bases, retention statement, SAP SE (cla-assistant.io operator) named as processor, contact `info@astrolabecloud.com`.
- **§10 Governing Law** — Dutch law, CISG excluded, exclusive jurisdiction Amsterdam, English authoritative.

## Review feedback (from `claude[bot]` review on this PR)

**Blockers — addressed:**
- ✅ Named legal entity (Astrolabe Cloud) added to the Background.
- ✅ Privacy contact email filled in (`info@astrolabecloud.com`).
- ✅ DRAFT banners removed from `CLA.md` and the Gist now that the text is the version cla-assistant.io is collecting signatures against.

**Non-blocking suggestions deferred to counsel review (or follow-up):**
- §7 title ("Notification of Changes") describes notifying Us of inaccurate representations; reviewer suggested "Accuracy of Representations" reads more cleanly. Cosmetic — not changed here to keep diffs minimal pending counsel.
- §10 carries a "without prejudice to mandatory consumer-protection rules" carve-out borrowed from the boilerplate; an employment-law carve-out may be more apt since contributors are licensors, not consumers. Counsel decision.
- No paper / non-GitHub signing fallback — currently all signers are expected to use GitHub via cla-assistant.io. If we ever need to accept signatures from contributors who don't use GitHub, a fallback path can be added.
- Background could state plainly: "this means we may offer a commercial version" — current wording implies but does not say it. Worth considering for retroactive-outreach friction.
- A `CONTRIBUTING.md` note about retroactive contributor outreach (~12 prior external authors) is not in this PR; it'll be tracked in a separate issue once the activation steps below land.

## Still to do (outside this PR)

- [ ] Whitelist `cbcoutinho` (and `*[bot]` patterns for renovate / github-actions / claude[bot]) in the cla-assistant.io repo configuration so maintainer/bot PRs aren't gated on signature.
- [ ] Update `CONTRIBUTING.md` to remove the DRAFT banner once cla-assistant.io coverage is verified end-to-end on a test PR.
- [ ] Track retroactive outreach to the ~12 prior external contributors in a follow-up issue.

## Test plan

- [ ] Render `CLA.md` and `CONTRIBUTING.md` on GitHub and verify formatting.
- [ ] Verify the cla-assistant.io bot comments and `license/cla` status check work as expected on a contributor PR.
- [ ] Confirm whitelist takes effect (maintainer PRs no longer prompted).

---

_This PR was generated with the help of AI, and reviewed by a Human_