### PR TITLE
fix(vector): escalate hard parse failures up the tier ladder (#399)

### DIFF
--- a/nextcloud_mcp_server/document_processors/escalation.py
+++ b/nextcloud_mcp_server/document_processors/escalation.py
@@ -7,8 +7,9 @@ The escalation ladder is the cheapest-first ordering of extraction tiers:
 It mirrors the ``tier`` vocabulary documented on
 :meth:`DocumentProcessor.tier <.base.DocumentProcessor.tier>` and the
 observability label set. On the *external* (procrastinate) ingest path each tier
-runs on its own queue + worker fleet; a document that a tier cannot parse well is
-**requeued onto the next tier's queue** rather than escalated inline. The
+runs on its own queue + worker fleet; a document that a tier cannot parse well --
+or cannot parse at all (a hard timeout/OOM failure, #399) -- is **requeued onto
+the next tier's queue** rather than dropped or escalated inline. The
 mechanism is a raised :class:`EscalateError` that the procrastinate retry
 strategy turns into a native ``RetryDecision(queue=<next-tier queue>)`` queue-hop
 (see ``vector/queue/procrastinate.py``).
@@ -112,11 +113,19 @@ class EscalateError(Exception):
     the junk text is never indexed, and it must never be swallowed by a broad
     ``except Exception`` on the indexing path.
 
-    ``reason`` uses the existing escalation label vocabulary: ``empty_text``
+    ``reason`` uses the post-parse quality vocabulary: ``empty_text``
     (scanned / no text layer), ``low_confidence`` (junk text layer), and
     ``corrupt_glyphs`` (a usable-looking layer whose extractor leaked raw glyph
     codes -- the broken-/ToUnicode case -- recovered by a different in-cluster
     extractor); ``unsupported`` and ``forced`` are reserved for future callers.
+
+    A second caller (``vector/processor._index_document``, #399) reuses this
+    signal to escalate a *hard parse failure* -- an isolated-worker timeout/OOM
+    on a pathological PDF -- up the ladder instead of dropping the document, so
+    ``reason`` may also carry a ``parse_failed_reason`` value (``timeout``,
+    ``oom``, ``error``). The ``from_tier``/``to_tier`` hop is identical; only the
+    reason label widens, which surfaces on
+    ``astrolabe_document_escalation_total{reason}``.
     """
 
     def __init__(self, *, from_tier: str, to_tier: str, reason: str) -> None:

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1120,22 +1120,59 @@ async def _index_document(
                 # fail again.
                 if not result.success:
                     reason = result.metadata.get("parse_failed_reason", "error")
-                    record_document_parse_failed(reason)
                     # The tier that produced this failed result: the worker's own
                     # tier on the per-tier path, else the deepest tier the inline
                     # pipeline reached (recorded as ``pipeline_tier``).
                     failing_tier = tier or result.metadata.get(
                         "pipeline_tier", TIER_LADDER[0]
                     )
-                    # An oversize PDF is rejected by the pre-parse size guard
-                    # before any tier runs (no pipeline_tier stamped on the inline
-                    # path) and no tier can ever parse it, so it is terminal
-                    # regardless of failing_tier. Otherwise, terminal == no higher
-                    # tier can run.
-                    terminal = (
-                        reason == "oversize"
-                        or registry.next_available_tier(failing_tier, settings) is None
+                    # The next tier that can still run above the failing one
+                    # (``None`` == terminal). An oversize PDF is rejected by the
+                    # pre-parse size guard before any tier runs (no pipeline_tier
+                    # stamped on the inline path) and no tier can ever parse it, so
+                    # it is terminal regardless of failing_tier.
+                    next_avail = (
+                        None
+                        if reason == "oversize"
+                        else registry.next_available_tier(failing_tier, settings)
                     )
+                    # #399: a hard parse failure (an isolated-worker timeout/OOM on
+                    # a pathological PDF) is not necessarily terminal. On the
+                    # per-tier path, if a higher tier can still run, ESCALATE the
+                    # failure to it rather than dropping the doc -- e.g. a
+                    # structured-tier pymupdf timeout on a garbled/huge plan hops to
+                    # OCR, where surya rasterizes + reads the rendered glyphs.
+                    # Without this the doc was marked "failed" and the scanner
+                    # re-queued it into the same failing tier forever (the retry
+                    # loop seen on 406-105-style plans). The inline pipeline (tier
+                    # is None) already ran every tier in one call, so it never hops
+                    # here -- its failures fall through to the terminal handling.
+                    if tier is not None and next_avail is not None:
+                        # Mirror the quality-gate hop in _parse_pdf_tier: record the
+                        # escalation + raise so the retry strategy requeues onto the
+                        # next tier's queue. Deliberately NOT counted as a parse
+                        # failure (no record_document_parse_failed / failed mark) --
+                        # that would both inflate the hard-parse-failure panel and
+                        # lose a document OCR can still read.
+                        record_document_escalation(failing_tier, next_avail, reason)
+                        logger.info(
+                            "Parse failure for %s at tier=%s (reason=%s); "
+                            "escalating to %s",
+                            file_path,
+                            failing_tier,
+                            reason,
+                            next_avail,
+                        )
+                        raise EscalateError(
+                            from_tier=failing_tier,
+                            to_tier=next_avail,
+                            reason=reason,
+                        )
+                    # Terminal: oversize, the inline pipeline exhausted every tier,
+                    # or the deepest per-tier rung failed. Count the failure and
+                    # dead-letter / mark it below.
+                    record_document_parse_failed(reason)
+                    terminal = next_avail is None
                     if terminal and doc_task.etag:
                         # No higher tier can run (e.g. structured timed out with
                         # OCR off), so retrying just re-burns the same failing

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -5,7 +5,8 @@ tier has NO higher escalation tier available (e.g. ``structured`` with OCR off),
 ``_index_document`` records a durable, content-addressed dead-letter marker
 instead of the per-user ``status="failed"`` placeholder mark — the latter could
 not stop the multi-user re-queue loop. A failure that still has a higher tier
-keeps the legacy per-user mark.
+available now ESCALATES to it (#399) — e.g. a structured-tier timeout hops to OCR
+— rather than being marked failed and re-queued into the same tier forever.
 
 The real ``ProcessorRegistry`` singleton is used so the terminal decision
 (``next_available_tier``) is exercised faithfully; only the parse itself, the
@@ -20,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nextcloud_mcp_server.document_processors.base import ProcessingResult
+from nextcloud_mcp_server.document_processors.escalation import EscalateError
 from nextcloud_mcp_server.vector import processor
 from nextcloud_mcp_server.vector.scanner import DocumentTask
 
@@ -72,6 +74,8 @@ def _patch_common(mocker, *, ocr_enabled: bool):
         update_ph=mocker.patch.object(
             processor, "update_placeholder_status", AsyncMock()
         ),
+        escalation=mocker.patch.object(processor, "record_document_escalation"),
+        parse_failed=mocker.patch.object(processor, "record_document_parse_failed"),
     )
     return spies
 
@@ -112,10 +116,18 @@ async def test_terminal_failure_dead_letters(mocker):
     spies.dead_metric.assert_called_once_with("timeout")
     spies.delete_ph.assert_awaited_once()  # volatile placeholder dropped
     spies.update_ph.assert_not_awaited()  # NOT the legacy per-user failed mark
+    # Terminal failure still counts as a parse failure and does not escalate.
+    spies.parse_failed.assert_called_once_with("timeout")
+    spies.escalation.assert_not_called()
 
 
-async def test_non_terminal_failure_keeps_legacy_mark(mocker):
-    """fast tier fails while structured is still available -> legacy failed mark."""
+async def test_non_terminal_failure_escalates_to_next_tier(mocker):
+    """fast tier fails while structured is still available -> escalate (#399).
+
+    A hard parse failure is no longer dropped when a higher tier can still run:
+    it hops to the next tier instead of being marked failed and re-queued onto
+    the same failing tier forever.
+    """
     spies = _patch_common(mocker, ocr_enabled=False)
     mocker.patch.object(
         processor,
@@ -131,14 +143,62 @@ async def test_non_terminal_failure_keeps_legacy_mark(mocker):
         ),
     )
 
-    result = await processor._index_document(
-        _file_task(), _nc_client(), MagicMock(), tier="fast"
+    with pytest.raises(EscalateError) as ei:
+        await processor._index_document(
+            _file_task(), _nc_client(), MagicMock(), tier="fast"
+        )
+
+    assert ei.value.from_tier == "fast"
+    assert ei.value.to_tier == "structured"
+    assert ei.value.reason == "error"
+    spies.escalation.assert_called_once_with("fast", "structured", "error")
+    # An escalation is NOT a parse failure: it must not inflate the failure panel
+    # nor mark/dead-letter the doc.
+    spies.parse_failed.assert_not_called()
+    spies.update_ph.assert_not_awaited()
+    spies.mark.assert_not_awaited()
+    spies.dead_metric.assert_not_called()
+
+
+async def test_structured_timeout_escalates_to_ocr_when_enabled(mocker):
+    """The 406-105 case: structured pymupdf timeout + OCR enabled -> hop to OCR.
+
+    Previously this marked the doc 'failed' and the scanner re-queued it into the
+    structured tier forever (the retry loop). Now it escalates to OCR, where surya
+    rasterizes + reads the rendered glyphs.
+    """
+    spies = _patch_common(mocker, ocr_enabled=True)
+    mocker.patch.object(
+        processor,
+        "_parse_pdf_tier",
+        AsyncMock(
+            return_value=ProcessingResult(
+                text="",
+                metadata={
+                    "parse_failed_reason": "timeout",
+                    "pipeline_tier": "structured",
+                },
+                processor="pymupdf",
+                success=False,
+                error="isolated parse failed (timeout)",
+            )
+        ),
     )
 
-    assert result is False
-    spies.update_ph.assert_awaited_once()  # legacy per-user failed mark
-    spies.mark.assert_not_awaited()  # NOT dead-lettered (structured can still run)
-    spies.dead_metric.assert_not_called()
+    with pytest.raises(EscalateError) as ei:
+        await processor._index_document(
+            _file_task(), _nc_client(), MagicMock(), tier="structured"
+        )
+
+    assert (ei.value.from_tier, ei.value.to_tier, ei.value.reason) == (
+        "structured",
+        "ocr",
+        "timeout",
+    )
+    spies.escalation.assert_called_once_with("structured", "ocr", "timeout")
+    spies.parse_failed.assert_not_called()
+    spies.mark.assert_not_awaited()
+    spies.update_ph.assert_not_awaited()
 
 
 async def test_oversize_failure_dead_letters_regardless_of_tier(mocker):


### PR DESCRIPTION
## Problem
The "Hard parse failures (workers killed)" panel kept showing failures. Root cause (Deck #399): on the per-tier ingest path, a **hard parse failure** (isolated-worker timeout/OOM on a pathological PDF) was marked `failed` and skipped whenever a higher tier existed — so the scanner re-queued it into the **same failing tier forever**, and it never escalated to OCR.

Concrete case (`blackbox-demo`): a 206-page planning PDF (`406-105-GENERAL - PLANNING APPLICATION.pdf`, ~29 MB) whose fast `pypdfium2` extraction (198k chars) tripped the glyph-corruption gate → escalated to structured `pymupdf` → **timed out at the 120s budget every attempt** → marked failed → re-queued → repeat. It never reached OCR, despite OCR being exactly the right tier for it.

## Fix
`_index_document` now treats a non-terminal parse failure like the post-parse quality gate: record the escalation and raise `EscalateError` so the retry strategy hops the job to the next tier's queue.

- structured-tier timeout → **escalates to OCR** (surya rasterises + reads the rendered glyphs).
- The hop is **not** counted as a parse failure (no `record_document_parse_failed` / failed-placeholder mark) → stops inflating the panel, and the doc is no longer dropped.
- **Terminal cases unchanged**: oversize PDFs, the inline pipeline (`tier is None`, already ran every tier), and the deepest per-tier rung still dead-letter.

`EscalateError`'s `reason` vocabulary now also carries parse-failure reasons (`timeout`/`oom`/`error`) on `astrolabe_document_escalation_total{reason}`; docstrings updated.

## Tests
- Rewrote `test_non_terminal_failure_keeps_legacy_mark` → escalation.
- Added `test_structured_timeout_escalates_to_ocr_when_enabled` (the 406-105 case).
- Asserted the terminal path still records the failure and does not escalate.

`ruff`/`format`/`ty` clean; full unit suite **1851 passed, 1 skipped**.

---

_This PR was generated with the help of AI, and reviewed by a Human_