### PR TITLE
Fix all-day calendar event update serialization

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1037,7 +1037,7 @@ class CalendarClient:
                             start_date = dt.datetime.fromisoformat(
                                 start_str.split("T")[0]
                             ).date()
-                            component["DTSTART"] = start_date
+                            component["DTSTART"] = vDDDTypes(start_date)
                         else:
                             start_dt, zi = self._parse_event_datetime(
                                 start_str, tz_name
@@ -1053,7 +1053,7 @@ class CalendarClient:
                             end_date = dt.datetime.fromisoformat(
                                 end_str.split("T")[0]
                             ).date()
-                            component["DTEND"] = end_date
+                            component["DTEND"] = vDDDTypes(end_date)
                         else:
                             end_dt, zi = self._parse_event_datetime(end_str, tz_name)
                             if zi is not None:


### PR DESCRIPTION
Fixes all-day event updates by serializing date-only DTSTART/DTEND values as iCalendar DATE values using vDDDTypes.
Previously, updating an all-day event with date-only start_datetime/end_datetime could serialize values like:
```text
DTSTART:2026-06-26
```
instead of:
```text
DTSTART;VALUE=DATE:20260626
```
This caused Nextcloud/SabreDAV to reject the update with HTTP 415 validation errors.

Tested manually against Nextcloud: create all-day event, read back, update all-day dates, read back, list by date range, then delete cleanup.

This fixes #895.