### PR TITLE
fix(mcp-server): OCR poll-status metric + WebDAV SEARCH scope escaping & observability

### DIFF
--- a/nextcloud_mcp_server/client/__init__.py
+++ b/nextcloud_mcp_server/client/__init__.py
@@ -294,8 +294,9 @@ class NextcloudClient:
                     )
                 except Exception as e:
                     logger.warning(
-                        "Tag-based directory walk failed for %r (tag %r): %s; "
-                        "skipping descendants",
+                        "Tag-based directory walk failed for %r (tag %r): %s. "
+                        "Skipping this folder and all its descendants — those "
+                        "files will NOT be indexed until the walk succeeds.",
                         dir_path,
                         tag_name,
                         e,

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -719,10 +719,24 @@ class WebDAVClient(BaseNextcloudClient):
             return results
 
         except HTTPStatusError as e:
-            logger.error("HTTP error during search: %s", e)
+            # Surface the server's actual reason: Nextcloud/Sabre returns an XML
+            # error body (e.g. "<s:message>...</s:message>") that pinpoints the
+            # cause — far more actionable than the generic httpx
+            # "Client error '400 Bad Request' for url '.../dav/'" string. A 400
+            # here almost always means a malformed SEARCH body (commonly an
+            # un-escaped character in the scope path).
+            detail = (e.response.text or "").strip().replace("\n", " ")
+            logger.error(
+                "WebDAV SEARCH failed: HTTP %s for scope %r — %s",
+                e.response.status_code,
+                scope or "<user root>",
+                detail[:500] or "(empty response body)",
+            )
             raise e
         except Exception as e:
-            logger.error("Unexpected error during search: %s", e)
+            logger.error(
+                "Unexpected error during WebDAV SEARCH (scope %r): %s", scope, e
+            )
             raise e
 
     async def search_files_all(
@@ -898,6 +912,14 @@ class WebDAVClient(BaseNextcloudClient):
         scope_path = f"/files/{username}"
         if scope:
             scope_path = f"{scope_path}/{scope.lstrip('/')}"
+        # XML-escape before embedding in <d:href>: a folder whose name contains
+        # '&', '<' or '>' (e.g. "Reports & Plans") otherwise produces a malformed
+        # SEARCH body that Nextcloud's Sabre/DAV parser rejects with 400 Bad
+        # Request — silently skipping that folder and all of its descendants
+        # during the tag-based indexing walk. Escaping keeps the path literal
+        # (Sabre unescapes it back), matching how folders without special
+        # characters already resolve.
+        scope_href = xml_escape(scope_path)
 
         # Build property list
         prop_xml = "\n".join([self._property_to_xml(prop) for prop in properties])
@@ -945,7 +967,7 @@ class WebDAVClient(BaseNextcloudClient):
         </d:select>
         <d:from>
             <d:scope>
-                <d:href>{scope_path}</d:href>
+                <d:href>{scope_href}</d:href>
                 <d:depth>infinity</d:depth>
             </d:scope>
         </d:from>

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -1150,7 +1150,7 @@ class WebDAVClient(BaseNextcloudClient):
                 <d:prop>
                     <d:displayname/>
                 </d:prop>
-                <d:literal>{pattern}</d:literal>
+                <d:literal>{xml_escape(pattern)}</d:literal>
             </d:like>
         """
 
@@ -1322,7 +1322,7 @@ class WebDAVClient(BaseNextcloudClient):
                 <d:prop>
                     <oc:tags/>
                 </d:prop>
-                <d:literal>%{tag_name}%</d:literal>
+                <d:literal>%{xml_escape(tag_name)}%</d:literal>
             </d:like>
         """
 

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -16,6 +16,7 @@ from nextcloud_mcp_server.observability.tracing import trace_operation
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 from .classifier import DocClassification, classify_from_text, image_coverage_per_page
 from .escalation import TIER_LADDER, EscalationDecision
+from .ocr import OCR_BATCH_PENDING_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -758,10 +759,6 @@ class ProcessorRegistry:
             # document_parse_total{status="error"} and the parse-rate dashboard shows
             # GPU-boot polling as errors. Genuine failures stay "error"; worker-killed
             # failures land in document_parse_failed_total.
-            from nextcloud_mcp_server.document_processors.ocr import (  # noqa: PLC0415
-                OCR_BATCH_PENDING_KEY,
-            )
-
             if result.metadata.get(OCR_BATCH_PENDING_KEY):
                 status = "pending"
             elif result.success:

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -751,7 +751,23 @@ class ProcessorRegistry:
             result.metadata.setdefault("pipeline_tier", tier)
             pages = int(result.metadata.get("page_count", 0) or 0)
             chars = len(result.text)
-            status = "success" if result.success else "error"
+            # A batch-OCR poll still in flight (GPU booting / batch queued) returns
+            # success=False + the pending sentinel; _parse_pdf_tier re-queues it via
+            # BatchPending, so it is NOT a parse failure. Record it as a distinct
+            # status="pending" — otherwise every poll inflates
+            # document_parse_total{status="error"} and the parse-rate dashboard shows
+            # GPU-boot polling as errors. Genuine failures stay "error"; worker-killed
+            # failures land in document_parse_failed_total.
+            from nextcloud_mcp_server.document_processors.ocr import (  # noqa: PLC0415
+                OCR_BATCH_PENDING_KEY,
+            )
+
+            if result.metadata.get(OCR_BATCH_PENDING_KEY):
+                status = "pending"
+            elif result.success:
+                status = "success"
+            else:
+                status = "error"
             record_document_parse(
                 processor.name,
                 tier,

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -744,16 +744,17 @@ def record_document_parse(
         pages: Number of pages parsed (0 if not page-based)
         chars: Number of characters extracted
         byte_size: Size of the source document in bytes
-        status: "success" or "error"
+        status: "success" | "error" | "pending" (a batch-OCR poll still in flight —
+            GPU booting / batch queued; re-queued via BatchPending, not a failure)
     """
     document_parse_duration_seconds.labels(
         processor=processor, tier=tier, status=status
     ).observe(duration)
     document_parse_total.labels(processor=processor, tier=tier, status=status).inc()
     # Throughput counters (pages/chars/bytes) accrue only on a full success.
-    # A partial extraction flagged success=False is recorded above as a
-    # parse-error but is intentionally excluded here so low-confidence output
-    # never inflates pipeline throughput.
+    # A partial extraction flagged success=False (recorded above as "error") or a
+    # batch-OCR poll still in flight ("pending") is intentionally excluded here so
+    # low-confidence output and GPU-boot polling never inflate pipeline throughput.
     if status == "success":
         if pages > 0:
             document_pages_processed_total.labels(processor=processor, tier=tier).inc(

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -237,7 +237,7 @@ qdrant_operations_total = Counter(
 document_parse_duration_seconds = Histogram(
     "astrolabe_document_parse_duration_seconds",
     "Document text-extraction (parse) duration in seconds",
-    ["processor", "tier", "status"],  # status: success | error
+    ["processor", "tier", "status"],  # status: success | error | pending
     # Buckets reach 300s: large PDFs exceed the 60s ceiling of the whole-doc
     # histogram, which would otherwise pile every large parse into +Inf.
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
@@ -246,7 +246,7 @@ document_parse_duration_seconds = Histogram(
 document_parse_total = Counter(
     "astrolabe_document_parse_total",
     "Total document parse attempts",
-    ["processor", "tier", "status"],  # status: success | error
+    ["processor", "tier", "status"],  # status: success | error | pending
 )
 
 document_pages_processed_total = Counter(

--- a/tests/client/webdav/test_webdav_search.py
+++ b/tests/client/webdav/test_webdav_search.py
@@ -266,3 +266,27 @@ async def test_search_properties_returned(
     assert len(present_optional) > 0, f"Should have at least one of {optional_props}"
 
     logger.info("Search returned properties: %s", list(result.keys()))
+
+
+async def test_search_scope_with_ampersand_does_not_400(nc_client: NextcloudClient):
+    """Regression: a folder whose name contains ``&`` must stay searchable.
+
+    Before the scope was XML-escaped, the SEARCH body embedded a bare ``&`` in
+    ``<d:href>``, so Nextcloud's Sabre/DAV parser rejected it with 400 and the
+    tag-based indexing walk skipped the folder and every descendant (a silent
+    indexing gap for any tenant with such a folder).
+    """
+    test_dir = f"mcp_amp_test_{uuid.uuid4().hex[:8]} & co"
+    await nc_client.webdav.create_directory(test_dir)
+    try:
+        await nc_client.webdav.write_file(f"{test_dir}/doc.txt", b"hello", "text/plain")
+        # Must not raise HTTP 400, and must locate the file within the '&' scope.
+        results = await nc_client.webdav.find_by_name("doc.txt", scope=test_dir)
+        assert any(r.get("name") == "doc.txt" for r in results), (
+            f"file in '&'-named folder was not found via SEARCH: {results}"
+        )
+    finally:
+        try:
+            await nc_client.webdav.delete_resource(test_dir)
+        except Exception as e:
+            logger.warning("Failed to cleanup test directory %s: %s", test_dir, e)

--- a/tests/contract/test_gateway_batch_ocr_consumer.py
+++ b/tests/contract/test_gateway_batch_ocr_consumer.py
@@ -78,7 +78,9 @@ async def test_poll_pending(gateway_consumer_pact):
         gateway_consumer_pact.upon_receiving("a poll for a still-running batch OCR job")
         .given("a pending batch OCR job mistral/job-pending exists")
         .with_request("GET", "/v1/ocr/batch/mistral/job-pending")
-        .will_respond_with(200)
+        # 202 Accepted while the batch is still processing (terminal polls are 200);
+        # the client keys off the body status, so it treats either as "keep polling".
+        .will_respond_with(202)
         .with_body({"status": "pending"}, content_type="application/json")
     )
 

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -697,3 +697,6 @@ def test_build_search_xml_escapes_angle_brackets_in_scope():
     href = root.find(".//{DAV:}href")
     assert href is not None
     assert href.text == f"/files/testuser/{scope}"
+    # Escaped forms present in the serialized body; raw angle brackets absent.
+    assert "weird <name>" not in body
+    assert "&lt;name&gt;" in body

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -675,8 +675,8 @@ def test_build_search_xml_escapes_special_chars_in_scope():
     assert href.text == f"/files/testuser/{scope}"
 
     # 3. The serialized body escapes the ampersand rather than emitting it raw.
-    assert "&amp;" in body
-    assert "Search & Retrieval" not in body
+    assert "& Plans" not in body  # no bare ampersand
+    assert "&amp; Plans" in body  # escaped form present
 
 
 @pytest.mark.unit

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -700,3 +700,36 @@ def test_build_search_xml_escapes_angle_brackets_in_scope():
     # Escaped forms present in the serialized body; raw angle brackets absent.
     assert "weird <name>" not in body
     assert "&lt;name&gt;" in body
+
+
+@pytest.mark.unit
+async def test_find_by_name_escapes_special_chars_in_pattern(mocker):
+    # The filename pattern is embedded in a <d:literal>; '&'/'<'/'>' must be
+    # escaped or the SEARCH body is malformed and Sabre 400s — the same bug class
+    # as the scope fix. Regression for the find_by_name path.
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mock_search = mocker.patch.object(client, "search_files", return_value=[])
+
+    await client.find_by_name("Costs & Revenue <draft>.pdf")
+
+    where = mock_search.call_args.kwargs["where_conditions"]
+    # Well-formed once wrapped with the DAV namespace (raised ParseError pre-fix).
+    ET.fromstring(f"<root xmlns:d='DAV:'>{where}</root>")
+    assert "&amp;" in where and "&lt;draft&gt;" in where
+    assert "Costs & Revenue" not in where  # no bare ampersand
+
+
+@pytest.mark.unit
+async def test_find_by_tag_escapes_special_chars_in_tag(mocker):
+    # Tag names can contain '&' (e.g. "R&D"); the tag literal must be escaped too.
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mock_search = mocker.patch.object(client, "search_files", return_value=[])
+
+    await client.find_by_tag("R&D")
+
+    where = mock_search.call_args.kwargs["where_conditions"]
+    ET.fromstring(
+        f"<root xmlns:d='DAV:' xmlns:oc='http://owncloud.org/ns'>{where}</root>"
+    )
+    assert "R&amp;D" in where
+    assert "R&D" not in where  # no bare ampersand

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -1,5 +1,6 @@
 """Unit tests for WebDAV client."""
 
+import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock
 
 import pytest
@@ -254,7 +255,7 @@ async def test_get_or_create_tag_creates_new_tag(mocker):
 
     # Mock no existing tag
     mocker.patch.object(client, "get_tag_by_name", return_value=None)
-    mocker.patch.object(
+    mock_create_tag = mocker.patch.object(
         client,
         "create_tag",
         return_value={"id": 42, "name": "vector-index", "userVisible": True},
@@ -265,7 +266,7 @@ async def test_get_or_create_tag_creates_new_tag(mocker):
 
     # Verify tag was created
     assert result["id"] == 42
-    client.create_tag.assert_called_once_with("vector-index", True, True)
+    mock_create_tag.assert_called_once_with("vector-index", True, True)
 
 
 @pytest.mark.unit
@@ -640,3 +641,59 @@ async def test_copy_resource_encodes_destination_header(mocker):
     destination = call.kwargs["headers"]["Destination"]
     assert "%23" in destination
     assert "#" not in destination
+
+
+@pytest.mark.unit
+def test_build_search_xml_escapes_special_chars_in_scope():
+    """A scope folder containing XML-special characters must yield a *well-formed*
+    SEARCH body, not malformed XML that Nextcloud rejects with 400.
+
+    Regression: a tagged folder whose name contains ``&`` (e.g. "Reports &
+    Plans") injected a bare ``&`` into ``<d:href>``, so Nextcloud's Sabre/DAV
+    parser 400'd the SEARCH and the tag-based indexing walk skipped the folder
+    and *all* its descendants (silent indexing gap).
+    """
+    client = WebDAVClient(AsyncMock(), "testuser")
+    scope = "Reports & Plans/2024"
+
+    body = client._build_search_xml(
+        scope=scope,
+        where_conditions=None,
+        properties=["displayname"],
+        order_by=None,
+        limit=None,
+    )
+
+    # 1. Must parse as well-formed XML (raised ParseError on the bare '&' before
+    #    the fix).
+    root = ET.fromstring(body)
+
+    # 2. The href round-trips to the *literal* path — Sabre unescapes ``&amp;``
+    #    back to ``&``, so matching is unchanged for folders without specials.
+    href = root.find(".//{DAV:}href")
+    assert href is not None
+    assert href.text == f"/files/testuser/{scope}"
+
+    # 3. The serialized body escapes the ampersand rather than emitting it raw.
+    assert "&amp;" in body
+    assert "Search & Retrieval" not in body
+
+
+@pytest.mark.unit
+def test_build_search_xml_escapes_angle_brackets_in_scope():
+    """``<`` / ``>`` in a folder name are escaped too (not just ``&``)."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    scope = "weird <name>"
+
+    body = client._build_search_xml(
+        scope=scope,
+        where_conditions=None,
+        properties=["displayname"],
+        order_by=None,
+        limit=None,
+    )
+
+    root = ET.fromstring(body)  # well-formed
+    href = root.find(".//{DAV:}href")
+    assert href is not None
+    assert href.text == f"/files/testuser/{scope}"

--- a/tests/unit/test_document_parse_metrics.py
+++ b/tests/unit/test_document_parse_metrics.py
@@ -22,6 +22,10 @@ from nextcloud_mcp_server.document_processors.base import (
     ProcessingResult,
     ProcessorError,
 )
+from nextcloud_mcp_server.document_processors.ocr import (
+    OCR_BATCH_PENDING_KEY,
+    OCR_BATCH_RETRY_IN_KEY,
+)
 from nextcloud_mcp_server.document_processors.registry import ProcessorRegistry
 from nextcloud_mcp_server.observability.metrics import (
     record_document_chunks,
@@ -153,11 +157,6 @@ class TestRegistryParseInstrumentation:
         # sentinel; _parse_pdf_tier re-queues it via BatchPending. It must record
         # status="pending", NOT "error" — otherwise every GPU-boot poll inflates
         # the parse-rate dashboard's error line.
-        from nextcloud_mcp_server.document_processors.ocr import (
-            OCR_BATCH_PENDING_KEY,
-            OCR_BATCH_RETRY_IN_KEY,
-        )
-
         result = ProcessingResult(
             text="",
             metadata={OCR_BATCH_PENDING_KEY: True, OCR_BATCH_RETRY_IN_KEY: 120},
@@ -252,6 +251,38 @@ class TestParseMetricHelpers:
         ) == pytest.approx(before_chars)
         assert metric_sample(
             "astrolabe_document_parse_total", {**labels, "status": "error"}
+        ) == pytest.approx(before_total + 1)
+
+    def test_pending_does_not_increment_throughput(self, metric_sample):
+        # A batch-OCR poll still in flight (status="pending") counts the attempt +
+        # duration but, like "error", must NOT bump pages/chars/bytes — only a full
+        # success accrues throughput (the `if status == "success"` gate).
+        labels = {"processor": "uttest-pending", "tier": "ocr"}
+        before_pages = metric_sample("astrolabe_document_pages_processed_total", labels)
+        before_bytes = metric_sample("astrolabe_document_bytes_processed_total", labels)
+        before_total = metric_sample(
+            "astrolabe_document_parse_total", {**labels, "status": "pending"}
+        )
+
+        record_document_parse(
+            "uttest-pending",
+            "ocr",
+            0.05,
+            pages=0,
+            chars=0,
+            byte_size=2500,
+            status="pending",
+        )
+
+        # Pending counts the attempt but NOT throughput.
+        assert metric_sample(
+            "astrolabe_document_pages_processed_total", labels
+        ) == pytest.approx(before_pages)
+        assert metric_sample(
+            "astrolabe_document_bytes_processed_total", labels
+        ) == pytest.approx(before_bytes)
+        assert metric_sample(
+            "astrolabe_document_parse_total", {**labels, "status": "pending"}
         ) == pytest.approx(before_total + 1)
 
     def test_record_document_chunks(self, metric_sample):

--- a/tests/unit/test_document_parse_metrics.py
+++ b/tests/unit/test_document_parse_metrics.py
@@ -148,6 +148,39 @@ class TestRegistryParseInstrumentation:
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs["status"] == "error"
 
+    async def test_batch_pending_records_pending_not_error(self, mock_tracer):
+        # A batch-OCR poll still in flight returns success=False + the pending
+        # sentinel; _parse_pdf_tier re-queues it via BatchPending. It must record
+        # status="pending", NOT "error" — otherwise every GPU-boot poll inflates
+        # the parse-rate dashboard's error line.
+        from nextcloud_mcp_server.document_processors.ocr import (
+            OCR_BATCH_PENDING_KEY,
+            OCR_BATCH_RETRY_IN_KEY,
+        )
+
+        result = ProcessingResult(
+            text="",
+            metadata={OCR_BATCH_PENDING_KEY: True, OCR_BATCH_RETRY_IN_KEY: 120},
+            processor="ocr",
+            success=False,
+        )
+        registry = ProcessorRegistry()
+        registry.register(
+            _FakeProcessor(result=result, proc_name="ocr", proc_tier="ocr")
+        )
+
+        with patch(
+            "nextcloud_mcp_server.document_processors.registry.record_document_parse"
+        ) as mock_record:
+            out = await registry.process(
+                b"%PDF-1.7", "application/pdf", filename="x.pdf"
+            )
+
+        assert out is result
+        mock_record.assert_called_once()
+        # Distinct status, not "error" — and not "success" (keeps it out of throughput).
+        assert mock_record.call_args.kwargs["status"] == "pending"
+
 
 class TestParseMetricHelpers:
     def test_success_increments_throughput_counters(self, metric_sample):


### PR DESCRIPTION
Broader **mcp-server OCR + observability** fixes surfaced during the 2026-06-23 S3-OCR cutover load test (Deck #406) and tenant indexing on cloudfleet/dev.

## 1. OCR GPU-boot polls were recorded as parse "errors"
While the burst GPU cold-boots, the OCR tier returns the pending sentinel (`success=False` + `OCR_BATCH_PENDING_KEY`) and `_parse_pdf_tier` re-queues via `BatchPending` — i.e. **polling**, not failing. But `_run_processor` mapped `success=False` → `status="error"`, so every poll inflated `astrolabe_document_parse_total{status="error"}`. On the tenant-fleet "Document parse rate" panel this showed **thousands of "errors" during a normal boot** (3277 vs 23 successes/30m) while `parse_failed_total` was 0.

**Fix:** record the pending sentinel as `status="pending"` (throughput counters already gate on `"success"`, so it's attempt+duration only). Genuine failures stay `"error"`; worker-kills stay in `parse_failed_total`.

## 2. WebDAV SEARCH 400'd on folder names containing `&`
`_build_search_xml` interpolated the scope path **raw** into `<d:href>`. A tagged folder whose name contains `&` (e.g. `Reports & Plans`) injected a bare `&` → malformed XML → Nextcloud's Sabre/DAV parser returned **400**, so the tag-based indexing walk **skipped that folder and all descendants** (silent indexing gap).

**Fix:** XML-escape the scope before embedding it in `<d:href>` (keeps the path literal — Sabre unescapes it back — so matching is unchanged for ordinary folders).

## 3. Operator-friendly logging
- `search_files`: on HTTP error, log **status + scope + the server's response body** (the actual Sabre reason) instead of the opaque generic httpx `"Client error '400 …' for url '.../dav/'"` string.
- Tag-walk warning now states the **impact** ("those files will NOT be indexed until the walk succeeds").

## Tests
- Unit: parse-pending records `status="pending"`; SEARCH body is well-formed XML + href round-trips for `&` and `<>` scopes.
- Integration: a file inside an `&`-named folder stays findable via SEARCH.
- Drive-by: assert on the patched mock (not the bound method) in `test_get_or_create_tag_creates_new_tag` so the file passes `ty`.

`pytest` (unit) + `ruff` + `ty` green.

## Refs
Deck #407 (OCR poll metric + companion dashboard fix, applied via Grafana MCP) and the WebDAV-search card. Nextcloud note "Incident 2026-06-23: embedding-gateway S3 OCR cutover".

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
