### PR TITLE
ci(vector-sync): relax single-user scan interval 5s→30s to stop churn flood

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,15 @@ services:
 
       # Semantic search configuration (ADR-007, ADR-021)
       - ENABLE_SEMANTIC_SEARCH=true
-      - VECTOR_SYNC_SCAN_INTERVAL=5
+      # The sync scanner runs an initial scan immediately on startup, so the
+      # corpus is indexed without waiting for the first periodic re-scan. A very
+      # short re-scan interval (was 5s) just re-queues the whole corpus faster
+      # than the workers can drain it: on a loaded CI runner pending_count
+      # snowballs (observed 1465 pending), sync never reaches idle, and the
+      # single-user vector tests (test_rag, test_sampling) time out. 30s matches
+      # the tuned multi-user-basic cadence and stays well within the tests' 90s
+      # sync-wait budget.
+      - VECTOR_SYNC_SCAN_INTERVAL=30
       - VECTOR_SYNC_PROCESSOR_WORKERS=2
       # Required to enable the /webhooks/nextcloud receiver (GHSA-8vh3-g2qg-2h2c).
       # Without it the route is not mounted and vector sync relies on polling.


### PR DESCRIPTION
## Summary

Fixes the intermittent **single-user** integration failures (`test_rag` / `test_sampling` timing out) caused by a vector-sync churn flood.

The single-user `mcp` container re-scanned the whole corpus every **5s**. Since the scanner already runs an initial scan on startup (the corpus is indexed without waiting for a periodic re-scan), the short interval only re-queues everything faster than the 2 workers can drain. On a loaded CI runner `pending_count` snowballs — **observed 1465 pending, `status` stuck `"syncing"`** — so freshly-created notes aren't indexed within the tests' 90s sync-wait, and `test_rag` / `test_sampling` cascade into 300s pytest timeouts.

Observed signature (single-user/nc32, PR #923 run):
```
AssertionError: Vector sync did not complete within 90 seconds.
  Last status: {... 'indexed_chunks': 295, 'pending_count': 1465, 'status': 'syncing'}
+ Failed: Timeout (>300.0s) from pytest-timeout  (test_rag x6, test_sampling x4)
```
It's load-dependent — the same code passed on `single-user/nc33` and on faster runs.

## Change

`docker-compose.yml`, single-user `mcp` container: `VECTOR_SYNC_SCAN_INTERVAL` **5 → 30**.

This matches the already-tuned `mcp-multi-user-basic` cadence (30s) and stays well within the tests' 90s sync-wait budget. `mcp-login-flow` is already at 60s. Workers left at 2.

| Container | SCAN_INTERVAL (before → after) |
|---|---|
| `mcp` (single-user) | **5 → 30** |
| `mcp-multi-user-basic` | 30 (unchanged) |
| `mcp-login-flow` | 60 (unchanged) |

This is the same flooding class previously tuned out of multi-user-basic; single-user was just never given the same treatment.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)