### PR TITLE
fix(documents): recover full text layer when pymupdf4llm under-extracts

### DIFF
--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -65,9 +65,10 @@ def _recover_underextracted_pages(doc: Any, chunks: list[dict[str, Any]]) -> Non
             raw = doc[i].get_text("text")
         except Exception:  # noqa: BLE001 -- per-page best effort, never fail the parse
             continue
-        if len(raw.strip()) >= _TEXTLAYER_FALLBACK_MIN_CHARS and len(
-            raw.strip()
-        ) >= _TEXTLAYER_FALLBACK_RATIO * max(len(md), 1):
+        raw_len = len(raw.strip())
+        if raw_len >= _TEXTLAYER_FALLBACK_MIN_CHARS and raw_len >= (
+            _TEXTLAYER_FALLBACK_RATIO * max(len(md), 1)
+        ):
             chunk["text"] = raw
 
 

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -15,7 +15,7 @@ in its process pool.
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import anyio
 import anyio.to_process
@@ -34,6 +34,41 @@ logger = logging.getLogger(__name__)
 
 # Guard so the address-space limit is applied once per (reused) worker process.
 _MEM_LIMIT_APPLIED = False
+
+# pymupdf4llm reconstructs reading-order markdown, which can DROP most of the text
+# on non-prose layouts (engineering drawings, scattered labels): observed 598 of a
+# 5080-char text layer on an A1 ventilation drawing -- which then mis-escalated to
+# the (paid) OCR tier despite the layer already containing the answer. When a page's
+# markdown recovers far less than its raw text layer, fall back to plain get_text for
+# that page: the text layer is the source of truth; markdown's value is structure,
+# not completeness, and the structured/pymupdf tier exists precisely to re-extract a
+# layer correctly. Trigger only on a CLEAR under-extraction (raw >= ratio x markdown
+# AND raw non-trivial) so clean prose -- whose markdown matches/exceeds get_text -- is
+# untouched.
+_TEXTLAYER_FALLBACK_RATIO = 3.0
+_TEXTLAYER_FALLBACK_MIN_CHARS = 64
+
+
+def _recover_underextracted_pages(doc: Any, chunks: list[dict[str, Any]]) -> None:
+    """Replace a page's markdown with its raw ``get_text`` layer (in place) when
+    ``to_markdown`` dropped most of it -- see ``_TEXTLAYER_FALLBACK_*``.
+
+    page_chunks=True yields one chunk per page in page order, so ``chunks[i]`` maps
+    to ``doc[i]`` (this worker always parses the full doc -- no ``pages=`` subset).
+    Per-page best effort: a get_text failure leaves that page's markdown as-is.
+    """
+    for i, chunk in enumerate(chunks):
+        if i >= doc.page_count:
+            break
+        md = (chunk.get("text") or "").strip()
+        try:
+            raw = doc[i].get_text("text")
+        except Exception:  # noqa: BLE001 -- per-page best effort, never fail the parse
+            continue
+        if len(raw.strip()) >= _TEXTLAYER_FALLBACK_MIN_CHARS and len(
+            raw.strip()
+        ) >= _TEXTLAYER_FALLBACK_RATIO * max(len(md), 1):
+            chunk["text"] = raw
 
 
 class PdfParseFailed(Exception):
