### PR TITLE
fix: close pypdfium2 page handle on error + cover classifier/OCR edge cases

### DIFF
--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -40,11 +40,15 @@ def _extract(content: bytes) -> tuple[str, dict[str, Any]]:
         page_texts: list[str] = []
         for i in range(len(pdf)):
             page = pdf[i]
-            textpage = page.get_textpage()
             try:
-                page_texts.append(textpage.get_text_bounded() or "")
+                textpage = page.get_textpage()
+                try:
+                    page_texts.append(textpage.get_text_bounded() or "")
+                finally:
+                    textpage.close()
             finally:
-                textpage.close()
+                # Outer finally so the page handle is freed even if
+                # get_textpage() raises on a corrupt page.
                 page.close()
         doc_meta = pdf.get_metadata_dict() or {}
     finally:

--- a/tests/unit/test_doc_classifier.py
+++ b/tests/unit/test_doc_classifier.py
@@ -188,8 +188,9 @@ def test_classify_from_text_no_pages_routes_fast():
 
 
 def test_classify_from_text_junk_layer_flags_bad_text_layer():
-    # Non-zero chars but low quality on every page (high ocr_frac) -> ocr +
-    # bad_text_layer (gated on ocr_frac, matching classify_pdf).
+    # Each short segment (<MIN_PAGE_CHARS) sets needs_ocr -> high ocr_frac, and
+    # total_chars>0 with mean_quality<MIN_TEXT_QUALITY (no-whitespace junk scores
+    # 0.0) -> bad_text_layer (gated on ocr_frac, matching classify_pdf).
     text = "x1y2zx1y2z"
     c = clf.classify_from_text(
         text,

--- a/tests/unit/test_doc_classifier.py
+++ b/tests/unit/test_doc_classifier.py
@@ -185,3 +185,20 @@ def test_classify_from_text_no_pages_routes_fast():
     assert c.recommended_tier == "fast"
     assert c.ocr_page_fraction == pytest.approx(0.0)
     assert c.flags == set()
+
+
+def test_classify_from_text_junk_layer_flags_bad_text_layer():
+    # Non-zero chars but low quality on every page (high ocr_frac) -> ocr +
+    # bad_text_layer (gated on ocr_frac, matching classify_pdf).
+    text = "x1y2zx1y2z"
+    c = clf.classify_from_text(
+        text,
+        [
+            {"page": 1, "start_offset": 0, "end_offset": 5},
+            {"page": 2, "start_offset": 5, "end_offset": 10},
+        ],
+    )
+    assert c.recommended_tier == "ocr"
+    assert c.total_chars > 0
+    assert "bad_text_layer" in c.flags
+    assert "no_text_layer" not in c.flags

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -71,6 +71,19 @@ def test_build_backend_auto_none_configured():
     assert ocr.build_ocr_backend(_settings()) is None
 
 
+def test_build_backend_gateway_missing_m2m_raises():
+    # client_id set but token_url/secret missing -> explicit ValueError (not a
+    # stripped assert), surfaced on backend resolution.
+    with pytest.raises(ValueError, match="EMBEDDING_GATEWAY_TOKEN_URL"):
+        ocr.build_ocr_backend(
+            _settings(
+                document_ocr_provider="gateway",
+                embedding_gateway_url="http://gw",
+                embedding_gateway_client_id="cid",
+            )
+        )
+
+
 def test_gateway_backend_url_normalization():
     b = ocr._GatewayOcrBackend("http://gw", "mistral/mistral-ocr-latest")
     assert b._url == "http://gw/v1/ocr"


### PR DESCRIPTION
## What

Small follow-up to the tiered document processor (#858), landing the **round-4 review nits** the reviewer approved without (so they missed the merge):

- **`pypdfium2_fast.py`** — free the page handle in an **outer `finally`** so a corrupt page that makes `get_textpage()` raise can't orphan the page handle (the document close doesn't free individual pages).
- **test** — `classify_from_text` junk-text-layer path (non-zero chars, low quality, high `ocr_frac`) flags `bad_text_layer`; the hot-path coverage gap the reviewer flagged (its absence let the shadow vs hot-path metric diverge unnoticed).
- **test** — `build_ocr_backend` raises `ValueError` when the gateway M2M `client_id` is set without its `token_url`/`secret`.

## Validation

29 classifier/OCR/pypdfium2 tests pass (incl. the 2 new); full unit suite green (1391); ruff/format/ty clean.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)