### PR TITLE
feat(ocr): store + expose gateway-provided OCR bounding boxes

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -26,10 +26,12 @@ batch path from the pod, and ``Settings`` rejects ``mode=batch`` at startup.
 """
 
 import base64
+import html as _html
 import logging
+import re
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -58,25 +60,71 @@ _OCR_CONNECT_TIMEOUT_SECONDS = 10.0
 OCR_BATCH_PENDING_KEY = "ocr_batch_pending"
 OCR_BATCH_RETRY_IN_KEY = "ocr_batch_retry_in"
 
+# Metadata key carrying per-block geometry from a layout-aware OCR backend (surya
+# via the gateway). A list of ``{"page", "bbox", "start_offset", "end_offset"}``:
+# the block's normalized [0,1] ``bbox`` plus its char span in the document text,
+# so ``vector/processor.generate_highlights`` can attribute a chunk to the blocks
+# it covers and store a pre-computed chunk bbox (else it falls back to pymupdf).
+OCR_BLOCK_SPANS_KEY = "ocr_block_spans"
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(html: str) -> str:
+    """Plain text of a block's ``html`` (tags removed, entities unescaped).
+
+    surya emits per-block ``html`` (e.g. ``<h1>Title</h1>``); the page markdown is
+    those texts joined by ``\\n\\n``, so the stripped text appears verbatim in the
+    page markdown — which is how a block is located within the text (below)."""
+    return _html.unescape(_TAG_RE.sub("", html)).strip()
+
+
+def _normalize_bbox(raw: Any) -> list[float] | None:
+    """A ``[x0, y0, x1, y1]`` bbox of four finite floats, or ``None`` if malformed.
+
+    The gateway returns normalized [0,1] coords (astrolabe-cloud-website#414); we
+    don't re-scale, only validate shape so a malformed block degrades to no-bbox
+    (pymupdf fallback) rather than corrupting a stored highlight."""
+    if not isinstance(raw, (list, tuple)) or len(raw) != 4:
+        return None
+    out: list[float] = []
+    for v in raw:
+        if not isinstance(v, (int, float)) or isinstance(v, bool):
+            return None
+        out.append(float(v))
+    return out
+
 
 def _pages_to_text(
-    pages: list[tuple[int, str]],
-) -> tuple[str, list[dict[str, Any]]]:
-    """Join per-page markdown (ordered by index) into one string + boundaries.
+    pages: Sequence[tuple[Any, ...]],
+) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
+    """Join per-page markdown (ordered by index) into one string + boundaries, and
+    compute per-block char spans when the page carries layout ``blocks``.
 
-    Pages are joined with a blank line. Boundaries are kept CONTIGUOUS (each
-    page owns its leading ``\\n\\n`` separator) so they index exactly into the
+    Each page is ``(index, markdown)`` or ``(index, markdown, blocks)`` where
+    ``blocks`` is the gateway's raw block list (each ``{"html", "bbox", …}``) or
+    ``None``. Pages are joined with a blank line. Boundaries are kept CONTIGUOUS
+    (each page owns its leading ``\\n\\n`` separator) so they index exactly into the
     returned text and ``boundaries[-1]["end_offset"] == len(text)`` -- the
-    ``search/pdf_highlighter`` contract. Consequence: a page's range starts at
-    its separator, not its first glyph (the fast pypdfium2 path joins with no
-    separator, so its ranges are glyph-tight). The 2-char offset is immaterial
-    to page-level chunk attribution.
+    ``search/pdf_highlighter`` contract. Consequence: a page's range starts at its
+    separator, not its first glyph (the fast pypdfium2 path joins with no
+    separator, so its ranges are glyph-tight). The 2-char offset is immaterial to
+    page-level chunk attribution.
+
+    Block spans: within a page, each block's stripped-html text is located in the
+    page markdown in ``reading_order`` (advancing a cursor), giving a doc-absolute
+    char span paired with the block's normalized bbox. A block whose text isn't
+    found verbatim, or has no usable bbox, is skipped (that region falls back to
+    pymupdf) rather than guessed at.
     """
     sep = "\n\n"
     parts: list[str] = []
     boundaries: list[dict[str, Any]] = []
+    block_spans: list[dict[str, Any]] = []
     offset = 0
-    for i, (index, markdown) in enumerate(sorted(pages, key=lambda p: p[0])):
+    for i, page in enumerate(sorted(pages, key=lambda p: p[0])):
+        index, markdown = page[0], page[1]
+        blocks = page[2] if len(page) > 2 else None
         chunk = markdown if i == 0 else sep + markdown
         start = offset
         offset += len(chunk)
@@ -84,7 +132,31 @@ def _pages_to_text(
         boundaries.append(
             {"page": index + 1, "start_offset": start, "end_offset": offset}
         )
-    return "".join(parts), boundaries
+        if not blocks:
+            continue
+        # markdown begins after this page's leading separator (none for page 0).
+        md_start = start + (0 if i == 0 else len(sep))
+        cursor = 0
+        for raw in blocks:
+            if not isinstance(raw, dict):
+                continue
+            bbox = _normalize_bbox(raw.get("bbox"))
+            text = _strip_html(raw.get("html") or "")
+            if bbox is None or not text:
+                continue
+            pos = markdown.find(text, cursor)
+            if pos < 0:
+                continue
+            cursor = pos + len(text)
+            block_spans.append(
+                {
+                    "page": index + 1,
+                    "bbox": bbox,
+                    "start_offset": md_start + pos,
+                    "end_offset": md_start + pos + len(text),
+                }
+            )
+    return "".join(parts), boundaries, block_spans
 
 
 def _batch_identity(
@@ -109,7 +181,10 @@ class _OcrBackend(ABC):
     @abstractmethod
     async def ocr(
         self, content: bytes, mime_type: str
-    ) -> tuple[str, list[dict[str, Any]]]: ...
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
+        """Return ``(text, page_boundaries, block_spans)``. ``block_spans`` is empty
+        for backends without layout geometry (Mistral)."""
+        ...
 
 
 class _GatewayOcrBackend(_OcrBackend):
@@ -125,7 +200,7 @@ class _GatewayOcrBackend(_OcrBackend):
 
     async def ocr(
         self, content: bytes, mime_type: str
-    ) -> tuple[str, list[dict[str, Any]]]:
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
         headers: dict[str, str] = {}
         if self._token_provider is not None:
             headers["Authorization"] = (
@@ -146,7 +221,13 @@ class _GatewayOcrBackend(_OcrBackend):
             resp = await client.post(self._url, json=payload, headers=headers)
             resp.raise_for_status()
             body = resp.json()
-        pages = [(p["index"], p.get("markdown", "")) for p in body.get("pages", [])]
+        # ``blocks`` carries per-block layout + normalized bbox from a layout-aware
+        # backend (surya); ``None`` for markdown-only backends (Mistral) — threaded
+        # to _pages_to_text, which turns it into per-block char spans.
+        pages = [
+            (p["index"], p.get("markdown", ""), p.get("blocks"))
+            for p in body.get("pages", [])
+        ]
         return _pages_to_text(pages)
 
 
@@ -163,7 +244,7 @@ class _MistralOcrBackend(_OcrBackend):
 
     async def ocr(
         self, content: bytes, mime_type: str
-    ) -> tuple[str, list[dict[str, Any]]]:
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
         data_url = (
             f"data:{mime_type};base64,{base64.b64encode(content).decode('ascii')}"
         )
@@ -398,7 +479,7 @@ class OcrProcessor(DocumentProcessor):
                 error="no OCR backend configured",
             )
         try:
-            text, boundaries = await backend.ocr(
+            text, boundaries, block_spans = await backend.ocr(
                 content, content_type.split(";")[0].strip().lower()
             )
         except (TimeoutError, httpx.TimeoutException):
@@ -434,6 +515,9 @@ class OcrProcessor(DocumentProcessor):
                 "page_count": len(boundaries),
                 "page_boundaries": boundaries,
                 "file_size": len(content),
+                # Only when the backend returned layout geometry (surya); absent for
+                # markdown-only backends so generate_highlights uses pymupdf.
+                **({OCR_BLOCK_SPANS_KEY: block_spans} if block_spans else {}),
             },
             processor=self.name,
         )
@@ -597,13 +681,17 @@ class OcrProcessor(DocumentProcessor):
                 success=False,
                 error=f"unexpected batch status: {result.status}",
             )
