### PR TITLE
docs: fix /health endpoint references and stale log examples (#766)

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -313,30 +313,51 @@ MCP clients (like Claude Desktop, LLM IDEs) can connect to your server:
 
 ### Check Server Health
 
+The server exposes two Kubernetes-style probe endpoints:
+
 ```bash
-# Test if server is responding
-curl http://localhost:8000/health
+# Liveness — server process is up (always 200 if running)
+curl http://localhost:8000/health/live
 
-# Expected response: HTTP 200 OK
+# Readiness — server can reach Nextcloud and (if enabled) Qdrant
+curl http://localhost:8000/health/ready
 ```
 
-### Check OAuth Configuration
+`/health/live` returns `200 OK` as long as the process is running. `/health/ready`
+returns `200 OK` with a JSON body describing each dependency check, or `503` with
+the same JSON body listing which checks failed — use the readiness probe when
+troubleshooting connectivity to Nextcloud or Qdrant.
 
-Look for these log messages on startup:
+### Check Deployment Mode
 
-**OAuth mode:**
+The server logs the detected deployment mode on startup. Look for these
+messages in the container logs:
+
+**At server boot (all modes):**
 ```
-INFO     OAuth mode detected (NEXTCLOUD_USERNAME/PASSWORD not set)
-INFO     Configuring MCP server for OAuth mode
-INFO     OIDC discovery successful
+INFO     ✅ Configuration validated successfully for <mode> mode
+INFO     Configuring MCP server for <mode> mode
+INFO     Health check endpoints enabled: /health/live, /health/ready
+```
+
+`<mode>` is one of `single_user_basic`, `multi_user_basic`, or
+`oauth_single_audience`, matching the `MCP_DEPLOYMENT_MODE` setting.
+
+**Additional OAuth-mode messages (at server boot):**
+```
 INFO     OAuth client ready: <client-id>...
-INFO     OAuth initialization complete
+INFO     OAuth configuration complete
 ```
 
-**BasicAuth mode:**
+**Additional single-user BasicAuth messages (per MCP session):**
+
+These fire when the first MCP client connects, not at server boot — if you
+have just started the container and no client has connected yet, you will not
+see them in the logs:
 ```
-INFO     BasicAuth mode detected (NEXTCLOUD_USERNAME/PASSWORD set)
-INFO     Initializing Nextcloud client with BasicAuth
+INFO     Starting MCP session in single-user BasicAuth mode
+INFO     Creating shared Nextcloud client with BasicAuth
+INFO     Client initialization complete
 ```
 
 ---
@@ -416,7 +437,7 @@ Common issues:
 
 ### Can't connect to server
 
-1. Verify server is running: `curl http://localhost:8000/health`
+1. Verify server is running: `curl http://localhost:8000/health/live`
 2. Check firewall settings
 3. Verify host binding (use `0.0.0.0` to allow network access)
 4. Check OAuth authentication if enabled

--- a/docs/running.md
+++ b/docs/running.md
@@ -336,18 +336,28 @@ messages in the container logs:
 **At server boot (all modes):**
 ```
 INFO     ✅ Configuration validated successfully for <mode> mode
-INFO     Configuring MCP server for <mode> mode
 INFO     Health check endpoints enabled: /health/live, /health/ready
 ```
 
 `<mode>` is one of `single_user_basic`, `multi_user_basic`, or
-`oauth_single_audience`, matching the `MCP_DEPLOYMENT_MODE` setting.
+`oauth_single`, matching the `MCP_DEPLOYMENT_MODE` setting.
+
+**Additional BasicAuth-mode messages (at server boot):**
+```
+INFO     Configuring MCP server for <mode> mode
+```
+
+Here `<mode>` is the enum value (`single_user_basic` or `multi_user_basic`).
 
 **Additional OAuth-mode messages (at server boot):**
 ```
+INFO     Configuring MCP server for OAuth mode
 INFO     OAuth client ready: <client-id>...
 INFO     OAuth configuration complete
 ```
+
+Note the OAuth boot line logs the literal string `OAuth mode`, not the enum
+value `oauth_single`.
 
 **Additional single-user BasicAuth messages (per MCP session):**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -290,10 +290,10 @@ kill <pid>
 2. **Test connectivity:**
    ```bash
    # Test from same machine
-   curl http://localhost:8000/health
+   curl http://localhost:8000/health/live
 
    # Test from network (if using --host 0.0.0.0)
-   curl http://<server-ip>:8000/health
+   curl http://<server-ip>:8000/health/live
    ```
 
 3. **Check firewall:**


### PR DESCRIPTION
## Summary

Closes #766.

- `docs/running.md` and `docs/troubleshooting.md` told users to `curl http://localhost:8000/health`, but the server only registers `/health/live` and `/health/ready` (Kubernetes-style probes — see `app.py:2011-2013`). The reporter's container log even confirmed this — `Health check endpoints enabled: /health/live, /health/ready` — yet the docs sent them at a 404.
- The "Check OAuth Configuration" block listed expected log lines (`BasicAuth mode detected …`, `OAuth mode detected …`, `OIDC discovery successful`, etc.) that no longer exist anywhere in the codebase — they were stale examples from an earlier version.
- The reported "missing BasicAuth log messages" symptom had a second cause: the real per-session messages (`Starting MCP session in single-user BasicAuth mode`, `Creating shared Nextcloud client with BasicAuth`, `Client initialization complete`) fire from `app_lifespan_basic` (`app.py:557-566`), which runs **per MCP session** — so a freshly-started container with no client connected yet won't show them.

This PR is docs-only:

- Replace the `/health` curl with `/health/live` (liveness) and `/health/ready` (readiness), with a one-liner on the readiness 503/JSON failure case for connectivity troubleshooting.
- Rewrite "Check OAuth Configuration" as "Check Deployment Mode" with the actual server-boot log lines (`✅ Configuration validated successfully for <mode> mode`, `Configuring MCP server for <mode> mode`, `Health check endpoints enabled: …`) and the additional mode-specific lines that fire at boot (OAuth) or per session (BasicAuth), with an explicit note that the BasicAuth lines won't appear until a client connects.
- Update the two `/health` references in `docs/troubleshooting.md` to `/health/live`.

No code paths or endpoint surface changed.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check -- nextcloud_mcp_server` — clean
- [ ] Visual: render `docs/running.md` and confirm the rewritten "Verifying Server Status" section reads correctly
- [ ] Smoke against a running container:
  ```bash
  docker compose --profile single-user up --build -d mcp
  curl -i http://localhost:8000/health/live    # expect 200
  curl -s http://localhost:8000/health/ready | jq .  # expect 200 with checks object
  ```
- [ ] Confirm boot-time log lines appear:
  ```bash
  docker compose logs mcp | grep -E "Configuration validated successfully|Configuring MCP server for|Health check endpoints enabled"
  ```

---

_This PR was generated with the help of AI, and reviewed by a Human_