### PR TITLE
test(contract): pin per-user-effective enabled_doc_types capability

### DIFF
--- a/tests/contract/test_astrolabe_capabilities_consumer.py
+++ b/tests/contract/test_astrolabe_capabilities_consumer.py
@@ -7,12 +7,17 @@ calls :meth:`NextcloudClient.capabilities` →
 ``ocs.data.capabilities.astrolabe.semantic_search.enabled_doc_types`` (the
 ``OCA\\Astrolabe\\Capabilities`` provider on the astrolabe side).
 
-This pact pins the request shape and the two states the consumer branches on:
+This pact pins the request shape and the states the consumer branches on:
 
 - some sources approved -> ``enabled_doc_types`` is a non-empty list, parsed to
   the corresponding frozenset (the search/scan/purge gates restrict to it)
 - every source disabled  -> ``enabled_doc_types`` is ``[]``, parsed to an empty
   frozenset (an all-disabled admin config — distinct from "no restriction")
+- per-user narrowing -> the capability call is authenticated per-user, so
+  ``enabled_doc_types`` is the *effective* set for the requesting user
+  (admin-enabled ∩ that user's own choices). The MCP server consumes the same
+  field unchanged, so a user who disabled a source sees it absent from their
+  set. This pins that per-user contract so astrolabe can't regress it.
 
 The "no astrolabe block" / fail-open (``None``) case is internal defensive
 handling for older astrolabe versions, not a contract obligation of the current
@@ -113,3 +118,39 @@ async def test_capabilities_report_all_sources_disabled(consumer_pact):
 
     # Present-but-empty => empty frozenset (restrict everything), NOT None.
     assert allowed == frozenset()
+
+
+async def test_capabilities_reflect_per_user_narrowing(consumer_pact):
+    """enabled_doc_types is the requesting user's effective set (admin ∩ user).
+
+    The capability call is authenticated per-user, so a user who disabled
+    ``notes`` for themselves sees ``note`` absent even though the admin allows
+    it. The MCP server reads the same field, so per-user gating/deletion needs
+    no wire-shape change.
+    """
+    clear_cache()
+    (
+        consumer_pact.upon_receiving(
+            "a request for OCS capabilities by a user who disabled notes"
+        )
+        .given("astrolabe reports effective sources for a user who disabled notes")
+        .with_request("GET", "/ocs/v2.php/cloud/capabilities")
+        .with_header("OCS-APIRequest", "true")
+        .will_respond_with(200)
+        .with_body(
+            # Admin allows file+note tenant-wide; this user narrowed out note,
+            # so their effective set is just file.
+            _ocs_capabilities(["file"]),
+            content_type="application/json",
+        )
+    )
+
+    with consumer_pact.serve() as srv:
+        client = NextcloudClient(
+            base_url=str(srv.url),
+            username="bob",
+            auth=BasicAuth("bob", "app-password"),
+        )
+        allowed = await allowed_doc_types(client, "bob")
+
+    assert allowed == frozenset({"file"})


### PR DESCRIPTION
## Summary

Companion to astrolabe's per-user enable/disable of searchable sources. Pins, via a consumer Pact interaction, that `capabilities.astrolabe.semantic_search.enabled_doc_types` is the **requesting user's effective set** (admin-enabled ∩ that user's own choices).

## Why no production code change

The OCS capabilities call is authenticated **per-user**, and the MCP server already:
- reads `enabled_doc_types` per-user (`allowed_doc_types()` is cached by `user_id`), and
- deletes a user's points for any doc_type absent from their effective set (the per-user consent backstop in `vector/scanner.py`).

So making the astrolabe-side effective set per-user flows through with **no parse/gating change here** — per-user gating and delete-on-disable already work. This PR just locks the contract so the provider can't regress the per-user semantics.

## Change

`tests/contract/test_astrolabe_capabilities_consumer.py`: add `test_capabilities_reflect_per_user_narrowing` — a user who disabled `notes` for themselves gets `enabled_doc_types` without `note`. Pact-first: astrolabe (provider) publishes/verifies this before the behavior is relied upon (ADR-029).

## Verification

- `uv run pytest -m contract tests/contract/test_astrolabe_capabilities_consumer.py` ✅ (3 passed); `ruff`/`ty` clean.

Tracked on Deck #378. Astrolabe companion: cbcoutinho/astrolabe#164.

---

_This PR was generated with the help of AI, and reviewed by a Human_
