### PR TITLE
fix(vector-sync): wire document streams into OAuthAppContext

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -348,6 +348,10 @@ class OAuthAppContext:
     server_client_id: Optional[str] = (
         None  # MCP server's OAuth client ID (static or DCR)
     )
+    document_send_stream: Optional[MemoryObjectSendStream] = None
+    document_receive_stream: Optional[MemoryObjectReceiveStream] = None
+    shutdown_event: Optional[anyio.Event] = None
+    scanner_wake_event: Optional[anyio.Event] = None
 
 
 class BasicAuthMiddleware:
@@ -1180,6 +1184,10 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                     oauth_client=oauth_client,
                     oauth_provider=oauth_provider,
                     server_client_id=client_id,
+                    document_send_stream=_vector_sync_state.document_send_stream,
+                    document_receive_stream=_vector_sync_state.document_receive_stream,
+                    shutdown_event=_vector_sync_state.shutdown_event,
+                    scanner_wake_event=_vector_sync_state.scanner_wake_event,
                 )
             finally:
                 logger.info("Shutting down MCP server")


### PR DESCRIPTION
## Summary

- `nc_get_vector_sync_status` was returning hardcoded `status="unknown"`, `indexed=0`, `pending=0` for all OAuth deployments — even when Qdrant had documents indexed and hybrid search was working.
- Root cause: `OAuthAppContext` (`app.py:339-350`) didn't include a `document_receive_stream` field. The tool reads it via `getattr(lifespan_ctx, "document_receive_stream", None)` (`server/semantic.py:675-677`), got `None`, and short-circuited at `semantic.py:683-688` before the Qdrant count query at line 697 could run.
- The management endpoint `/api/v1/vector-sync/status` was unaffected because it reads from `request.app.state.document_receive_stream` (set by the Starlette lifespan), not the MCP lifespan context.
- Fix mirrors what `AppContext` (BasicAuth mode) already does: add the four vector-sync fields to `OAuthAppContext` and populate them from `_vector_sync_state` at the OAuth lifespan `yield` site.

## Diagnosis evidence

CloudWatch logs from `/ecs/nextcloud-mcp-server` showed background sync running normally and the management endpoint returning 200, but the MCP tool consistently returned `status="unknown"` — the only code path that produces that value is the early-return when `document_receive_stream is None`.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run ty check -- nextcloud_mcp_server/app.py` — clean
- [x] `uv run pytest tests/unit/` — 575 passed
- [ ] Redeploy ECS task and verify `nc_get_vector_sync_status` returns real `indexed_documents` / `pending_documents` counts instead of `status="unknown"`

---

_This PR was generated with the help of AI, and reviewed by a Human_