### PR TITLE
refactor(ocr): consolidate the two OCR tiers into one configurable tier

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -633,6 +633,31 @@ document parse-failed. Each poll re-fetches + re-classifies the PDF (a known v1
 inefficiency, bounded by the poll cadence); one batch job is submitted per
 document (coalescing many documents per job is a planned follow-up).
 
+#### Upgrade notes: OCR-tier consolidation
+
+The two OCR rungs (`ocr-incluster` / `ocr-upstream`) were merged into one `ocr`
+tier. When upgrading from a deployment that used the split tiers:
+
+- **`DOCUMENT_OCR_INCLUSTER_ENABLED` / `DOCUMENT_OCR_INCLUSTER_MODEL` are removed.**
+  Configure the single tier with `DOCUMENT_OCR_PROVIDER` + `DOCUMENT_OCR_MODEL`
+  (the gateway routes on the model's `<provider>/` prefix, so surya is reached by
+  setting e.g. `DOCUMENT_OCR_PROVIDER=gateway` + `DOCUMENT_OCR_MODEL=surya/surya-ocr-2`).
+- **Dead-letter retry burst.** The dead-letter signature dropped its `ocric=`
+  component, so a deployment that had `DOCUMENT_OCR_INCLUSTER_ENABLED=true` will see
+  its signature change on upgrade and **automatically re-attempt** documents that
+  were dead-lettered while the in-cluster rung was on. This is intended (those docs
+  can OCR via the unified tier) but can produce a burst of OCR jobs on
+  scanned-doc-heavy instances right after deploy — expect it and scale the OCR
+  worker fleet accordingly.
+- **Batch mode now fails loud instead of downgrading to sync.** `DOCUMENT_OCR_MODE=batch`
+  requires the embedding gateway (rejected at startup without `EMBEDDING_GATEWAY_URL`)
+  and the Postgres ingest queue. On the in-process (`INGEST_QUEUE=memory`) path —
+  which can't defer a poll — batch raises at ingest time rather than silently
+  transcribing synchronously; use `DOCUMENT_OCR_MODE=sync` there.
+- **In-flight jobs are drained.** Jobs still parked on the old `ingest-ocr-incluster`
+  / `ingest-ocr-upstream` queues during a rolling upgrade are processed by the new
+  `ocr` worker and routed back to the single `ocr` tier — nothing is stranded.
+
 ### Embedding Service Configuration
 
 The server picks an embedding provider via auto-detection. Priority order

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -572,9 +572,30 @@ A PDF larger than `DOCUMENT_MAX_PDF_SIZE_MB` fails fast with reason `oversize`
 of being handed to the tiers, where a 40+ MB scan would otherwise burn the full
 OCR timeout for zero recovered text.
 
+#### OCR tier configuration
+
+OCR is a single configurable escalation tier. Enable it and choose the backend,
+model, and execution mode:
+
+```dotenv
+DOCUMENT_OCR_ENABLED=true              # route scanned/no-text-layer PDFs to OCR (default: false)
+DOCUMENT_OCR_PROVIDER=auto            # "auto" | "gateway" | "mistral" | "none"
+DOCUMENT_OCR_MODEL=mistral/mistral-ocr-latest  # provider-namespaced model id
+```
+
+- **`DOCUMENT_OCR_PROVIDER`** selects the backend: `gateway` posts to the Astrolabe
+  Cloud model gateway's `POST /v1/ocr` (no provider keys in the pod; the gateway
+  routes on the model's `<provider>/` prefix, so it serves Mistral, surya, etc.);
+  `mistral` calls the Mistral OCR API directly (`MISTRAL_API_KEY`); `auto` prefers
+  the gateway (if `EMBEDDING_GATEWAY_URL` is set) then direct Mistral; `none`
+  disables OCR.
+- **`DOCUMENT_OCR_MODEL`** is the provider-namespaced model id — e.g.
+  `mistral/mistral-ocr-latest` (Mistral) or `surya/surya-ocr-2` (surya, via the
+  gateway). The gateway routes on the prefix; the direct Mistral backend strips it.
+
 #### OCR execution mode: synchronous vs batch (Deck #332)
 
