### PR TITLE
fix(contacts): surface ORG/TITLE/NOTE/URL/CATEGORIES/PHOTO on read (refs #716)

### DIFF
--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -119,6 +119,24 @@ def _parse_bday(value: str | date | None) -> date | None:
     return None
 
 
+def _first_custom(custom: dict[str, str | list[str]], key: str) -> str | None:
+    """Return the first raw value pythonvCard4 stashed in ``custom[key]``.
+
+    The library has no typed parser for ORG / TITLE / unencoded PHOTO, so they
+    end up in ``Contact.custom`` keyed by property name. The library's typeshed
+    declares the values as ``str | list[str]`` even though the current parser
+    always appends to a list — accept both shapes so we don't break on a future
+    library version that switches to bare strings. Returns ``None`` when the
+    key is absent or the value is empty.
+    """
+    values = custom.get(key)
+    if isinstance(values, list):
+        return values[0] if values else None
+    if isinstance(values, str):
+        return values or None
+    return None
+
+
 def _safe_vcard_value(value: Any) -> Any:
     """Escape newlines in a value so it can't inject additional vCard properties.
 
@@ -446,6 +464,16 @@ class ContactsClient(BaseNextcloudClient):
 
             contact = Contact.from_vcard(addressdata)
 
+            # pythonvCard4's parser has no branch for ORG / TITLE — they fall
+            # through into ``contact.custom`` as a list of raw values. PHOTO
+            # only gets typed-parsed when the line carries an ``ENCODING=``
+            # parameter; otherwise it lands in ``custom`` too. Pull them out
+            # here so the read side surfaces what the write side persisted
+            # (issue #716 follow-up).
+            org_value = _first_custom(contact.custom, "ORG")
+            title_value = _first_custom(contact.custom, "TITLE")
+            photo_value = contact.photo_data or _first_custom(contact.custom, "PHOTO")
+
             contacts.append(
                 {
                     "vcard_id": vcard_id,
@@ -458,6 +486,12 @@ class ContactsClient(BaseNextcloudClient):
                         else contact.bday,
                         "email": contact.email,
                         "tel": contact.tel,
+                        "org": org_value,
+                        "title": title_value,
+                        "note": contact.note,
+                        "url": contact.url,
+                        "categories": contact.categories,
+                        "photo": photo_value,
                     },
                     "addressdata": addressdata,
                 }

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -65,14 +65,34 @@ def _parse_vcard_fields(
 def _raw_contact_to_model(raw: dict) -> Contact:
     """Convert a raw contact dict from the contacts client to a Contact model.
 
-    Maps fullname, nickname, birthday, email, and tel fields.
-    Email/tel values may be plain strings, dicts with ``value``/``type`` keys,
-    or lists of either – see :func:`_parse_vcard_fields`.
+    Maps fullname, nickname, birthday, email, tel, org, title, note, url,
+    categories, and photo fields. Email/tel values may be plain strings, dicts
+    with ``value``/``type`` keys, or lists of either – see
+    :func:`_parse_vcard_fields`.
     """
     contact_info = raw.get("contact", {})
 
     emails = _parse_vcard_fields(contact_info.get("email"), "email")
     phones = _parse_vcard_fields(contact_info.get("tel"), "phone")
+
+    # URL is parsed by pythonvCard4 into a plain ``list[str]``. Single-string
+    # inputs surface as such too. Either way wrap each into a ContactField.
+    raw_urls = contact_info.get("url")
+    if isinstance(raw_urls, str):
+        raw_urls = [raw_urls] if raw_urls else []
+    urls = [
+        ContactField(type="url", value=u)
+        for u in (raw_urls or [])
+        if isinstance(u, str) and u
+    ]
+
+    # CATEGORIES is parsed as ``list[str]``. Accept a comma-separated string
+    # too for forward-compat with library updates that might change shape.
+    raw_categories = contact_info.get("categories") or []
+    if isinstance(raw_categories, str):
+        categories = [c.strip() for c in raw_categories.split(",") if c.strip()]
+    else:
+        categories = [c for c in raw_categories if isinstance(c, str) and c]
 
     # Nickname goes into custom_fields (no dedicated model field)
     custom_fields: dict[str, Any] = {}
@@ -84,11 +104,17 @@ def _raw_contact_to_model(raw: dict) -> Contact:
         uid=raw["vcard_id"],
         fn=contact_info.get("fullname", ""),
         etag=raw.get("getetag"),
+        organization=contact_info.get("org"),
+        title=contact_info.get("title"),
+        note=contact_info.get("note"),
+        photo=contact_info.get("photo"),
         birthday=contact_info["birthday"].isoformat()
         if isinstance(contact_info.get("birthday"), date)
         else contact_info.get("birthday"),
         emails=emails,
         phones=phones,
+        urls=urls,
+        categories=categories,
         custom_fields=custom_fields,
     )
 

--- a/tests/server/test_contacts_mcp.py
+++ b/tests/server/test_contacts_mcp.py
@@ -1,5 +1,6 @@
 """Integration tests for Contacts MCP tools."""
 
+import json
 import logging
 import uuid
 
@@ -10,6 +11,11 @@ from nextcloud_mcp_server.client import NextcloudClient
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.integration
+
+
+def _extract_payload(tool_result) -> dict:
+    """Return the JSON-decoded text content of an MCP tool result."""
+    return json.loads(tool_result.content[0].text)
 
 
 async def test_mcp_contacts_workflow(
@@ -61,6 +67,23 @@ async def test_mcp_contacts_workflow(
         raw_vcard = created.get("addressdata", "")
         assert "ORG:MCP Test Corp" in raw_vcard
         assert f"NOTE:Created by test {unique_suffix}" in raw_vcard
+
+        # 4a. Read-side round-trip — issue #716 follow-up. The write side has
+        # been correct since PR #719, but the MCP list/search tools returned
+        # ``organization: null`` / ``note: null`` because pythonvCard4 stashes
+        # ORG/TITLE in ``custom`` and the server's _raw_contact_to_model never
+        # surfaced ``note`` / ``urls`` either.
+        search_result = await nc_mcp_client.call_tool(
+            "nc_contacts_search_contacts",
+            {"query": unique_suffix, "addressbook": addressbook_name},
+        )
+        assert search_result.isError is False
+        search_payload = _extract_payload(search_result)
+        assert search_payload["total_count"] == 1
+        searched = search_payload["contacts"][0]
+        assert searched["uid"] == contact_uid
+        assert searched["organization"] == "MCP Test Corp"
+        assert searched["note"] == f"Created by test {unique_suffix}"
 
         # 4b. Update with a URL — regression guard for PR #719 review:
         # _merge_vcard_properties previously had no URL handler, silently dropping it.

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -11,6 +11,7 @@ import pytest
 
 from nextcloud_mcp_server.client.contacts import (
     _build_contact_from_data,
+    _first_custom,
     _normalize_contact_data,
     _wrap_contact_field,
 )
@@ -199,6 +200,31 @@ def test_missing_fn_logs_warning(caplog):
             # pythonvCard4 may raise on missing fn; we only care about the warning log.
             pass
     assert any("fn" in r.message.lower() for r in caplog.records)
+
+
+class TestFirstCustom:
+    """``_first_custom`` is the read-side companion to PR #719 — it pulls
+    ORG / TITLE / unencoded PHOTO out of pythonvCard4's ``custom`` dict because
+    the library has no typed parser for them.
+    """
+
+    def test_returns_first_value_from_list(self):
+        assert _first_custom({"ORG": ["Acme Corp"]}, "ORG") == "Acme Corp"
+
+    def test_returns_first_value_when_library_uses_bare_string(self):
+        """The library's typeshed allows ``str`` as a value shape too. Accept it
+        so we don't break if the parser changes shape upstream.
+        """
+        assert _first_custom({"TITLE": "Engineer"}, "TITLE") == "Engineer"
+
+    def test_returns_none_for_missing_key(self):
+        assert _first_custom({"ORG": ["Acme"]}, "TITLE") is None
+
+    def test_returns_none_for_empty_list(self):
+        assert _first_custom({"ORG": []}, "ORG") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _first_custom({"ORG": ""}, "ORG") is None
 
 
 class TestNormalizeContactData:

--- a/tests/unit/test_response_models.py
+++ b/tests/unit/test_response_models.py
@@ -389,6 +389,73 @@ def test_contact_mapping_missing_optional_fields():
 
 
 @pytest.mark.unit
+def test_contact_mapping_surfaces_org_title_note_url_categories_photo():
+    """Issue #716 follow-up: ORG / TITLE / NOTE / URL / CATEGORIES / PHOTO must
+    round-trip from the raw client dict onto the response model.
+
+    Before this fix, the server-side mapper ignored these keys even when the
+    client supplied them, so MCP responses returned ``organization: null`` /
+    ``note: null`` for contacts that did have the fields set in their vCard.
+    """
+    raw_contact = {
+        "vcard_id": "full-1",
+        "getetag": '"etag"',
+        "contact": {
+            "fullname": "Alice",
+            "org": "Acme Corp",
+            "title": "Engineer",
+            "note": "Met at conference",
+            "url": ["https://acme.example.com"],
+            "categories": ["vip", "customer"],
+            "photo": "https://photos.example.com/alice.jpg",
+        },
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert contact.organization == "Acme Corp"
+    assert contact.title == "Engineer"
+    assert contact.note == "Met at conference"
+    assert len(contact.urls) == 1
+    assert contact.urls[0].value == "https://acme.example.com"
+    assert contact.urls[0].type == "url"
+    assert contact.categories == ["vip", "customer"]
+    assert contact.photo == "https://photos.example.com/alice.jpg"
+
+
+@pytest.mark.unit
+def test_contact_mapping_accepts_url_as_plain_string():
+    """The client dict normally carries ``url`` as a list, but accept a plain
+    string for forward-compat with library changes that might collapse single
+    entries.
+    """
+    raw_contact = {
+        "vcard_id": "url-str-1",
+        "contact": {"fullname": "Bob", "url": "https://bob.example.com"},
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert len(contact.urls) == 1
+    assert contact.urls[0].value == "https://bob.example.com"
+
+
+@pytest.mark.unit
+def test_contact_mapping_categories_accepts_comma_string():
+    """A comma-separated string is split into discrete categories on the read
+    side, matching how the write side parses ``categories``.
+    """
+    raw_contact = {
+        "vcard_id": "cat-1",
+        "contact": {"fullname": "Carol", "categories": "vip, customer, archived"},
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert contact.categories == ["vip", "customer", "archived"]
+
+
+@pytest.mark.unit
 def test_list_contacts_response_wraps_contacts():
     """Test ListContactsResponse wraps contacts correctly for MCP output."""
     contacts = [


### PR DESCRIPTION
## Summary

- Follow-up to [#719](https://github.com/cbcoutinho/nextcloud-mcp-server/pull/719) — which fixed the **write** side of [#716](https://github.com/cbcoutinho/nextcloud-mcp-server/issues/716) — addressing @elvisdragonmao's observation that `ORG` and `NOTE` *come back as null* and the user profile image *is always null* after PR #719 merged.
- Root cause was the **read** side, not the write side:
  - `pythonvCard4.Contact.from_vcard()` has no typed parser for `ORG` or `TITLE`; both fall through into `Contact.custom`. `PHOTO` only gets typed-parsed when the line carries an `ENCODING=` parameter; otherwise it also lands in `custom`.
  - `ContactsClient.list_contacts` (`nextcloud_mcp_server/client/contacts.py`) only put `fullname`/`nickname`/`birthday`/`email`/`tel` into the dict it returned. `note`, `url`, `categories`, and the `custom` dict were silently dropped.
  - `_raw_contact_to_model` (`nextcloud_mcp_server/server/contacts.py`) had no mapping for `organization`/`title`/`note`/`urls`/`categories`/`photo` even if the client had provided them.
- Net effect: contacts were stored correctly on disk by PR #719 but MCP read tools returned `organization: null` / `note: null` / `title: null` / etc.

## Changes

- **`client/contacts.py`** — new `_first_custom(custom, key)` helper that pulls the first value pythonvCard4 stashes in `Contact.custom` for ORG/TITLE/unencoded PHOTO. Handles both the current list-shape and the bare-string shape the library's typeshed advertises. `list_contacts` now adds `org`/`title`/`note`/`url`/`categories`/`photo` to its per-contact dict (in addition to the existing fields).
- **`server/contacts.py`** — `_raw_contact_to_model` maps the new client-dict keys onto `Contact.organization` / `.title` / `.note` / `.urls` / `.categories` / `.photo`. URL accepts both `list[str]` and plain-string shapes; categories accepts a comma-separated string for forward-compat with library changes.

## Reproduction (pre-fix, current master)

```python
nc_contacts_create_contact(
    addressbook="contacts", uid="issue716-repro-read",
    contact_data={"fn": "Repro User", "email": "repro@example.com",
                  "phone": "555-0716", "organization": "Acme Corp",
                  "title": "Engineer", "note": "Issue 716 read-side repro"})
```

Raw vCard via WebDAV (write side is correct — PR #719 works):
```
BEGIN:VCARD
VERSION:3.0
FN:Repro User
EMAIL;TYPE=HOME:repro@example.com
TEL;TYPE=HOME:555-0716
ORG:Acme Corp
TITLE:Engineer
UID:issue716-repro-read
NOTE:Issue 716 read-side repro
END:VCARD
```

But `nc_contacts_search_contacts(query="Repro")` returned:
```json
{"uid": "issue716-repro-read", "fn": "Repro User",
 "organization": null, "title": null, "note": null,
 "urls": [], "categories": [], "photo": null, ...}
```

## Verification (post-fix)

Same payload (with `url` and `categories` added), against the rebuilt single-user docker stack:
```json
{"uid": "issue716-verify-fix", "fn": "Verify User",
 "organization": "Acme Corp", "title": "Engineer",
 "note": "Read-side fix verification",
 "urls": [{"type": "url", "value": "https://acme.example.com", ...}],
 "categories": ["vip", "customer"], ...}
```

## Test plan

- [x] `uv run pytest tests/unit/` — 1075 passed, 1 skipped (incl. five new `TestFirstCustom` cases and three new `_raw_contact_to_model` cases covering the full field set, plain-string URL, comma-string categories)
- [x] `uv run pytest tests/unit/client/test_contacts.py tests/unit/test_response_models.py -v`
- [x] `uv run pytest tests/server/test_contacts_mcp.py -v` — integration test now decodes the `nc_contacts_search_contacts` MCP response and asserts `organization` + `note` round-trip end-to-end (direct regression coverage for @elvisdragonmao's complaint)
- [x] `uv run pytest tests/client/contacts/ -v`
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `uv run ty check -- nextcloud_mcp_server` — clean
- [x] Live end-to-end via `mcp__nextcloud-docker__nc_contacts_create_contact` → `nc_contacts_search_contacts` against the local single-user docker stack

## Out of scope

@elvisdragonmao also reported `'NoneType' object has no attribute 'replace'` when *updating* contacts with `ORG`/`NOTE`. I couldn't reproduce this against current master with either `{"organization": ..., "note": ...}` or `{"phone": ...}` payloads — the update completes cleanly and the vCard is correct. May have been incidentally fixed by PR #719 or scenario-specific. Not addressed in this PR; happy to dig further if a reproducer surfaces.

---

_This PR was generated with the help of AI, and reviewed by a Human_