### PR TITLE
fix: lower DOCUMENT_PDF_GRAPHICS_LIMIT default 5000 → 1000 (parse timeouts)

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -133,7 +133,7 @@ _DEFAULTS: dict[str, Any] = {
     "document_chunk_size": 2048,
     "document_chunk_overlap": 200,
     # PDF parse isolation (OOM guard)
-    "document_pdf_graphics_limit": 5000,
+    "document_pdf_graphics_limit": 1000,
     "document_parse_timeout_seconds": 120.0,
     "document_parse_mem_limit_mb": 1536,
     # Observability
@@ -712,9 +712,14 @@ class Settings:
 
     # PDF parse isolation (OOM guard). The parse runs in a subprocess so one
     # pathological file fails that doc, not the pod.
-    # to_markdown graphics cap; pages above it skip graphics analysis. Must be
-    # >=1 -- pymupdf4llm treats 0 as "no cap", which re-exposes the OOM.
-    document_pdf_graphics_limit: int = 5000
+    # to_markdown graphics cap: pages with more vector drawings than this skip
+    # the O(n^2) find_tables analysis. Must be >=1 -- pymupdf4llm treats 0 as
+    # "no cap", which re-exposes the OOM. Default 1000: form/table PDFs have
+    # ~1.5k grid-line drawings per page, which at the old 5000 cap slipped
+    # through uncapped and timed out after ~17s/page (for zero recovered
+    # tables); at 1000 they parse in ~3s with identical text. Pages with genuine
+    # simple tables (<1000 drawings) still get table detection.
+    document_pdf_graphics_limit: int = 1000
     # wall-clock cap per parse; the worker subprocess is killed on timeout.
     # float so a fractional DOCUMENT_PARSE_TIMEOUT_SECONDS is honoured, matching
     # anyio.move_on_after's float seconds.

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -182,7 +182,7 @@ async def test_processor_success_builds_page_boundaries(monkeypatch):
     assert "Hello world" in result.text
     assert result.metadata["page_boundaries"][0]["page"] == 1
     # settings forwarded to the isolated parse
-    assert seen["graphics_limit"] == 5000
+    assert seen["graphics_limit"] == 1000
     assert seen["timeout_seconds"] == 120
     assert seen["mem_limit_mb"] == 1536
 


### PR DESCRIPTION
## Problem

The OOM hotfix (#852) set `graphics_limit=5000`. That stopped the 955k-drawing **OOM bomb**, but a **second pathology** slips through: form/table PDFs (e.g. scanned-then-OCR'd student records) have **~1,500 grid-line vector drawings per page** — *under* 5000, so they're never capped. Uncapped, pymupdf4llm's O(n²) `find_tables` grinds **~17 s/page**, so a 7-page form hits the **120 s timeout**.

Production confirms the scope: **all 6 current backfill parse failures in `tenant-blackbox-demo` are `reason=timeout`** — zero OOM, zero error. They're all this.

## Evidence (7-page `Student 1a.pdf`)

| `graphics_limit` | parse time | extracted text | tables recovered |
|---|---|---|---|
| 2000 | **119 s → timeout** | 14,310 ch | **0** |
| **1000** | **2.9 s** | 14,532 ch | 0 |
| 500 | 2.7 s | 14,532 ch | 0 |

The expensive `find_tables` pass produces **zero markdown tables** on these dense forms even when allowed to run for 119 s — the text is identical whether capped or not, so capping is pure win here.

## Fix

Lower the default `DOCUMENT_PDF_GRAPHICS_LIMIT` **5000 → 1000**:
- The ~1.5k-drawing form pages are now capped → parse in **~3 s** with identical text (verified end-to-end: `Student 1a.pdf` 120 s timeout → **2.2 s OK, 7 chunks**).
- The OOM bomb (955k ≫ 1000) stays capped exactly as before.
- Pages with **genuine simple tables (<1000 drawings)** still get table detection.

Still per-tenant tunable via `DOCUMENT_PDF_GRAPHICS_LIMIT`; the 120 s timeout remains the safety net. Properly recovering tables on dense/graphics-heavy pages is the job of the future tier-2 (docling) path, not this O(n²) heuristic.

Two-line change (default + the wiring test's forwarded-value assertion); isolation suite green (10 passed).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)