### PR TITLE
feat(vector): meter bytes_ingested / bytes_stored at indexing

### DIFF
--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -296,6 +296,20 @@ def should_use_page_aware(
     return page_aware_enabled and doc_type == "file" and bool(page_boundaries)
 
 
+def ingested_byte_size(content_bytes: bytes | None, content: str) -> int:
+    """Bytes ingested for one document (card #401).
+
+    Files carry their raw WebDAV binary in ``content_bytes`` — that raw size is
+    what the customer ingested. Text doc types (note, deck card, news item) have
+    no binary (``content_bytes is None``), so fall back to the UTF-8 size of the
+    extracted text. Selecting on ``content_bytes is not None`` (not ``doc_type``)
+    keeps this correct for any future binary-backed type.
+    """
+    if content_bytes is not None:
+        return len(content_bytes)
+    return len(content.encode("utf-8"))
+
+
 async def record_indexing_usage(
     *,
     enabled: bool,
@@ -307,11 +321,13 @@ async def record_indexing_usage(
     token_count: int,
     total_chars: int,
     page_count: int | None,
+    bytes_ingested: int,
+    bytes_stored: int,
     pipeline_tier: str | None = None,
 ) -> None:
     """Record the billable usage events for one embedded document.
 
-    Two metered dimensions (Deck #67), recorded independently:
+    Metered dimensions (Deck #67 / #401), recorded independently:
 
     - ``tokens_embedded`` — the embedding request's token count, recorded for
       *every* embedded document. The same metric search records, so the meter
@@ -324,15 +340,30 @@ async def record_indexing_usage(
       ``pages_embedded`` row — only ``tokens_embedded``. There is deliberately
       no chars/tokens-per-page constant: pages map 1:1 to parsed document pages
       (card #282).
+    - ``bytes_ingested`` — the raw source size at ingestion time, recorded for
+      *every* embedded document. For files this is the raw binary size fetched
+      from WebDAV; for text doc types (note, deck card, news item — no binary)
+      it is the UTF-8 size of the extracted text. The caller resolves the right
+      source per ``doc_type`` (see the call site).
+    - ``bytes_stored`` — the UTF-8 byte size of the chunk texts persisted as
+      Qdrant payload excerpts, recorded for *every* embedded document. Reflects
+      the indexed footprint and so includes chunk-overlap duplication; it is
+      therefore typically larger than ``bytes_ingested`` for text content.
 
     Best-effort and flag-gated: a metering failure is logged and never breaks
     indexing. ``chunk_count`` is the empty-batch no-op guard — a document that
-    produced no chunks embedded nothing, so both events are skipped rather than
+    produced no chunks embedded nothing, so all events are skipped rather than
     writing zero-value rows. ``pages_embedded`` is additionally skipped when
     ``page_count`` is absent or not strictly positive — gating on the page count
     itself (not the ``doc_type``) keeps this correct if a future non-PDF parsed
     type starts reporting pages, and a malformed non-positive count meters as
-    "no pages" rather than emitting a zero/negative billing row.
+    "no pages" rather than emitting a zero/negative billing row. The
+    ``bytes_*`` events are likewise skipped on a non-positive count.
+
+    Cross-repo note: the control-plane rollup silently ignores a ``metric`` its
+    catalog doesn't know (see migration 007), so ``bytes_ingested`` /
+    ``bytes_stored`` only bill once the CP metric catalog + Stripe meter learn
+    them too (card #401).
 
     Privacy note: ``user_id`` stays tenant-local — the CP rollup aggregates
     GROUP BY (day, metric) into ``usage_daily`` (no metadata column), so nothing
@@ -393,6 +424,25 @@ async def record_indexing_usage(
                     metadata=metadata,
                     enabled=True,
                 )
+        # Byte-volume dimensions (card #401), recorded for every embedded
+        # document. Appended after the conditional pages block so the
+        # tokens-then-pages ordering above is preserved. Each is skipped on a
+        # non-positive count to avoid writing a zero-value billing row (the
+        # chunk_count guard already filtered truly-empty documents).
+        if bytes_ingested > 0:
+            await store.record_usage_event(
+                metric="bytes_ingested",
+                value=bytes_ingested,
+                metadata=metadata,
+                enabled=True,
+            )
+        if bytes_stored > 0:
+            await store.record_usage_event(
+                metric="bytes_stored",
+                value=bytes_stored,
+                metadata=metadata,
+                enabled=True,
+            )
     except Exception:
         # Reached only when shared()/store construction itself raises
         # (record_usage_event swallows its own write failures). Metering is on,
@@ -1411,6 +1461,12 @@ async def _index_document(
                     and not isinstance(raw_page_count, bool)
                     else None
                 ),
+                # bytes_ingested: raw source size at ingestion (raw WebDAV binary
+                # for files, UTF-8 text size for text doc types). See helper.
+                bytes_ingested=ingested_byte_size(content_bytes, content),
+                # bytes_stored: UTF-8 size of the chunk texts persisted as Qdrant
+                # payload excerpts (includes chunk-overlap duplication).
+                bytes_stored=sum(len(t.encode("utf-8")) for t in chunk_texts),
                 # Tier that produced the parsed pages (registry stamps it on the
                 # result metadata); text doc types stay "fast". Narrow defensively
                 # to str|None — file_metadata is loosely typed (Any values).

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -300,10 +300,10 @@ def ingested_byte_size(content_bytes: bytes | None, content: str) -> int:
     """Bytes ingested for one document (card #401).
 
     Files carry their raw WebDAV binary in ``content_bytes`` — that raw size is
-    what the customer ingested. Text doc types (note, deck card, news item) have
-    no binary (``content_bytes is None``), so fall back to the UTF-8 size of the
-    extracted text. Selecting on ``content_bytes is not None`` (not ``doc_type``)
-    keeps this correct for any future binary-backed type.
+    what the customer ingested. Text doc types (note, deck card, news item, mail
+    message) have no binary (``content_bytes is None``), so fall back to the
+    UTF-8 size of the extracted text. Selecting on ``content_bytes is not None``
+    (not ``doc_type``) keeps this correct for any future binary-backed type.
     """
     if content_bytes is not None:
         return len(content_bytes)
@@ -1462,7 +1462,8 @@ async def _index_document(
                     else None
                 ),
                 # bytes_ingested: raw source size at ingestion (raw WebDAV binary
-                # for files, UTF-8 text size for text doc types). See helper.
+                # for files, UTF-8 text size for text doc types — note,
+                # deck_card, news_item, mail_message). See helper.
                 bytes_ingested=ingested_byte_size(content_bytes, content),
                 # bytes_stored: UTF-8 size of the chunk texts persisted as Qdrant
                 # payload excerpts (includes chunk-overlap duplication).

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -342,9 +342,9 @@ async def record_indexing_usage(
       (card #282).
     - ``bytes_ingested`` — the raw source size at ingestion time, recorded for
       *every* embedded document. For files this is the raw binary size fetched
-      from WebDAV; for text doc types (note, deck card, news item — no binary)
-      it is the UTF-8 size of the extracted text. The caller resolves the right
-      source per ``doc_type`` (see the call site).
+      from WebDAV; for text doc types (note, deck card, news item, mail message
+      — no binary) it is the UTF-8 size of the extracted text. The caller
+      resolves the right source per ``doc_type`` (see the call site).
     - ``bytes_stored`` — the UTF-8 byte size of the chunk texts persisted as
       Qdrant payload excerpts, recorded for *every* embedded document. Reflects
       the indexed footprint and so includes chunk-overlap duplication; it is

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -50,6 +50,15 @@ def test_ingested_byte_size_text_uses_utf8_length():
 
 
 @pytest.mark.unit
+def test_ingested_byte_size_mail_message_uses_utf8():
+    """mail_message has no binary (content_bytes=None) → same UTF-8 arm as text."""
+    # mail_message sets content_bytes=None in the processor, so it must measure
+    # the extracted text, not be mistaken for a binary-backed (file) doc type.
+    mail = "Subject: Hello\nBody text"
+    assert processor.ingested_byte_size(None, mail) == len(mail.encode("utf-8"))
+
+
+@pytest.mark.unit
 async def test_parsed_file_records_pages_and_tokens(store_spy):
     """A parsed PDF fires all events: pages_embedded = real page count."""
     await processor.record_indexing_usage(

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -1,12 +1,16 @@
-"""Unit tests for the indexing-path usage-metering helper (Deck #67).
+"""Unit tests for the indexing-path usage-metering helper (Deck #67 / #401).
 
 ``record_indexing_usage`` records the billable events after a document's chunks
 are embedded: ``tokens_embedded`` for every document, and ``pages_embedded``
 only for parsed files (real ``page_count``). Text content (no ``page_count``)
 meters tokens only — ``pages_embedded`` is a charge for parsing, not content
-size (card #282). These cover the value mapping, the flag/zero-chunk no-ops, the
-text-only path, and the best-effort failure path without standing up the full
-document pipeline.
+size (card #282). The byte-volume dimensions ``bytes_ingested`` /
+``bytes_stored`` (card #401) are recorded for every document, skipped only on a
+non-positive count. These cover the value mapping, the flag/zero-chunk no-ops,
+the text-only path, and the best-effort failure path without standing up the
+full document pipeline. (The call site's raw-binary-vs-UTF-8 source selection
+for ``bytes_ingested`` lives in the document pipeline and is exercised by the
+integration smoke path, not these helper-level tests.)
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -28,8 +32,26 @@ def store_spy(monkeypatch):
 
 
 @pytest.mark.unit
+def test_ingested_byte_size_files_use_raw_binary():
+    """A file's bytes_ingested is its raw binary size, not the text size."""
+    # Raw bytes longer than the decoded text would suggest (e.g. PDF overhead):
+    # the helper must report the binary length, ignoring `content`.
+    raw = b"%PDF-1.7 ...binary..." + b"\x00" * 500
+    assert processor.ingested_byte_size(raw, "short extracted text") == len(raw)
+
+
+@pytest.mark.unit
+def test_ingested_byte_size_text_uses_utf8_length():
+    """Text doc types (content_bytes=None) fall back to UTF-8 byte length."""
+    # Multibyte char: 1 code point, 2 UTF-8 bytes — len(str) would undercount.
+    text = "café"
+    assert processor.ingested_byte_size(None, text) == len(text.encode("utf-8"))
+    assert processor.ingested_byte_size(None, text) == 5  # c a f é(2)
+
+
+@pytest.mark.unit
 async def test_parsed_file_records_pages_and_tokens(store_spy):
-    """A parsed PDF fires both events: pages_embedded = real page count."""
+    """A parsed PDF fires all events: pages_embedded = real page count."""
     await processor.record_indexing_usage(
         enabled=True,
         provider="mistral",
@@ -40,15 +62,24 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
         token_count=4242,
         total_chars=170826,
         page_count=12,
+        bytes_ingested=204800,
+        bytes_stored=178000,
     )
 
     calls = store_spy.record_usage_event.await_args_list
     by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
-    # pages_embedded is the real parsed-page count, NOT the chunk count.
-    assert by_metric == {"pages_embedded": 12, "tokens_embedded": 4242}
+    # pages_embedded is the real parsed-page count, NOT the chunk count;
+    # bytes_* are the raw-ingest / stored-chunk byte counts (card #401).
+    assert by_metric == {
+        "tokens_embedded": 4242,
+        "pages_embedded": 12,
+        "bytes_ingested": 204800,
+        "bytes_stored": 178000,
+    }
     # Intentional ordering: tokens (recorded for every doc) before pages (the
     # conditional parsing cost). Asserted so a refactor can't silently reverse
-    # it — a comment alone is easier to delete than a failing test.
+    # it — a comment alone is easier to delete than a failing test. The byte
+    # rows are appended after the pages block, so these two stay valid.
     assert calls[0].kwargs["metric"] == "tokens_embedded"
     assert calls[1].kwargs["metric"] == "pages_embedded"
     for c in calls:
@@ -61,8 +92,8 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
 
 
 @pytest.mark.unit
-async def test_text_doc_records_tokens_only(store_spy):
-    """Unparsed text content (no page_count) meters tokens, never pages."""
+async def test_text_doc_records_tokens_and_bytes_no_pages(store_spy):
+    """Unparsed text content (no page_count) meters tokens + bytes, never pages."""
     await processor.record_indexing_usage(
         enabled=True,
         provider="mistral",
@@ -73,17 +104,24 @@ async def test_text_doc_records_tokens_only(store_spy):
         token_count=512,
         total_chars=7000,
         page_count=None,
+        bytes_ingested=7100,
+        bytes_stored=8200,
     )
 
     calls = store_spy.record_usage_event.await_args_list
     by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
-    assert by_metric == {"tokens_embedded": 512}
+    # Byte rows fire for text docs (they have no page_count, so no pages row).
+    assert by_metric == {
+        "tokens_embedded": 512,
+        "bytes_ingested": 7100,
+        "bytes_stored": 8200,
+    }
     assert "pages_embedded" not in by_metric
 
 
 @pytest.mark.unit
 async def test_zero_pages_skips_pages(store_spy):
-    """page_count=0 (e.g. an empty/corrupt PDF) records tokens but no pages."""
+    """page_count=0 (e.g. an empty/corrupt PDF) records tokens+bytes but no pages."""
     await processor.record_indexing_usage(
         enabled=True,
         provider="mistral",
@@ -94,16 +132,22 @@ async def test_zero_pages_skips_pages(store_spy):
         token_count=99,
         total_chars=1000,
         page_count=0,
+        bytes_ingested=2048,
+        bytes_stored=1100,
     )
 
     calls = store_spy.record_usage_event.await_args_list
     by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
-    assert by_metric == {"tokens_embedded": 99}
+    assert by_metric == {
+        "tokens_embedded": 99,
+        "bytes_ingested": 2048,
+        "bytes_stored": 1100,
+    }
 
 
 @pytest.mark.unit
 async def test_negative_pages_skips_pages(store_spy):
-    """A malformed negative page_count meters as 'no pages' (tokens only)."""
+    """A malformed negative page_count meters as 'no pages' (tokens+bytes only)."""
     await processor.record_indexing_usage(
         enabled=True,
         provider="mistral",
@@ -114,10 +158,39 @@ async def test_negative_pages_skips_pages(store_spy):
         token_count=99,
         total_chars=1000,
         page_count=-1,
+        bytes_ingested=2048,
+        bytes_stored=1100,
     )
 
     calls = store_spy.record_usage_event.await_args_list
     by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    assert by_metric == {
+        "tokens_embedded": 99,
+        "bytes_ingested": 2048,
+        "bytes_stored": 1100,
+    }
+
+
+@pytest.mark.unit
+async def test_nonpositive_bytes_skip_byte_rows(store_spy):
+    """Zero/negative byte counts are skipped (no zero-value billing rows)."""
+    await processor.record_indexing_usage(
+        enabled=True,
+        provider="mistral",
+        model="mistral-embed",
+        doc_type="note",
+        user_id="alice",
+        chunk_count=4,
+        token_count=99,
+        total_chars=0,
+        page_count=None,
+        bytes_ingested=0,
+        bytes_stored=-5,
+    )
+
+    calls = store_spy.record_usage_event.await_args_list
+    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    # Only tokens_embedded survives — neither byte row is written.
     assert by_metric == {"tokens_embedded": 99}
 
 
@@ -134,6 +207,8 @@ async def test_disabled_is_noop(store_spy):
         token_count=20,
         total_chars=5,
         page_count=3,
+        bytes_ingested=4096,
+        bytes_stored=512,
     )
     store_spy.record_usage_event.assert_not_awaited()
 
@@ -151,6 +226,8 @@ async def test_zero_chunks_is_noop(store_spy):
         token_count=0,
         total_chars=0,
         page_count=3,
+        bytes_ingested=4096,
+        bytes_stored=512,
     )
     store_spy.record_usage_event.assert_not_awaited()
 
@@ -175,6 +252,8 @@ async def test_store_failure_is_swallowed(monkeypatch):
         token_count=7,
         total_chars=9,
         page_count=2,
+        bytes_ingested=4096,
+        bytes_stored=512,
     )
 
 
@@ -191,6 +270,8 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         token_count=900,
         total_chars=40000,
         page_count=8,
+        bytes_ingested=51200,
+        bytes_stored=41000,
         pipeline_tier="ocr",
     )
     by_metric = {
@@ -202,6 +283,8 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         "tokens_embedded": 900,
         "pages_embedded": 8,
         "pages_ocr": 8,
+        "bytes_ingested": 51200,
+        "bytes_stored": 41000,
     }
     # pipeline_tier is threaded into the billing metadata for CP attribution.
     for c in store_spy.record_usage_event.await_args_list:
