### PR TITLE
fix(qdrant): use collection_exists for startup probe (multi-tenant safe)

### DIFF
--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -71,12 +71,21 @@ async def get_qdrant_client() -> AsyncQdrantClient:
 
         expected_dimension = embedding_service.get_dimension()
 
-        # Explicitly check if collection exists
+        # Explicitly check if collection exists.
+        #
+        # Use `collection_exists(name)` (per-collection HEAD-style probe)
+        # rather than `get_collections()` (cluster-wide list). In managed
+        # multi-tenant Qdrant Cloud setups, per-tenant JWTs are scoped
+        # to a single collection and `get_collections()` returns 403
+        # Forbidden by design — listing other tenants' collections would
+        # be a security regression. `collection_exists` only requires
+        # access to the named collection, which the tenant JWT has.
         logger.debug(f"Checking if collection '{collection_name}' exists...")
-        collections = await _qdrant_client.get_collections()
-        collection_names = [c.name for c in collections.collections]
+        collection_present = await _qdrant_client.collection_exists(
+            collection_name=collection_name
+        )
 
-        if collection_name in collection_names:
+        if collection_present:
             # Collection exists - validate dimensions
             logger.debug(
                 f"Collection '{collection_name}' found, validating dimensions..."


### PR DESCRIPTION
## Summary

Replaces the cluster-wide \`get_collections()\` startup call with the per-collection \`collection_exists(name)\` probe. The original call returns \`403 Forbidden\` whenever the configured Qdrant credential is scoped to a single collection (the recommended security boundary for managed multi-tenant Qdrant Cloud deployments).

## What broke

In a multi-tenant managed deployment, each tenant's Qdrant JWT is minted with collection-scoped access:

\`\`\`json
{
  \"access\": [{\"collection\": \"tenant_<uuid>\", \"access\": \"rw\"}]
}
\`\`\`

This is a deliberate security boundary — a tenant should not be able to enumerate other tenants' collections. The MCP server's current startup path calls \`get_collections()\` (cluster-wide list), which Qdrant denies on a collection-scoped JWT:

\`\`\`
qdrant_client.http.exceptions.UnexpectedResponse: 403 (Forbidden)
raw response: {\"error\":\"forbidden\"}
RuntimeError: Cannot start vector sync - Qdrant initialization failed
\`\`\`

The FastAPI lifespan crashes; the Pod CrashLoopBackOffs.

## Fix

Switch to \`collection_exists(collection_name)\` — a HEAD-style per-collection probe. Only requires access to the named collection, which the tenant JWT has.

\`\`\`diff
- collections = await _qdrant_client.get_collections()
- collection_names = [c.name for c in collections.collections]
- if collection_name in collection_names:
+ collection_present = await _qdrant_client.collection_exists(
+     collection_name=collection_name
+ )
+ if collection_present:
\`\`\`

## Compatibility

- **Single-tenant / admin-key setups**: unaffected. Both \`get_collections\` and \`collection_exists\` were authorized; this just picks the narrower one.
- **Multi-tenant scoped-JWT setups**: now boots cleanly.
- **Cold-start with no pre-provisioned collection**: behavior unchanged — \`collection_exists\` returns \`False\`, code path enters \`create_collection\`. Whether that succeeds depends on whether the JWT has create-collection rights (managed setups typically pre-provision the collection externally; admin-key setups can create on the fly).

## Test plan

- [ ] Existing integration tests at \`tests/integration/test_qdrant_collection_creation.py\` and \`tests/integration/test_semantic_search.py\` still pass — they use admin client outside the production startup path; \`get_collections()\` calls in those tests are intentional and remain.
- [ ] Manual: run a smoke against Astrolabe Cloud's per-tenant scoped-JWT setup; tenant Pod reaches \`1/1 Running\` instead of CrashLoopBackOff at the FastAPI lifespan stage.

## Discovery context

Hit during Astrolabe Cloud smoke16 with chart \`nextcloud-mcp-server-0.62.1\` (which itself fixed a separate login-flow OIDC env-var bug at <https://github.com/cbcoutinho/helm-charts/pull/28>). The OIDC fix unblocked the Pod far enough that it now reaches the Qdrant init step — surfacing this multi-tenant scope mismatch.

---

_This PR was generated with the help of AI, and reviewed by a Human_