### PR TITLE
test(astrolabe): install app from Nextcloud app store; bump submodule to v0.16.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       # Mount OIDC development directory outside /var/www/html to avoid rsync conflicts
       # The post-installation hook will register /opt/apps as an additional app directory
       #- ./third_party:/opt/apps:ro
-      - ./third_party/astrolabe:/opt/apps/astrolabe:ro
+      #- ./third_party/astrolabe:/opt/apps/astrolabe:ro
       #- ./third_party/oidc:/opt/apps/oidc:ro
     environment:
       - NEXTCLOUD_TRUSTED_DOMAINS=app


### PR DESCRIPTION
## What

- Comment out the `./third_party/astrolabe:/opt/apps/astrolabe` bind mount in `docker-compose.yml`, so the Nextcloud `app` container no longer uses the vendored dev copy by default.
- Bump the `third_party/astrolabe` submodule **v0.16.1 → v0.16.6**.

## Why

With the dev mount removed, the post-installation hook `app-hooks/post-installation/20-install-astrolabe-app.sh` falls through to its existing app-store branch:

```sh
else
    echo "astrolabe app not found, installing from app store..."
    php occ app:install astrolabe
    php occ app:enable astrolabe
fi
```

So the dev/CI stack now exercises the **published Nextcloud app-store package** instead of a locally built source tree. This is the same migration already done for the OIDC app, and it verifies the released app actually works end-to-end — catching packaging issues (e.g. missing built JS/CSS assets in the published package) that a from-source build would mask. **A green CI run on this branch is the test:** the integration/oauth/login-flow jobs install astrolabe from the store and run against it.

v0.16.6 also pulls in the background-indexing re-login fix (cbcoutinho/astrolabe#93).

## Retained on purpose

- The commented `/opt/apps/astrolabe` mount and the CI **"Build Astrolabe app"** step are kept, so developers can re-enable the mount locally and still iterate against the vendored source on demand.

## Notes / risk

- Requires astrolabe to be published to the Nextcloud app store and compatible with the CI Nextcloud versions (31, 32; `info.xml` declares min 31 / max 33). If the store lags the submodule tag, CI installs whatever store version is published — which is exactly the signal this change surfaces.

Deck: Astrolabe Cloud POC card #129.

---

_This PR was generated with the help of AI, and reviewed by a Human_