### PR TITLE
refactor(config): align OAUTH_SINGLE_AUDIENCE enum value with documented env-var

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -336,28 +336,18 @@ messages in the container logs:
 **At server boot (all modes):**
 ```
 INFO     ✅ Configuration validated successfully for <mode> mode
+INFO     Configuring MCP server for <mode> mode
 INFO     Health check endpoints enabled: /health/live, /health/ready
 ```
 
 `<mode>` is one of `single_user_basic`, `multi_user_basic`, or
-`oauth_single`, matching the `MCP_DEPLOYMENT_MODE` setting.
-
-**Additional BasicAuth-mode messages (at server boot):**
-```
-INFO     Configuring MCP server for <mode> mode
-```
-
-Here `<mode>` is the enum value (`single_user_basic` or `multi_user_basic`).
+`oauth_single_audience`, matching the `MCP_DEPLOYMENT_MODE` setting.
 
 **Additional OAuth-mode messages (at server boot):**
 ```
-INFO     Configuring MCP server for OAuth mode
 INFO     OAuth client ready: <client-id>...
 INFO     OAuth configuration complete
 ```
-
-Note the OAuth boot line logs the literal string `OAuth mode`, not the enum
-value `oauth_single`.
 
 **Additional single-user BasicAuth messages (per MCP session):**
 

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1167,7 +1167,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
     # Create MCP server based on detected mode
     if mode == AuthMode.OAUTH_SINGLE_AUDIENCE:
-        logger.info("Configuring MCP server for OAuth mode")
+        logger.info("Configuring MCP server for %s mode", mode.value)
         # Asynchronously get the OAuth configuration
 
         (

--- a/nextcloud_mcp_server/config_validators.py
+++ b/nextcloud_mcp_server/config_validators.py
@@ -25,7 +25,7 @@ class AuthMode(Enum):
 
     SINGLE_USER_BASIC = "single_user_basic"
     MULTI_USER_BASIC = "multi_user_basic"
-    OAUTH_SINGLE_AUDIENCE = "oauth_single"
+    OAUTH_SINGLE_AUDIENCE = "oauth_single_audience"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Follow-up cleanup to #785. The reviewer there caught that I'd written `oauth_single_audience` in the boot-log doc example, but the enum value is actually `\"oauth_single\"` (`config_validators.py:28`). I patched the doc to match the code (commit 5f01312c). On reflection that was the wrong direction: every other surface — ADR-021, `env.sample`, the configuration-migration guides, the `mode_map` key at `config_validators.py:188` — consistently uses `oauth_single_audience`. A user who follows the docs to set `MCP_DEPLOYMENT_MODE=oauth_single_audience` and then greps their logs for that string finds nothing, because `f\"... for {mode.value} mode\"` lines (`config_validators.py:199`, `app.py:1015`) print `oauth_single`.

The divergence is historical: ADR-021 originally defined two OAuth variants (`OAUTH_SINGLE_AUDIENCE` + `OAUTH_TOKEN_EXCHANGE`), and `\"oauth_single\"` was picked as a shorter value. When token-exchange OAuth was removed in `57303135`, the inconsistency was not cleaned up.

This PR makes three small changes:

- **`config_validators.py:28`** — enum value `\"oauth_single\"` → `\"oauth_single_audience\"`. The `mode_map` (lines 185-189) already keys on `\"oauth_single_audience\"`, so explicit-mode detection is unchanged. No call site reads the literal `\"oauth_single\"` (verified by grep against `nextcloud_mcp_server/`, `tests/`, `docs/`); every consumer uses the `AuthMode` identifier or the `mode_map`.
- **`app.py:1170`** — the OAuth boot log was hardcoded to `\"Configuring MCP server for OAuth mode\"` while the BasicAuth branch (line 1239) uses `f\"... for {mode.value} mode\"`. Made the OAuth branch uniform so all three modes log the same shape, with the value matching what users set in `MCP_DEPLOYMENT_MODE`.
- **`docs/running.md`** — revert the per-mode boot-log carve-up that #785 (commit 5f01312c) added to work around the inconsistency. The uniform-substitution wording is now correct.

**Deliberately out of scope:** the `auth_mode` field in `/health/ready` (`app.py:1936`) returns short client-facing strings (`\"oauth\"`, `\"basic\"`, `\"multi_user_basic\"`) — that's a stable contract with Astrolabe and other downstream clients (see the comment at lines 1933-1934). Untouched.

## Test plan

- [x] \`uv run ruff check\` — clean
- [x] \`uv run ruff format --check\` — clean
- [x] \`uv run ty check -- nextcloud_mcp_server\` — clean
- [x] \`uv run pytest tests/unit/test_config_validators.py -x\` — 44 passed (the OAuth single-audience tests in particular)
- [x] \`uv run pytest tests/unit/ -x\` — 1004 passed
- [ ] Smoke against a running OAuth-mode container:
  \`\`\`bash
  docker compose --profile login-flow up --build -d mcp-login-flow
  docker compose logs mcp-login-flow | grep -E \"Configuration validated successfully|Configuring MCP server\"
  # Expect uniform string: \"oauth_single_audience\" in both lines.
  curl -s http://localhost:8000/health/ready | jq .checks.auth_mode
  # Expect \"oauth\" — Astrolabe contract unchanged.
  \`\`\`

---

_This PR was generated with the help of AI, and reviewed by a Human_