-        text, boundaries = _pages_to_text(result.pages)
+        # Block spans are populated when the batch backend returned layout geometry
+        # (surya via the gateway's batch route, normalized [0,1]); empty for
+        # markdown-only backends (Mistral), where bbox falls back to pymupdf.
+        text, boundaries, block_spans = _pages_to_text(result.pages)
         return ProcessingResult(
             text=text,
             metadata={
                 "page_count": len(boundaries),
                 "page_boundaries": boundaries,
                 "file_size": len(content),
+                **({OCR_BLOCK_SPANS_KEY: block_spans} if block_spans else {}),
             },
             processor=self.name,
         )

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -80,11 +80,13 @@ def _strip_html(html: str) -> str:
 
 
 def _normalize_bbox(raw: Any) -> list[float] | None:
-    """A ``[x0, y0, x1, y1]`` bbox of four finite floats, or ``None`` if malformed.
+    """A ``[x0, y0, x1, y1]`` bbox of four floats in [0, 1], or ``None`` if malformed.
 
-    The gateway returns normalized [0,1] coords (astrolabe-cloud-website#414); we
-    don't re-scale, only validate shape so a malformed block degrades to no-bbox
-    (pymupdf fallback) rather than corrupting a stored highlight."""
+    The gateway returns normalized [0,1] coords (astrolabe-cloud-website#414). We
+    validate shape AND range: a value outside [0, 1] means the gateway sent
+    unnormalized (e.g. pixel) coords — a contract drift (API/version skew) — so we
+    drop the bbox (-> pymupdf fallback) rather than storing geometry that would
+    render off-page. Either malformed shape or out-of-range degrades to no-bbox."""
     if not isinstance(raw, (list, tuple)) or len(raw) != 4:
         return None
     out: list[float] = []
@@ -92,6 +94,9 @@ def _normalize_bbox(raw: Any) -> list[float] | None:
         if not isinstance(v, (int, float)) or isinstance(v, bool):
             return None
         out.append(float(v))
+    if not all(0.0 <= v <= 1.0 for v in out):
+        logger.debug("dropping out-of-range OCR bbox (expected normalized): %s", out)
+        return None
     return out
 
 

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -97,6 +97,11 @@ def _normalize_bbox(raw: Any) -> list[float] | None:
     if not all(0.0 <= v <= 1.0 for v in out):
         logger.debug("dropping out-of-range OCR bbox (expected normalized): %s", out)
         return None
+    # Degenerate (zero/negative-area) boxes render as an invisible highlight — drop
+    # them so a chunk falls back to pymupdf rather than storing a useless rect.
+    if out[2] <= out[0] or out[3] <= out[1]:
+        logger.debug("dropping zero/negative-area OCR bbox: %s", out)
+        return None
     return out
 
 
@@ -228,10 +233,12 @@ class _GatewayOcrBackend(_OcrBackend):
             body = resp.json()
         # ``blocks`` carries per-block layout + normalized bbox from a layout-aware
         # backend (surya); ``None`` for markdown-only backends (Mistral) — threaded
-        # to _pages_to_text, which turns it into per-block char spans.
+        # to _pages_to_text, which turns it into per-block char spans. ``index``
+        # falls back to position (defensive, matching the batch client) so a missing
+        # field degrades to ordered pages rather than a KeyError.
         pages = [
-            (p["index"], p.get("markdown", ""), p.get("blocks"))
-            for p in body.get("pages", [])
+            (p.get("index", i), p.get("markdown", ""), p.get("blocks"))
+            for i, p in enumerate(body.get("pages", []))
         ]
         return _pages_to_text(pages)
 

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -156,6 +156,18 @@ def _pages_to_text(
                 continue
             pos = markdown.find(text, cursor)
             if pos < 0:
+                # Block text not in the page markdown at/after the cursor — the
+                # join invariant (markdown == block texts joined by \n\n) didn't
+                # hold for this block (e.g. gateway reformatting / version drift).
+                # Skip it (that region falls back to pymupdf); log so a systematic
+                # break is diagnosable rather than silently losing highlights.
+                logger.debug(
+                    "OCR block text %r not found in page %s markdown at cursor %s; "
+                    "skipping its bbox",
+                    text[:40],
+                    index + 1,
+                    cursor,
+                )
                 continue
             cursor = pos + len(text)
             block_spans.append(

--- a/nextcloud_mcp_server/embedding/gateway_batch_client.py
+++ b/nextcloud_mcp_server/embedding/gateway_batch_client.py
@@ -58,7 +58,11 @@ class BatchPollResult:
     """
 
     status: str
-    pages: list[tuple[int, str]]
+    # Per-page ``(index, markdown)`` or ``(index, markdown, blocks)`` — ``blocks``
+    # carries surya's per-block layout (normalized [0,1] bbox) when the backend
+    # provides it, ``None`` for markdown-only backends (Mistral). Threaded straight
+    # into ``_pages_to_text``, which turns blocks into per-block char spans.
+    pages: list[tuple[Any, ...]]
     error: str | None = None
 
     @property
@@ -193,7 +197,10 @@ def _result_from_success(body: dict[str, Any]) -> BatchPollResult:
         )
     # Defensive on both fields (the page index falls back to position) so a
     # malformed page object degrades rather than raising KeyError mid-parse.
+    # ``blocks`` (surya layout + normalized bbox) is carried through when present;
+    # ``None`` for markdown-only backends.
     pages = [
-        (p.get("index", i), p.get("markdown", "")) for i, p in enumerate(item["pages"])
+        (p.get("index", i), p.get("markdown", ""), p.get("blocks"))
+        for i, p in enumerate(item["pages"])
     ]
     return BatchPollResult(status=_SUCCEEDED, pages=pages)

--- a/nextcloud_mcp_server/embedding/gateway_batch_client.py
+++ b/nextcloud_mcp_server/embedding/gateway_batch_client.py
@@ -58,11 +58,11 @@ class BatchPollResult:
     """
 
     status: str
-    # Per-page ``(index, markdown)`` or ``(index, markdown, blocks)`` — ``blocks``
-    # carries surya's per-block layout (normalized [0,1] bbox) when the backend
-    # provides it, ``None`` for markdown-only backends (Mistral). Threaded straight
-    # into ``_pages_to_text``, which turns blocks into per-block char spans.
-    pages: list[tuple[Any, ...]]
+    # Per-page ``(index, markdown, blocks)`` — ``blocks`` carries surya's per-block
+    # layout (normalized [0,1] bbox) when the backend provides it, ``None`` for
+    # markdown-only backends (Mistral). Threaded straight into ``_pages_to_text``,
+    # which turns blocks into per-block char spans.
+    pages: list[tuple[int, str, list[dict[str, Any]] | None]]
     error: str | None = None
 
     @property

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -214,6 +214,31 @@ async def _parse_pdf_tier(
     return result
 
 
+def _ocr_chunk_bboxes(
+    chunks, block_spans: list[dict[str, Any]]
+) -> dict[int, list[tuple[float, float, float, float]]]:
+    """Attribute OCR block bboxes to chunks by char-span overlap.
+
+    ``block_spans`` is the OCR tier's per-block geometry (``OCR_BLOCK_SPANS_KEY``):
+    each ``{"bbox": [x0,y0,x1,y1] normalized, "start_offset", "end_offset", ...}``.
+    A block belongs to chunk *i* when their char spans intersect (half-open
+    overlap: ``block.start < chunk.end and block.end > chunk.start``). Returns
+    ``chunk_index -> [bbox, ...]`` (a chunk spanning N blocks gets N bboxes, in the
+    spans' reading order), omitting chunks with no overlapping block. Pure +
+    module-level so the interval-overlap predicate is unit-testable in isolation."""
+    out: dict[int, list[tuple[float, float, float, float]]] = {}
+    for i, chunk in enumerate(chunks):
+        boxes = [
+            (s["bbox"][0], s["bbox"][1], s["bbox"][2], s["bbox"][3])
+            for s in block_spans
+            if s["start_offset"] < chunk.end_offset
+            and s["end_offset"] > chunk.start_offset
+        ]
+        if boxes:
+            out[i] = boxes
+    return out
+
+
 def assign_page_numbers(chunks, page_boundaries):
     """Assign page numbers to chunks based on page boundaries.
 
@@ -1451,25 +1476,21 @@ async def _index_document(
         ocr_block_spans = file_metadata.get(OCR_BLOCK_SPANS_KEY)
         if ocr_block_spans:
             spans = cast(list[dict[str, Any]], ocr_block_spans)
-            for i, chunk in enumerate(chunks):
-                # Interval overlap: a block belongs to the chunk if their char spans
-                # intersect. Preserve reading order (spans are already ordered).
-                # ``s["bbox"]`` is a validated 4-element normalized list (_normalize_bbox).
-                boxes = [
-                    (s["bbox"][0], s["bbox"][1], s["bbox"][2], s["bbox"][3])
-                    for s in spans
-                    if s["start_offset"] < chunk.end_offset
-                    and s["end_offset"] > chunk.start_offset
-                ]
-                if boxes:
-                    chunk_bboxes[i] = boxes
-            bbox_source = "ocr"
+            attributed = _ocr_chunk_bboxes(chunks, spans)
+            chunk_bboxes.update(attributed)
+            # Only stamp "ocr" when something was actually attributed — a non-empty
+            # spans list that overlaps no chunk leaves the source unset (nothing is
+            # stored either way; the payload gates on `i in chunk_bboxes`).
+            if attributed:
+                bbox_source = "ocr"
             logger.info(
                 "Attributed OCR bboxes for %s/%s chunks (%s blocks)",
-                len(chunk_bboxes),
+                len(attributed),
                 len(chunks),
                 len(spans),
             )
+            # OCR'd (scanned) docs have no text layer, so pymupdf can't help — do
+            # NOT fall through to it even when attribution found nothing.
             return
 
         with trace_operation(

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1499,8 +1499,14 @@ async def _index_document(
                     len(spans),
                     len(chunks),
                 )
-            # OCR'd (scanned) docs have no text layer, so pymupdf can't help — do
-            # NOT fall through to it even when attribution found nothing.
+            # One path for the WHOLE document: when the OCR tier ran, surya OCRs
+            # every rendered page, so its blocks cover the whole doc — pymupdf has
+            # no text layer to add (a scanned doc) and we do NOT fall through to it,
+            # even when attribution found nothing. Caveat: a mixed native+OCR PDF
+            # gets OCR geometry only; native-page chunks won't also get pymupdf
+            # highlights. That's acceptable — escalation to OCR is a whole-document
+            # decision, so a mixed doc is rare, and unmatched blocks are logged in
+            # _pages_to_text for diagnosis.
             return
 
         with trace_operation(

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -50,6 +50,7 @@ from nextcloud_mcp_server.vector.dead_letter import (
     mark_dead_letter,
 )
 from nextcloud_mcp_server.vector.document_chunker import (
+    ChunkWithPosition,
     DocumentChunker,
     PageAwareChunker,
 )
@@ -215,7 +216,7 @@ async def _parse_pdf_tier(
 
 
 def _ocr_chunk_bboxes(
-    chunks, block_spans: list[dict[str, Any]]
+    chunks: list[ChunkWithPosition], block_spans: list[dict[str, Any]]
 ) -> dict[int, list[tuple[float, float, float, float]]]:
     """Attribute OCR block bboxes to chunks by char-span overlap.
 
@@ -1483,12 +1484,21 @@ async def _index_document(
             # stored either way; the payload gates on `i in chunk_bboxes`).
             if attributed:
                 bbox_source = "ocr"
-            logger.info(
-                "Attributed OCR bboxes for %s/%s chunks (%s blocks)",
-                len(attributed),
-                len(chunks),
-                len(spans),
-            )
+                logger.info(
+                    "Attributed OCR bboxes for %s/%s chunks (%s blocks)",
+                    len(attributed),
+                    len(chunks),
+                    len(spans),
+                )
+            else:
+                # OCR returned geometry but none overlapped a chunk — unexpected
+                # (offset accounting / empty chunks); warn so it's visible.
+                logger.warning(
+                    "OCR returned %s blocks but none overlapped any of %s chunks; "
+                    "no pre-computed bboxes stored",
+                    len(spans),
+                    len(chunks),
+                )
             # OCR'd (scanned) docs have no text layer, so pymupdf can't help — do
             # NOT fall through to it even when attribution found nothing.
             return

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1311,6 +1311,9 @@ async def _index_document(
     # `chunk.page_number` (offset-based) and stored as `page_number`
     # in the Qdrant payload, so we don't carry an `actual_page_num` here.
     chunk_bboxes: dict[int, list[tuple[float, float, float, float]]] = {}
+    # Where the bboxes came from — "ocr" (gateway-provided per-block geometry) or
+    # "pymupdf" (local text-search). Stamped on each chunk payload that has a bbox.
+    bbox_source: str | None = None
 
     # Determine if we need PDF highlighting
     is_pdf = doc_task.doc_type == "file" and content_type == "application/pdf"
@@ -1423,13 +1426,51 @@ async def _index_document(
             )
 
     async def generate_highlights():
-        """Compute chunk bounding boxes for PDF chunks (CPU-bound, no rendering)."""
-        nonlocal chunk_bboxes
+        """Compute chunk bounding boxes for PDF chunks (CPU-bound, no rendering).
+
+        Prefers OCR-provided geometry: when the OCR tier returned per-block bboxes
+        (surya via the gateway, normalized [0,1] — ``OCR_BLOCK_SPANS_KEY`` in
+        metadata), a chunk's bbox is the set of blocks whose char span it overlaps,
+        and ``bbox_source`` is ``"ocr"``. This is the ONLY viable source for an
+        OCR'd (scanned) doc — its PDF has no text layer for pymupdf to search. When
+        no OCR geometry is present (fast/structured tiers, Mistral OCR), fall back
+        to the pymupdf text-search path (``bbox_source="pymupdf"``)."""
+        nonlocal chunk_bboxes, bbox_source
         if not is_pdf:
             return
 
         # Type narrowing: content_bytes is set for PDF files
         assert content_bytes is not None
+
+        # Lazy import (mirrors _parse_pdf_tier): keep the document stack off the
+        # module load path; this runs only for PDFs on the indexing path.
+        from nextcloud_mcp_server.document_processors.ocr import (  # noqa: PLC0415
+            OCR_BLOCK_SPANS_KEY,
+        )
+
+        ocr_block_spans = file_metadata.get(OCR_BLOCK_SPANS_KEY)
+        if ocr_block_spans:
+            spans = cast(list[dict[str, Any]], ocr_block_spans)
+            for i, chunk in enumerate(chunks):
+                # Interval overlap: a block belongs to the chunk if their char spans
+                # intersect. Preserve reading order (spans are already ordered).
+                boxes = [
+                    (b[0], b[1], b[2], b[3])
+                    for s in spans
+                    if s["start_offset"] < chunk.end_offset
+                    and s["end_offset"] > chunk.start_offset
+                    and (b := s["bbox"])
+                ]
+                if boxes:
+                    chunk_bboxes[i] = boxes
+            bbox_source = "ocr"
+            logger.info(
+                "Attributed OCR bboxes for %s/%s chunks (%s blocks)",
+                len(chunk_bboxes),
+                len(chunks),
+                len(spans),
+            )
+            return
 
         with trace_operation(
             "vector_sync.compute_chunk_bboxes",
@@ -1466,6 +1507,8 @@ async def _index_document(
 
             for chunk_index, (bboxes, _) in batch_results.items():
                 chunk_bboxes[chunk_index] = bboxes
+            if chunk_bboxes:
+                bbox_source = "pymupdf"
 
             logger.info(
                 "Computed bboxes for %s/%s chunks", len(chunk_bboxes), len(chunks)
@@ -1663,7 +1706,13 @@ async def _index_document(
                     # relative to page width/height. Replaces the legacy
                     # `highlighted_page_image` (Deck #76). The page number
                     # comes from `page_number` (set above for PDF chunks).
-                    **({"chunk_bbox": chunk_bboxes[i]} if i in chunk_bboxes else {}),
+                    # ``bbox_source`` records provenance ("ocr" = gateway-provided
+                    # surya geometry, "pymupdf" = local text-search).
+                    **(
+                        {"chunk_bbox": chunk_bboxes[i], "bbox_source": bbox_source}
+                        if i in chunk_bboxes
+                        else {}
+                    ),
                 },
             )
         )

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1454,12 +1454,12 @@ async def _index_document(
             for i, chunk in enumerate(chunks):
                 # Interval overlap: a block belongs to the chunk if their char spans
                 # intersect. Preserve reading order (spans are already ordered).
+                # ``s["bbox"]`` is a validated 4-element normalized list (_normalize_bbox).
                 boxes = [
-                    (b[0], b[1], b[2], b[3])
+                    (s["bbox"][0], s["bbox"][1], s["bbox"][2], s["bbox"][3])
                     for s in spans
                     if s["start_offset"] < chunk.end_offset
                     and s["end_offset"] > chunk.start_offset
-                    and (b := s["bbox"])
                 ]
                 if boxes:
                     chunk_bboxes[i] = boxes

--- a/tests/contract/test_gateway_batch_ocr_consumer.py
+++ b/tests/contract/test_gateway_batch_ocr_consumer.py
@@ -121,7 +121,62 @@ async def test_poll_succeeded_returns_pages(gateway_consumer_pact):
         )
 
     assert result.is_succeeded
-    assert result.pages == [(0, "# Page one")]
+    # pages are (index, markdown, blocks) — blocks is None for a markdown-only
+    # backend (Mistral) that emits no layout geometry.
+    assert result.pages == [(0, "# Page one", None)]
+
+
+async def test_poll_succeeded_returns_pages_with_bboxes(gateway_consumer_pact):
+    """A layout-aware backend (surya) returns per-block ``bbox`` (normalized [0,1])
+    in each page's ``blocks``; the client carries them through for chunk attribution.
+    Pins that the optional geometry is present + shaped as the consumer reads it."""
+    (
+        gateway_consumer_pact.upon_receiving(
+            "a poll for a succeeded batch OCR job with layout bboxes"
+        )
+        .given("a succeeded batch OCR job mistral/job-bbox with layout blocks exists")
+        .with_request("GET", "/v1/ocr/batch/mistral/job-bbox")
+        .will_respond_with(200)
+        .with_body(
+            {
+                "status": "succeeded",
+                "results": [
+                    {
+                        "custom_id": "0",
+                        "pages": [
+                            {
+                                "index": match.integer(0),
+                                "markdown": match.string("Heading"),
+                                "blocks": match.each_like(
+                                    {
+                                        # Fixed-length [x0,y0,x1,y1] normalized [0,1].
+                                        "bbox": [
+                                            match.number(0.11),
+                                            match.number(0.1),
+                                            match.number(0.4),
+                                            match.number(0.13),
+                                        ],
+                                        "html": match.string("<h1>Heading</h1>"),
+                                    }
+                                ),
+                            }
+                        ],
+                    }
+                ],
+            },
+            content_type="application/json",
+        )
+    )
+
+    with gateway_consumer_pact.serve() as srv:
+        result = await GatewayBatchOcrClient(str(srv.url), _MODEL).poll(
+            "mistral/job-bbox"
+        )
+
+    assert result.is_succeeded
+    # One page carrying its blocks list (third tuple element).
+    idx, markdown, blocks = result.pages[0]
+    assert idx == 0 and blocks and len(blocks[0]["bbox"]) == 4
 
 
 async def test_poll_failed_surfaces_error(gateway_consumer_pact):

--- a/tests/contract/test_gateway_ocr_consumer.py
+++ b/tests/contract/test_gateway_ocr_consumer.py
@@ -50,10 +50,14 @@ async def test_sync_ocr_returns_pages_with_bboxes(gateway_consumer_pact):
         .with_body(
             {
                 "model": match.string(_SURYA_MODEL),
+                # TWO blocks on one page, so the contract makes the join-order
+                # invariant explicit: page markdown == block texts joined by "\n\n"
+                # in reading order, which is what _pages_to_text relies on to locate
+                # each block and emit its char span.
                 "pages": [
                     {
                         "index": match.integer(0),
-                        "markdown": "Heading",
+                        "markdown": "Heading\n\nBody text",
                         "blocks": [
                             {
                                 # Fixed-length [x0,y0,x1,y1] normalized [0,1] — a
@@ -66,7 +70,16 @@ async def test_sync_ocr_returns_pages_with_bboxes(gateway_consumer_pact):
                                     match.number(0.13),
                                 ],
                                 "html": "<h1>Heading</h1>",
-                            }
+                            },
+                            {
+                                "bbox": [
+                                    match.number(0.11),
+                                    match.number(0.2),
+                                    match.number(0.6),
+                                    match.number(0.23),
+                                ],
+                                "html": "<p>Body text</p>",
+                            },
                         ],
                     }
                 ],
@@ -80,13 +93,17 @@ async def test_sync_ocr_returns_pages_with_bboxes(gateway_consumer_pact):
             str(srv.url), _SURYA_MODEL
         ).ocr(_DOC, "application/pdf")
 
-    assert text == "Heading"
-    # The block's stripped-html text was located in the page markdown -> one span
-    # carrying the normalized bbox.
-    assert len(block_spans) == 1
-    span = block_spans[0]
-    assert len(span["bbox"]) == 4
-    assert text[span["start_offset"] : span["end_offset"]] == "Heading"
+    assert text == "Heading\n\nBody text"
+    # Both blocks located in reading order -> two spans, each mapping back onto its
+    # own text slice (proves the join-order dependency holds end-to-end).
+    assert len(block_spans) == 2
+    assert (
+        text[block_spans[0]["start_offset"] : block_spans[0]["end_offset"]] == "Heading"
+    )
+    assert (
+        text[block_spans[1]["start_offset"] : block_spans[1]["end_offset"]]
+        == "Body text"
+    )
 
 
 async def test_sync_ocr_without_blocks_falls_back(gateway_consumer_pact):

--- a/tests/contract/test_gateway_ocr_consumer.py
+++ b/tests/contract/test_gateway_ocr_consumer.py
@@ -1,0 +1,125 @@
+"""Consumer contract: nextcloud-mcp-server -> embedding-gateway SYNC OCR (#387).
+
+The OCR tier's synchronous backend (:class:`_GatewayOcrBackend` in
+``document_processors/ocr.py``) POSTs a document to ``POST /v1/ocr`` and reads
+per-page ``index`` + ``markdown``, and — when a layout-aware backend (surya) is
+configured — per-block ``bbox`` (normalized [0,1]) + ``html`` from ``pages[].blocks``,
+which it turns into per-block char spans for pre-computed search highlights.
+
+This pact pins those response shapes for the ``astrolabe-cloud-gateway`` provider
+(verified in astrolabe-cloud-website, services/embedding-gateway). Only the fields
+the client reads are asserted, so the contract stays additive-safe. Two interactions:
+a surya response WITH ``blocks[].bbox`` and a Mistral response WITHOUT blocks (the
+pymupdf-fallback trigger). The gateway is unauthenticated today, so no bearer is
+sent. See ADR-029.
+"""
+
+import base64
+
+import pytest
+from pact import match
+
+from nextcloud_mcp_server.document_processors.ocr import _GatewayOcrBackend
+
+pytestmark = pytest.mark.contract
+
+_SURYA_MODEL = "surya/surya-ocr-2"
+_MISTRAL_MODEL = "mistral/mistral-ocr-latest"
+_DOC = b"%PDF-1.4 contract test"
+_DOC_B64 = base64.b64encode(_DOC).decode("ascii")
+
+
+async def test_sync_ocr_returns_pages_with_bboxes(gateway_consumer_pact):
+    """surya: each page carries ``blocks[].bbox`` (normalized [0,1]) + ``html``; the
+    backend locates each block's text in the page markdown and emits a char span."""
+    (
+        gateway_consumer_pact.upon_receiving(
+            "a sync OCR request for a surya layout doc"
+        )
+        .given("the gateway OCRs a document with surya and returns layout bboxes")
+        .with_request("POST", "/v1/ocr")
+        .with_body(
+            {
+                "model": _SURYA_MODEL,
+                "document_b64": _DOC_B64,
+                "mime_type": "application/pdf",
+            },
+            content_type="application/json",
+        )
+        .will_respond_with(200)
+        .with_body(
+            {
+                "model": match.string(_SURYA_MODEL),
+                "pages": [
+                    {
+                        "index": match.integer(0),
+                        "markdown": "Heading",
+                        "blocks": [
+                            {
+                                # Fixed-length [x0,y0,x1,y1] normalized [0,1] — a
+                                # literal 4-list of number matchers (NOT each_like,
+                                # which would emit a 1-element example).
+                                "bbox": [
+                                    match.number(0.11),
+                                    match.number(0.1),
+                                    match.number(0.4),
+                                    match.number(0.13),
+                                ],
+                                "html": "<h1>Heading</h1>",
+                            }
+                        ],
+                    }
+                ],
+            },
+            content_type="application/json",
+        )
+    )
+
+    with gateway_consumer_pact.serve() as srv:
+        text, boundaries, block_spans = await _GatewayOcrBackend(
+            str(srv.url), _SURYA_MODEL
+        ).ocr(_DOC, "application/pdf")
+
+    assert text == "Heading"
+    # The block's stripped-html text was located in the page markdown -> one span
+    # carrying the normalized bbox.
+    assert len(block_spans) == 1
+    span = block_spans[0]
+    assert len(span["bbox"]) == 4
+    assert text[span["start_offset"] : span["end_offset"]] == "Heading"
+
+
+async def test_sync_ocr_without_blocks_falls_back(gateway_consumer_pact):
+    """Mistral: no ``blocks`` -> no block spans (the consumer renders bboxes via
+    pymupdf at query time). Pins that a markdown-only response is valid."""
+    (
+        gateway_consumer_pact.upon_receiving(
+            "a sync OCR request for a markdown-only doc"
+        )
+        .given("the gateway OCRs a document with mistral and returns no layout blocks")
+        .with_request("POST", "/v1/ocr")
+        .with_body(
+            {
+                "model": _MISTRAL_MODEL,
+                "document_b64": _DOC_B64,
+                "mime_type": "application/pdf",
+            },
+            content_type="application/json",
+        )
+        .will_respond_with(200)
+        .with_body(
+            {
+                "model": match.string(_MISTRAL_MODEL),
+                "pages": [{"index": match.integer(0), "markdown": "Plain text"}],
+            },
+            content_type="application/json",
+        )
+    )
+
+    with gateway_consumer_pact.serve() as srv:
+        text, _boundaries, block_spans = await _GatewayOcrBackend(
+            str(srv.url), _MISTRAL_MODEL
+        ).ocr(_DOC, "application/pdf")
+
+    assert text == "Plain text"
+    assert block_spans == []

--- a/tests/unit/test_gateway_batch_client.py
+++ b/tests/unit/test_gateway_batch_client.py
@@ -120,8 +120,28 @@ async def test_poll_succeeded_maps_pages(monkeypatch):
     _patch_transport(monkeypatch, lambda r: httpx.Response(200, json=body))
     result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
     assert result.is_succeeded
-    # Order is preserved as returned; _pages_to_text sorts downstream.
-    assert result.pages == [(1, "two"), (0, "one")]
+    # Order is preserved as returned; _pages_to_text sorts downstream. The third
+    # tuple element is the per-page ``blocks`` (None here — markdown-only backend).
+    assert result.pages == [(1, "two", None), (0, "one", None)]
+
+
+async def test_poll_succeeded_carries_blocks(monkeypatch):
+    """surya-style ``blocks`` (layout + normalized bbox) are threaded through the
+    poll result so the OCR processor can compute per-block char spans."""
+    blocks = [{"html": "<p>two</p>", "bbox": [0.1, 0.2, 0.3, 0.4]}]
+    body = {
+        "status": "succeeded",
+        "results": [
+            {
+                "custom_id": "d",
+                "pages": [{"index": 0, "markdown": "two", "blocks": blocks}],
+            }
+        ],
+    }
+    _patch_transport(monkeypatch, lambda r: httpx.Response(200, json=body))
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
+    assert result.is_succeeded
+    assert result.pages == [(0, "two", blocks)]
 
 
 async def test_poll_failed_surfaces_error(monkeypatch):

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -39,13 +39,72 @@ def _settings(**kw) -> Any:  # a Settings stand-in (only the read fields matter)
 
 
 def test_pages_to_text_orders_and_exact_boundaries():
-    text, boundaries = ocr._pages_to_text([(1, "B"), (0, "A")])  # out of order
+    text, boundaries, block_spans = ocr._pages_to_text(
+        [(1, "B"), (0, "A")]
+    )  # unordered
     assert text == "A\n\nB"
     assert boundaries[0] == {"page": 1, "start_offset": 0, "end_offset": 1}
     assert boundaries[1]["page"] == 2
     # contiguous + offsets index exactly into the text
     assert boundaries[0]["end_offset"] <= boundaries[1]["start_offset"]
     assert boundaries[-1]["end_offset"] == len(text)
+    # No layout blocks supplied -> no block spans.
+    assert block_spans == []
+
+
+def test_pages_to_text_computes_block_spans_from_blocks():
+    """With surya-style blocks, each block's stripped-html text is located in the
+    page markdown and paired with its normalized bbox as a doc-absolute char span."""
+    pages = [
+        (
+            0,
+            "Invoice Summary\n\nTotal due: 42.00 USD",
+            [
+                {"html": "<h1>Invoice Summary</h1>", "bbox": [0.1, 0.1, 0.4, 0.13]},
+                {
+                    "html": "<p>Total due: 42.00 USD</p>",
+                    "bbox": [0.1, 0.16, 0.31, 0.18],
+                },
+            ],
+        ),
+        (
+            1,
+            "Terms",
+            [{"html": "<h1>Terms</h1>", "bbox": [0.1, 0.1, 0.2, 0.12]}],
+        ),
+    ]
+    text, boundaries, spans = ocr._pages_to_text(pages)
+    assert len(spans) == 3
+    # First block span maps exactly onto "Invoice Summary" at the doc start.
+    s0 = spans[0]
+    assert s0["page"] == 1 and s0["bbox"] == [0.1, 0.1, 0.4, 0.13]
+    assert text[s0["start_offset"] : s0["end_offset"]] == "Invoice Summary"
+    # Second block onto the page-1 body text.
+    s1 = spans[1]
+    assert text[s1["start_offset"] : s1["end_offset"]] == "Total due: 42.00 USD"
+    # Page-2 block span lands on page 2's text.
+    s2 = spans[2]
+    assert s2["page"] == 2 and text[s2["start_offset"] : s2["end_offset"]] == "Terms"
+
+
+def test_pages_to_text_skips_blocks_without_bbox_or_unmatched_text():
+    """A block with no bbox, or whose text isn't in the markdown, is skipped
+    (that region falls back to pymupdf) rather than guessed."""
+    pages = [
+        (
+            0,
+            "real text here",
+            [
+                {"html": "<p>real text here</p>"},  # no bbox -> skip
+                {
+                    "html": "<p>not in markdown</p>",
+                    "bbox": [0.1, 0.1, 0.2, 0.2],
+                },  # unmatched
+            ],
+        )
+    ]
+    _text, _b, spans = ocr._pages_to_text(pages)
+    assert spans == []
 
 
 # --- backend selection -------------------------------------------------------
@@ -195,7 +254,11 @@ async def test_processor_unsupported_when_no_backend(monkeypatch):
 async def test_processor_success(monkeypatch):
     class _FakeBackend:
         async def ocr(self, content, mime_type):
-            return "hello world", [{"page": 1, "start_offset": 0, "end_offset": 11}]
+            return (
+                "hello world",
+                [{"page": 1, "start_offset": 0, "end_offset": 11}],
+                [],
+            )
 
     monkeypatch.setattr(ocr, "get_settings", lambda: _settings())
     monkeypatch.setattr(ocr, "build_ocr_backend", lambda s, **kw: _FakeBackend())

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -107,6 +107,27 @@ def test_pages_to_text_skips_blocks_without_bbox_or_unmatched_text():
     assert spans == []
 
 
+def test_normalize_bbox_shape_and_range():
+    """Valid normalized bbox passes; wrong arity, non-numbers, bools, and
+    out-of-range (unnormalized/pixel) coords all degrade to None (pymupdf fallback)."""
+    assert ocr._normalize_bbox([0.1, 0.2, 0.3, 0.4]) == [0.1, 0.2, 0.3, 0.4]
+    assert ocr._normalize_bbox([0.0, 0.0, 1.0, 1.0]) == [0.0, 0.0, 1.0, 1.0]
+    assert ocr._normalize_bbox([0.1, 0.2, 0.3]) is None  # wrong arity
+    assert ocr._normalize_bbox([0.1, 0.2, 0.3, "x"]) is None  # non-number
+    assert ocr._normalize_bbox([True, 0.2, 0.3, 0.4]) is None  # bool excluded
+    # Unnormalized pixel coords (gateway contract drift) are dropped, not stored.
+    assert ocr._normalize_bbox([0.0, 800.0, 1200.0, 1600.0]) is None
+    assert ocr._normalize_bbox([-0.1, 0.2, 0.3, 0.4]) is None
+
+
+def test_pages_to_text_drops_unnormalized_block_bbox():
+    """A block whose bbox is out of [0,1] (unnormalized) yields no span — the
+    page falls back to pymupdf rather than storing off-page geometry."""
+    pages = [(0, "Heading", [{"html": "<h1>Heading</h1>", "bbox": [0, 100, 500, 200]}])]
+    _text, _b, spans = ocr._pages_to_text(pages)
+    assert spans == []
+
+
 # --- backend selection -------------------------------------------------------
 
 
@@ -267,6 +288,26 @@ async def test_processor_success(monkeypatch):
     assert r.text == "hello world"
     assert r.metadata["page_count"] == 1
     assert r.processor == "ocr"
+    # Empty block_spans -> the OCR_BLOCK_SPANS_KEY metadata is omitted entirely.
+    assert ocr.OCR_BLOCK_SPANS_KEY not in r.metadata
+
+
+async def test_processor_success_with_blocks_sets_block_spans(monkeypatch):
+    """When the backend returns non-empty block spans (surya layout), they're
+    surfaced under OCR_BLOCK_SPANS_KEY for generate_highlights to attribute."""
+    spans = [
+        {"page": 1, "bbox": [0.1, 0.1, 0.4, 0.2], "start_offset": 0, "end_offset": 5}
+    ]
+
+    class _FakeBackend:
+        async def ocr(self, content, mime_type):
+            return ("hello", [{"page": 1, "start_offset": 0, "end_offset": 5}], spans)
+
+    monkeypatch.setattr(ocr, "get_settings", lambda: _settings())
+    monkeypatch.setattr(ocr, "build_ocr_backend", lambda s, **kw: _FakeBackend())
+    r = await ocr.OcrProcessor().process(b"%PDF-1.7", "application/pdf")
+    assert r.success is True
+    assert r.metadata[ocr.OCR_BLOCK_SPANS_KEY] == spans
 
 
 async def test_processor_backend_error_returns_success_false(monkeypatch):
@@ -502,7 +543,9 @@ async def test_batch_existing_pending_polls_and_defers(monkeypatch):
 async def test_batch_succeeded_returns_indexed_result(monkeypatch):
     preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(
-        poll=BatchPollResult(status="succeeded", pages=[(0, "# One"), (1, "## Two")])
+        poll=BatchPollResult(
+            status="succeeded", pages=[(0, "# One", None), (1, "## Two", None)]
+        )
     )
     store = _FakeStore(preset=preset)
     _wire_batch(monkeypatch, client=client, store=store)
@@ -515,6 +558,29 @@ async def test_batch_succeeded_returns_indexed_result(monkeypatch):
     assert r.text == "# One\n\n## Two"
     assert r.metadata["page_count"] == 2
     assert ("u1", "d1", "file", "v1") in store.deleted  # row cleaned up
+
+
+async def test_batch_succeeded_with_blocks_sets_block_spans(monkeypatch):
+    """A layout-aware batch backend (surya) returns 3-tuple pages with blocks; the
+    OCR processor must thread them into OCR_BLOCK_SPANS_KEY (the batch->bbox path,
+    distinct from the sync path) so a scanned PDF gets pre-computed highlights."""
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
+    pages = [
+        (0, "Heading", [{"html": "<h1>Heading</h1>", "bbox": [0.1, 0.1, 0.4, 0.2]}])
+    ]
+    client = _FakeBatchClient(poll=BatchPollResult(status="succeeded", pages=pages))
+    store = _FakeStore(preset=preset)
+    _wire_batch(monkeypatch, client=client, store=store)
+
+    r = await ocr.OcrProcessor().process(
+        b"%PDF", "application/pdf", options=dict(_IDENTITY)
+    )
+
+    assert r.success is True and r.text == "Heading"
+    spans = r.metadata[ocr.OCR_BLOCK_SPANS_KEY]
+    assert len(spans) == 1
+    assert spans[0]["bbox"] == [0.1, 0.1, 0.4, 0.2]
+    assert r.text[spans[0]["start_offset"] : spans[0]["end_offset"]] == "Heading"
 
 
 async def test_batch_failed_marks_parse_error(monkeypatch):

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -118,6 +118,25 @@ def test_normalize_bbox_shape_and_range():
     # Unnormalized pixel coords (gateway contract drift) are dropped, not stored.
     assert ocr._normalize_bbox([0.0, 800.0, 1200.0, 1600.0]) is None
     assert ocr._normalize_bbox([-0.1, 0.2, 0.3, 0.4]) is None
+    # Degenerate zero/negative-area boxes (invisible highlight) are dropped.
+    assert ocr._normalize_bbox([0.0, 0.0, 0.0, 0.0]) is None
+    assert ocr._normalize_bbox([0.5, 0.5, 0.5, 0.6]) is None  # zero width
+    assert ocr._normalize_bbox([0.4, 0.5, 0.3, 0.6]) is None  # x1 < x0
+
+
+@pytest.mark.parametrize(
+    "html, expected",
+    [
+        ("<h1>Heading</h1>", "Heading"),
+        ("<p>Total due: 42.00 USD</p>", "Total due: 42.00 USD"),
+        ("<p>a <b>bold</b> word</p>", "a bold word"),  # nested tags stripped
+        ("AT&amp;T &lt;x&gt;", "AT&T <x>"),  # entities unescaped
+        ("  <p>  trim  </p>  ", "trim"),  # outer whitespace stripped
+        ("", ""),
+    ],
+)
+def test_strip_html(html, expected):
+    assert ocr._strip_html(html) == expected
 
 
 def test_pages_to_text_drops_unnormalized_block_bbox():

--- a/tests/unit/test_processor_routing.py
+++ b/tests/unit/test_processor_routing.py
@@ -60,3 +60,47 @@ class TestShouldUsePageAware:
             )
             is False
         )
+
+
+class TestOcrChunkBboxes:
+    """`_ocr_chunk_bboxes` attributes OCR block bboxes to chunks by char-span overlap."""
+
+    @staticmethod
+    def _chunk(start, end):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(start_offset=start, end_offset=end)
+
+    @staticmethod
+    def _span(start, end, bbox):
+        return {"start_offset": start, "end_offset": end, "bbox": bbox}
+
+    def test_single_block_per_chunk(self):
+        from nextcloud_mcp_server.vector.processor import _ocr_chunk_bboxes
+
+        chunks = [self._chunk(0, 10), self._chunk(10, 20)]
+        spans = [
+            self._span(0, 8, [0.1, 0.1, 0.4, 0.2]),
+            self._span(10, 18, [0.1, 0.3, 0.5, 0.4]),
+        ]
+        out = _ocr_chunk_bboxes(chunks, spans)
+        assert out == {0: [(0.1, 0.1, 0.4, 0.2)], 1: [(0.1, 0.3, 0.5, 0.4)]}
+
+    def test_chunk_spanning_two_blocks_gets_two_bboxes(self):
+        from nextcloud_mcp_server.vector.processor import _ocr_chunk_bboxes
+
+        # One chunk [0,20) overlaps both blocks -> two bboxes in reading order.
+        chunks = [self._chunk(0, 20)]
+        spans = [
+            self._span(0, 8, [0.1, 0.1, 0.4, 0.2]),
+            self._span(10, 18, [0.1, 0.3, 0.5, 0.4]),
+        ]
+        out = _ocr_chunk_bboxes(chunks, spans)
+        assert out == {0: [(0.1, 0.1, 0.4, 0.2), (0.1, 0.3, 0.5, 0.4)]}
+
+    def test_no_overlap_yields_empty(self):
+        from nextcloud_mcp_server.vector.processor import _ocr_chunk_bboxes
+
+        # Chunk [50,60) overlaps no block -> omitted (pymupdf fallback territory).
+        out = _ocr_chunk_bboxes([self._chunk(50, 60)], [self._span(0, 8, [0, 0, 1, 1])])
+        assert out == {}


### PR DESCRIPTION
## Summary

When a layout-aware OCR backend (**surya** via the embedding gateway) returns per-block bounding boxes (**normalized [0,1]**) in its `/v1/ocr` response, the mcp-server now persists them so the search/visualization API exposes **pre-computed** chunk bboxes instead of recomputing via pymupdf. When the gateway returns no geometry (fast/structured tiers, Mistral OCR), the **pymupdf path remains the fallback**. The mcp-server stays backend-ignorant — it POSTs the document and consumes `blocks` if present.

Implements the consumer side of Deck board 12 card #387 (companion gateway work: astrolabe-cloud-website #414).

## What changed

- **`document_processors/ocr.py`** — parse `pages[].blocks` from the sync gateway response (and batch via `gateway_batch_client`). `_pages_to_text` locates each block's stripped-html text in the page markdown — relying on the verified property that the page `markdown` is the per-block texts joined by `\n\n` in reading order — to emit doc-absolute per-block char spans paired with the normalized bbox, threaded as `OCR_BLOCK_SPANS_KEY` in `ProcessingResult.metadata`. Mistral returns no blocks.
- **`vector/processor.py` `generate_highlights`** — when OCR block spans are present, a chunk's bbox is the set of blocks whose char span it overlaps (`bbox_source="ocr"`); otherwise the pymupdf text-search path (`bbox_source="pymupdf"`). Both store `chunk_bbox` + `bbox_source` in the Qdrant payload. (A scanned/OCR'd PDF has no text layer for pymupdf, so OCR geometry is the only viable source there.)
- **Contract tests** — consumer-driven Pact pinning the `/v1/ocr` (sync, new) and batch-poll response shapes incl. optional normalized `blocks[].bbox` (provider `astrolabe-cloud-gateway`), with + without bboxes.
- **Unit tests** — block-span computation, html-strip / bbox-normalize, unmatched-block skipping, 3-tuple page threading, batch-client block threading.

## Testing

- `uv run pytest tests/unit/` → green (incl. new bbox tests); `uv run pytest -m contract tests/contract/` → green
- `ruff check` / `ruff format --check` / `ty check` → clean
- **End-to-end against the live gateway** (`surya/surya-ocr-2`, v0.11.1+#414): PDF → normalized [0,1] bboxes, multi-page, `markdown == blocks joined by \n\n` holds.

## Coordinated change

- **astrolabe-cloud-website #414** — gateway accepts PDFs for surya + returns normalized bboxes (sync), and (this branch's companion work) batch PDF support. Verified together against the A30 GPU.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)