### PR TITLE
ci(claude-review): use sticky tracking comment instead of stacking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -33,10 +33,16 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1.0.90
+        uses: anthropics/claude-code-action@905d4eb99ab3d43143d74fb0dcae537f29ac330a # v1.0.97
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "renovate-bot-cbcoutinho"
+          # Reuse a single tracking comment per PR instead of stacking new comments
+          # on every push. track_progress forces tag mode (which posts a tracking
+          # comment) and use_sticky_comment makes that comment overwrite the prior
+          # Claude review on subsequent runs.
+          track_progress: true
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -50,9 +56,11 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Deliver the review by updating the tracking comment via
+            `mcp__github_comment__update_claude_comment`. Do not create a
+            separate PR comment — the tracking comment is the sticky review.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Summary

- Bump `anthropics/claude-code-action` pin to v1.0.97 and turn on `track_progress` + `use_sticky_comment` so each PR gets one tracking comment that the action edits in place on subsequent pushes, instead of stacking a fresh comment per push.
- Update the prompt to deliver the review by editing the tracking comment via `mcp__github_comment__update_claude_comment`, and drop `Bash(gh pr comment:*)` from `--allowed-tools` since that path is no longer used.
- Widen permissions from `read` to `write` on `pull-requests` and `issues` so the action can edit its own comment.

Mirrors the pattern already in production at [`astrolabe-cloud-website`](../../../astrolabe-cloud-website/.github/workflows/claude-code-review.yml) — see PR #737 for an example of the previous behavior (a duplicate stacking review comment is exactly what motivated this change).

## Test plan

- [ ] Open a draft PR or push to an existing one after merge — confirm a single `claude` tracking comment appears and is overwritten on subsequent pushes.
- [ ] Verify Claude does not fall back to `gh pr comment` (now removed from `--allowed-tools`).
- [ ] Confirm the action has permission to edit its own comment (`pull-requests: write`, `issues: write`).

---

_This PR was generated with the help of AI, and reviewed by a Human_