### PR TITLE
fix(vector): attribute OCR bboxes whitespace-insensitively + page guard

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -173,6 +173,8 @@ def _pages_to_text(
         # dropped ~40% of blocks -> missing/disconnected highlights. We search the
         # whitespace-free projection and map hits back to real offsets via norm_idx.
         norm_md, norm_idx = _ws_index_map(markdown)
+        # ncursor advances only on a successful match (below), never on a skip — so
+        # a dropped block can't cause later in-order blocks to be missed.
         ncursor = 0
         for raw in blocks:
             if not isinstance(raw, dict):

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -74,8 +74,9 @@ def _strip_html(html: str) -> str:
     """Plain text of a block's ``html`` (tags removed, entities unescaped).
 
     surya emits per-block ``html`` (e.g. ``<h1>Title</h1>``); the page markdown is
-    those texts joined by ``\\n\\n``, so the stripped text appears verbatim in the
-    page markdown — which is how a block is located within the text (below)."""
+    those texts joined by ``\\n\\n``, so the stripped text appears in the page
+    markdown modulo whitespace — which is how a block is located within the text
+    (below, whitespace-insensitively)."""
     return _html.unescape(_TAG_RE.sub("", html)).strip()
 
 
@@ -105,6 +106,24 @@ def _normalize_bbox(raw: Any) -> list[float] | None:
     return out
 
 
+def _ws_index_map(s: str) -> tuple[str, list[int]]:
+    """Whitespace-free projection of ``s`` plus the original index of each kept char.
+
+    Lets a block's tag-stripped text be located in the page markdown ignoring
+    whitespace: surya's per-block ``html`` fuses tokens across ``<br/>``/``<li>``/
+    ``<td>`` when tags are removed, while the markdown renders those boundaries as
+    spaces/newlines. Match on ``"".join(s.split())`` of both, then map a hit at
+    normalized position ``k`` back to ``s`` via the returned index list.
+    """
+    kept: list[str] = []
+    idx: list[int] = []
+    for j, ch in enumerate(s):
+        if not ch.isspace():
+            kept.append(ch)
+            idx.append(j)
+    return "".join(kept), idx
+
+
 def _pages_to_text(
     pages: Sequence[tuple[Any, ...]],
 ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
@@ -123,9 +142,11 @@ def _pages_to_text(
 
     Block spans: within a page, each block's stripped-html text is located in the
     page markdown in ``reading_order`` (advancing a cursor), giving a doc-absolute
-    char span paired with the block's normalized bbox. A block whose text isn't
-    found verbatim, or has no usable bbox, is skipped (that region falls back to
-    pymupdf) rather than guessed at.
+    char span paired with the block's normalized bbox. Matching IGNORES whitespace
+    (tag stripping fuses tokens across ``<br/>``/``<li>``/``<td>`` that the markdown
+    renders as spaces/newlines) and maps the hit back to real offsets. A block whose
+    text isn't found even whitespace-insensitively, or has no usable bbox, is skipped
+    (that region falls back to pymupdf) rather than guessed at.
     """
     sep = "\n\n"
     parts: list[str] = []
@@ -146,7 +167,13 @@ def _pages_to_text(
             continue
         # markdown begins after this page's leading separator (none for page 0).
         md_start = start + (0 if i == 0 else len(sep))
-        cursor = 0
+        # Locate blocks IGNORING whitespace: tag stripping fuses tokens across
+        # <br/>/<li>/<td> (``recommendation`` + ``that`` -> ``recommendationthat``)
+        # that the page markdown renders as spaces/newlines, so a verbatim find
+        # dropped ~40% of blocks -> missing/disconnected highlights. We search the
+        # whitespace-free projection and map hits back to real offsets via norm_idx.
+        norm_md, norm_idx = _ws_index_map(markdown)
+        ncursor = 0
         for raw in blocks:
             if not isinstance(raw, dict):
                 continue
@@ -154,28 +181,33 @@ def _pages_to_text(
             text = _strip_html(raw.get("html") or "")
             if bbox is None or not text:
                 continue
-            pos = markdown.find(text, cursor)
-            if pos < 0:
-                # Block text not in the page markdown at/after the cursor — the
-                # join invariant (markdown == block texts joined by \n\n) didn't
-                # hold for this block (e.g. gateway reformatting / version drift).
-                # Skip it (that region falls back to pymupdf); log so a systematic
-                # break is diagnosable rather than silently losing highlights.
+            needle = "".join(text.split())
+            if not needle:
+                continue
+            npos = norm_md.find(needle, ncursor)
+            if npos < 0:
+                # Not in the page markdown at/after the cursor even
+                # whitespace-insensitively — genuine drift (gateway reformatting /
+                # version skew / block reordering). Skip it (that region falls back
+                # to pymupdf); log so a systematic break is diagnosable rather than
+                # silently losing highlights.
                 logger.debug(
-                    "OCR block text %r not found in page %s markdown at cursor %s; "
-                    "skipping its bbox",
+                    "OCR block text %r not located in page %s markdown after cursor "
+                    "%s; skipping its bbox",
                     text[:40],
                     index + 1,
-                    cursor,
+                    ncursor,
                 )
                 continue
-            cursor = pos + len(text)
+            o_start = norm_idx[npos]
+            o_end = norm_idx[npos + len(needle) - 1] + 1
+            ncursor = npos + len(needle)
             block_spans.append(
                 {
                     "page": index + 1,
                     "bbox": bbox,
-                    "start_offset": md_start + pos,
-                    "end_offset": md_start + pos + len(text),
+                    "start_offset": md_start + o_start,
+                    "end_offset": md_start + o_end,
                 }
             )
     return "".join(parts), boundaries, block_spans

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -221,19 +221,32 @@ def _ocr_chunk_bboxes(
     """Attribute OCR block bboxes to chunks by char-span overlap.
 
     ``block_spans`` is the OCR tier's per-block geometry (``OCR_BLOCK_SPANS_KEY``):
-    each ``{"bbox": [x0,y0,x1,y1] normalized, "start_offset", "end_offset", ...}``.
-    A block belongs to chunk *i* when their char spans intersect (half-open
-    overlap: ``block.start < chunk.end and block.end > chunk.start``). Returns
-    ``chunk_index -> [bbox, ...]`` (a chunk spanning N blocks gets N bboxes, in the
-    spans' reading order), omitting chunks with no overlapping block. Pure +
-    module-level so the interval-overlap predicate is unit-testable in isolation."""
+    each ``{"bbox": [x0,y0,x1,y1] normalized, "start_offset", "end_offset",
+    "page", ...}``. A block belongs to chunk *i* when their char spans intersect
+    (half-open overlap: ``block.start < chunk.end and block.end > chunk.start``)
+    AND the block's page matches the chunk's ``page_number``.
+
+    The page guard makes attribution correct-by-construction independent of the
+    chunker. ``chunk_bbox`` is stored as a flat rect list rendered on the chunk's
+    single ``page_number``, so a block from a *different* page must not be
+    attributed — its box would render on the wrong page at the wrong page's
+    coordinates. The page-aware chunker keeps every chunk single-page (guard is a
+    no-op), but the page-agnostic char-based chunker can straddle a page break: on
+    Student 147, 9/16 char-based chunks pulled blocks from two pages. When a chunk
+    has no ``page_number`` (no page boundaries), fall back to overlap-only.
+
+    Returns ``chunk_index -> [bbox, ...]`` (a chunk spanning N blocks gets N bboxes,
+    in the spans' reading order), omitting chunks with no overlapping block. Pure +
+    module-level so the predicate is unit-testable in isolation."""
     out: dict[int, list[tuple[float, float, float, float]]] = {}
     for i, chunk in enumerate(chunks):
+        page = getattr(chunk, "page_number", None)
         boxes = [
             (s["bbox"][0], s["bbox"][1], s["bbox"][2], s["bbox"][3])
             for s in block_spans
             if s["start_offset"] < chunk.end_offset
             and s["end_offset"] > chunk.start_offset
+            and (page is None or s.get("page") == page)
         ]
         if boxes:
             out[i] = boxes

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -234,6 +234,9 @@ def _ocr_chunk_bboxes(
     no-op), but the page-agnostic char-based chunker can straddle a page break: on
     Student 147, 9/16 char-based chunks pulled blocks from two pages. When a chunk
     has no ``page_number`` (no page boundaries), fall back to overlap-only.
+    Conversely, a span without a ``page`` key is excluded from any chunk that has a
+    ``page_number`` — ``_pages_to_text`` always stamps ``page`` on OCR spans, so this
+    only affects externally-built spans.
 
     Returns ``chunk_index -> [bbox, ...]`` (a chunk spanning N blocks gets N bboxes,
     in the spans' reading order), omitting chunks with no overlapping block. Pure +

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -132,6 +132,21 @@ def test_pages_to_text_matches_blocks_ignoring_whitespace():
     assert spans[1]["bbox"] == [0.1, 0.1, 1.0, 0.24]
 
 
+def test_ws_index_map_strips_whitespace_and_maps_indices():
+    """The projection drops whitespace; the index list maps each kept char back to
+    its original position, so a normalized hit resolves to a real offset."""
+    s, idx = ocr._ws_index_map("hello world")
+    assert s == "helloworld"
+    assert idx == [0, 1, 2, 3, 4, 6, 7, 8, 9, 10]
+    # Leading/trailing spaces, tabs and newlines are all dropped; indices stay
+    # aligned so idx can be used to slice the original string back out.
+    original = "  a\tb\nc "
+    s2, idx2 = ocr._ws_index_map(original)
+    assert s2 == "abc"
+    assert idx2 == [2, 4, 6]
+    assert "".join(original[i] for i in idx2) == "abc"
+
+
 def test_pages_to_text_skips_blocks_without_bbox_or_unmatched_text():
     """A block with no bbox, or whose text isn't in the markdown, is skipped
     (that region falls back to pymupdf) rather than guessed."""

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -87,6 +87,51 @@ def test_pages_to_text_computes_block_spans_from_blocks():
     assert s2["page"] == 2 and text[s2["start_offset"] : s2["end_offset"]] == "Terms"
 
 
+def test_pages_to_text_matches_blocks_ignoring_whitespace():
+    """A block whose tag-stripped text fuses tokens across ``<br/>`` (no separator),
+    while the page markdown renders those breaks as spaces, is still located and
+    given a span — a verbatim find would drop it. This is the Student 147 page-15
+    regression (the FLASHMAN'S passage), where ~40% of blocks lost their bbox and
+    highlights came back disconnected.
+
+    The span must cover the full sentence region in the markdown."""
+    markdown = (
+        "YEAR 11 LEADERS AWARD\n\n"
+        'I am making a recommendation that Louis receives the "FLASHMAN\'S AWARD".'
+    )
+    body_html = (
+        "<p>I am making a recommendation<br/>that Louis receives the<br/>"
+        '"FLASHMAN\'S AWARD".</p>'
+    )
+    # Precondition: the fused stripped text is NOT a verbatim substring (the bug).
+    assert ocr._strip_html(body_html) not in markdown
+    pages = [
+        (
+            0,
+            markdown,
+            [
+                {
+                    "html": "<h2>YEAR 11 LEADERS AWARD</h2>",
+                    "bbox": [0.1, 0.02, 0.9, 0.07],
+                },
+                {"html": body_html, "bbox": [0.1, 0.1, 1.0, 0.24]},
+            ],
+        )
+    ]
+    text, _b, spans = ocr._pages_to_text(pages)
+    # Both blocks now get spans (pre-fix: only the heading matched verbatim).
+    assert len(spans) == 2
+    assert (
+        text[spans[0]["start_offset"] : spans[0]["end_offset"]]
+        == "YEAR 11 LEADERS AWARD"
+    )
+    # The body span maps back onto the real (whitespace-bearing) markdown sentence.
+    assert text[spans[1]["start_offset"] : spans[1]["end_offset"]] == (
+        'I am making a recommendation that Louis receives the "FLASHMAN\'S AWARD".'
+    )
+    assert spans[1]["bbox"] == [0.1, 0.1, 1.0, 0.24]
+
+
 def test_pages_to_text_skips_blocks_without_bbox_or_unmatched_text():
     """A block with no bbox, or whose text isn't in the markdown, is skipped
     (that region falls back to pymupdf) rather than guessed."""

--- a/tests/unit/test_processor_routing.py
+++ b/tests/unit/test_processor_routing.py
@@ -66,14 +66,19 @@ class TestOcrChunkBboxes:
     """`_ocr_chunk_bboxes` attributes OCR block bboxes to chunks by char-span overlap."""
 
     @staticmethod
-    def _chunk(start, end):
+    def _chunk(start, end, page_number=None):
         from types import SimpleNamespace
 
-        return SimpleNamespace(start_offset=start, end_offset=end)
+        return SimpleNamespace(
+            start_offset=start, end_offset=end, page_number=page_number
+        )
 
     @staticmethod
-    def _span(start, end, bbox):
-        return {"start_offset": start, "end_offset": end, "bbox": bbox}
+    def _span(start, end, bbox, page=None):
+        s = {"start_offset": start, "end_offset": end, "bbox": bbox}
+        if page is not None:
+            s["page"] = page
+        return s
 
     def test_single_block_per_chunk(self):
         from nextcloud_mcp_server.vector.processor import _ocr_chunk_bboxes
@@ -104,3 +109,18 @@ class TestOcrChunkBboxes:
         # Chunk [50,60) overlaps no block -> omitted (pymupdf fallback territory).
         out = _ocr_chunk_bboxes([self._chunk(50, 60)], [self._span(0, 8, [0, 0, 1, 1])])
         assert out == {}
+
+    def test_page_guard_excludes_block_from_other_page(self):
+        from nextcloud_mcp_server.vector.processor import _ocr_chunk_bboxes
+
+        # A chunk assigned page 2 whose char range also overlaps a page-1 block
+        # (possible when a chunk straddles a page break, e.g. the char-based
+        # chunker). The page-1 box must NOT be attributed — it would render on
+        # page 2 at page-1 coordinates. Only the page-2 block survives.
+        chunks = [self._chunk(0, 20, page_number=2)]
+        spans = [
+            self._span(0, 8, [0.1, 0.1, 0.4, 0.2], page=1),
+            self._span(10, 18, [0.1, 0.3, 0.5, 0.4], page=2),
+        ]
+        out = _ocr_chunk_bboxes(chunks, spans)
+        assert out == {0: [(0.1, 0.3, 0.5, 0.4)]}


### PR DESCRIPTION
## Problem

OCR-indexed (scanned) PDFs lose ~40% of their per-block bounding boxes, so search highlights in the Astrolabe UI come back **sparse and disconnected**, with some matched chunks showing no highlight at all. Repro: searching `"flashman's leadership award"` on `Student 147.pdf` (blackbox-demo) p15 highlighted **2 of ~6 lines** as two disjoint strips, skipping the actual FLASHMAN'S passage.

## Root cause

`_pages_to_text` located each OCR block's geometry by a **verbatim** `markdown.find(_strip_html(block.html))`. But `_strip_html` deletes `<br/>`/`<li>`/`<td>` tags with no separator, fusing tokens (`recommendation`+`that` → `recommendationthat`), while the gateway page markdown renders those boundaries as spaces/newlines. So the find missed and the block was **dropped** — and scanned docs have no pymupdf fallback, so those lines got no box.

Measured on Student 147: **56/92 blocks matched verbatim; whitespace-normalized matching recovers all 36 (→ 92/92, 0 residual)**.

A second, latent issue surfaced while investigating: `_ocr_chunk_bboxes` attributes blocks by char-overlap only and the payload is a flat `chunk_bbox` list rendered on a **single** `page_number`. The page-aware chunker keeps chunks single-page so this is currently safe, but the page-agnostic char-based chunker straddles page breaks — **9/16** char-based chunks on Student 147 pulled blocks from two pages, which would render on the wrong page.

## Fix

- **Whitespace-insensitive block matching** in `_pages_to_text` (`_ws_index_map`): match on the whitespace-free projection of the page markdown, map the hit back to real char offsets. Preserves the gateway markdown as the indexed/embedded text (no search-quality change).
- **Page guard** in `_ocr_chunk_bboxes`: only attribute a block whose `page` matches the chunk's `page_number` (falls back to overlap-only when no page info). No-op under the page-aware chunker; backstops the char-based path so a cross-page block can never render on the wrong page.

## Evidence (real OCR through a local gateway → leaf.cloud GPU)

| metric | before | after |
|---|---|---|
| block spans attributed | 56 / 92 | **92 / 92** |
| chunks with a bbox | 16 / 20 | **20 / 20** |
| p15 FLASHMAN chunk boxes | 2 (disjoint) | **5 (contiguous)** |
| char-based cross-page chunks | 9 | **0 (guarded)** |

## Tests

- `test_pages_to_text_matches_blocks_ignoring_whitespace` — reproduces the `<br/>` fusion drop.
- `test_page_guard_excludes_block_from_other_page` — a cross-page block is not attributed.
- Full OCR suite green (65 passed), ruff + ty clean.

Deck: nextcloud-mcp-server Product board #402.

Not included (cosmetic follow-up, tracked on #402): merging vertically-adjacent line boxes into a single rect — full coverage already makes passages render contiguously.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
