### PR TITLE
fix(health): forward api-key to Qdrant /readyz so Cloud probes work

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1960,9 +1960,21 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
         if vector_sync_enabled and qdrant_url:
             start_time = time.time()
+            # Self-hosted Qdrant exposes /readyz unauthenticated, but
+            # Qdrant Cloud's auth gateway returns 403 for any
+            # unauthenticated request — so we have to forward the same
+            # api-key the configured AsyncQdrantClient uses (see
+            # vector/qdrant_client.py). Without this header, every
+            # readiness probe against a Cloud cluster returns 503,
+            # blocking the Pod from reaching Ready.
+            qdrant_headers = (
+                {"api-key": settings.qdrant_api_key} if settings.qdrant_api_key else {}
+            )
             try:
                 async with httpx.AsyncClient(timeout=2.0) as client:
-                    response = await client.get(f"{qdrant_url}/readyz")
+                    response = await client.get(
+                        f"{qdrant_url}/readyz", headers=qdrant_headers
+                    )
                     duration = time.time() - start_time
                     if response.status_code == 200:
                         checks["qdrant"] = "ok"


### PR DESCRIPTION
## Summary

The readiness handler called `${QDRANT_URL}/readyz` with a bare `httpx.AsyncClient` — no headers. That works against self-hosted Qdrant (where `/readyz` is anonymous), but **Qdrant Cloud's auth gateway returns 403 for any unauthenticated request**, including `/readyz`, `/livez` and `/healthz`. Every probe against a Cloud cluster fell into the \"status 403\" branch, the handler returned 503, and the Pod never went Ready — even when the configured `AsyncQdrantClient` itself was authenticating fine for the actual collection traffic.

## What changed

`nextcloud_mcp_server/app.py` (`health_ready`): forward `settings.qdrant_api_key` as the `api-key` header (mirroring what `vector/qdrant_client.py:540` already does for the real client). When the key is unset (self-hosted / anonymous case) we send no header, so existing self-hosted deployments are unchanged.

\`\`\`diff
+qdrant_headers = (
+    {\"api-key\": settings.qdrant_api_key} if settings.qdrant_api_key else {}
+)
 try:
     async with httpx.AsyncClient(timeout=2.0) as client:
-        response = await client.get(f\"{qdrant_url}/readyz\")
+        response = await client.get(
+            f\"{qdrant_url}/readyz\", headers=qdrant_headers
+        )
\`\`\`

## How it manifested

Spotted while smoke-testing Astrolabe Cloud's per-tenant Qdrant Cloud key provisioning (cbcoutinho/astrolabe-cloud-website#96). With the per-tenant database API key working, the data-plane Pod successfully ran:

\`\`\`
Initializing Qdrant collection...
Using existing Qdrant collection: tenant_<id> (dimension=1024, model=mistral-embed)
Qdrant collection ready
Application startup complete.
Uvicorn running on http://0.0.0.0:8000
\`\`\`

But the Pod stayed `0/1` Ready. Kubelet events:

\`\`\`
Readiness probe failed: HTTP probe failed with statuscode: 503
\`\`\`

Direct curl confirmed the cause:

\`\`\`
$ curl -i https://<cluster>.eu-west-1-0.aws.cloud.qdrant.io/readyz
HTTP/2 403
{\"error\":\"forbidden\"}

$ curl -i -H \"api-key: <invalid>\" .../readyz   # also 403 on bad key
$ curl -i -H \"api-key: <valid>\" .../readyz     # 200 OK
\`\`\`

`/livez` and `/healthz` behave identically — all gated.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `ty check` clean
- [x] Existing health-related tests still pass (`tests/unit/test_logging_filter.py` covers the access-log filter for `/health/*`)
- [x] Self-hosted unchanged: when `QDRANT_API_KEY` is unset, no header is sent (same wire shape as before)
- [ ] Smoke against Qdrant Cloud (will redeploy this fix into the smoke19 tenant Pod and confirm the workflow's `wait-for-tenant-Ready` step completes — currently blocked on this exact 503)

## Why no test was added

`health_ready` is a nested closure inside `get_app(...)`, so unit-testing it in isolation would require a refactor to lift it to module scope (separate change). For a 3-line behavioural fix that's easy to verify by curl, that felt like over-bundling. Happy to extract + add tests in a follow-up if preferred.

---

_This PR was generated with the help of AI, and reviewed by a Human_