@@ -95,13 +130,19 @@ def _parse_pdf_worker(
     doc = pymupdf.open("pdf", content)
     try:
         # page_chunks=True makes to_markdown return list[dict], not str.
-        return pymupdf4llm.to_markdown(  # type: ignore[return-value]
-            doc,
-            write_images=write_images,
-            image_path=image_path if write_images else None,
-            page_chunks=True,
-            graphics_limit=graphics_limit,
+        chunks = cast(
+            "list[dict[str, Any]]",
+            pymupdf4llm.to_markdown(
+                doc,
+                write_images=write_images,
+                image_path=image_path if write_images else None,
+                page_chunks=True,
+                graphics_limit=graphics_limit,
+            ),
         )
+        # Recover pages where markdown reconstruction dropped most of the text layer.
+        _recover_underextracted_pages(doc, chunks)
+        return chunks
     finally:
         doc.close()
 

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -289,3 +289,52 @@ def test_recover_keeps_adequate_markdown():
         assert chunks[0]["text"] == good_md
     finally:
         doc.close()
+
+
+# Lightweight fake doc/page for the edge paths (no pymupdf needed).
+class _FakePage:
+    def __init__(self, text: str, *, raises: bool = False) -> None:
+        self._text = text
+        self._raises = raises
+
+    def get_text(self, _kind: str) -> str:
+        if self._raises:
+            raise RuntimeError("page extraction blew up")
+        return self._text
+
+
+class _FakeDoc:
+    def __init__(self, pages: list[_FakePage]) -> None:
+        self._pages = pages
+        self.page_count = len(pages)
+
+    def __getitem__(self, i: int) -> _FakePage:
+        assert i < self.page_count, "indexed a page beyond page_count"
+        return self._pages[i]
+
+
+def test_recover_skips_page_on_get_text_error():
+    # The per-page best-effort branch: a get_text failure leaves the chunk as-is.
+    chunks = [{"text": "tiny", "metadata": {}}]
+    _isolation._recover_underextracted_pages(
+        _FakeDoc([_FakePage("", raises=True)]), chunks
+    )
+    assert chunks[0]["text"] == "tiny"
+
+
+def test_recover_fires_on_empty_markdown():
+    # Empty markdown (to_markdown returned nothing) + a rich raw layer -> fall back.
+    rich = "x" * 200
+    chunks = [{"text": "", "metadata": {}}]
+    _isolation._recover_underextracted_pages(_FakeDoc([_FakePage(rich)]), chunks)
+    assert chunks[0]["text"] == rich
+
+
+def test_recover_ignores_chunks_beyond_page_count():
+    # The i >= page_count guard: extra chunks (never expected from page_chunks=True)
+    # are left untouched and no out-of-range page is indexed.
+    rich = "y" * 200
+    chunks = [{"text": "tiny", "metadata": {}}, {"text": "extra", "metadata": {}}]
+    _isolation._recover_underextracted_pages(_FakeDoc([_FakePage(rich)]), chunks)
+    assert chunks[0]["text"] == rich  # page 0 recovered
+    assert chunks[1]["text"] == "extra"  # extra chunk untouched (loop broke)

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -251,3 +251,41 @@ async def test_processor_parse_failure_returns_success_false(monkeypatch):
     assert result.success is False
     assert result.text == ""
     assert result.metadata["parse_failed_reason"] == "oom"
+
+
+# --- text-layer fallback when pymupdf4llm markdown under-extracts (drawings) ---
+
+
+def _doc_with_text(text: str) -> pymupdf.Document:
+    doc = pymupdf.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_textbox(pymupdf.Rect(36, 36, 559, 806), text, fontsize=10)
+    return doc
+
+
+def test_recover_replaces_underextracted_page():
+    # A page whose raw text layer is rich, but whose markdown chunk recovered almost
+    # nothing (the pymupdf4llm-on-a-drawing failure): fall back to get_text.
+    full = " ".join(f"word{i}" for i in range(120))  # ~800 clean chars
+    doc = _doc_with_text(full)
+    try:
+        chunks = [{"text": "tiny", "metadata": {}}]
+        _isolation._recover_underextracted_pages(doc, chunks)
+        assert "word100" in chunks[0]["text"]
+        assert len(chunks[0]["text"]) > _isolation._TEXTLAYER_FALLBACK_MIN_CHARS
+    finally:
+        doc.close()
+
+
+def test_recover_keeps_adequate_markdown():
+    # Markdown that already captured the text (>= raw / ratio) is left untouched, so
+    # structured output keeps its markdown structure for normal docs.
+    full = " ".join(f"word{i}" for i in range(120))
+    doc = _doc_with_text(full)
+    try:
+        good_md = "# Heading\n\n" + full
+        chunks = [{"text": good_md, "metadata": {}}]
+        _isolation._recover_underextracted_pages(doc, chunks)
+        assert chunks[0]["text"] == good_md
+    finally:
+        doc.close()


### PR DESCRIPTION
## Why
A handwritten-annotated A1 ventilation drawing (blackbox-demo `PLAN 2.pdf`) wasn't searchable for *"which file mentions ductwork grilles that were ripped"* — even though its embedded OCR **text layer already contains the answer** (5,080 chars incl. *"Ductwork for supply grilles has ripped. Recommend A/C unit for server cupboard"*).

Root cause (verified locally against the live wrapper + the classifier):
1. `pypdfium2` (tier-1 fast) leaks glyph codes on this file (control-char ratio **0.28**) → classified `corrupt_glyphs` → escalates to the **structured** tier (correct by design: pymupdf should re-extract a broken-ToUnicode layer cleanly).
2. The structured tier runs **`pymupdf4llm.to_markdown`**, which reconstructs reading-order markdown and **drops most of the text on non-prose layouts** — it recovered only **598 of 5,080 chars**. The post-parse quality gate then judged that 598 as `low_confidence` and escalated to the **OCR tier** — which under-extracted it *and* OOM'd the GPU wrapper.

Plain `page.get_text` recovers the layer cleanly (5,080 chars, control-ratio 0.0, classifies `fast`). The text was always there; markdown reconstruction discarded it.

## What
In the isolated parse worker (`_isolation.py`), after `to_markdown`, fall back to plain `page.get_text` for any page whose markdown recovered far less than its raw text layer (`raw >= 3× markdown` and `raw >= 64` chars). The text layer is the source of truth; markdown's value is structure, not completeness, and the structured tier exists precisely to re-extract a layer correctly. Clean prose (markdown ≈/≥ get_text) is untouched.

## Effect
- `PLAN 2.pdf` → structured tier now extracts **5,080 chars**, classifies **`fast`**, indexes the annotation → **no OCR escalation, no GPU**. (Confirmed end-to-end against the file via `PyMuPDFProcessor.process` + `classify_from_text`.)
- More broadly: text-dense **non-prose PDFs** (engineering drawings, code listings, dense tables) with a usable embedded text layer stop being wastefully routed to the on-demand GPU OCR tier.

## Tests
`test_recover_replaces_underextracted_page` + `test_recover_keeps_adequate_markdown`. `ruff` + `ty` clean; 239 related unit tests pass.

## Verification note
Code-level e2e is proven on the real file (recovers the text, classifies `fast`). The live tenant re-index → semantic-search-returns-PLAN-2.pdf check happens after this releases + deploys.

Refs Deck #411.

---

_This PR was generated with the help of AI, and reviewed by a Human_