### PR TITLE
refactor(auth): drop built-in well-known MCP client list

### DIFF
--- a/nextcloud_mcp_server/auth/client_registry.py
+++ b/nextcloud_mcp_server/auth/client_registry.py
@@ -140,15 +140,14 @@ class ClientRegistry:
             )
 
     def _get_client_name(self, client_id: str) -> str:
-        """Get human-readable name for client_id."""
-        known_names = {
-            "claude-desktop": "Claude Desktop",
-            "claude-ai": "Claude AI",
-            "continue-dev": "Continue IDE Extension",
-            "zed-editor": "Zed Editor",
-            "vscode-mcp": "VS Code MCP Extension",
-        }
-        return known_names.get(client_id, client_id.replace("-", " ").title())
+        """Derive a human-readable display name from a client_id.
+
+        There is no built-in list of "well-known" clients: every client must be
+        opted in explicitly via ``ALLOWED_MCP_CLIENTS`` (mirroring the
+        management-API ``ALLOWED_MGMT_CLIENT`` allowlist). The display name is
+        derived generically from the client_id.
+        """
+        return client_id.replace("-", " ").title()
 
     def validate_client(
         self,

--- a/tests/unit/test_client_registry.py
+++ b/tests/unit/test_client_registry.py
@@ -157,8 +157,11 @@ def test_validate_redirect_uri_localhost_wildcard(monkeypatch):
 
 
 def test_client_name_resolution(monkeypatch):
-    registry = _get_registry(monkeypatch, "claude-desktop, custom-tool")
+    # Names are derived generically from the client_id — there is no built-in
+    # "well-known" client map, so previously special-cased ids now title-case.
+    registry = _get_registry(monkeypatch, "claude-desktop, claude-ai, custom-tool")
     assert registry.get_client("claude-desktop").name == "Claude Desktop"
+    assert registry.get_client("claude-ai").name == "Claude Ai"
     assert registry.get_client("custom-tool").name == "Custom Tool"
 
 


### PR DESCRIPTION
## Summary

Removes the hardcoded "well-known" MCP client list from the client registry. Admission already requires explicit opt-in via `ALLOWED_MCP_CLIENTS` (fail-closed when unset), but the registry still carried a built-in map that gave recognized display names to `claude-desktop`, `claude-ai`, `continue-dev`, `zed-editor`, and `vscode-mcp`.

This baked a recognized-client list into the server. To mirror the management-API auth surface (`ALLOWED_MGMT_CLIENT`), which has no built-in client list, the map is removed and the display name is now derived generically from the `client_id`.

Net behavior:
- **Default is none** — no client is recognized or named by default.
- Clients are admitted only when listed explicitly in `ALLOWED_MCP_CLIENTS`.
- **DCR stays off** unless `ENABLE_DCR=true` (unchanged).

## Changes

- `nextcloud_mcp_server/auth/client_registry.py` — remove the `known_names` map; `_get_client_name` derives the name generically (`client_id.replace("-", " ").title()`), with a docstring noting there is no built-in well-known list.
- `tests/unit/test_client_registry.py` — assert generic derivation explicitly, including that a previously special-cased id (`claude-ai`) now title-cases to `Claude Ai` rather than `Claude AI`.

## Verification

- `pytest tests/unit/test_client_registry.py` → 19 passed
- `ruff check`, `ruff format --check`, `ty check` → clean

---

_This PR was generated with the help of AI, and reviewed by a Human_