### PR TITLE
fix(docker): enable PYTHONFAULTHANDLER for native-crash diagnostics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ COPY . .
 RUN uv sync --locked --no-dev --no-editable --no-cache --extra postgres
 
 ENV PYTHONUNBUFFERED=1
+# Dump a Python + C-level traceback to stderr on a fatal native fault
+# (SIGSEGV/SIGABRT/SIGFPE/SIGBUS). In-process native code -- pymupdf's
+# classify/metadata open and embedded Qdrant -- can segfault the interpreter
+# during indexing, and without faulthandler the container just exits 139/133
+# with no logs (see issue #926). The handler is cheap and writes nothing in
+# normal operation.
+ENV PYTHONFAULTHANDLER=1
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH=/app/.venv/bin:$PATH
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata


### PR DESCRIPTION
## Summary

Self-hosters hitting native-code segfaults during indexing (#926) currently get
**zero diagnostic output** — the container just exits `139` (SIGSEGV) / `133`
(SIGTRAP) with no logs. The image sets only `PYTHONUNBUFFERED=1`, so a fatal
fault in a C extension dumps nothing.

This enables `PYTHONFAULTHANDLER=1` in the image, which makes CPython print a
Python + C-level traceback to stderr on `SIGSEGV`/`SIGABRT`/`SIGFPE`/`SIGBUS`.
That makes the faulting library identifiable from `docker logs` — the most
likely in-process native suspects being pymupdf's **unsandboxed**
classify/metadata `pymupdf.open` (`classifier.py`, `pymupdf.py`) and **embedded
Qdrant** (`QDRANT_LOCATION` local mode), both of which run in the main process.
The heavy `pymupdf4llm.to_markdown` parse is already isolated in a worker
subprocess (`document_processors/_isolation.py`), so it is not the suspect.

The handler is dormant during normal operation: no output, negligible overhead.

## Why this matters for #926

The reporter's container exits every few hours with `139`/`133` and "no logs
referring to what happened." Those codes are native faults (not OOM `137`, not
CPU throttling), so the absence of logs is expected without faulthandler. This
change is the minimal step to turn the next crash into an actionable traceback.

It does **not** by itself fix the crash — follow-ups under discussion include
sandboxing the in-process `pymupdf.open` calls and recommending a network Qdrant
over embedded mode for indexing workloads.

## Testing

Build-only change (image `ENV`). No code paths altered.

---

_This PR was generated with the help of AI, and reviewed by a Human_