@@ -221,8 +304,15 @@ async def test_fast_tier_does_not_record_pages_ocr(store_spy):
         token_count=500,
         total_chars=20000,
         page_count=4,
+        bytes_ingested=25600,
+        bytes_stored=20500,
         pipeline_tier="fast",
     )
     metrics = {c.kwargs["metric"] for c in store_spy.record_usage_event.await_args_list}
     assert "pages_ocr" not in metrics
-    assert metrics == {"tokens_embedded", "pages_embedded"}
+    assert metrics == {
+        "tokens_embedded",
+        "pages_embedded",
+        "bytes_ingested",
+        "bytes_stored",
+    }


### PR DESCRIPTION
## Summary

Adds two **byte-volume** billing dimensions to the indexing usage path so the
Astrolabe Cloud pricing model can bill on ingest/storage volume alongside the
existing `tokens_embedded` / `pages_embedded` / `pages_ocr` measures (Deck #67 / **#401**).

**Key point:** `usage_events` is schema-flexible (`metric`/`value`/`metadata` rows,
migration `007`), so this is **new metric rows, not a schema migration** — recorded
through the existing flag-gated, best-effort `UsageEventStore` in
`record_indexing_usage()`.

## What's metered

- **`bytes_ingested`** — raw source size at ingestion time. Raw WebDAV binary size
  for files; UTF-8 size of the extracted text for text doc types
  (note / deck_card / news_item, which have no binary). The source selection is
  extracted into a pure `ingested_byte_size()` helper so it's directly unit-tested.
- **`bytes_stored`** — UTF-8 byte sum of the chunk texts persisted as Qdrant payload
  excerpts (reflects the indexed footprint, including chunk-overlap duplication).

Both are recorded for **every** embedded document, skipped on a non-positive count
(no zero-value rows), best-effort, and gated on `USAGE_METERING_ENABLED`. The
tokens-first record ordering is preserved.

## ⚠️ Cross-repo dependency (billing does not take effect from this PR alone)

Migration `007` warns: the control-plane rollup **silently ignores** a `metric` its
catalog doesn't know. So `bytes_ingested` / `bytes_stored` only bill once added to:
- the CP metric catalog + rollup (astrolabe-cloud-website) — cf. rename card #283
- the Stripe billing meter/catalog (homelab-terraform) — cf. catalog cards #281/#286

Tracked on Deck card **#401** (board 8, Stripe Billing).

## Testing

- `tests/unit/test_processor_metering.py` — updated all cases, added a
  non-positive-skip guard test and two `ingested_byte_size()` helper tests (raw-binary
  vs UTF-8 arms). 12 passed.
- Full unit suite green (1851 passed); ruff / ruff-format / ty clean.

---

_This PR was generated with the help of AI, and reviewed by a Human_