### PR TITLE
ci: drop deprecated NC31 from matrix, enable NC33, stage NC34

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         nextcloud_version:
-          - "31"
           - "32"
-          # - "33"  # Disabled until all upstream apps support NC 33
+          - "33"
+          # - "34"  # Disabled until all upstream apps support NC 34
         mode:
           - "single-user"
           - "multi-user-basic"
@@ -69,14 +69,14 @@ jobs:
           - "keycloak"
         include:
           # Version-specific image pins — Renovate updates these via customManagers in renovate.json
-          # Each entry is pinned to its major version (e.g., NC 31 only gets 31.x updates)
-          - nextcloud_version: "31"
-            nextcloud_image: "docker.io/library/nextcloud:31.0.14@sha256:07ec73cc816e58d6f45a162cd53ef886462c29271a23fc68d0124cec276e3767"
+          # Each entry is pinned to its major version (e.g., NC 32 only gets 32.x updates)
           - nextcloud_version: "32"
             nextcloud_image: "docker.io/library/nextcloud:32.0.11@sha256:3ae4045d53e890680ec35e3e4349332123d959c72808aceb44930e79f1be9b9b"
-          # Disabled until all upstream apps support NC 33
-          # - nextcloud_version: "33"
-          #   nextcloud_image: "docker.io/library/nextcloud:33.0.5@sha256:56bdc45109067500fd0832fa64832b7c77a167d9394cbf5f0f4b59740b94194d"
+          - nextcloud_version: "33"
+            nextcloud_image: "docker.io/library/nextcloud:33.0.5@sha256:56bdc45109067500fd0832fa64832b7c77a167d9394cbf5f0f4b59740b94194d"
+          # Disabled until all upstream apps support NC 34
+          # - nextcloud_version: "34"
+          #   nextcloud_image: "docker.io/library/nextcloud:34.0.0@sha256:851ca6ef9da101ce3c8a32ec7b6fc65a726b380b5f466307a54c17d32fb77c9a"
 
           # Mode-specific properties
           - mode: single-user

--- a/renovate.json
+++ b/renovate.json
@@ -14,16 +14,16 @@
     },
     {
       "description": "Pin each Nextcloud matrix entry to its own major version",
-      "matchDepNames": ["nextcloud-31"],
-      "allowedVersions": "/^31\\./"
-    },
-    {
       "matchDepNames": ["nextcloud-32"],
       "allowedVersions": "/^32\\./"
     },
     {
       "matchDepNames": ["nextcloud-33"],
       "allowedVersions": "/^33\\./"
+    },
+    {
+      "matchDepNames": ["nextcloud-34"],
+      "allowedVersions": "/^34\\./"
     },
     {
       "description": "Pin docker-compose.yml Nextcloud image to 32.x",

--- a/tests/server/login_flow/conftest.py
+++ b/tests/server/login_flow/conftest.py
@@ -246,8 +246,14 @@ async def _complete_login_flow_v2(browser, login_url: str) -> None:
         await page.goto(login_url, wait_until="networkidle", timeout=60000)
         logger.info("Step 1 - Current URL: %s", page.url)
 
-        # Step 1: "Connect to your account" page - click "Log in"
-        login_btn = page.get_by_role("button", name="Log in")
+        # Step 1: "Connect to your account" page - click "Log in".
+        # exact=True is required: NC33's connect page also renders an
+        # "Alternative log in using app password" button, and a non-exact
+        # "Log in" name substring-matches both -> Playwright strict-mode error
+        # that was silently swallowed below, leaving the flow stuck on the
+        # connect page (every login-flow test then times out "Login Flow v2 did
+        # not complete"). NC32 has a single match, so exact=True is safe there.
+        login_btn = page.get_by_role("button", name="Log in", exact=True)
         try:
             await login_btn.wait_for(timeout=10000)
             await login_btn.click()
@@ -803,8 +809,14 @@ async def _complete_login_flow_v2_as_user(
         await page.goto(login_url, wait_until="networkidle", timeout=60000)
         logger.info("[%s] Step 1 - Current URL: %s", username, page.url)
 
-        # Step 1: "Connect to your account" page - click "Log in"
-        login_btn = page.get_by_role("button", name="Log in")
+        # Step 1: "Connect to your account" page - click "Log in".
+        # exact=True is required: NC33's connect page also renders an
+        # "Alternative log in using app password" button, and a non-exact
+        # "Log in" name substring-matches both -> Playwright strict-mode error
+        # that was silently swallowed below, leaving the flow stuck on the
+        # connect page (every login-flow test then times out "Login Flow v2 did
+        # not complete"). NC32 has a single match, so exact=True is safe there.
+        login_btn = page.get_by_role("button", name="Log in", exact=True)
         try:
             await login_btn.wait_for(timeout=10000)
             await login_btn.click()


### PR DESCRIPTION
## Summary

Nextcloud 31 reached **deprecation (02/2026)**, so it's removed from the integration test matrix. NC33 (previously disabled pending upstream app support) is enabled, and NC34 is staged as a commented, ready-to-enable entry.

## Changes

- **`.github/workflows/test.yml`**
  - `nextcloud_version`: `[31, 32]` → `[32, 33]`; `# 34` commented.
  - Image pins: removed NC31, activated NC33 (`33.0.5`), added commented NC34 (`34.0.0@sha256:851ca6…`).
  - The Renovate `customManager` regex already matches commented entries (`#?`), so the NC34 digest is kept fresh once present.
- **`renovate.json`**: dropped the `nextcloud-31` pin rule, added `nextcloud-34` (`/^34\./`).
- **`docker-compose.yml`**: unchanged — it already defaults to `32.0.11` (Renovate-pinned to 32.x). The NC31 that showed up in local runs comes from a shell-exported `NEXTCLOUD_IMAGE`, not the compose default.

The matrix stays at **2 NC versions × 4 modes = 8 jobs** (NC 31→32, 32→33).

## ⚠️ Heads-up on NC33

NC33 was previously gated behind *"Disabled until all upstream apps support NC 33."* This PR enables it, so the NC33 lanes will install the app-store apps (calendar, contacts, deck, tables, news, cookbook, spreed, notes, oidc, user_oidc) on NC33 for the first time. **If any upstream app doesn't yet publish an NC33-compatible release, its `occ app:install` will fail and the NC33 lanes will go red** — that's a real signal, not a flake. Astrolabe itself supports NC33 (appstore manifest `>=31.0.0 <34.0.0`). CI on this PR will show whether the rest are ready.

## Note on the matrix's hidden version skew

Worth tracking separately: each NC lane installs whatever app-store version is compatible with that NC major, so the matrix silently tests different app frontends across lanes (this is what broke the nc32 plotly UI test in #921 — astrolabe `0.24` `<input>` on nc31 vs `0.29` `<textarea>` on nc32). Enabling NC33 adds a third frontend revision into the mix.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
