### PR TITLE
fix(vector): key _potentially_deleted by doc_type to avoid cross-type collisions

### DIFF
--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -130,8 +130,10 @@ class DocumentTask:
 
 
 # Track documents potentially deleted (grace period before actual deletion)
-# Format: {(user_id, doc_id): first_missing_timestamp}
-_potentially_deleted: dict[tuple[str, str], float] = {}
+# Format: {(user_id, doc_id, doc_type): first_missing_timestamp}. doc_type is
+# part of the key so the same numeric id under different doc types (a note 42
+# and a mail_message 42 for one user) tracks grace periods independently.
+_potentially_deleted: dict[tuple[str, str, str], float] = {}
 
 
 async def get_last_indexed_timestamp(user_id: str) -> int | None:
@@ -705,7 +707,7 @@ async def scan_user_documents(
                 if etag and await claim_existing_index(
                     file_id, "file", etag, user_id, current_path=file_path
                 ):
-                    _potentially_deleted.pop((user_id, file_id), None)
+                    _potentially_deleted.pop((user_id, file_id, "file"), None)
                     logger.debug(
                         "Dedup: file %s (ID: %s) already indexed in tenant; "
                         "granted access to %s without reprocessing",
@@ -724,7 +726,7 @@ async def scan_user_documents(
                 # user-agnostic placeholder's user_id is overwritten by the last
                 # scanner, so every other user re-queued it on a loop.
                 if etag and await is_dead_lettered(file_id, "file", etag, tiers_sig):
-                    _potentially_deleted.pop((user_id, file_id), None)
+                    _potentially_deleted.pop((user_id, file_id, "file"), None)
                     logger.debug(
                         "Skipping dead-lettered file %s (ID: %s) until content/"
                         "tier change",
@@ -758,7 +760,7 @@ async def scan_user_documents(
                 else:
                     # Incremental sync: check if file exists and compare modified_at
                     # If file reappeared, remove from potentially_deleted
-                    file_key = (user_id, file_id)
+                    file_key = (user_id, file_id, "file")
                     if file_key in _potentially_deleted:
                         logger.debug(
                             "File %s (ID: %s) reappeared, removing from deletion grace period",
@@ -876,7 +878,7 @@ async def scan_user_documents(
             if not initial_sync:
                 for file_id in indexed_file_ids:
                     if file_id not in nextcloud_file_ids:
-                        file_key = (user_id, file_id)
+                        file_key = (user_id, file_id, "file")
 
                         if file_key in _potentially_deleted:
                             # Check if grace period elapsed
@@ -1048,7 +1050,7 @@ async def scan_notes(
         else:
             # Incremental sync: check if document exists and compare modified_at
             # If document reappeared, remove from potentially_deleted
-            doc_key = (user_id, doc_id)
+            doc_key = (user_id, doc_id, "note")
             if doc_key in _potentially_deleted:
                 logger.debug(
                     "Document %s reappeared, removing from deletion grace period",
@@ -1123,7 +1125,7 @@ async def scan_notes(
     # Use grace period: only delete after 2 consecutive scans confirm absence
     for doc_id in indexed_doc_ids:
         if doc_id not in nextcloud_doc_ids:
-            doc_key = (user_id, doc_id)
+            doc_key = (user_id, doc_id, "note")
 
             if doc_key in _potentially_deleted:
                 # Already marked as potentially deleted, check if grace period elapsed
@@ -1258,7 +1260,7 @@ async def scan_news_items(
             queued += 1
         else:
             # Incremental sync: check if item exists and compare modified_at
-            doc_key = (user_id, doc_id)
+            doc_key = (user_id, doc_id, "news_item")
             if doc_key in _potentially_deleted:
                 logger.debug(
                     "News item %s reappeared, removing from deletion grace period",
@@ -1322,7 +1324,7 @@ async def scan_news_items(
 
         for doc_id in indexed_item_ids:
             if doc_id not in nextcloud_item_ids:
-                doc_key = (user_id, doc_id)
+                doc_key = (user_id, doc_id, "news_item")
 
                 if doc_key in _potentially_deleted:
                     first_missing_time = _potentially_deleted[doc_key]
@@ -1531,7 +1533,7 @@ async def scan_mail_messages(
                     )
                     queued += 1
                 else:
-                    doc_key = (user_id, doc_id)
+                    doc_key = (user_id, doc_id, "mail_message")
                     if doc_key in _potentially_deleted:
                         logger.debug(
                             "Mail message %s reappeared, removing from deletion "
@@ -1606,7 +1608,7 @@ async def scan_mail_messages(
 
         for doc_id in indexed_message_ids:
             if doc_id not in nextcloud_message_ids:
-                doc_key = (user_id, doc_id)
+                doc_key = (user_id, doc_id, "mail_message")
 
                 if doc_key in _potentially_deleted:
                     first_missing_time = _potentially_deleted[doc_key]
@@ -1751,7 +1753,7 @@ async def scan_deck_cards(
                     queued += 1
                 else:
                     # Incremental sync: check if card exists and compare modified_at
-                    doc_key = (user_id, doc_id)
+                    doc_key = (user_id, doc_id, "deck_card")
                     if doc_key in _potentially_deleted:
                         logger.debug(
                             "Deck card %s reappeared, removing from deletion grace period",
@@ -1815,7 +1817,7 @@ async def scan_deck_cards(
 
         for doc_id in indexed_card_ids:
             if doc_id not in nextcloud_card_ids:
-                doc_key = (user_id, doc_id)
+                doc_key = (user_id, doc_id, "deck_card")
 
                 if doc_key in _potentially_deleted:
                     first_missing_time = _potentially_deleted[doc_key]

--- a/tests/unit/vector/test_scanner_mail.py
+++ b/tests/unit/vector/test_scanner_mail.py
@@ -192,7 +192,7 @@ async def test_incremental_reappeared_message_clears_grace(mocker):
     _patch_incremental(
         mocker, indexed_ids=["100"], existing_metadata={"modified_at": 1700000000}
     )
-    scanner_module._potentially_deleted[("alice", "100")] = 123.0
+    scanner_module._potentially_deleted[("alice", "100", "mail_message")] = 123.0
     nc_client = _single_message_client([{"databaseId": 100, "dateInt": 1700000000}])
 
     stream = _CollectingStream()
@@ -206,14 +206,14 @@ async def test_incremental_reappeared_message_clears_grace(mocker):
 
     assert queued == 0
     assert stream.tasks == []
-    assert ("alice", "100") not in scanner_module._potentially_deleted
+    assert ("alice", "100", "mail_message") not in scanner_module._potentially_deleted
 
 
 async def test_incremental_deletes_after_grace_period(mocker):
     """An indexed message gone from Nextcloud past the grace period is deleted."""
     _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
     # Seed the grace period far in the past so the delta exceeds grace_period.
-    scanner_module._potentially_deleted[("alice", "999")] = 0.0
+    scanner_module._potentially_deleted[("alice", "999", "mail_message")] = 0.0
     # Mailbox now returns no messages, so 999 is missing.
     nc_client = _single_message_client([])
 
@@ -228,7 +228,11 @@ async def test_incremental_deletes_after_grace_period(mocker):
 
     assert queued == 1
     assert [(t.doc_id, t.operation) for t in stream.tasks] == [("999", "delete")]
-    assert ("alice", "999") not in scanner_module._potentially_deleted
+    assert (
+        "alice",
+        "999",
+        "mail_message",
+    ) not in scanner_module._potentially_deleted
 
 
 async def test_incremental_first_missing_starts_grace(mocker):
@@ -249,4 +253,32 @@ async def test_incremental_first_missing_starts_grace(mocker):
     # First miss only starts the grace period — nothing queued, nothing deleted.
     assert queued == 0
     assert stream.tasks == []
-    assert ("alice", "999") in scanner_module._potentially_deleted
+    assert ("alice", "999", "mail_message") in scanner_module._potentially_deleted
+
+
+async def test_grace_key_isolated_by_doc_type(mocker):
+    """A mail message reappearing must not clear a same-id note's grace period.
+
+    Regression for Deck #376: the grace-period key includes doc_type, so a
+    note 42 and a mail_message 42 for one user no longer collide.
+    """
+    # Mail message 42 is indexed and up-to-date (so it isn't re-queued), and is
+    # present in Nextcloud (so the reappeared-clear path runs for mail).
+    _patch_incremental(
+        mocker, indexed_ids=["42"], existing_metadata={"modified_at": 1700000000}
+    )
+    # A note 42 is mid-grace-period for the same user.
+    scanner_module._potentially_deleted[("alice", "42", "note")] = 123.0
+    nc_client = _single_message_client([{"databaseId": 42, "dateInt": 1700000000}])
+
+    stream = _CollectingStream()
+    await scan_mail_messages(
+        user_id="alice",
+        send_stream=stream,
+        nc_client=nc_client,
+        initial_sync=False,
+        scan_id=1,
+    )
+
+    # The note's grace entry is untouched by the mail scan (no cross-type stomp).
+    assert ("alice", "42", "note") in scanner_module._potentially_deleted


### PR DESCRIPTION
## Summary

Fixes a latent cross-doc-type collision in the vector scanner's deletion grace-period tracking.

`nextcloud_mcp_server/vector/scanner.py` tracked `_potentially_deleted` keyed by `(user_id, doc_id)` — a module-global dict **shared across all five scanners** (notes, news, deck, file, mail). Every source uses small auto-increment integer ids, so e.g. a note `42` and a mail message `42` for the same user collided on `("alice", "42")`. A reappearing document of one type would clear (or a missing one would stomp) the grace-period entry of a same-id document of a *different* type, causing early or late eviction. No data loss, but incorrect. PR #935 (mail) widened the collision pool to four numeric types.

## Change

Re-key `_potentially_deleted` to `(user_id, doc_id, doc_type)` at all 12 read/write sites (file scan + `scan_notes`/`scan_news_items`/`scan_deck_cards`/`scan_mail_messages`). Per-type behaviour is unchanged; the doc types are now tracked independently.

## Tests

- Updated the mail scanner test seeds to 3-tuple keys.
- Added `test_grace_key_isolated_by_doc_type`: a reappearing mail message no longer clears a same-id note's grace entry.
- Full unit suite green (1845 passed); `ruff`, `ruff format`, `ty` clean.

Resolves Deck #376 (the follow-up the claude reviewer flagged on #935 as belonging in its own focused PR).

---

_This PR was generated with the help of AI, and reviewed by a Human_