-The tier-3 OCR processor has two execution modes, selected by `DOCUMENT_OCR_MODE`:
+The OCR tier has two execution modes, selected by `DOCUMENT_OCR_MODE`:
 
 ```dotenv
 DOCUMENT_OCR_MODE=sync                 # "sync" (default) | "batch"
@@ -591,12 +612,16 @@ DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS=86400  # give up + mark timeout after this (
   **half the OCR cost**, so it suits large-corpus backfill rather than
   interactive ingest.
 
-Batch mode is **opt-in and gateway-only**: it routes Mistral's Batch API
-*through* the gateway's batch routes (no provider keys in the pod). With the
-direct `mistral` backend, no `EMBEDDING_GATEWAY_URL`, or on the in-process
-(`INGEST_QUEUE=memory`) pipeline — which can't defer a poll — batch transparently
-**falls back to synchronous OCR**. So enabling it requires the Postgres ingest
-queue (the per-tier procrastinate workers) and the gateway embedding backend.
+Batch mode is **opt-in and gateway-routed**: the embedding gateway is the
+batching layer, so batch OCR always routes *through* the gateway's batch routes
+(no provider keys in the pod). This is how batch works even when the chosen *sync*
+backend is direct Mistral — we leverage the gateway to batch for backends that
+have no native batch path from the pod. Because it needs a gateway, `DOCUMENT_OCR_MODE=batch`
+**requires `EMBEDDING_GATEWAY_URL`**: the server rejects the combination at startup
+rather than silently downgrading to synchronous OCR. Batch also requires the
+Postgres ingest queue (the per-tier procrastinate workers); the in-process
+(`INGEST_QUEUE=memory`) pipeline can't defer a poll, so use `DOCUMENT_OCR_MODE=sync`
+there.
 
 Mechanics: the OCR tier submits the job, records its id in the `batch_ocr_jobs`
 app-DB table (keyed on the document + its etag), and raises a re-poll deferral so

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -335,7 +335,7 @@ def _init_worker_observability(settings: Settings) -> None:
 )
 @click.option(
     "--tier",
-    type=click.Choice(["fast", "structured", "ocr-incluster", "ocr-upstream"]),
+    type=click.Choice(["fast", "structured", "ocr"]),
     default=None,
     help=(
         "Run only this extraction tier's queue (Deck #323). Omit to drain ALL "
@@ -354,9 +354,8 @@ def worker(concurrency: int | None, tier: str | None):
 
     \b
     With --tier the worker drains only that tier's queue (``ingest-<tier>``), so
-    a CPU-bound ``fast`` fleet, an in-cluster ``structured`` fleet, an on-demand
-    GPU ``ocr-incluster`` fleet, and a paid ``ocr-upstream`` fleet scale
-    independently. Without it, all tier queues are drained in
+    a CPU-bound ``fast`` fleet, an in-cluster ``structured`` fleet, and an ``ocr``
+    fleet scale independently. Without it, all tier queues are drained in
     one process (handy for dev / a single Deployment). A low-quality parse hops
     the job to the next tier's queue automatically (see TieredEscalationStrategy).
 
@@ -387,7 +386,8 @@ def worker(concurrency: int | None, tier: str | None):
         ALL_INGEST_QUEUES,
         INGEST_QUEUE_MAINTENANCE,
         LEGACY_INGEST_QUEUE,
-        LEGACY_INGEST_QUEUE_OCR,
+        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
+        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
         TIER_QUEUES,
         apply_ingest_queue_schema,
         get_procrastinate_app,
@@ -395,21 +395,26 @@ def worker(concurrency: int | None, tier: str | None):
 
     # Which queues this process drains. A single tier -> just its queue; no tier
     # -> every tier queue PLUS the legacy queues, so a rolling upgrade never
-    # strands jobs deferred under the pre-#323 single queue or the pre-#353 single
-    # OCR queue. The upstream OCR worker also drains the pre-split ``ingest-ocr``
-    # queue (the old single OCR tier defaulted to upstream/Mistral). Every worker
-    # drains the maintenance queue so the periodic stalled-job reclaim fires
-    # regardless of which tier(s) are scaled up (procrastinate dedups the
-    # periodic, so multiple drainers don't multiply the reclaim).
+    # strands jobs deferred under the pre-#323 single queue or the pre-#353 split
+    # OCR queues (now consolidated into ``ingest-ocr``). The ``ocr`` worker also
+    # drains those two split OCR queues so in-flight OCR jobs from a pre-
+    # consolidation deploy still get processed. Every worker drains the maintenance
+    # queue so the periodic stalled-job reclaim fires regardless of which tier(s)
+    # are scaled up (procrastinate dedups the periodic, so multiple drainers don't
+    # multiply the reclaim).
     if tier is not None:
         queues = [TIER_QUEUES[tier], INGEST_QUEUE_MAINTENANCE]
-        if tier == "ocr-upstream":
-            queues.insert(1, LEGACY_INGEST_QUEUE_OCR)
+        if tier == "ocr":
+            queues[1:1] = [
+                LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
+                LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+            ]
     else:
         queues = [
             *ALL_INGEST_QUEUES,
             LEGACY_INGEST_QUEUE,
-            LEGACY_INGEST_QUEUE_OCR,
+            LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
+            LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
             INGEST_QUEUE_MAINTENANCE,
         ]
 

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -386,8 +386,7 @@ def worker(concurrency: int | None, tier: str | None):
         ALL_INGEST_QUEUES,
         INGEST_QUEUE_MAINTENANCE,
         LEGACY_INGEST_QUEUE,
-        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
-        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+        LEGACY_OCR_QUEUES,
         TIER_QUEUES,
         apply_ingest_queue_schema,
         get_procrastinate_app,
@@ -405,16 +404,12 @@ def worker(concurrency: int | None, tier: str | None):
     if tier is not None:
         queues = [TIER_QUEUES[tier], INGEST_QUEUE_MAINTENANCE]
         if tier == "ocr":
-            queues[1:1] = [
-                LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
-                LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
-            ]
+            queues[1:1] = sorted(LEGACY_OCR_QUEUES)
     else:
         queues = [
             *ALL_INGEST_QUEUES,
             LEGACY_INGEST_QUEUE,
-            LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
-            LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+            *sorted(LEGACY_OCR_QUEUES),
             INGEST_QUEUE_MAINTENANCE,
         ]
 

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -188,9 +188,10 @@ _DEFAULTS: dict[str, Any] = {
     # OCR execution mode (Deck #332). "sync" (default) transcribes inline via the
     # backend's synchronous path. "batch" routes to the gateway's async Batch OCR
     # job (~50% cheaper, minutes-hours latency) for large-corpus backfill — opt-in
-    # and gateway-only; with the direct mistral backend or no gateway it falls
-    # back to sync. The submit->defer-poll loop runs on the per-tier procrastinate
-    # path; the inline/memory pool can't defer, so batch falls back to sync there.
+    # and gateway-routed. It requires EMBEDDING_GATEWAY_URL (rejected at startup
+    # otherwise, see __post_init__) and the per-tier procrastinate path; the
+    # inline/memory pool can't defer a poll, so batch raises there rather than
+    # silently downgrading to sync.
     "document_ocr_mode": "sync",
     # Seconds between batch-job polls (the procrastinate re-enqueue delay). Each
     # poll re-runs the tier; keep it well above a few seconds.

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -157,18 +157,15 @@ _DEFAULTS: dict[str, Any] = {
     "document_tier1_engine": "pypdfium2",
     "document_ocr_enabled": False,
     # OCR backend: "auto" picks gateway (if EMBEDDING_GATEWAY_URL) else mistral
-    # (if MISTRAL_API_KEY); "gateway"/"mistral" force one; "none" disables.
+    # (if MISTRAL_API_KEY); "gateway"/"mistral" force one; "none" disables. The
+    # gateway routes on the model's "<provider>/" prefix, so it serves Mistral,
+    # surya (in-cluster GPU over the tailnet), etc. — one configurable OCR tier.
     "document_ocr_provider": "auto",
     # Provider-namespaced OCR model id (gateway routes on the prefix; the direct
-    # mistral backend strips it).
+    # mistral backend strips it). e.g. "mistral/mistral-ocr-latest" (Mistral) or
+    # "surya/surya-ocr-2" (surya via the gateway) — never hard-coded, only this
+    # default.
     "document_ocr_model": "mistral/mistral-ocr-latest",
-    # In-cluster OCR tier (tier2, Deck #353): the on-demand burst GPU, reached
-    # ONLY via the embedding gateway. Off + per-tenant by default; tried before the
-    # paid upstream OCR rung. The model is a config value (the gateway routes on its
-    # "<provider>/" prefix) — surya is the current pick but swappable (e.g.
-    # "lightonocr/...") and is NEVER hard-coded, only this default.
-    "document_ocr_incluster_enabled": False,
-    "document_ocr_incluster_model": "surya/surya-ocr-2",
     # OCR escalation triggers (tier-0). A page is OCR-worthy when its text is
     # near-empty (< min_page_chars) OR low-quality (< min_text_quality) OR (when
     # detect_scanned) mostly a raster image; a doc escalates when the OCR-worthy
@@ -882,27 +879,24 @@ class Settings:
     # permissive license, no find_tables) is the hot path; "pymupdf" is a
     # deprecated rollback to pymupdf4llm (AGPL, graphics-limited) for one corpus.
     document_tier1_engine: str = "pypdfium2"
-    # Route scanned/no-text-layer PDFs to the tier-3 OCR provider. Off by
-    # default; when off, the fast tier is terminal.
+    # Route scanned/no-text-layer PDFs to the OCR tier. Off by default; when off,
+    # the fast tier is terminal.
     document_ocr_enabled: bool = False
-    # OCR backend selection: "auto" | "gateway" | "mistral" | "none".
+    # OCR backend selection: "auto" | "gateway" | "mistral" | "none". The gateway
+    # routes on the model's "<provider>/" prefix, so it serves Mistral, surya, etc.
     document_ocr_provider: str = "auto"
-    # Provider-namespaced OCR model id (e.g. "mistral/mistral-ocr-latest"). The
-    # gateway routes on the "<provider>/" prefix; the direct mistral backend
-    # strips it.
+    # Provider-namespaced OCR model id (e.g. "mistral/mistral-ocr-latest" or
+    # "surya/surya-ocr-2"). The gateway routes on the "<provider>/" prefix; the
+    # direct mistral backend strips it.
     document_ocr_model: str = "mistral/mistral-ocr-latest"
-    # In-cluster OCR tier (tier2, Deck #353): on-demand burst GPU reached ONLY via
-    # the embedding gateway; off + per-tenant, tried before the upstream rung. The
-    # model is a swappable config value (surya is the current pick, never hardcoded).
-    document_ocr_incluster_enabled: bool = False
-    document_ocr_incluster_model: str = "surya/surya-ocr-2"
     # OCR backend HTTP request timeout (seconds). float for parity with the
     # parse timeout / httpx.Timeout; per-tenant tunable so a gateway with a
     # shorter ceiling isn't masked by the 180s default.
     document_ocr_timeout_seconds: float = 180.0
-    # OCR execution mode: "sync" | "batch" (Deck #332). batch is opt-in,
-    # gateway-only, and used for large-corpus backfill; it falls back to sync when
-    # no gateway backend resolves or the path can't defer (inline/memory pool).
+    # OCR execution mode: "sync" | "batch" (Deck #332). batch is opt-in and routes
+    # through the embedding gateway's async Batch OCR job (large-corpus backfill).
+    # It requires a gateway: with no EMBEDDING_GATEWAY_URL, __post_init__ rejects
+    # mode=batch at startup rather than silently downgrading to sync.
     document_ocr_mode: str = "sync"
     # Batch-job poll cadence (procrastinate re-enqueue delay) and hard deadline.
     document_ocr_batch_poll_seconds: int = 120
@@ -1089,6 +1083,20 @@ class Settings:
         if self.embedding_provider == "gateway" and not self.embedding_gateway_url:
             raise ValueError(
                 "EMBEDDING_GATEWAY_URL is required when EMBEDDING_PROVIDER=gateway"
+            )
+        # Batch OCR routes through the embedding gateway's async Batch API (the only
+        # batch path from the pod), so it requires a gateway. Fail fast rather than
+        # silently downgrading to synchronous OCR at ingest time. provider=none means
+        # OCR is off entirely, so the mode is moot there.
+        if (
+            self.document_ocr_mode == "batch"
+            and self.document_ocr_provider != "none"
+            and not self.embedding_gateway_url
+        ):
+            raise ValueError(
+                "DOCUMENT_OCR_MODE=batch requires EMBEDDING_GATEWAY_URL (batch OCR "
+                "routes through the embedding gateway); use DOCUMENT_OCR_MODE=sync "
+                "for the direct backend without a gateway"
             )
         if (
             self.collection_metadata_source == "api"
@@ -1547,8 +1555,6 @@ def get_settings() -> Settings:
         "document_ocr_enabled": "DOCUMENT_OCR_ENABLED",
         "document_ocr_provider": "DOCUMENT_OCR_PROVIDER",
         "document_ocr_model": "DOCUMENT_OCR_MODEL",
-        "document_ocr_incluster_enabled": "DOCUMENT_OCR_INCLUSTER_ENABLED",
-        "document_ocr_incluster_model": "DOCUMENT_OCR_INCLUSTER_MODEL",
         "document_ocr_timeout_seconds": "DOCUMENT_OCR_TIMEOUT_SECONDS",
         "document_ocr_mode": "DOCUMENT_OCR_MODE",
         "document_ocr_batch_poll_seconds": "DOCUMENT_OCR_BATCH_POLL_SECONDS",

--- a/nextcloud_mcp_server/document_processors/__init__.py
+++ b/nextcloud_mcp_server/document_processors/__init__.py
@@ -8,29 +8,19 @@ from .registry import ProcessorRegistry, get_registry
 
 # Register processors at module initialization. The tiered PDF pipeline selects
 # by tier (not priority): Pypdfium2FastProcessor is the ``fast`` tier,
-# PyMuPDFProcessor the ``structured`` rollback, and TWO OcrProcessor instances are
-# the OCR rungs — ``ocr-incluster`` (the on-demand burst GPU, gateway-only, reached
-# via the embedding gateway over the tailnet; e.g. surya) tried before
-# ``ocr-upstream`` (paid Mistral). Each is reached only when its own opt-in flag is
-# set. OCR gets the lowest priorities so it's never the non-tiered default for PDFs.
+# PyMuPDFProcessor the ``structured`` rollback, and a single OcrProcessor is the
+# ``ocr`` tier — its backend (gateway vs direct Mistral), model (Mistral, surya,
+# …), and sync/batch mode are all chosen from settings. It is reached only when
+# ``document_ocr_enabled`` is set. OCR gets the lowest priority so it's never the
+# non-tiered default for PDFs.
 _registry = get_registry()
 _registry.register(Pypdfium2FastProcessor(), priority=20)
 _registry.register(PyMuPDFProcessor(), priority=10)
 _registry.register(
     OcrProcessor(
-        name="ocr-incluster",
-        tier="ocr-incluster",
-        model_setting="document_ocr_incluster_model",
-        gateway_only=True,
-    ),
-    priority=2,
-)
-_registry.register(
-    OcrProcessor(
-        name="ocr-upstream",
-        tier="ocr-upstream",
+        name="ocr",
+        tier="ocr",
         model_setting="document_ocr_model",
-        gateway_only=False,
     ),
     priority=1,
 )

--- a/nextcloud_mcp_server/document_processors/classifier.py
+++ b/nextcloud_mcp_server/document_processors/classifier.py
@@ -90,8 +90,8 @@ class DocClassification:
     mean_text_quality: float
     ocr_page_fraction: float  # fraction of sampled pages flagged needs_ocr
     # Classifier vocabulary (coarse): "fast" | "structured" | "ocr". "ocr" means
-    # "needs OCR" — the registry resolves it to a concrete rung (ocr-incluster ->
-    # ocr-upstream) via next_available_tier; it is NOT the TIER_LADDER tier name.
+    # "needs OCR" — the registry resolves it to the OCR tier via
+    # next_available_tier (the backend/model are configured, not tier-split).
     recommended_tier: str
     mean_control_ratio: float = 0.0  # doc-level C0-control-char ratio (glyph-leak)
     flags: set[str] = field(

--- a/nextcloud_mcp_server/document_processors/escalation.py
+++ b/nextcloud_mcp_server/document_processors/escalation.py
@@ -2,7 +2,7 @@
 
 The escalation ladder is the cheapest-first ordering of extraction tiers:
 
-    fast  ->  structured  ->  ocr-incluster  ->  ocr-upstream   ( ->  llm, reserved)
+    fast  ->  structured  ->  ocr   ( ->  llm, reserved)
 
 It mirrors the ``tier`` vocabulary documented on
 :meth:`DocumentProcessor.tier <.base.DocumentProcessor.tier>` and the
@@ -24,11 +24,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-# Cheapest-first. OCR is split into two rungs: ``ocr-incluster`` (the on-demand
-# burst GPU, e.g. surya, reached via the embedding gateway over the tailnet) tried
-# BEFORE ``ocr-upstream`` (paid Mistral). ``llm`` is reserved (see
-# base.DocumentProcessor.tier) and not wired yet.
-TIER_LADDER: tuple[str, ...] = ("fast", "structured", "ocr-incluster", "ocr-upstream")
+# Cheapest-first. ``ocr`` is the single configurable OCR tier: the backend (direct
+# Mistral vs the embedding gateway, which can route Mistral, surya, etc.) and the
+# model are chosen by ``document_ocr_provider`` + ``document_ocr_model``. ``llm`` is
+# reserved (see base.DocumentProcessor.tier) and not wired yet.
+TIER_LADDER: tuple[str, ...] = ("fast", "structured", "ocr")
 
 
 def escalation_tiers_signature(settings: Any) -> str:
@@ -43,7 +43,7 @@ def escalation_tiers_signature(settings: Any) -> str:
     Derived purely from settings (not the live ``ProcessorRegistry``) so it is
     identical across the API/scanner and worker roles: the *registered* processor
     set is build-constant, so the only runtime variables are the OCR-enabled gate
-    (``document_ocr_enabled`` — the single tier toggle today) and the tier-1 engine
+    (``document_ocr_enabled`` — the single OCR-tier toggle) and the tier-1 engine
     pin (``document_tier1_engine``). Enabling OCR changes the signature, so the
     pathological-but-OCR-recoverable documents dead-lettered while OCR was off are
     re-attempted automatically.
@@ -57,7 +57,6 @@ def escalation_tiers_signature(settings: Any) -> str:
     """
     return (
         f"ocr={int(bool(settings.document_ocr_enabled))};"
-        f"ocric={int(bool(settings.document_ocr_incluster_enabled))};"
         f"t1={settings.document_tier1_engine}"
     )
 
@@ -144,8 +143,8 @@ class BatchPending(Exception):
     ``except Exception`` on the indexing path, never counted as a drop/parse
     error, and never marks the placeholder failed (the doc isn't done yet).
     Unlike ``EscalateError`` it does NOT change queue — the job stays on its own
-    (``ocr-upstream``) tier queue and is simply deferred (batch mode is the
-    upstream Mistral path only; the in-cluster rung is synchronous).
+    (``ocr``) tier queue and is simply deferred (batch mode routes through the
+    embedding gateway's async Batch OCR job).
     """
 
     def __init__(self, *, retry_in: int) -> None:

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -1,12 +1,15 @@
-"""Tier-3 OCR processor.
+"""OCR tier processor.
 
 Routes scanned / no-text-layer PDFs (the tier-0 classifier's ``ocr`` verdict) to
-an OCR backend that returns per-page markdown. Two interchangeable backends,
-selected by ``document_ocr_provider``:
+an OCR backend that returns per-page markdown. The single ``ocr`` tier is fully
+configurable: operators enable OCR, pick the backend, the model, and sync/batch.
+
+Two interchangeable backends, selected by ``document_ocr_provider``:
 
   * ``gateway`` -- POST the document to the Astrolabe Cloud model gateway's
     ``POST /v1/ocr`` (the same M2M-authenticated gateway as embeddings; NO
-    provider keys in the pod). The platform default.
+    provider keys in the pod). The gateway routes on the ``<provider>/`` model
+    prefix, so one backend serves Mistral, surya, etc. The platform default.
   * ``mistral`` -- call the Mistral OCR API directly from the pod
     (``MISTRAL_API_KEY``), for self-hosters / deployments without the gateway.
 
@@ -14,6 +17,12 @@ selected by ``document_ocr_provider``:
 Mistral (if ``MISTRAL_API_KEY``). Both return GitHub-flavoured markdown + exact
 ``page_boundaries``; bbox is re-derived from the PDF bytes + boundaries by
 ``search/pdf_highlighter``, as for the other tiers.
+
+Batch mode (``document_ocr_mode=batch``) always routes through the embedding
+gateway's async Batch OCR job — the gateway is the batching layer, so it works
+even when the chosen sync backend is direct Mistral (or, in principle, any
+backend that lacks a native batch API). With no gateway configured there is no
+batch path from the pod, and ``Settings`` rejects ``mode=batch`` at startup.
 """
 
 import base64
@@ -28,7 +37,7 @@ import httpx
 
 from nextcloud_mcp_server.config import Settings, get_settings
 
-from .base import DocumentProcessor, ProcessingResult
+from .base import DocumentProcessor, ProcessingResult, ProcessorError
 
 if TYPE_CHECKING:
     # Annotation-only import (the runtime import is lazy, inside
@@ -206,14 +215,19 @@ def _build_gateway_token_provider(settings: Settings) -> Any:
 def build_gateway_batch_client(
     settings: Settings, *, model: str | None = None
 ) -> "GatewayBatchOcrClient | None":
-    """Build a ``GatewayBatchOcrClient`` when the gateway is the OCR backend, else
-    ``None`` (so batch mode falls back to sync for provider=mistral / no gateway).
-    Batch OCR is gateway-only — Mistral's Batch API is reached *through* the
-    gateway's batch routes, never directly from the pod.
+    """Build a ``GatewayBatchOcrClient`` for batch OCR, or ``None`` when batch is
+    not possible (OCR disabled, or no gateway configured).
 
-    ``model`` overrides ``settings.document_ocr_model`` so a per-tier OCR rung
-    (e.g. the in-cluster tier) submits its own provider-namespaced model id."""
-    if settings.document_ocr_provider not in ("gateway", "auto"):
+    The embedding gateway is the batching layer: batch OCR is always reached
+    *through* the gateway's ``/v1/ocr/batch`` routes (the model's namespaced prefix
+    picks the upstream — Mistral's Batch API, surya, etc.). So batch works even
+    when the chosen *sync* backend is direct Mistral — we leverage the gateway to
+    batch for backends that have no native batch path from the pod. With no
+    ``EMBEDDING_GATEWAY_URL`` there is no batch path, and ``Settings`` rejects
+    ``document_ocr_mode=batch`` at startup; this returns ``None`` defensively.
+
+    ``model`` overrides ``settings.document_ocr_model``."""
+    if settings.document_ocr_provider == "none":
         return None
     if not settings.embedding_gateway_url:
         return None
@@ -227,45 +241,21 @@ def build_gateway_batch_client(
 
 
 def build_ocr_backend(
-    settings: Settings, *, model: str | None = None, gateway_only: bool = False
+    settings: Settings, *, model: str | None = None
 ) -> _OcrBackend | None:
-    """Select an OCR backend from settings, or None when none is available.
+    """Select the synchronous OCR backend from settings, or None when none is
+    available.
 
-    ``model`` overrides ``settings.document_ocr_model`` so a per-tier OCR rung
-    binds its own provider-namespaced model id. ``gateway_only`` forces the
-    gateway backend (never the direct Mistral fallback) — used by the **in-cluster**
-    OCR tier, whose backend (e.g. surya on the burst GPU) is reachable ONLY through
-    the embedding gateway over the tailnet; with no gateway URL the tier is
-    disabled (warn) rather than misrouted to a direct backend that can't serve it.
+    ``model`` overrides ``settings.document_ocr_model`` (rarely needed; the OCR
+    tier binds its own provider-namespaced model id). Backend selection is purely
+    provider/model-driven: ``gateway``/``auto`` use the gateway (which routes on the
+    model's ``<provider>/`` prefix — Mistral, surya, etc.), ``mistral``/``auto`` use
+    the direct Mistral API, and ``none`` disables OCR.
     """
     provider = settings.document_ocr_provider
     # `is not None` (not truthiness): an empty model string must NOT silently fall
-    # back to the upstream default and misroute a per-tier rung.
+    # back to the upstream default.
     model = model if model is not None else settings.document_ocr_model
-
-    if gateway_only:
-        # The in-cluster tier is gateway-only and never touches the `mistral`
-        # provider, but provider=none still suppresses it. Warn so an operator who
-        # set provider=none to disable Mistral doesn't silently lose the GPU tier.
-        if provider == "none":
-            if settings.document_ocr_incluster_enabled:
-                logger.warning(
-                    "DOCUMENT_OCR_PROVIDER=none disables in-cluster OCR even with "
-                    "DOCUMENT_OCR_INCLUSTER_ENABLED=true; set it to 'gateway' or "
-                    "'auto' to keep the in-cluster tier"
-                )
-            return None
-        if settings.embedding_gateway_url:
-            return _GatewayOcrBackend(
-                settings.embedding_gateway_url,
-                model,
-                _build_gateway_token_provider(settings),
-            )
-        logger.warning(
-            "in-cluster OCR tier requires EMBEDDING_GATEWAY_URL (it routes through "
-            "the gateway, never a direct backend); this OCR tier is disabled"
-        )
-        return None
 
     if provider == "none":
         return None
@@ -301,37 +291,30 @@ def build_ocr_backend(
 
 
 class OcrProcessor(DocumentProcessor):
-    """OCR processor for both OCR rungs — tier2 in-cluster (gateway-only GPU) and
-    tier3 upstream (gateway or direct Mistral backend). One class, two registered
-    instances bound to different ``(tier, model_setting, gateway_only)``."""
+    """The single configurable OCR tier. Backend (gateway vs direct Mistral),
+    model, and sync/batch are all chosen from settings; one registered instance
+    serves the ``ocr`` tier."""
 
     def __init__(
         self,
-        # The defaults describe the UPSTREAM (tier3) rung and exist for
-        # test/bare-construction convenience only. Application wiring
-        # (document_processors/__init__.py) ALWAYS passes every arg explicitly for
-        # both rungs — don't rely on these defaults in app code.
+        # The defaults describe the ``ocr`` tier; the keyword args exist for
+        # test/bare-construction convenience. Application wiring
+        # (document_processors/__init__.py) passes them explicitly.
         *,
-        name: str = "ocr-upstream",
-        tier: str = "ocr-upstream",
+        name: str = "ocr",
+        tier: str = "ocr",
         model_setting: str = "document_ocr_model",
-        gateway_only: bool = False,
     ) -> None:
-        # One OcrProcessor class serves BOTH OCR rungs; instances are bound to a
-        # tier + the settings attribute holding their provider-namespaced model id
-        # (+ whether the backend is gateway-only). The in-cluster rung is
-        # gateway-only (its model, e.g. surya, is reachable solely via the
-        # gateway); the upstream rung keeps the configurable gateway/mistral
-        # selection. surya is NEVER hard-coded here — only a config default.
-        # Fail fast on a misconfigured model_setting (a typo in a constructor call)
-        # so it surfaces at startup, not as an AttributeError mid-OCR. The string
-        # only ever comes from hardcoded defaults in __init__.py, never user input.
+        # The instance is bound to a tier + the settings attribute holding its
+        # provider-namespaced model id. Fail fast on a misconfigured model_setting
+        # (a typo in a constructor call) so it surfaces at startup, not as an
+        # AttributeError mid-OCR. The string only ever comes from hardcoded defaults
+        # in __init__.py, never user input.
         if not hasattr(Settings, model_setting):
             raise ValueError(f"Unknown model_setting: {model_setting!r}")
         self._name = name
         self._tier = tier
         self._model_setting = model_setting
-        self._gateway_only = gateway_only
         # Resolve the backend once and reuse it: rebuilding per call would create
         # a fresh GatewayTokenProvider each time (discarding its M2M-token cache
         # -> a token fetch per document) and a new Mistral SDK client per call.
@@ -345,12 +328,10 @@ class OcrProcessor(DocumentProcessor):
         self._backend_lock: anyio.Lock | None = None
         # Batch-mode (Deck #332): the gateway batch client is cached like the sync
         # backend so its GatewayTokenProvider keeps its M2M-token cache across
-        # documents. ``_batch_fallback_warned`` rate-limits the "can't batch,
-        # using sync" warning to once per pod.
+        # documents.
         self._batch_client_resolved = False
         self._batch_client: GatewayBatchOcrClient | None = None
         self._batch_client_lock: anyio.Lock | None = None
-        self._batch_fallback_warned = False
 
     @property
     def name(self) -> str:
@@ -377,21 +358,20 @@ class OcrProcessor(DocumentProcessor):
         settings = get_settings()
 
         # Batch mode (Deck #332): submit to the gateway's async Batch OCR job and
-        # poll across procrastinate retries. Returns a result (incl. the
-        # "pending" sentinel) when handled, or None to fall back to the
-        # synchronous path below (no gateway backend, or no per-doc identity — the
-        # inline/memory pool can't defer a poll).
+        # poll across procrastinate retries. ``_process_batch`` always handles the
+        # document — it returns a result (incl. the "pending" sentinel) or RAISES.
+        # It never silently downgrades to synchronous OCR: if no batch-capable
+        # backend is configured the operator opted into a mode that can't run, and
+        # the failure is surfaced (``Settings`` also rejects this at startup) rather
+        # than quietly transcribing synchronously.
         #
         # A transport error from _process_batch (e.g. the gateway briefly down)
         # is intentionally NOT caught here: it propagates to procrastinate for a
-        # durable retry rather than silently falling back to sync. If you've opted
-        # into batch mode you want the retry, not an unexpected sync transcription.
+        # durable retry.
         if settings.document_ocr_mode == "batch":
-            batch_result = await self._process_batch(
+            return await self._process_batch(
                 content, content_type, filename, options, settings
             )
-            if batch_result is not None:
-                return batch_result
 
         if not self._backend_resolved:
             if self._backend_lock is None:
@@ -401,7 +381,6 @@ class OcrProcessor(DocumentProcessor):
                     self._backend = build_ocr_backend(
                         settings,
                         model=getattr(settings, self._model_setting),
-                        gateway_only=self._gateway_only,
                     )
                     self._backend_resolved = True
         backend = self._backend
@@ -460,16 +439,14 @@ class OcrProcessor(DocumentProcessor):
         )
 
     async def _get_batch_client(self) -> "GatewayBatchOcrClient | None":
-        """Cached gateway batch client (or ``None`` when batch isn't applicable —
-        provider=mistral / no gateway). Resolved once under the backend lock so the
+        """Cached gateway batch client (or ``None`` when batch isn't possible — OCR
+        disabled, or no gateway configured). Resolved once under its own lock so the
         token provider's M2M cache survives across documents.
 
-        The in-cluster (``gateway_only``) rung never uses batch mode: it targets
-        the on-demand GPU, which is synchronous/low-latency, while batch OCR is the
-        upstream (Mistral) async-job path. So even with ``DOCUMENT_OCR_MODE=batch``
-        set globally, the in-cluster tier stays on the synchronous backend."""
-        if self._gateway_only:
-            return None
+        Batch OCR always routes through the embedding gateway (the batching layer),
+        so this is non-``None`` whenever a gateway is configured, regardless of the
+        chosen *sync* backend — that is how we batch for direct backends that lack a
+        native batch API."""
         if not self._batch_client_resolved:
             if self._batch_client_lock is None:
                 self._batch_client_lock = anyio.Lock()
@@ -483,15 +460,6 @@ class OcrProcessor(DocumentProcessor):
                     self._batch_client_resolved = True
         return self._batch_client
 
-    def _batch_fallback(self, reason: str, filename: str | None) -> None:
-        """Warn once that batch mode is falling back to the synchronous path."""
-        if not self._batch_fallback_warned:
-            logger.warning(
-                "DOCUMENT_OCR_MODE=batch but %s; falling back to synchronous OCR",
-                reason,
-            )
-            self._batch_fallback_warned = True
-
     async def _process_batch(
         self,
         content: bytes,
@@ -499,34 +467,39 @@ class OcrProcessor(DocumentProcessor):
         filename: str | None,
         options: dict[str, Any] | None,
         settings: Settings,
-    ) -> ProcessingResult | None:
+    ) -> ProcessingResult:
         """Submit + poll a one-document batch OCR job.
 
-        Returns a :class:`ProcessingResult` when batch handled the document — the
-        terminal success/failure result, or the *pending sentinel* (``success=False``
-        + ``OCR_BATCH_PENDING_KEY`` metadata) that ``_parse_pdf_tier`` turns into a
-        ``BatchPending`` re-poll. Returns ``None`` to fall back to synchronous OCR
-        (no gateway backend, or no per-doc identity — the inline pool can't defer).
+        Always handles the document in batch mode: returns a terminal
+        :class:`ProcessingResult` (success/failure), or the *pending sentinel*
+        (``success=False`` + ``OCR_BATCH_PENDING_KEY`` metadata) that
+        ``_parse_pdf_tier`` turns into a ``BatchPending`` re-poll. It NEVER falls
+        back to synchronous OCR — when batch can't run it raises
+        :class:`ProcessorError` rather than silently downgrading (``Settings`` also
+        rejects ``mode=batch`` without a gateway at startup).
         """
-        # Per-doc identity is threaded via ``options`` only on the per-tier
-        # procrastinate path; the inline/memory pool omits it and can't defer a
-        # poll, so batch is inapplicable there.
-        identity = _batch_identity(options)
-        if identity is None:
-            self._batch_fallback("no per-document identity (inline path)", filename)
-            return None
         client = await self._get_batch_client()
         if client is None:
-            # The in-cluster (gateway_only) rung returns None here BY DESIGN — the
-            # GPU is synchronous-only, batch is the upstream Mistral path — so don't
-            # emit the "no gateway backend" warning (the gateway IS configured; that
-            # warning would send an operator chasing a non-existent config problem).
-            if not self._gateway_only:
-                self._batch_fallback(
-                    "no gateway backend (provider=mistral or EMBEDDING_GATEWAY_URL unset)",
-                    filename,
-                )
-            return None
+            # No batch path from the pod: batch OCR routes through the embedding
+            # gateway, and either OCR is disabled (provider=none) or no gateway is
+            # configured. Fail loud rather than transcribe synchronously.
+            raise ProcessorError(
+                "DOCUMENT_OCR_MODE=batch requires the embedding gateway: set "
+                "EMBEDDING_GATEWAY_URL (and an enabled DOCUMENT_OCR_PROVIDER) so "
+                "batch OCR can route through the gateway's async Batch API, or use "
+                "DOCUMENT_OCR_MODE=sync."
+            )
+        # Per-doc identity is threaded via ``options`` only on the per-tier
+        # procrastinate path; the inline/memory pool omits it and can't defer a
+        # poll, so batch cannot run there.
+        identity = _batch_identity(options)
+        if identity is None:
+            raise ProcessorError(
+                "DOCUMENT_OCR_MODE=batch is only supported on the worker (postgres) "
+                "ingest path, which defers the batch poll across retries; the "
+                "inline/memory pool cannot. Use DOCUMENT_OCR_MODE=sync for in-process "
+                "ingestion."
+            )
 
         # Lazy import: keep the vector/DB stack off the document_processors load
         # path (mirrors the EscalateError lazy import in vector/processor).

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -480,14 +480,20 @@ class OcrProcessor(DocumentProcessor):
         """
         client = await self._get_batch_client()
         if client is None:
-            # No batch path from the pod: batch OCR routes through the embedding
-            # gateway, and either OCR is disabled (provider=none) or no gateway is
+            # No batch path from the pod. Two distinct causes — name the real one so
+            # an operator isn't sent chasing a gateway problem when OCR is simply off.
+            if settings.document_ocr_provider == "none":
+                raise ProcessorError(
+                    "DOCUMENT_OCR_PROVIDER=none disables OCR, so batch OCR cannot "
+                    "run. Set DOCUMENT_OCR_PROVIDER to gateway/auto (with "
+                    "EMBEDDING_GATEWAY_URL) to use DOCUMENT_OCR_MODE=batch."
+                )
+            # Otherwise: batch OCR routes through the embedding gateway, which isn't
             # configured. Fail loud rather than transcribe synchronously.
             raise ProcessorError(
                 "DOCUMENT_OCR_MODE=batch requires the embedding gateway: set "
-                "EMBEDDING_GATEWAY_URL (and an enabled DOCUMENT_OCR_PROVIDER) so "
-                "batch OCR can route through the gateway's async Batch API, or use "
-                "DOCUMENT_OCR_MODE=sync."
+                "EMBEDDING_GATEWAY_URL so batch OCR can route through the gateway's "
+                "async Batch API, or use DOCUMENT_OCR_MODE=sync."
             )
         # Per-doc identity is threaded via ``options`` only on the per-tier
         # procrastinate path; the inline/memory pool omits it and can't defer a

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -334,7 +334,7 @@ class ProcessorRegistry:
         # is off here the would-be escalation is simply not taken (the gate below);
         # operators reading the suppressed counter are on the procrastinate fleet.
         #
-        # Escalate to OCR (tier-3) when enabled and a provider is registered. Fires
+        # Escalate to the OCR tier when enabled and a provider is registered. Fires
         # for a scanned / no-text-layer doc (recommended "ocr"), and also for an
         # unresolved "structured" recommendation -- a glyph-corrupt doc whose
         # structured rung wasn't registered -- so the inline path falls through to
@@ -349,16 +349,11 @@ class ProcessorRegistry:
             and not structured_failed
             and classification.recommended_tier in ("ocr", "structured")
             and classification.page_count > 0
-            and (
-                settings.document_ocr_enabled or settings.document_ocr_incluster_enabled
-            )
+            and settings.document_ocr_enabled
         ):
-            # Inline (memory pool) path: no queues to hop, so pick the cheapest
-            # available OCR rung (in-cluster GPU before paid upstream) via the same
-            # availability walk the queue path uses.
-            ocr_tier = self.next_available_tier(
-                from_tier, settings, minimum="ocr-incluster"
-            )
+            # Inline (memory pool) path: no queues to hop, so resolve the OCR tier
+            # via the same availability walk the queue path uses.
+            ocr_tier = self.next_available_tier(from_tier, settings, minimum="ocr")
             ocr = self._pdf_processor_for_tier(ocr_tier) if ocr_tier else None
             # `ocr is not None` already implies `ocr_tier is not None` at runtime,
             # but the type checker can't infer that across the conditional above,
@@ -462,13 +457,8 @@ class ProcessorRegistry:
             return None
         try:
             image_coverage = None
-            # Scan detection feeds either OCR rung (tier2 in-cluster or tier3
-            # upstream), so run it whenever EITHER is enabled — a tenant with
-            # only in-cluster OCR on still needs image-coverage scan signals.
-            ocr_any_enabled = (
-                settings.document_ocr_enabled or settings.document_ocr_incluster_enabled
-            )
-            if ocr_any_enabled and settings.document_ocr_detect_scanned:
+            # Scan detection feeds the OCR tier, so run it whenever OCR is enabled.
+            if settings.document_ocr_enabled and settings.document_ocr_detect_scanned:
                 try:
                     image_coverage = image_coverage_per_page(content)
                 except Exception:
@@ -518,19 +508,18 @@ class ProcessorRegistry:
         ``ignore_ocr_enabled`` drops only the OCR-enabled gate (not the registered-
         processor requirement): it answers "would this tier run if OCR were turned
         on?" — used to compute the *ideal* escalation target for the what-if-OCR
-        suppressed-escalation signal. (Both OCR rungs — ``ocr-incluster`` and
-        ``ocr-upstream`` — have their own enabled gate; non-OCR tiers have none.)
+        suppressed-escalation signal. (The ``ocr`` tier has the
+        ``document_ocr_enabled`` gate; non-OCR tiers have none.)
         """
         if self._pdf_processor_for_tier(tier) is None:
             return False
-        # Each OCR rung has its own opt-in flag (in-cluster vs upstream); a rung is
-        # unavailable when its flag is off (unless we're computing the what-if
-        # ideal target). Non-OCR tiers have no enabled gate.
-        ocr_enable = {
-            "ocr-incluster": settings.document_ocr_incluster_enabled,
-            "ocr-upstream": settings.document_ocr_enabled,
-        }
-        if not ignore_ocr_enabled and tier in ocr_enable and not ocr_enable[tier]:
+        # The OCR tier is opt-in via ``document_ocr_enabled`` (unless we're computing
+        # the what-if ideal target). Non-OCR tiers have no enabled gate.
+        if (
+            not ignore_ocr_enabled
+            and tier == "ocr"
+            and not settings.document_ocr_enabled
+        ):
             return False
         return True
 
@@ -628,15 +617,13 @@ class ProcessorRegistry:
 
         Target-tier routing:
 
-        - ``total_chars == 0`` (scanned / no text layer) -> target the cheapest
-          OCR rung (``ocr-incluster``) directly; ``next_available_tier`` falls
-          through to ``ocr-upstream`` if in-cluster is disabled/unregistered.
-          Text-extractor tiers (``structured``) cannot conjure text from a pure
-          raster scan, so a structured hop would just be wasted.
+        - ``total_chars == 0`` (scanned / no text layer) -> target the ``ocr`` tier
+          directly. Text-extractor tiers (``structured``) cannot conjure text from a
+          pure raster scan, so a structured hop would just be wasted.
         - glyph-corrupt text layer (``recommended_tier == "structured"``) -> target
           the ``structured`` tier; pymupdf re-extracts a broken-/ToUnicode layer
           correctly, so OCR is never the target for this case.
-        - low-confidence but non-empty layer -> escalate to the next rung, so a
+        - low-confidence but non-empty layer -> escalate to the next tier, so a
           different in-cluster extractor can try before paying for OCR.
 
         Hop vs suppressed: if the ideal target tier can run, return a ``"hop"``.
@@ -670,10 +657,8 @@ class ProcessorRegistry:
             minimum = "structured"
             reason = "corrupt_glyphs"
         elif classification.total_chars == 0:
-            # Scanned / no text layer: target the cheapest OCR rung (in-cluster
-            # GPU); next_available_tier then falls through to the upstream rung if
-            # in-cluster is disabled/unregistered.
-            minimum = "ocr-incluster"
+            # Scanned / no text layer: target the OCR tier.
+            minimum = "ocr"
             reason = "empty_text"
         else:
             minimum = None

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -708,15 +708,13 @@ def update_ingest_queue_depth(by_queue: dict[str, dict[str, int]] | None) -> Non
     from nextcloud_mcp_server.vector.queue.procrastinate import (  # noqa: PLC0415
         ALL_INGEST_QUEUES,
         LEGACY_INGEST_QUEUE,
-        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
-        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+        LEGACY_OCR_QUEUES,
     )
 
     for queue in (
         *ALL_INGEST_QUEUES,
         LEGACY_INGEST_QUEUE,
-        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
-        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+        *sorted(LEGACY_OCR_QUEUES),
     ):
         for status in _INGEST_DEPTH_STATUSES:
             ingest_queue_depth.labels(queue=queue, status=status).set(0)

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -708,10 +708,16 @@ def update_ingest_queue_depth(by_queue: dict[str, dict[str, int]] | None) -> Non
     from nextcloud_mcp_server.vector.queue.procrastinate import (  # noqa: PLC0415
         ALL_INGEST_QUEUES,
         LEGACY_INGEST_QUEUE,
-        LEGACY_INGEST_QUEUE_OCR,
+        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
+        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
     )
 
-    for queue in (*ALL_INGEST_QUEUES, LEGACY_INGEST_QUEUE, LEGACY_INGEST_QUEUE_OCR):
+    for queue in (
+        *ALL_INGEST_QUEUES,
+        LEGACY_INGEST_QUEUE,
+        LEGACY_INGEST_QUEUE_OCR_INCLUSTER,
+        LEGACY_INGEST_QUEUE_OCR_UPSTREAM,
+    ):
         for status in _INGEST_DEPTH_STATUSES:
             ingest_queue_depth.labels(queue=queue, status=status).set(0)
     for queue, per_status in by_queue.items():

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -356,15 +356,11 @@ async def record_indexing_usage(
                 metadata=metadata,
                 enabled=True,
             )
-            # Paid-OCR pages are metered as a SEPARATE line (Deck #323) so the
-            # expensive tier's cost is billable independently of CPU-cheap parsing
-            # -- pages_embedded counts all parsed pages, pages_ocr only the paid
-            # OCR tier's. After the OCR split (Deck #353) "paid" = the UPSTREAM
-            # (Mistral) rung; the in-cluster GPU rung's cost is recovered via the
-            # burst lifecycle, not per-page, so it is NOT metered here (separate
-            # per-tier OCR metering is a billing follow-up). Gated on the tier so
-            # it's emitted exactly when the doc hit upstream OCR.
-            if pipeline_tier == "ocr-upstream":
+            # OCR pages are metered as a SEPARATE line (Deck #323) so the OCR
+            # tier's cost is billable independently of CPU-cheap parsing --
+            # pages_embedded counts all parsed pages, pages_ocr only the OCR tier's.
+            # Gated on the tier so it's emitted exactly when the doc hit OCR.
+            if pipeline_tier == "ocr":
                 await store.record_usage_event(
                     metric="pages_ocr",
                     value=page_count,

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -91,7 +91,7 @@ LEGACY_INGEST_QUEUE = "ingest"
 LEGACY_INGEST_QUEUE_OCR_INCLUSTER = "ingest-ocr-incluster"
 LEGACY_INGEST_QUEUE_OCR_UPSTREAM = "ingest-ocr-upstream"
 # Split OCR queues that should drain back onto the single OCR tier during rollout.
-_LEGACY_OCR_QUEUES: frozenset[str] = frozenset(
+LEGACY_OCR_QUEUES: frozenset[str] = frozenset(
     {LEGACY_INGEST_QUEUE_OCR_INCLUSTER, LEGACY_INGEST_QUEUE_OCR_UPSTREAM}
 )
 # Back-compat alias for callers that imported the old single-queue constant.
@@ -109,7 +109,7 @@ INGEST_QUEUE_MAINTENANCE = "ingest-maintenance"
 _MANAGED_QUEUES: tuple[str, ...] = (
     *ALL_INGEST_QUEUES,
     LEGACY_INGEST_QUEUE,
-    *sorted(_LEGACY_OCR_QUEUES),
+    *sorted(LEGACY_OCR_QUEUES),
 )
 
 # Blueprint namespace → registered task names are prefixed ``ingest:``.
@@ -125,7 +125,7 @@ def tier_for_queue(queue: str | None) -> str:
     any unrecognised queue) defaults to the cheapest tier.
 
     The two split OCR queues from the #353 tier2/tier3 split
-    (``_LEGACY_OCR_QUEUES``) map to the now-single ``ocr`` tier so in-flight OCR
+    (``LEGACY_OCR_QUEUES``) map to the now-single ``ocr`` tier so in-flight OCR
     jobs from a pre-consolidation deploy keep OCR'ing rather than dropping back to
     ``fast``. The set is transient (only during a single rollout window).
     """
@@ -133,7 +133,7 @@ def tier_for_queue(queue: str | None) -> str:
     tier = _QUEUE_TIERS.get(queue)
     if tier is not None:
         return tier
-    if queue in _LEGACY_OCR_QUEUES:
+    if queue in LEGACY_OCR_QUEUES:
         return "ocr"
     return "fast"
 

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -66,30 +66,34 @@ logger = logging.getLogger(__name__)
 # network-bound ``ocr`` fleet scale (and fail) independently.
 INGEST_QUEUE_FAST = "ingest-fast"
 INGEST_QUEUE_STRUCTURED = "ingest-structured"
-# OCR split into two rungs (Deck #353): in-cluster (burst GPU via the gateway,
-# the queue the GPU autoscaler counts) tried before upstream (paid Mistral).
-INGEST_QUEUE_OCR_INCLUSTER = "ingest-ocr-incluster"
-INGEST_QUEUE_OCR_UPSTREAM = "ingest-ocr-upstream"
+# A single OCR queue: the OCR tier's backend (gateway vs direct Mistral) and model
+# (Mistral, surya, …) are configured, not split across queues. ``ingest-ocr`` is
+# also the pre-#353 name, so pre-split jobs parked on it are now handled natively.
+INGEST_QUEUE_OCR = "ingest-ocr"
 
 # tier -> queue. The producer always defers onto the cheapest tier's queue; a
 # low-quality parse hops the job up the ladder via the retry strategy below.
 TIER_QUEUES: dict[str, str] = {
     "fast": INGEST_QUEUE_FAST,
     "structured": INGEST_QUEUE_STRUCTURED,
-    "ocr-incluster": INGEST_QUEUE_OCR_INCLUSTER,
-    "ocr-upstream": INGEST_QUEUE_OCR_UPSTREAM,
+    "ocr": INGEST_QUEUE_OCR,
 }
 _QUEUE_TIERS: dict[str, str] = {queue: tier for tier, queue in TIER_QUEUES.items()}
 ALL_INGEST_QUEUES: tuple[str, ...] = tuple(TIER_QUEUES.values())
-# New jobs start here; the OCR rungs are reached only by escalation.
+# New jobs start here; the OCR tier is reached only by escalation.
 DEFAULT_INGEST_QUEUE = INGEST_QUEUE_FAST
 
-# Legacy single-queue name (pre-#323) and the pre-split single OCR queue
-# (pre-#353). A rolling upgrade may still have jobs parked on either; a worker
-# can drain them alongside the tier queues, and the job-count / reclaim helpers
-# include them so nothing is stranded.
+# Legacy single-queue name (pre-#323) and the two split OCR queues (the #353
+# tier2/tier3 split, now consolidated back into ``ingest-ocr``). A rolling upgrade
+# may still have jobs parked on these; a worker can drain them alongside the tier
+# queues, and the job-count / reclaim helpers include them so nothing is stranded.
 LEGACY_INGEST_QUEUE = "ingest"
-LEGACY_INGEST_QUEUE_OCR = "ingest-ocr"
+LEGACY_INGEST_QUEUE_OCR_INCLUSTER = "ingest-ocr-incluster"
+LEGACY_INGEST_QUEUE_OCR_UPSTREAM = "ingest-ocr-upstream"
+# Split OCR queues that should drain back onto the single OCR tier during rollout.
+_LEGACY_OCR_QUEUES: frozenset[str] = frozenset(
+    {LEGACY_INGEST_QUEUE_OCR_INCLUSTER, LEGACY_INGEST_QUEUE_OCR_UPSTREAM}
+)
 # Back-compat alias for callers that imported the old single-queue constant.
 INGEST_QUEUE_NAME = DEFAULT_INGEST_QUEUE
 
@@ -105,7 +109,7 @@ INGEST_QUEUE_MAINTENANCE = "ingest-maintenance"
 _MANAGED_QUEUES: tuple[str, ...] = (
     *ALL_INGEST_QUEUES,
     LEGACY_INGEST_QUEUE,
-    LEGACY_INGEST_QUEUE_OCR,
+    *sorted(_LEGACY_OCR_QUEUES),
 )
 
 # Blueprint namespace → registered task names are prefixed ``ingest:``.
@@ -120,16 +124,18 @@ def tier_for_queue(queue: str | None) -> str:
     job's current queue *is* its tier. A job on the legacy ``ingest`` queue (or
     any unrecognised queue) defaults to the cheapest tier.
 
-    The pre-split legacy OCR queue ``ingest-ocr`` (``LEGACY_INGEST_QUEUE_OCR``)
-    is deliberately NOT mapped here, so it also resolves to ``fast``. These are
-    in-flight jobs enqueued before the tier2/tier3 split; running them at fast
-    re-extracts (an empty layer for a scanned doc), which re-enters the ladder
-    and naturally re-escalates to ``ocr-incluster`` (the cheap GPU rung) — one
-    extra cheap hop, but it keeps stranded legacy OCR jobs OFF the paid upstream
-    rung rather than mapping them straight to ``ocr-upstream``. The set is
-    transient (only during a single rollout window).
+    The two split OCR queues from the #353 tier2/tier3 split
+    (``_LEGACY_OCR_QUEUES``) map to the now-single ``ocr`` tier so in-flight OCR
+    jobs from a pre-consolidation deploy keep OCR'ing rather than dropping back to
+    ``fast``. The set is transient (only during a single rollout window).
     """
-    return _QUEUE_TIERS.get(queue or "", "fast")
+    queue = queue or ""
+    tier = _QUEUE_TIERS.get(queue)
+    if tier is not None:
+        return tier
+    if queue in _LEGACY_OCR_QUEUES:
+        return "ocr"
+    return "fast"
 
 
 # A crashed worker leaves its job in ``doing``; reclaim it once its (per-worker)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -121,6 +121,9 @@ class TestGetSettings:
             "DOCUMENT_OCR_MODE": "batch",
             "DOCUMENT_OCR_BATCH_POLL_SECONDS": "45",
             "DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS": "3600",
+            # batch routes through the gateway, so it requires a gateway URL
+            # (validated in __post_init__).
+            "EMBEDDING_GATEWAY_URL": "https://gw",
         },
         clear=True,
     )
@@ -137,7 +140,11 @@ class TestGetSettings:
         assert settings.document_ocr_batch_poll_seconds == 45
         assert settings.document_ocr_batch_max_wait_seconds == 3600
 
-    @patch.dict(os.environ, {"DOCUMENT_OCR_MODE": "Batch"}, clear=True)
+    @patch.dict(
+        os.environ,
+        {"DOCUMENT_OCR_MODE": "Batch", "EMBEDDING_GATEWAY_URL": "https://gw"},
+        clear=True,
+    )
     def test_document_ocr_mode_case_normalised(self):
         """DOCUMENT_OCR_MODE is case-insensitive (normalised in __post_init__ via
         _enum_fields, like DOCUMENT_OCR_PROVIDER) — "Batch" -> "batch"."""
@@ -148,6 +155,14 @@ class TestGetSettings:
     def test_document_ocr_mode_invalid_rejected(self):
         _reload_config()
         with pytest.raises(ValueError, match="DOCUMENT_OCR_MODE"):
+            get_settings()
+
+    @patch.dict(os.environ, {"DOCUMENT_OCR_MODE": "batch"}, clear=True)
+    def test_document_ocr_mode_batch_requires_gateway(self):
+        """batch OCR routes through the embedding gateway, so mode=batch without
+        EMBEDDING_GATEWAY_URL is rejected at startup (no silent sync downgrade)."""
+        _reload_config()
+        with pytest.raises(ValueError, match="DOCUMENT_OCR_MODE=batch requires"):
             get_settings()
 
     @patch.dict(

--- a/tests/unit/test_escalation_signature.py
+++ b/tests/unit/test_escalation_signature.py
@@ -19,12 +19,9 @@ from nextcloud_mcp_server.document_processors.escalation import (
 pytestmark = pytest.mark.unit
 
 
-def _settings(
-    *, ocr: bool, ocr_incluster: bool = False, engine: str = "pypdfium2"
-) -> SimpleNamespace:
+def _settings(*, ocr: bool, engine: str = "pypdfium2") -> SimpleNamespace:
     return SimpleNamespace(
         document_ocr_enabled=ocr,
-        document_ocr_incluster_enabled=ocr_incluster,
         document_tier1_engine=engine,
     )
 
@@ -40,14 +37,6 @@ def test_enabling_ocr_changes_signature() -> None:
     assert escalation_tiers_signature(
         _settings(ocr=False)
     ) != escalation_tiers_signature(_settings(ocr=True))
-
-
-def test_enabling_ocr_incluster_changes_signature() -> None:
-    # Enabling the in-cluster (tier2) rung adds an escalation tier independently of
-    # the upstream rung -> previously dead-lettered scanned docs become retryable.
-    assert escalation_tiers_signature(
-        _settings(ocr=False, ocr_incluster=False)
-    ) != escalation_tiers_signature(_settings(ocr=False, ocr_incluster=True))
 
 
 def test_tier1_engine_change_changes_signature() -> None:

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -1,4 +1,4 @@
-"""Unit tests for the tier-3 OCR processor + backend selection."""
+"""Unit tests for the OCR tier processor + backend selection."""
 
 from types import SimpleNamespace
 from typing import Any
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from nextcloud_mcp_server.document_processors import ocr
+from nextcloud_mcp_server.document_processors.base import ProcessorError
 from nextcloud_mcp_server.embedding.gateway_batch_client import BatchPollResult
 from nextcloud_mcp_server.vector import batch_ocr_store as _bos
 
@@ -18,7 +19,6 @@ def _settings(**kw) -> Any:  # a Settings stand-in (only the read fields matter)
     base = dict(
         document_ocr_provider="auto",
         document_ocr_model="mistral/mistral-ocr-latest",
-        document_ocr_incluster_enabled=False,
         document_ocr_timeout_seconds=180.0,
         document_ocr_mode="sync",
         document_ocr_batch_poll_seconds=120,
@@ -83,147 +83,63 @@ def test_build_backend_auto_none_configured():
 @pytest.mark.parametrize(
     "kw, expect_client",
     [
-        # batch is gateway-only: the direct mistral backend never gets a client.
+        # No gateway URL -> no batch path from the pod.
         (dict(document_ocr_provider="mistral", mistral_api_key="k"), False),
-        # gateway selected but no URL -> no client (falls back to sync).
         (dict(document_ocr_provider="gateway"), False),
+        # Gateway configured -> a batch client regardless of the sync provider:
+        # batch routes through the gateway even for the direct mistral backend
+        # (we leverage the gateway to batch for backends without native batch).
         (
             dict(document_ocr_provider="gateway", embedding_gateway_url="https://gw"),
             True,
         ),
         (dict(document_ocr_provider="auto", embedding_gateway_url="https://gw"), True),
+        (
+            dict(
+                document_ocr_provider="mistral",
+                mistral_api_key="k",
+                embedding_gateway_url="https://gw",
+            ),
+            True,
+        ),
+        # OCR disabled entirely -> never a batch client.
         (dict(document_ocr_provider="none", embedding_gateway_url="https://gw"), False),
     ],
 )
-def test_build_gateway_batch_client_gateway_only(kw, expect_client):
+def test_build_gateway_batch_client(kw, expect_client):
     client = ocr.build_gateway_batch_client(_settings(**kw))
     assert (client is not None) is expect_client
 
 
-# --- in-cluster (tier2) backend: gateway-forced + configurable model -----------
+# --- model id handling (provider-namespaced, configurable) ---------------------
 
 
-def test_build_backend_gateway_only_forces_gateway():
-    """The in-cluster tier is gateway-only: even with provider=mistral + a key it
-    builds the gateway backend, NEVER the direct Mistral fallback (the GPU is
-    reachable solely through the gateway)."""
+def test_build_backend_empty_model_does_not_fall_back():
+    """An empty model string must NOT silently fall back to the configured default
+    (an `or` would); the backend keeps the empty id it was handed."""
     b = ocr.build_ocr_backend(
-        _settings(
-            document_ocr_provider="mistral",
-            mistral_api_key="k",
-            embedding_gateway_url="https://gw",
-        ),
-        gateway_only=True,
-    )
-    assert isinstance(b, ocr._GatewayOcrBackend)
-
-
-def test_build_backend_gateway_only_no_url_disabled():
-    """Gateway-only with no gateway URL -> disabled (None), never a direct backend."""
-    assert (
-        ocr.build_ocr_backend(_settings(mistral_api_key="k"), gateway_only=True) is None
-    )
-
-
-def test_build_backend_gateway_only_provider_none_warns_when_incluster_enabled(caplog):
-    """provider=none also suppresses the gateway-only in-cluster tier (it never uses
-    the mistral provider, but the global `none` gate still applies). When in-cluster
-    is enabled this is almost certainly an operator mistake -> warn so it's visible."""
-    with caplog.at_level(
-        "WARNING", logger="nextcloud_mcp_server.document_processors.ocr"
-    ):
-        b = ocr.build_ocr_backend(
-            _settings(
-                document_ocr_provider="none",
-                embedding_gateway_url="https://gw",
-                document_ocr_incluster_enabled=True,
-            ),
-            gateway_only=True,
-        )
-    assert b is None
-    assert any(
-        "DOCUMENT_OCR_PROVIDER=none disables in-cluster" in r.message
-        for r in caplog.records
-    )
-
-
-def test_build_backend_gateway_only_provider_none_silent_when_incluster_disabled(
-    caplog,
-):
-    """provider=none with in-cluster OFF is a deliberate disable -> no warning noise."""
-    with caplog.at_level(
-        "WARNING", logger="nextcloud_mcp_server.document_processors.ocr"
-    ):
-        b = ocr.build_ocr_backend(
-            _settings(document_ocr_provider="none", embedding_gateway_url="https://gw"),
-            gateway_only=True,
-        )
-    assert b is None
-    assert not any("disables in-cluster" in r.message for r in caplog.records)
-
-
-def test_build_backend_empty_model_does_not_fall_back(caplog):
-    """An empty model string must NOT silently fall back to the upstream default
-    (an `or` would); the in-cluster rung keeps the empty id it was handed."""
-    b = ocr.build_ocr_backend(
-        _settings(embedding_gateway_url="https://gw"),
+        _settings(document_ocr_provider="gateway", embedding_gateway_url="https://gw"),
         model="",
-        gateway_only=True,
     )
     assert isinstance(b, ocr._GatewayOcrBackend)
     assert b._model == ""
 
 
 def test_build_backend_model_override_is_not_hardcoded():
-    """The per-tier model is whatever config passes -- surya by default, but fully
-    swappable (e.g. lightonocr) with no code change."""
+    """The OCR model is whatever config passes -- mistral/surya by default, but
+    fully swappable (e.g. lightonocr) with no code change."""
     surya = ocr.build_ocr_backend(
-        _settings(embedding_gateway_url="https://gw"),
+        _settings(document_ocr_provider="gateway", embedding_gateway_url="https://gw"),
         model="surya/surya-ocr-2",
-        gateway_only=True,
     )
     assert isinstance(surya, ocr._GatewayOcrBackend)
     assert surya._model == "surya/surya-ocr-2"
     lit = ocr.build_ocr_backend(
-        _settings(embedding_gateway_url="https://gw"),
+        _settings(document_ocr_provider="gateway", embedding_gateway_url="https://gw"),
         model="lightonocr/lightonocr-1b",
-        gateway_only=True,
     )
     assert isinstance(lit, ocr._GatewayOcrBackend)
     assert lit._model == "lightonocr/lightonocr-1b"  # config-driven, not hardcoded
-
-
-async def test_incluster_processor_resolves_its_model_gateway_only(monkeypatch):
-    """An OcrProcessor bound to the in-cluster rung builds its backend with its own
-    configured model (document_ocr_incluster_model) and gateway_only=True."""
-    captured: dict[str, Any] = {}
-
-    class _FakeBackend:
-        async def ocr(self, content, mime_type):
-            return "ocr text", [{"page": 1, "start_offset": 0, "end_offset": 8}]
-
-    def _spy(settings, *, model=None, gateway_only=False):
-        captured["model"] = model
-        captured["gateway_only"] = gateway_only
-        return _FakeBackend()
-
-    monkeypatch.setattr(ocr, "build_ocr_backend", _spy)
-    monkeypatch.setattr(
-        ocr,
-        "get_settings",
-        lambda: _settings(
-            document_ocr_incluster_model="surya/surya-ocr-2",
-            embedding_gateway_url="https://gw",
-        ),
-    )
-    proc = ocr.OcrProcessor(
-        name="ocr-incluster",
-        tier="ocr-incluster",
-        model_setting="document_ocr_incluster_model",
-        gateway_only=True,
-    )
-    await proc.process(b"%PDF", "application/pdf", "x.pdf")
-    assert captured == {"model": "surya/surya-ocr-2", "gateway_only": True}
 
 
 def test_no_surya_string_literal_in_document_processors():
@@ -287,7 +203,7 @@ async def test_processor_success(monkeypatch):
     assert r.success is True
     assert r.text == "hello world"
     assert r.metadata["page_count"] == 1
-    assert r.processor == "ocr-upstream"
+    assert r.processor == "ocr"
 
 
 async def test_processor_backend_error_returns_success_false(monkeypatch):
@@ -485,61 +401,6 @@ def _wire_batch(monkeypatch, *, client, store, settings=None):
     monkeypatch.setattr(_bos.BatchOcrJobStore, "shared", classmethod(_shared))
 
 
-async def test_gateway_only_processor_never_uses_batch_mode(monkeypatch):
-    """The in-cluster (gateway_only) rung targets the synchronous GPU; batch mode
-    is the upstream Mistral async-job path. _get_batch_client returns None and
-    never builds a batch client even with DOCUMENT_OCR_MODE=batch set globally —
-    while the upstream (gateway_only=False) processor still resolves one."""
-    called = {"n": 0}
-
-    def _spy(settings, **kw):
-        called["n"] += 1
-        return _FakeBatchClient()
-
-    monkeypatch.setattr(
-        ocr,
-        "get_settings",
-        lambda: _settings(
-            document_ocr_mode="batch",
-            document_ocr_provider="gateway",
-            embedding_gateway_url="https://gw",
-            document_ocr_incluster_model="surya/surya-ocr-2",
-        ),
-    )
-    monkeypatch.setattr(ocr, "build_gateway_batch_client", _spy)
-
-    incluster = ocr.OcrProcessor(
-        name="ocr-incluster",
-        tier="ocr-incluster",
-        model_setting="document_ocr_incluster_model",
-        gateway_only=True,
-    )
-    assert await incluster._get_batch_client() is None
-    assert called["n"] == 0  # short-circuited before building anything
-
-    # _process_batch returns None for the gateway-only rung WITHOUT emitting the
-    # misleading "no gateway backend" warning (the gateway IS configured; the rung
-    # is simply synchronous-only). _batch_fallback_warned stays False to prove it.
-    result = await incluster._process_batch(
-        b"%PDF-1.7",
-        "application/pdf",
-        "x.pdf",
-        dict(_IDENTITY),
-        _settings(
-            document_ocr_mode="batch",
-            document_ocr_provider="gateway",
-            embedding_gateway_url="https://gw",
-            document_ocr_incluster_model="surya/surya-ocr-2",
-        ),
-    )
-    assert result is None
-    assert incluster._batch_fallback_warned is False
-
-    upstream = ocr.OcrProcessor()  # gateway_only=False
-    assert await upstream._get_batch_client() is not None
-    assert called["n"] == 1
-
-
 async def test_batch_first_run_submits_and_returns_pending_sentinel(monkeypatch):
     client = _FakeBatchClient()
     store = _FakeStore()
@@ -645,26 +506,32 @@ async def test_batch_deadline_exceeded_marks_timeout(monkeypatch):
     assert ("u1", "d1", "file", "v1") in store.deleted
 
 
-async def test_batch_falls_back_to_sync_when_no_gateway(monkeypatch):
+async def test_batch_raises_when_no_gateway(monkeypatch):
+    """batch mode with no batch-capable backend (no gateway) must RAISE, never
+    silently downgrade to synchronous OCR."""
+
     class _FakeBackend:
-        async def ocr(self, content, mime_type):
-            return "sync text", [{"page": 1, "start_offset": 0, "end_offset": 9}]
+        async def ocr(self, content, mime_type):  # pragma: no cover - must not run
+            raise AssertionError("sync backend must not be used in batch mode")
 
     settings = _settings(document_ocr_mode="batch", document_ocr_provider="mistral")
     monkeypatch.setattr(ocr, "get_settings", lambda: settings)
     monkeypatch.setattr(ocr, "build_gateway_batch_client", lambda s, **kw: None)
     monkeypatch.setattr(ocr, "build_ocr_backend", lambda s, **kw: _FakeBackend())
 
-    r = await ocr.OcrProcessor().process(
-        b"%PDF", "application/pdf", options=dict(_IDENTITY)
-    )
-    assert r.success is True and r.text == "sync text"
+    with pytest.raises(ProcessorError, match="EMBEDDING_GATEWAY_URL"):
+        await ocr.OcrProcessor().process(
+            b"%PDF", "application/pdf", options=dict(_IDENTITY)
+        )
 
 
-async def test_batch_falls_back_to_sync_when_no_identity(monkeypatch):
+async def test_batch_raises_when_no_identity(monkeypatch):
+    """batch mode on the inline path (no per-doc identity) can't defer a poll, so
+    it RAISES rather than silently transcribing synchronously."""
+
     class _FakeBackend:
-        async def ocr(self, content, mime_type):
-            return "sync text", [{"page": 1, "start_offset": 0, "end_offset": 9}]
+        async def ocr(self, content, mime_type):  # pragma: no cover - must not run
+            raise AssertionError("sync backend must not be used in batch mode")
 
     client = _FakeBatchClient()
     settings = _settings(
@@ -676,9 +543,9 @@ async def test_batch_falls_back_to_sync_when_no_identity(monkeypatch):
     monkeypatch.setattr(ocr, "build_gateway_batch_client", lambda s, **kw: client)
     monkeypatch.setattr(ocr, "build_ocr_backend", lambda s, **kw: _FakeBackend())
 
-    # No options -> inline path -> batch inapplicable -> sync fallback.
-    r = await ocr.OcrProcessor().process(b"%PDF", "application/pdf", options=None)
-    assert r.success is True and r.text == "sync text"
+    # No options -> inline path -> batch can't defer -> raise (not sync fallback).
+    with pytest.raises(ProcessorError, match="worker"):
+        await ocr.OcrProcessor().process(b"%PDF", "application/pdf", options=None)
     assert client.submitted == []  # never attempted batch
 
 

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -525,6 +525,22 @@ async def test_batch_raises_when_no_gateway(monkeypatch):
         )
 
 
+async def test_batch_raises_provider_none_names_the_real_cause(monkeypatch):
+    """provider=none in batch mode raises a message about OCR being disabled, not a
+    misleading 'gateway missing' error (the startup guard exempts provider=none)."""
+    settings = _settings(
+        document_ocr_mode="batch",
+        document_ocr_provider="none",
+        embedding_gateway_url="https://gw",
+    )
+    monkeypatch.setattr(ocr, "get_settings", lambda: settings)
+
+    with pytest.raises(ProcessorError, match="DOCUMENT_OCR_PROVIDER=none"):
+        await ocr.OcrProcessor().process(
+            b"%PDF", "application/pdf", options=dict(_IDENTITY)
+        )
+
+
 async def test_batch_raises_when_no_identity(monkeypatch):
     """batch mode on the inline path (no per-doc identity) can't defer a poll, so
     it RAISES rather than silently transcribing synchronously."""

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -191,7 +191,7 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         token_count=900,
         total_chars=40000,
         page_count=8,
-        pipeline_tier="ocr-upstream",
+        pipeline_tier="ocr",
     )
     by_metric = {
         c.kwargs["metric"]: c.kwargs["value"]
@@ -205,7 +205,7 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
     }
     # pipeline_tier is threaded into the billing metadata for CP attribution.
     for c in store_spy.record_usage_event.await_args_list:
-        assert c.kwargs["metadata"]["pipeline_tier"] == "ocr-upstream"
+        assert c.kwargs["metadata"]["pipeline_tier"] == "ocr"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_registry_tiering.py
+++ b/tests/unit/test_registry_tiering.py
@@ -74,7 +74,6 @@ class _Settings:
         engine="pypdfium2",
         classify=True,
         ocr=False,
-        ocr_incluster=False,
         min_text_quality=0.5,
         page_fraction=0.5,
         min_page_chars=16,
@@ -86,13 +85,10 @@ class _Settings:
     ):
         self.document_tier1_engine = engine
         self.document_classify_enabled = classify
-        # ``ocr`` enables the UPSTREAM rung (document_ocr_enabled); ``ocr_incluster``
-        # the in-cluster GPU rung (tried first). The model attrs let
-        # build_ocr_backend resolve a per-tier model id.
+        # ``ocr`` enables the single OCR tier (document_ocr_enabled). The model
+        # attr lets build_ocr_backend resolve the OCR model id.
         self.document_ocr_enabled = ocr
-        self.document_ocr_incluster_enabled = ocr_incluster
         self.document_ocr_model = "mistral/mistral-ocr-latest"
-        self.document_ocr_incluster_model = "surya/surya-ocr-2"
         self.document_ocr_min_text_quality = min_text_quality
         self.document_ocr_page_fraction = page_fraction
         self.document_ocr_min_page_chars = min_page_chars
@@ -202,10 +198,10 @@ async def test_ocr_escalation_on_empty_text(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
     r = _registry(
         (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr text"), 5),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
+    assert res.processor == "ocr"
     esc.assert_called_once()
 
 
@@ -217,7 +213,7 @@ async def test_zero_page_pdf_does_not_escalate(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
     r = _registry(
         (_Fake("fast", "fast", text="", pages=0), 20),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
     assert res.processor == "fast"
@@ -238,7 +234,7 @@ async def test_ocr_failure_falls_back_to_fast(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_escalation", MagicMock())
     r = _registry(
         (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-upstream", "ocr-upstream", text="", success=False), 5),
+        (_Fake("ocr", "ocr", text="", success=False), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
     assert res.processor == "fast"
@@ -249,7 +245,7 @@ async def test_no_ocr_escalation_when_disabled(monkeypatch):
     monkeypatch.setattr(reg_mod, "get_settings", lambda: _Settings(ocr=False))
     r = _registry(
         (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
     # Fast tier is terminal when OCR is disabled.
@@ -296,11 +292,11 @@ async def test_glyph_corrupt_no_structured_falls_through_to_ocr(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
     r = _registry(
         (_Fake("fast", "fast", text=_GLYPH), 20),
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr recovered text"), 5),
+        (_Fake("ocr", "ocr", text="ocr recovered text"), 5),
     )  # no structured registered
     res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
-    esc.assert_called_once_with("fast", "ocr-upstream", "corrupt_glyphs")
+    assert res.processor == "ocr"
+    esc.assert_called_once_with("fast", "ocr", "corrupt_glyphs")
 
 
 async def test_inline_lowconf_tries_structured_before_ocr(monkeypatch):
@@ -312,7 +308,7 @@ async def test_inline_lowconf_tries_structured_before_ocr(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast", text="x" * 40), 20),  # one long token -> quality ~0
         (_Fake("structured", "structured", text="clean recovered prose text here"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr text"), 5),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
     assert res.processor == "structured"
@@ -328,11 +324,11 @@ async def test_inline_empty_skips_structured_straight_to_ocr(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast", text=""), 20),
         (_Fake("structured", "structured", text="should not run"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr text"), 5),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
-    esc.assert_called_once_with("fast", "ocr-upstream", "empty_text")
+    assert res.processor == "ocr"
+    esc.assert_called_once_with("fast", "ocr", "empty_text")
 
 
 async def test_inline_fast_structured_ocr_cascade(monkeypatch):
@@ -346,13 +342,13 @@ async def test_inline_fast_structured_ocr_cascade(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast", text="x" * 40), 20),  # quality ~0, non-empty
         (_Fake("structured", "structured", text=""), 10),  # re-extract empty
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr recovered text"), 5),
+        (_Fake("ocr", "ocr", text="ocr recovered text"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
+    assert res.processor == "ocr"
     assert esc.call_args_list == [
         call("fast", "structured", "low_confidence"),
-        call("structured", "ocr-upstream", "empty_text"),
+        call("structured", "ocr", "empty_text"),
     ]
 
 
@@ -366,13 +362,13 @@ async def test_inline_structured_still_corrupt_escalates_to_ocr(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast", text=_GLYPH), 20),
         (_Fake("structured", "structured", text=_GLYPH), 10),  # still corrupt
-        (_Fake("ocr-upstream", "ocr-upstream", text="ocr recovered text"), 5),
+        (_Fake("ocr", "ocr", text="ocr recovered text"), 5),
     )
     res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
+    assert res.processor == "ocr"
     assert esc.call_args_list == [
         call("fast", "structured", "corrupt_glyphs"),
-        call("structured", "ocr-upstream", "corrupt_glyphs"),
+        call("structured", "ocr", "corrupt_glyphs"),
     ]
 
 
@@ -382,7 +378,7 @@ def test_evaluate_escalation_glyph_corrupt_goes_structured(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text=_GLYPH,
@@ -406,7 +402,7 @@ def test_evaluate_escalation_glyph_corrupt_no_structured_falls_through_to_ocr(
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     r = _registry(
         (_Fake("fast", "fast"), 20),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )  # no structured registered
     res = ProcessingResult(
         text=_GLYPH,
@@ -419,7 +415,7 @@ def test_evaluate_escalation_glyph_corrupt_no_structured_falls_through_to_ocr(
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=True))
-    assert decision == EscalationDecision("hop", "ocr-upstream", "corrupt_glyphs")
+    assert decision == EscalationDecision("hop", "ocr", "corrupt_glyphs")
 
 
 def test_evaluate_escalation_glyph_corrupt_no_structured_ocr_disabled_suppressed(
@@ -431,7 +427,7 @@ def test_evaluate_escalation_glyph_corrupt_no_structured_ocr_disabled_suppressed
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     r = _registry(
         (_Fake("fast", "fast"), 20),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )  # structured not registered; ocr registered but disabled below
     res = ProcessingResult(
         text=_GLYPH,
@@ -444,9 +440,7 @@ def test_evaluate_escalation_glyph_corrupt_no_structured_ocr_disabled_suppressed
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=False))
-    assert decision == EscalationDecision(
-        "suppressed", "ocr-upstream", "corrupt_glyphs"
-    )
+    assert decision == EscalationDecision("suppressed", "ocr", "corrupt_glyphs")
 
 
 # --- Per-tier external path (Deck #323) -------------------------------------
@@ -458,7 +452,7 @@ async def test_process_tier_runs_named_tier(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = await r.process_tier(b"%PDF-1.7", "application/pdf", "f.pdf", "structured")
     assert res.processor == "structured"
@@ -478,10 +472,8 @@ async def test_process_tier_oversize_fails_fast(monkeypatch):
     monkeypatch.setattr(
         reg_mod, "get_settings", lambda: _Settings(max_pdf_size_mb=0.001)
     )
-    r = _registry((_Fake("ocr-upstream", "ocr-upstream"), 5))
-    res = await r.process_tier(
-        b"x" * 4096, "application/pdf", "big.pdf", "ocr-upstream"
-    )
+    r = _registry((_Fake("ocr", "ocr"), 5))
+    res = await r.process_tier(b"x" * 4096, "application/pdf", "big.pdf", "ocr")
     assert res.success is False
     assert res.metadata["parse_failed_reason"] == "oversize"
 
@@ -490,7 +482,7 @@ def test_next_available_tier_walks_ladder():
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     # ocr disabled -> structured is the only target above fast.
     s = _Settings(ocr=False)
@@ -498,25 +490,24 @@ def test_next_available_tier_walks_ladder():
     assert r.next_available_tier("structured", s) is None  # ocr gated off
     # ocr enabled -> reachable; minimum skips the structured rung.
     s_ocr = _Settings(ocr=True)
-    assert r.next_available_tier("structured", s_ocr) == "ocr-upstream"
-    assert (
-        r.next_available_tier("fast", s_ocr, minimum="ocr-upstream") == "ocr-upstream"
-    )
+    assert r.next_available_tier("fast", s_ocr) == "structured"
+    assert r.next_available_tier("structured", s_ocr) == "ocr"
+    assert r.next_available_tier("fast", s_ocr, minimum="ocr") == "ocr"
+    # The OCR tier is the top of the ladder -> terminal.
+    assert r.next_available_tier("ocr", s_ocr) is None
 
 
 def test_next_available_tier_skips_unregistered():
     # No structured processor -> fast escalates straight to ocr.
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
-    assert r.next_available_tier("fast", _Settings(ocr=True)) == "ocr-upstream"
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
+    assert r.next_available_tier("fast", _Settings(ocr=True)) == "ocr"
 
 
 def test_evaluate_escalation_good_text_indexes(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     r = _registry(
         (_Fake("fast", "fast", text="This is clean readable prose text."), 20),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text="This is clean readable prose text.",
@@ -535,7 +526,7 @@ def test_evaluate_escalation_empty_jumps_to_ocr(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text="",
@@ -546,7 +537,7 @@ def test_evaluate_escalation_empty_jumps_to_ocr(monkeypatch):
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=True))
-    assert decision == EscalationDecision("hop", "ocr-upstream", "empty_text")
+    assert decision == EscalationDecision("hop", "ocr", "empty_text")
 
 
 def test_evaluate_escalation_lowconf_goes_to_structured(monkeypatch):
@@ -556,7 +547,7 @@ def test_evaluate_escalation_lowconf_goes_to_structured(monkeypatch):
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text=junk,
@@ -574,9 +565,7 @@ def test_evaluate_escalation_lowconf_goes_to_structured(monkeypatch):
 
 def test_evaluate_escalation_failure_not_escalated(monkeypatch):
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
     res = ProcessingResult(
         text="",
         metadata={"parse_failed_reason": "error"},
@@ -607,9 +596,7 @@ def test_evaluate_escalation_terminal_when_no_higher_tier(monkeypatch):
 def test_evaluate_escalation_zero_page_does_not_escalate(monkeypatch):
     """A zero-page (empty/corrupt) PDF never escalates on the external path."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
     res = ProcessingResult(
         text="",
         metadata={"page_count": 0, "page_boundaries": []},
@@ -623,9 +610,7 @@ def test_evaluate_escalation_lowconf_to_ocr_when_no_structured(monkeypatch):
     unregistered structured rung), not to None."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     junk = "z" * 40  # non-empty but junk -> recommended ocr, total_chars > 0
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
     res = ProcessingResult(
         text=junk,
         metadata={
@@ -637,16 +622,14 @@ def test_evaluate_escalation_lowconf_to_ocr_when_no_structured(monkeypatch):
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=True))
-    assert decision == EscalationDecision("hop", "ocr-upstream", "low_confidence")
+    assert decision == EscalationDecision("hop", "ocr", "low_confidence")
 
 
 def test_evaluate_escalation_suppressed_when_ocr_disabled(monkeypatch):
     """OCR off: a scanned doc does NOT hop to ocr; it returns a 'suppressed'
     decision (the what-if-OCR signal) so the caller indexes at the current tier."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
     res = ProcessingResult(
         text="",
         metadata={
@@ -656,32 +639,7 @@ def test_evaluate_escalation_suppressed_when_ocr_disabled(monkeypatch):
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=False))
-    assert decision == EscalationDecision("suppressed", "ocr-upstream", "empty_text")
-
-
-def test_evaluate_escalation_suppressed_targets_incluster_four_rung(monkeypatch):
-    """Four-rung registry, BOTH OCR flags off: the suppressed what-if-OCR signal
-    names the *cheapest* ideal rung (ocr-incluster), not ocr-upstream, since the
-    ideal-target walk (ignore_ocr_enabled) picks the cheapest registered OCR rung."""
-    monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast"), 20),
-        (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-incluster", "ocr-incluster"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
-    )
-    res = ProcessingResult(
-        text="",
-        metadata={
-            "page_count": 1,
-            "page_boundaries": [{"page": 1, "start_offset": 0, "end_offset": 0}],
-        },
-        processor="fast",
-    )
-    decision = r.evaluate_escalation(
-        res, b"%PDF", "fast", _Settings(ocr=False, ocr_incluster=False)
-    )
-    assert decision == EscalationDecision("suppressed", "ocr-incluster", "empty_text")
+    assert decision == EscalationDecision("suppressed", "ocr", "empty_text")
 
 
 def test_evaluate_escalation_lowconf_suppressed_when_only_ocr_disabled(monkeypatch):
@@ -689,9 +647,7 @@ def test_evaluate_escalation_lowconf_suppressed_when_only_ocr_disabled(monkeypat
     the would-be hop is suppressed (not a structured hop, which isn't registered)."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     junk = "q" * 40
-    r = _registry(
-        (_Fake("fast", "fast"), 20), (_Fake("ocr-upstream", "ocr-upstream"), 5)
-    )
+    r = _registry((_Fake("fast", "fast"), 20), (_Fake("ocr", "ocr"), 5))
     res = ProcessingResult(
         text=junk,
         metadata={
@@ -703,9 +659,7 @@ def test_evaluate_escalation_lowconf_suppressed_when_only_ocr_disabled(monkeypat
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=False))
-    assert decision == EscalationDecision(
-        "suppressed", "ocr-upstream", "low_confidence"
-    )
+    assert decision == EscalationDecision("suppressed", "ocr", "low_confidence")
 
 
 def test_evaluate_escalation_structured_hop_not_suppressed_when_ocr_off(monkeypatch):
@@ -716,7 +670,7 @@ def test_evaluate_escalation_structured_hop_not_suppressed_when_ocr_off(monkeypa
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text=junk,
@@ -751,15 +705,14 @@ def test_evaluate_escalation_terminal_when_ocr_unregistered_and_off(monkeypatch)
 def test_evaluate_escalation_empty_suppressed_even_when_structured_registered(
     monkeypatch,
 ):
-    """empty_text uses minimum='ocr-incluster', so it skips structured even when
-    structured IS registered: with OCR off it suppresses to the cheapest registered
-    OCR rung (here ocr-upstream, the only one registered in this test), never hops
-    to structured (a text extractor can't conjure text from a raster scan)."""
+    """empty_text uses minimum='ocr', so it skips structured even when structured
+    IS registered: with OCR off it suppresses to the OCR tier, never hops to
+    structured (a text extractor can't conjure text from a raster scan)."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),  # registered but skipped for empty
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     res = ProcessingResult(
         text="",
@@ -770,85 +723,10 @@ def test_evaluate_escalation_empty_suppressed_even_when_structured_registered(
         processor="fast",
     )
     decision = r.evaluate_escalation(res, b"%PDF", "fast", _Settings(ocr=False))
-    assert decision == EscalationDecision("suppressed", "ocr-upstream", "empty_text")
+    assert decision == EscalationDecision("suppressed", "ocr", "empty_text")
 
 
-# --- tier2 in-cluster OCR rung (Deck #353) -----------------------------------
-
-
-async def test_inline_empty_routes_to_ocr_incluster_before_upstream(monkeypatch):
-    """Both OCR rungs enabled + registered: an empty text layer hops to the
-    in-cluster (tier2) rung FIRST, never straight to the paid upstream rung."""
-    monkeypatch.setattr(
-        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_incluster=True)
-    )
-    esc = MagicMock()
-    monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
-    r = _registry(
-        (_Fake("fast", "fast", text=""), 20),
-        (_Fake("structured", "structured", text="should not run"), 10),
-        (_Fake("ocr-incluster", "ocr-incluster", text="incluster ocr text"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream", text="upstream ocr text"), 5),
-    )
-    res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-incluster"
-    esc.assert_called_once_with("fast", "ocr-incluster", "empty_text")
-
-
-async def test_inline_only_incluster_enabled_routes_to_incluster(monkeypatch):
-    """Tenant with ONLY in-cluster OCR on (upstream off): empty text still hops
-    to the in-cluster rung (its own enable flag gates it, independent of upstream)."""
-    monkeypatch.setattr(
-        reg_mod, "get_settings", lambda: _Settings(ocr=False, ocr_incluster=True)
-    )
-    esc = MagicMock()
-    monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
-    r = _registry(
-        (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-incluster", "ocr-incluster", text="incluster ocr text"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream", text="upstream ocr text"), 5),
-    )
-    res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-incluster"
-    esc.assert_called_once_with("fast", "ocr-incluster", "empty_text")
-
-
-async def test_inline_incluster_disabled_skips_to_upstream(monkeypatch):
-    """In-cluster registered but DISABLED, upstream enabled: the disabled tier2
-    rung is skipped and the job escalates to the upstream rung."""
-    monkeypatch.setattr(
-        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_incluster=False)
-    )
-    esc = MagicMock()
-    monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
-    r = _registry(
-        (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-incluster", "ocr-incluster", text="incluster ocr text"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream", text="upstream ocr text"), 5),
-    )
-    res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "ocr-upstream"
-    esc.assert_called_once_with("fast", "ocr-upstream", "empty_text")
-
-
-async def test_inline_incluster_failure_falls_back_to_fast_not_upstream(monkeypatch):
-    """CURRENT behavior (pins the known follow-up gap): when the chosen in-cluster
-    rung runs but FAILS (e.g. GPU 503 -> success=False), the inline path keeps the
-    tier-1 result rather than cascading to the paid upstream rung. OCR is an
-    enhancement, not a gate. (A future change will escalate transient GPU failures
-    to ocr-upstream; this test makes that diff explicit.)"""
-    monkeypatch.setattr(
-        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_incluster=True)
-    )
-    monkeypatch.setattr(reg_mod, "record_document_escalation", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast", text=""), 20),
-        (_Fake("ocr-incluster", "ocr-incluster", text="", success=False), 6),
-        (_Fake("ocr-upstream", "ocr-upstream", text="upstream ocr text"), 5),
-    )
-    res = await r.process(b"%PDF-1.7", "application/pdf")
-    assert res.processor == "fast"
-    assert res.success is True
+# --- single OCR tier (external path) -----------------------------------------
 
 
 def _empty_result() -> ProcessingResult:
@@ -862,67 +740,33 @@ def _empty_result() -> ProcessingResult:
     )
 
 
-def test_evaluate_escalation_empty_text_hops_to_incluster(monkeypatch):
-    """External path: empty text targets the cheapest OCR rung (in-cluster, tier2)
-    when it is enabled + registered."""
+def test_evaluate_escalation_empty_text_hops_to_ocr(monkeypatch):
+    """External path: empty text targets the OCR tier when it is enabled +
+    registered."""
     monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-incluster", "ocr-incluster"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
     decision = r.evaluate_escalation(
-        _empty_result(), b"%PDF", "fast", _Settings(ocr=True, ocr_incluster=True)
+        _empty_result(), b"%PDF", "fast", _Settings(ocr=True)
     )
-    assert decision == EscalationDecision("hop", "ocr-incluster", "empty_text")
+    assert decision == EscalationDecision("hop", "ocr", "empty_text")
 
 
-def test_evaluate_escalation_incluster_disabled_hops_to_upstream(monkeypatch):
-    """External path: in-cluster disabled -> next_available_tier falls through to
-    the upstream rung (a real hop, not a suppression, since upstream is on)."""
-    monkeypatch.setattr(reg_mod, "record_document_classification", MagicMock())
-    r = _registry(
-        (_Fake("fast", "fast"), 20),
-        (_Fake("ocr-incluster", "ocr-incluster"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
-    )
-    decision = r.evaluate_escalation(
-        _empty_result(), b"%PDF", "fast", _Settings(ocr=True, ocr_incluster=False)
-    )
-    assert decision == EscalationDecision("hop", "ocr-upstream", "empty_text")
-
-
-def test_next_available_tier_walks_full_four_rung_ladder():
-    """next_available_tier walks fast -> structured -> ocr-incluster ->
-    ocr-upstream when every rung is registered + enabled."""
+def test_evaluate_escalation_ignore_ocr_enabled_computes_ideal_target():
+    """The ideal-target walk (ignore_ocr_enabled) resolves the OCR tier even when
+    the OCR-enabled gate is off -- this is what backs the suppressed what-if-OCR
+    signal."""
     r = _registry(
         (_Fake("fast", "fast"), 20),
         (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-incluster", "ocr-incluster"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
+        (_Fake("ocr", "ocr"), 5),
     )
-    s = _Settings(ocr=True, ocr_incluster=True)
-    assert r.next_available_tier("fast", s) == "structured"
-    assert r.next_available_tier("structured", s) == "ocr-incluster"
-    assert r.next_available_tier("ocr-incluster", s) == "ocr-upstream"
-    assert r.next_available_tier("ocr-upstream", s) is None
-    # minimum pins the floor: from fast with minimum=ocr-incluster skips structured.
-    assert r.next_available_tier("fast", s, minimum="ocr-incluster") == "ocr-incluster"
-
-
-def test_next_available_tier_incluster_disabled_skips_to_upstream():
-    """A disabled in-cluster rung is skipped; the walk lands on the upstream rung."""
-    r = _registry(
-        (_Fake("fast", "fast"), 20),
-        (_Fake("structured", "structured"), 10),
-        (_Fake("ocr-incluster", "ocr-incluster"), 6),
-        (_Fake("ocr-upstream", "ocr-upstream"), 5),
-    )
-    s = _Settings(ocr=True, ocr_incluster=False)
-    assert r.next_available_tier("structured", s) == "ocr-upstream"
-    # ...but the *ideal* target ignoring the enable gate is still in-cluster.
-    assert (
-        r.next_available_tier("structured", s, ignore_ocr_enabled=True)
-        == "ocr-incluster"
-    )
+    s = _Settings(ocr=False)
+    # OCR gated off -> structured is the only available target above structured's
+    # predecessor; the OCR tier is terminal when disabled.
+    assert r.next_available_tier("structured", s) is None
+    # ...but the *ideal* target ignoring the enable gate is the OCR tier.
+    assert r.next_available_tier("structured", s, ignore_ocr_enabled=True) == "ocr"

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -29,7 +29,6 @@ pytestmark = pytest.mark.unit
 def _settings(*, ocr_enabled: bool) -> SimpleNamespace:
     return SimpleNamespace(
         document_ocr_enabled=ocr_enabled,
-        document_ocr_incluster_enabled=False,
         document_tier1_engine="pypdfium2",
         get_collection_name=lambda: "c",
     )

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -115,7 +115,7 @@ class TestProcessDocumentTask:
         # Calling the Task runs its wrapped function in-process. The job is on the
         # ocr queue, so the queue-aware task must derive tier="ocr".
         await pq.process_document_task(
-            _ctx(pq.INGEST_QUEUE_OCR_UPSTREAM),
+            _ctx(pq.INGEST_QUEUE_OCR),
             user_id="alice",
             doc_id="42",
             doc_type="note",
@@ -131,7 +131,7 @@ class TestProcessDocumentTask:
         # Worker disables the in-process retry loop; durable retry is the queue's.
         assert captured["max_retries"] == 1
         # Tier is derived from the job's queue (escalation enabled by default).
-        assert captured["tier"] == "ocr-upstream"
+        assert captured["tier"] == "ocr"
         fake_client.close.assert_awaited_once()
 
     async def test_pipeline_error_propagates_and_closes_client(self, monkeypatch):

--- a/tests/unit/vector/test_tiered_escalation_strategy.py
+++ b/tests/unit/vector/test_tiered_escalation_strategy.py
@@ -36,25 +36,23 @@ def _job(queue: str = pq.INGEST_QUEUE_FAST, attempts: int = 1) -> Job:
 class TestLadder:
     def test_next_tier_ordering(self):
         assert next_tier("fast") == "structured"
-        assert next_tier("structured") == "ocr-incluster"
-        assert next_tier("ocr-incluster") == "ocr-upstream"
-        assert next_tier("ocr-upstream") is None  # terminal
+        assert next_tier("structured") == "ocr"
+        assert next_tier("ocr") is None  # terminal
         assert next_tier("unknown") is None
 
     def test_ladder_is_cheapest_first(self):
-        assert TIER_LADDER == ("fast", "structured", "ocr-incluster", "ocr-upstream")
+        assert TIER_LADDER == ("fast", "structured", "ocr")
 
     def test_tier_for_queue(self):
-        assert pq.tier_for_queue(pq.INGEST_QUEUE_OCR_INCLUSTER) == "ocr-incluster"
-        assert pq.tier_for_queue(pq.INGEST_QUEUE_OCR_UPSTREAM) == "ocr-upstream"
+        assert pq.tier_for_queue(pq.INGEST_QUEUE_OCR) == "ocr"
         assert pq.tier_for_queue(pq.INGEST_QUEUE_STRUCTURED) == "structured"
         # Legacy / unknown / None all fall back to the cheapest tier.
         assert pq.tier_for_queue(pq.LEGACY_INGEST_QUEUE) == "fast"
         assert pq.tier_for_queue(None) == "fast"
-        # The pre-split legacy OCR queue also resolves to fast (NOT ocr-upstream):
-        # stranded in-flight jobs re-extract empty and re-escalate via the ladder
-        # to the cheap ocr-incluster rung, never straight to paid upstream.
-        assert pq.tier_for_queue(pq.LEGACY_INGEST_QUEUE_OCR) == "fast"
+        # The two pre-consolidation split OCR queues resolve to the single ``ocr``
+        # tier so in-flight OCR jobs from an older deploy keep OCR'ing during rollout.
+        assert pq.tier_for_queue(pq.LEGACY_INGEST_QUEUE_OCR_INCLUSTER) == "ocr"
+        assert pq.tier_for_queue(pq.LEGACY_INGEST_QUEUE_OCR_UPSTREAM) == "ocr"
 
 
 class TestTieredEscalationStrategy:
@@ -62,22 +60,10 @@ class TestTieredEscalationStrategy:
         return pq.TieredEscalationStrategy(max_transient_attempts=max_transient)
 
     def test_escalate_hops_to_target_queue(self):
-        exc = EscalateError(
-            from_tier="fast", to_tier="ocr-upstream", reason="empty_text"
-        )
+        exc = EscalateError(from_tier="fast", to_tier="ocr", reason="empty_text")
         decision = self._strategy().get_retry_decision(exception=exc, job=_job())
         assert decision is not None
-        assert decision.queue == pq.INGEST_QUEUE_OCR_UPSTREAM
-
-    def test_escalate_hops_to_incluster_queue(self):
-        # tier2 in-cluster (Deck #353): structured -> ocr-incluster lands on the
-        # in-cluster queue the GPU sentinel watches, not the paid upstream queue.
-        exc = EscalateError(
-            from_tier="structured", to_tier="ocr-incluster", reason="empty_text"
-        )
-        decision = self._strategy().get_retry_decision(exception=exc, job=_job())
-        assert decision is not None
-        assert decision.queue == pq.INGEST_QUEUE_OCR_INCLUSTER
+        assert decision.queue == pq.INGEST_QUEUE_OCR
 
     def test_escalate_to_structured(self):
         exc = EscalateError(
@@ -93,13 +79,11 @@ class TestTieredEscalationStrategy:
         assert decision is None
 
     def test_escalate_unwraps_exception_group(self):
-        exc = EscalateError(
-            from_tier="fast", to_tier="ocr-upstream", reason="empty_text"
-        )
+        exc = EscalateError(from_tier="fast", to_tier="ocr", reason="empty_text")
         group = ExceptionGroup("wrapped", [exc])
         decision = self._strategy().get_retry_decision(exception=group, job=_job())
         assert decision is not None
-        assert decision.queue == pq.INGEST_QUEUE_OCR_UPSTREAM
+        assert decision.queue == pq.INGEST_QUEUE_OCR
 
     def test_transient_retries_same_queue_under_cap(self):
         decision = self._strategy(max_transient=5).get_retry_decision(
@@ -147,7 +131,7 @@ class TestTieredEscalationStrategy:
         before = datetime.now(timezone.utc)
         decision = self._strategy().get_retry_decision(
             exception=BatchPending(retry_in=120),
-            job=_job(queue=pq.INGEST_QUEUE_OCR_UPSTREAM),
+            job=_job(queue=pq.INGEST_QUEUE_OCR),
         )
         after = datetime.now(timezone.utc)
         assert decision is not None


### PR DESCRIPTION
## Summary

The #353 split created two OCR rungs — `ocr-incluster` (surya via the gateway, `gateway_only`) and `ocr-upstream` (Mistral, gateway or direct). They are the **same `OcrProcessor` registered twice**, differing only in *which model* and *how the backend is reached* — both already expressible via `document_ocr_provider` + `document_ocr_model`. This collapses them into a **single configurable `ocr` tier**.

## What changed

- **One `ocr` tier.** `TIER_LADDER = (fast, structured, ocr)`; one `ingest-ocr` queue; one registered `OcrProcessor`. Backend selection is purely provider/model-driven — the gateway routes on the model's `<provider>/` prefix (Mistral, surya, …).
- **Removed** `DOCUMENT_OCR_INCLUSTER_ENABLED` / `DOCUMENT_OCR_INCLUSTER_MODEL`, the `gateway_only` mechanism, and the per-rung availability/escalation branches.
- **Batch OCR no longer silently downgrades to sync.** It always routes through the embedding gateway's async Batch API (the batching layer — so it works even for a direct backend that lacks native batch). `DOCUMENT_OCR_MODE=batch` without a gateway is **rejected at startup** (`Settings.__post_init__`); the processor raises rather than transcribing synchronously.
- **Rollout safety.** The two split queues (`ingest-ocr-incluster`, `ingest-ocr-upstream`) are kept as legacy-drain constants so in-flight OCR jobs from a pre-consolidation deploy are still processed and mapped back onto the single `ocr` tier (`tier_for_queue` + the worker drain set).
- `escalation_tiers_signature` drops the `ocric=` component; `pages_ocr` metering gates on the single `ocr` tier.
- Docs (`docs/configuration.md`) + unit tests updated to the single-tier vocabulary.

## Testing

- `uv run pytest tests/unit/` → **1831 passed, 1 skipped**
- `ruff check` / `ruff format --check` / `ty check` → clean

## Coordinated change

- **helm-charts**: companion PR drops `inclusterEnabled`/`inclusterModel` and the split worker tiers (release in lockstep via appVersion).

## Follow-up (separate PR)

- Storing surya-provided bounding boxes in the vector DB (exposed by the search API, pymupdf fallback) is deferred: it needs the surya per-page image-rendering path wired in the gateway OCR backend, after which the mcp-server (which renders the images and owns the dimensions) normalizes the bboxes — no gateway/website change required.

Deck: board 7 card #381.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)