### PR TITLE
fix(qdrant): use get_collection for startup probe (multi-tenant safe, take 2)

### DIFF
--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -3,6 +3,7 @@
 import logging
 
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.models import Distance, VectorParams
 
 from nextcloud_mcp_server.config import get_settings
@@ -71,26 +72,33 @@ async def get_qdrant_client() -> AsyncQdrantClient:
 
         expected_dimension = embedding_service.get_dimension()
 
-        # Explicitly check if collection exists.
+        # Existence check folded into the get_collection() call.
         #
-        # Use `collection_exists(name)` (per-collection HEAD-style probe)
-        # rather than `get_collections()` (cluster-wide list). In managed
-        # multi-tenant Qdrant Cloud setups, per-tenant JWTs are scoped
-        # to a single collection and `get_collections()` returns 403
-        # Forbidden by design — listing other tenants' collections would
-        # be a security regression. `collection_exists` only requires
-        # access to the named collection, which the tenant JWT has.
-        logger.debug(f"Checking if collection '{collection_name}' exists...")
-        collection_present = await _qdrant_client.collection_exists(
-            collection_name=collection_name
-        )
+        # In managed multi-tenant Qdrant Cloud setups, per-tenant JWTs are
+        # scoped to a single collection (`access: [{"collection": "...",
+        # "access": "rw"}]`) and Qdrant denies the cluster-level meta
+        # endpoints `GET /collections` (used by `get_collections()`) and
+        # `GET /collections/{name}/exists` (used by `collection_exists()`)
+        # with 403 Forbidden — by design, since listing or probing
+        # collections cluster-wide is a tenant-isolation boundary.
+        # `GET /collections/{name}` (the underlying call for
+        # `get_collection()`) is the only existence-probe permitted on a
+        # collection-scoped JWT — it returns 200 with the collection
+        # detail on hit and 404 on miss.
+        logger.debug(f"Fetching collection '{collection_name}' details...")
+        collection_info = None
+        try:
+            collection_info = await _qdrant_client.get_collection(collection_name)
+        except UnexpectedResponse as exc:
+            if exc.status_code != 404:
+                raise
+            logger.debug(f"Collection '{collection_name}' not found (404).")
 
-        if collection_present:
+        if collection_info is not None:
             # Collection exists - validate dimensions
             logger.debug(
                 f"Collection '{collection_name}' found, validating dimensions..."
             )
-            collection_info = await _qdrant_client.get_collection(collection_name)
             # Handle both named vectors (dict) and legacy single vector
             vectors = collection_info.config.params.vectors
             if isinstance(vectors, dict):


### PR DESCRIPTION
## Summary

Follow-up to #778 — \`collection_exists()\` is **also** denied by Qdrant Cloud on a collection-scoped JWT (which #778 was supposed to fix). The proper fix is one level deeper: use \`get_collection(name)\` (\`GET /collections/{name}\`) and treat a 404 \`UnexpectedResponse\` as the \"doesn't exist\" signal.

## What still broke after #778

Astrolabe Cloud's smoke17 ran on the post-#778 image and crashed with:

\`\`\`
qdrant_client.http.exceptions.UnexpectedResponse: 403 (Forbidden)
raw response: {\"error\":\"forbidden\"}
File \"qdrant_client.py\", line 84, in get_qdrant_client
    collection_present = await _qdrant_client.collection_exists(...)
\`\`\`

Even though #778 already swapped \`get_collections()\` → \`collection_exists()\`, both endpoints turn out to be cluster-meta operations that Qdrant Cloud denies on a collection-scoped JWT.

## Qdrant Cloud's JWT scope rules (as observed)

| qdrant-client method | HTTP endpoint | Permitted with collection-scoped JWT? |
|----------------------|---------------|---------------------------------------|
| \`get_collections()\` | \`GET /collections\` | ❌ 403 |
| \`collection_exists()\` | \`GET /collections/{name}/exists\` | ❌ 403 |
| **\`get_collection()\`** | **\`GET /collections/{name}\`** | **✅ 200 / 404** |
| \`create_collection()\` | \`PUT /collections/{name}\` | ❌ (managed by external admin) |
| \`delete_collection()\` | \`DELETE /collections/{name}\` | ❌ |
| \`upsert\`, \`search\`, \`query\`, \`count\`, etc. | \`/collections/{name}/points/*\` | ✅ |

\`get_collection(name)\` is the **only existence-probe** permitted on a collection-scoped JWT — anything that returns metadata about ANY collection (or aggregates across collections) is denied.

## Fix

Fold the existence check into the \`get_collection()\` call that already runs immediately afterward for dimension validation. 404 → doesn't exist → fall through to \`create_collection()\` (cold-start path unchanged); 200 → existed, validate dimensions; any other status code → re-raise.

\`\`\`diff
- collection_present = await _qdrant_client.collection_exists(
-     collection_name=collection_name
- )
- if collection_present:
-     collection_info = await _qdrant_client.get_collection(collection_name)
+ collection_info = None
+ try:
+     collection_info = await _qdrant_client.get_collection(collection_name)
+ except UnexpectedResponse as exc:
+     if exc.status_code != 404:
+         raise
+     # 404 → collection doesn't exist; fall through to create
+ if collection_info is not None:
\`\`\`

Bonus: one fewer round-trip on the happy path (existence + detail were two calls; now one).

## Compatibility

- **Single-tenant / admin-key setups**: unaffected. \`get_collection()\` was already the canonical detail call; we're just consolidating around it.
- **Multi-tenant scoped-JWT setups**: now boots cleanly.
- **Cold-start (collection missing)**: unchanged — 404 → enters \`create_collection()\` branch.

## Test plan

- [ ] Existing integration tests under \`tests/integration/test_qdrant_collection_creation.py\` still pass — they use admin clients outside the production startup path; no \`collection_exists\` on the path I changed.
- [ ] Manual: Astrolabe Cloud smoke18 against multi-tenant Qdrant Cloud — Pod reaches \`1/1 Running\` (the test #778 was supposed to validate but missed because the failure mode shifted from \`get_collections\` → \`collection_exists\` after that fix landed).

---

_This PR was generated with the help of AI, and reviewed by a Human_