### PR TITLE
feat(calendar): add nc_calendar_complete_todo convenience tool

### DIFF
--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -1105,6 +1105,50 @@ def configure_calendar_tools(mcp: FastMCP):
         return await client.calendar.delete_todo(calendar_name, todo_uid)
 
     @mcp.tool(
+        title="Complete Todo Task",
+        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+    )
+    @require_scopes("todo.write", "calendar.read")
+    @instrument_tool
+    async def nc_calendar_complete_todo(
+        calendar_name: str,
+        todo_uid: str,
+        ctx: Context,
+        completed_at: Optional[str] = None,
+    ):
+        """Mark a todo/task as completed.
+
+        Convenience wrapper around nc_calendar_update_todo that sets
+        STATUS=COMPLETED, PERCENT-COMPLETE=100, and the COMPLETED
+        timestamp in one call. Equivalent to invoking update_todo with
+        those three fields populated; useful for AI clients where
+        "complete this task" is a more natural phrasing than "set status
+        to COMPLETED, set percent_complete to 100, set completed
+        timestamp".
+
+        Args:
+            calendar_name: Name of the calendar containing the todo
+            todo_uid: UID of the todo to mark complete
+            ctx: MCP context
+            completed_at: Optional ISO 8601 completion timestamp.
+                Defaults to the current UTC time if not provided.
+
+        Returns:
+            Dict with the update result.
+        """
+        client = await get_client(ctx)
+        if completed_at is None:
+            completed_at = dt.datetime.now(dt.timezone.utc).isoformat()
+        todo_data = {
+            "status": "COMPLETED",
+            "percent_complete": 100,
+            "completed": completed_at,
+        }
+        return await client.calendar.update_todo(
+            calendar_name, todo_uid, todo_data
+        )
+
+    @mcp.tool(
         title="Search Todo Tasks",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     )


### PR DESCRIPTION
## Summary

Adds `nc_calendar_complete_todo` — a one-shot "complete this task" tool that wraps the existing `update_todo` to set `STATUS=COMPLETED`, `PERCENT-COMPLETE=100`, and a `COMPLETED` timestamp in a single call.

## Why

The same operation is already possible through `nc_calendar_update_todo`:

```
update_todo(
  calendar_name=..., todo_uid=...,
  status="COMPLETED",
  percent_complete=100,
  completed="<now in ISO 8601>",
)
```

…but for AI clients, "complete this task" is a much more natural phrasing than "set three specific fields, and remember to compute the current timestamp." The dedicated tool also pairs naturally with the existing `create_todo` / `update_todo` / `delete_todo` trio, mirroring CalDAV libraries that ship a one-shot complete operation (e.g., the Node CalDAV client stack).

The new tool is a thin wrapper:

```python
async def nc_calendar_complete_todo(calendar_name, todo_uid, ctx, completed_at=None):
    if completed_at is None:
        completed_at = dt.datetime.now(dt.timezone.utc).isoformat()
    return await client.calendar.update_todo(calendar_name, todo_uid, {
        "status": "COMPLETED",
        "percent_complete": 100,
        "completed": completed_at,
    })
```

No client-side, model, or schema changes — the existing `update_todo` client method already accepts these three fields.

## Verification

End-to-end against a live Nextcloud 33.0.2 instance:

1. `nc_calendar_create_todo(calendar_name="tasks", summary="…", description="…")` → returned UID
2. `nc_calendar_complete_todo(calendar_name="tasks", todo_uid=<UID>)` → `{"status_code": 200, "uid": "<UID>", "href": "…"}`
3. `nc_calendar_search_todos(calendar_name="tasks", query="…")` → entry shows `status: "COMPLETED"`, `percent_complete: 100`, `completed: "2026-…"`
4. `nc_calendar_delete_todo(...)` cleanup OK

## Notes

- Annotation: `idempotentHint=True` — calling complete on an already-completed todo just refreshes the COMPLETED timestamp (matches CalDAV semantics).
- Scope: `todo.write, calendar.read` (same as `update_todo`).
- License: AGPL-3.0, same as the project.