### PR TITLE
refactor: prune dead pre-LOGIN_FLOW config/runtime branches (ADR-022 cleanup)

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1789,10 +1789,19 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                         )
                         break
 
-                # Determine authentication mode for background sync
-                # Login Flow v2 and multi-user BasicAuth: use app passwords
-                # OAuth mode (without Login Flow): use OAuth refresh tokens
-                use_basic_auth = not oauth_enabled or settings.enable_login_flow
+                # Background sync always uses app passwords post-ADR-022:
+                # `oauth_enabled` now implies `enable_login_flow` (single
+                # source of truth is `MCP_DEPLOYMENT_MODE`), so the old
+                # `not oauth_enabled or settings.enable_login_flow` was always
+                # True. The OAuth-refresh code paths in
+                # `vector/oauth_sync.py` (gated on `use_basic_auth=False`)
+                # are now unreachable; pruning them — and dropping the
+                # `use_basic_auth` parameter from `user_manager_task` /
+                # `oauth_processor_task` — is tracked as a separate
+                # follow-up. Keep the variable name + the conditional
+                # wiring at the call sites for now so the parallel-prune
+                # PR is a clean mechanical diff.
+                use_basic_auth = True
 
                 # Start background tasks using anyio TaskGroup
                 async with anyio.create_task_group() as tg:

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -43,8 +43,9 @@ _DEFAULTS: dict[str, Any] = {
     "userinfo_uri": None,
     "oidc_resource_server_id": None,
     # Mode flags
-    "enable_multi_user_basic_auth": False,
-    "enable_login_flow": False,
+    # NOTE: `enable_multi_user_basic_auth` and `enable_login_flow` are
+    # intentionally absent — they are derived from MCP_DEPLOYMENT_MODE in
+    # Settings.__post_init__ (ADR-022) and not read from the dynaconf store.
     "enable_semantic_search": False,
     "enable_background_operations": False,
     "vector_sync_enabled": False,


### PR DESCRIPTION
## Summary

Tiny post-merge cleanup of two dead branches left behind by [#787](https://github.com/cbcoutinho/nextcloud-mcp-server/pull/787) (the ADR-022 LOGIN_FLOW rename). Both items were explicitly called out as deferred in #787's reviewer thread.

| File | Change |
|---|---|
| \`nextcloud_mcp_server/config.py\` | Drop \`enable_multi_user_basic_auth\` and \`enable_login_flow\` from the dynaconf \`_DEFAULTS\` dict. They were removed from \`_field_map\` in #787 so \`get_settings()\` never read them anyway, but their presence in \`_DEFAULTS\` was visually misleading. Replaced with a NOTE comment pointing at \`Settings.__post_init__\` as the canonical derivation site. |
| \`nextcloud_mcp_server/app.py\` | Hard-code \`use_basic_auth = True\` (was \`not oauth_enabled or settings.enable_login_flow\`). After #787 enforced \`oauth_enabled ↔ enable_login_flow\` via \`__post_init__\`, that expression was always True. Comment explains the invariant. |

**No runtime behaviour change** — both lines already evaluated to their hard-coded values in every supported deployment mode after #787.

## Deliberately out of scope

The deeper \`vector/oauth_sync.py\` cleanup — dropping the \`use_basic_auth\` parameter from \`user_manager_task\` / \`oauth_processor_task\` / \`get_user_client\` and deleting the now-unreachable OAuth-token-refresh code paths — is **separate and larger**, and deserves its own focused review cycle. The current PR keeps the call-site \`token_broker if not use_basic_auth else None\` wiring intact so that follow-up can be a clean mechanical diff.

The token_broker construction itself stays in \`app.py\` — it's still used by the management API revoke endpoint (\`app.state.oauth_context[\"token_broker\"]\`), so it isn't dead.

## Test plan

- [x] \`uv run ruff check\` — clean
- [x] \`uv run ruff format --check\` — clean
- [x] \`uv run ty check -- nextcloud_mcp_server\` — clean
- [x] \`uv run pytest tests/unit/ -x\` — 1010 passed
- [ ] Integration tests for \`mcp-login-flow\` and \`mcp-multi-user-basic\` profiles (the two that exercise the \`use_basic_auth = True\` background-sync path) — CI will run these.

---

_This PR was generated with the help of AI, and reviewed by a Human_