### PR TITLE
fix(vector): index dead_letter payload field to stop ingest loop

### DIFF
--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -70,8 +70,11 @@ def _dead_letter_filter(doc_id: str, doc_type: str) -> Filter:
     """Match the dead-letter marker for one document (tenant-wide, no user_id).
 
     Includes ``is_placeholder=True`` (redundant with ``dead_letter=True``, which
-    nothing else sets) so Qdrant can lean on the existing ``is_placeholder``
-    payload index.
+    nothing else sets) to inherit the search exclusion. Note both fields must be
+    payload-indexed: Qdrant strict mode requires an index for *every* condition
+    in a filter, so ``dead_letter`` carries its own index (registered in
+    ``qdrant_client._PAYLOAD_INDEX_FIELDS``) — without it this scroll 400s and
+    ``is_dead_lettered`` fail-opens, re-queuing the document forever.
     """
     return Filter(
         must=[

--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -54,6 +54,19 @@ _PAYLOAD_INDEX_FIELDS: dict[str, PayloadSchemaType] = {
     "owner_id": PayloadSchemaType.KEYWORD,
     "doc_type": PayloadSchemaType.KEYWORD,
     "is_placeholder": PayloadSchemaType.BOOL,
+    # dead_letter is the bool used by the durable terminal-failure marker lookup
+    # (see vector/dead_letter.py: ``_dead_letter_filter`` ANDs
+    # ``FieldCondition(key="dead_letter", match=True)`` onto the is_placeholder
+    # condition). Qdrant strict mode requires an index for *every* field in a
+    # filter, not just one, so reusing the is_placeholder index is not enough:
+    # without a dead_letter index the scroll 400s ("Index required but not found
+    # for dead_letter") on Qdrant Cloud / network mode. ``is_dead_lettered`` then
+    # fail-opens to "process normally", so the scanner re-queues every file every
+    # cycle and no document is ever recognised as dead-lettered — an ingest loop.
+    # BOOL (the value is a literal True on every marker point); idempotent startup
+    # migration like the fields above, so existing collections gain it with no
+    # content re-index and no operator action.
+    "dead_letter": PayloadSchemaType.BOOL,
     "chunk_index": PayloadSchemaType.INTEGER,
     "chunk_start_offset": PayloadSchemaType.INTEGER,
     "chunk_end_offset": PayloadSchemaType.INTEGER,

--- a/tests/unit/vector/test_qdrant_client.py
+++ b/tests/unit/vector/test_qdrant_client.py
@@ -98,6 +98,19 @@ def test_file_path_indexed_as_text():
     assert _PAYLOAD_INDEX_FIELDS.get("file_path") == PayloadSchemaType.TEXT
 
 
+@pytest.mark.unit
+def test_dead_letter_indexed_as_bool():
+    """The dead-letter lookup (vector/dead_letter.py) filters on dead_letter=True.
+
+    Qdrant strict mode requires an index for every field in a filter, so reusing
+    the is_placeholder index is not enough — without a dead_letter index the
+    scroll 400s, ``is_dead_lettered`` fail-opens, and the scanner re-queues every
+    document forever (the ingest loop this registry entry prevents). BOOL because
+    the marker payload stores a literal True.
+    """
+    assert _PAYLOAD_INDEX_FIELDS.get("dead_letter") == PayloadSchemaType.BOOL
+
+
 # ---------------------------------------------------------------------------
 # _ensure_payload_indexes
 # ---------------------------------------------------------------------------

--- a/tests/unit/vector/test_qdrant_client.py
+++ b/tests/unit/vector/test_qdrant_client.py
@@ -889,6 +889,7 @@ async def test_ensure_payload_indexes_summarises_failed_fields(mocker, caplog):
     assert "doc_id" in summary[0]
     assert "doc_type" in summary[0]
     assert "is_placeholder" in summary[0]
+    assert "dead_letter" in summary[0]
     assert "chunk_index" in summary[0]
     assert "chunk_start_offset" in summary[0]
     assert "chunk_end_offset" in summary[0]


### PR DESCRIPTION
## Problem

Investigating error-looping tenants on the astrolabe-cloud **dev** cluster: ingest workers were stuck reprocessing the same documents over and over and never suppressing them via the dead-letter queue (DLQ).

Root cause, found in this repo: the durable terminal-failure marker lookup in `vector/dead_letter.py` (`_dead_letter_filter`) ANDs `FieldCondition(key="dead_letter", match=True)` onto the `is_placeholder` condition, but **`dead_letter` was never registered in `_PAYLOAD_INDEX_FIELDS`**. Qdrant strict mode (Cloud / network mode) requires a payload index for *every* field in a filter — not just one — so the scroll fails:

```
400 Bad Request — "Index required but not found for \"dead_letter\" of one of the
following types: [bool]. Help: Create an index for this key or use a different filter."
```

`is_dead_lettered()` is fail-safe and degrades to `False` ("process normally") on any Qdrant error, so:

1. The scanner re-queues **every** file on every cycle (no document is ever recognised as dead-lettered) → unbounded ingest loop.
2. The flood of duplicate re-enqueues collided with stalled in-flight jobs, so `reclaim_stalled_jobs` crashed with `UniqueViolation` on `procrastinate_jobs_queueing_lock_idx_v1` every cycle.

### Evidence (dev cluster, Loki)
- `tenant-smoke-test-20260531`: ~3,478 `Dead-letter lookup failed` / hr + 12 `reclaim_stalled_jobs` `UniqueViolation` / hr; file IDs marching through the whole corpus, never converging.
- `tenant-blackbox-demo`: only 24 lookup-failures/hr and DLQ working (its collection already has the index) → slow but converging, no reclaim crashes.

## Fix

Register `dead_letter` as a `BOOL` payload index in `_PAYLOAD_INDEX_FIELDS`. `_ensure_payload_indexes` is idempotent and runs at startup, so **existing deployed collections gain the index on the next rollout** — no content re-index, no manual Qdrant mutation, no operator action. This restores DLQ suppression, which in turn removes the duplicate re-enqueues that were crashing the reclaimer.

Also corrected the now-misleading comment in `_dead_letter_filter` (it claimed the filter could lean on the `is_placeholder` index).

## Tests
- New contract test `test_dead_letter_indexed_as_bool`.
- Existing dynamic contract/ensure tests (keyed off `_PAYLOAD_INDEX_FIELDS`) automatically cover creating the new field.
- `tests/unit/vector/{test_qdrant_client,test_dead_letter,test_placeholder,test_processor_dead_letter}.py` — 60 passed. ruff + ty clean.

## Notes / follow-up
- The `reclaim_stalled_jobs` `UniqueViolation` is downstream of this loop and should stop once duplicate re-enqueues cease. Hardening that path to tolerate a per-job lock collision (so one collision can't abort the whole sweep) is a sensible separate follow-up.

---

_This PR was generated with the help of AI, and reviewed by a Human_