### PR TITLE
fix(providers): pin an explicit timeout on Mistral embedding requests

### DIFF
--- a/nextcloud_mcp_server/providers/mistral.py
+++ b/nextcloud_mcp_server/providers/mistral.py
@@ -27,6 +27,25 @@ MISTRAL_EMBEDDING_DIMENSIONS: dict[str, int] = {
 # but we keep this in line with sibling providers (OpenAI=100, Ollama=32).
 BATCH_SIZE = 64
 
+# Per-request timeout (milliseconds) applied to embedding calls.
+#
+# NOTE: We pass this explicitly on every request instead of configuring a
+# timeout on an injected httpx client, because the mistralai SDK ignores
+# client-level timeouts for embeddings. Its generated ``embeddings.create*``
+# methods hard-default ``timeout_ms`` (60_000) and feed that scalar straight
+# into ``httpx.build_request(timeout=...)``, which *replaces* any
+# ``httpx.Timeout`` configured on the client. Consequently an injected
+# ``AsyncClient(timeout=...)`` is silently dropped, and a distinct ``connect``
+# timeout cannot be expressed at all (the SDK exposes only a single scalar).
+#   - Upstream: mistralai/client-python#449 (the original "SDK passes
+#     timeout=None and overrides the client" hang; fixed in v2.3.0) plus the
+#     residual per-method-default override discussed there and tracked via
+#     #474.
+#   - We pin mistralai 2.4.5 on purpose (2.4.6 was a supply-chain compromise,
+#     #523), so setting the bound explicitly here keeps it intentional and
+#     independent of the SDK's internal default.
+_EMBED_TIMEOUT_MS = 60_000
+
 _NO_EMBEDDING_MODEL_MSG = "Embedding not supported - no embedding_model configured"
 
 
@@ -100,6 +119,7 @@ class MistralProvider(Provider):
         response = await self.client.embeddings.create_async(
             model=self.embedding_model,
             inputs=[text],
+            timeout_ms=_EMBED_TIMEOUT_MS,
         )
 
         if not response.data or response.data[0].embedding is None:
@@ -151,6 +171,7 @@ class MistralProvider(Provider):
         response = await self.client.embeddings.create_async(
             model=self.embedding_model,
             inputs=batch,
+            timeout_ms=_EMBED_TIMEOUT_MS,
         )
 
         # Defensive: response.data items have Optional fields. Sort by index

--- a/tests/unit/providers/test_mistral.py
+++ b/tests/unit/providers/test_mistral.py
@@ -6,6 +6,7 @@ import pytest
 from mistralai.client.errors import SDKError
 
 from nextcloud_mcp_server.providers.mistral import (
+    _EMBED_TIMEOUT_MS,
     BATCH_SIZE,
     MISTRAL_EMBEDDING_DIMENSIONS,
     MistralProvider,
@@ -50,9 +51,12 @@ async def test_mistral_embedding_single(mock_mistral_client):
     embedding = await provider.embed("hello world")
 
     assert embedding == [0.1, 0.2, 0.3]
+    # An explicit timeout_ms is always passed: the SDK ignores client-level
+    # httpx timeouts for embeddings (see NOTE in mistral.py / upstream #449).
     mock_mistral_client.embeddings.create_async.assert_awaited_once_with(
         model="mistral-embed",
         inputs=["hello world"],
+        timeout_ms=_EMBED_TIMEOUT_MS,
     )
 
 


### PR DESCRIPTION
## Summary

`MistralProvider` made embedding calls without setting any timeout, leaving the bound entirely to the `mistralai` SDK's internal default. This change passes an explicit `timeout_ms` (60s) on every `embeddings.create_async` call so the timeout is intentional and tunable.

This surfaced while investigating why a tenant's hourly vector-sync wasn't picking up newly uploaded files. The scanner/processor was healthy and Qdrant calls were bounded (`qdrant_client.py` passes `timeout=30`, which httpx applies to all phases incl. connect), but the Mistral embedding call — the one external dependency in the single-worker processor path — had no application-level timeout configured. Since the processor runs single-worker (`VECTOR_SYNC_PROCESSOR_WORKERS=1`), any stall there serializes and backs up the in-memory ingest queue.

## Why not configure a client-level connect timeout?

The obvious fix — inject `httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=5.0))` into the SDK — **does not work** for embeddings:

- The SDK's generated `embeddings.create_async` hard-defaults `timeout_ms` (60_000) and feeds that scalar into `httpx.build_request(timeout=...)`, which **replaces** any client-configured `httpx.Timeout`. An injected client is silently ignored.
- `timeout_ms` is a single scalar, so a *separate* `connect` timeout can't be expressed via this SDK at all.

This is the residual of upstream **[mistralai/client-python#449](https://github.com/mistralai/client-python/issues/449)** (the original `timeout=None`-overrides-the-client hang, fixed in v2.3.0; the server-side hang is tracked in **#474**). A `NOTE` in `mistral.py` records the rationale so the next person doesn't re-attempt the injected-client route.

We deliberately pin `mistralai==2.4.5` (2.4.6 was a supply-chain compromise — **#523**), so making the bound explicit here keeps it independent of the SDK's internal default.

## Changes

- `providers/mistral.py`: add `_EMBED_TIMEOUT_MS` constant (with explanatory NOTE) and pass it on both `embeddings.create_async` calls.
- `tests/unit/providers/test_mistral.py`: assert `timeout_ms` is forwarded.

## Testing

- `ruff check` / `ruff format --check` / `ty check` — clean
- `pytest tests/unit/providers/ -q` — 24 passed

---

_This PR was generated with the help of AI, and reviewed by a Human_