### PR TITLE
feat(ingest): add INGEST_LISTEN_NOTIFY toggle for poll-only worker

### DIFF
--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -440,11 +440,12 @@ def worker(concurrency: int | None, tier: str | None):
             # pipeline like every other startup message.
             logger.info(
                 "Ingest worker started: tier=%s queues=%s concurrency=%s "
-                "delete_succeeded=%s",
+                "delete_succeeded=%s listen_notify=%s",
                 tier or "all",
                 queues,
                 workers,
                 settings.ingest_delete_succeeded_jobs,
+                settings.ingest_listen_notify,
             )
             await app.run_worker_async(
                 queues=queues,
@@ -456,6 +457,11 @@ def worker(concurrency: int | None, tier: str | None):
                 delete_jobs="successful"
                 if settings.ingest_delete_succeeded_jobs
                 else "never",
+                # LISTEN/NOTIFY for near-instant job pickup. Set
+                # INGEST_LISTEN_NOTIFY=false to run poll-only when DATABASE_URL
+                # routes through a transaction-mode pooler (PgBouncer), which
+                # drops the LISTEN registration on backend checkin (Deck #424).
+                listen_notify=settings.ingest_listen_notify,
             )
 
     anyio.run(_run)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -258,6 +258,16 @@ _DEFAULTS: dict[str, Any] = {
     # queue-depth metric clean). Set false to retain succeeded rows for audit
     # (note: indexing success is also recorded in logs/metrics regardless).
     "ingest_delete_succeeded_jobs": True,
+    # Whether the procrastinate worker uses LISTEN/NOTIFY for job pickup (Deck
+    # #424). True (default) = near-instant wakeup via a long-lived LISTEN
+    # connection. Set false to run POLL-ONLY when DATABASE_URL routes through a
+    # transaction-mode connection pooler (PgBouncer transaction mode), which is
+    # incompatible with LISTEN/NOTIFY — the LISTEN registration is dropped when
+    # the backend returns to the pool. Poll-only trades a few seconds of pickup
+    # latency (fetch_job_polling_interval) for pooler safety; job queries still
+    # multiplex through the pooler. Snapshotted at worker startup; needs a
+    # restart to change.
+    "ingest_listen_notify": True,
     # Per-tier escalation on the procrastinate (postgres) ingest path (Deck
     # #323). When true, a document that a tier cannot parse well is requeued onto
     # the next tier's queue (fast -> structured -> ocr) via a native procrastinate
@@ -941,6 +951,7 @@ class Settings:
     mcp_role: str = "all"  # api | worker | all (Deck #183 two-pod model)
     ingest_stalled_job_seconds: int = 300  # crashed-worker reclaim threshold
     ingest_delete_succeeded_jobs: bool = True  # drop succeeded ingest jobs
+    ingest_listen_notify: bool = True  # False = poll-only (txn-mode pooler, Deck #424)
     ingest_escalation_enabled: bool = True  # per-tier queue-hop (Deck #323)
     ingest_transient_max_attempts: int = 5  # same-tier transient-retry cap
     ingest_reclaim_retry_delay_seconds: int = 30  # stagger reclaimed-job retries
@@ -1583,6 +1594,7 @@ def get_settings() -> Settings:
         "mcp_role": "MCP_ROLE",
         "ingest_stalled_job_seconds": "INGEST_STALLED_JOB_SECONDS",
         "ingest_delete_succeeded_jobs": "INGEST_DELETE_SUCCEEDED_JOBS",
+        "ingest_listen_notify": "INGEST_LISTEN_NOTIFY",
         "ingest_escalation_enabled": "INGEST_ESCALATION_ENABLED",
         "ingest_transient_max_attempts": "INGEST_TRANSIENT_MAX_ATTEMPTS",
         "ingest_reclaim_retry_delay_seconds": "INGEST_RECLAIM_RETRY_DELAY_SECONDS",

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -23,6 +23,16 @@ class TestDecompositionDefaults:
         assert s.collection_metadata_source == "qdrant"
         assert s.embedding_gateway_url is None
         assert s.tenant_id is None
+        # LISTEN/NOTIFY stays on by default — poll-only is opt-in for
+        # transaction-mode poolers (Deck #424).
+        assert s.ingest_listen_notify is True
+
+    def test_listen_notify_toggle(self):
+        # The worker passes this straight to procrastinate's
+        # run_worker_async(listen_notify=...); false = poll-only for a
+        # transaction-mode pooler (PgBouncer).
+        assert Settings(ingest_listen_notify=False).ingest_listen_notify is False
+        assert Settings(ingest_listen_notify=True).ingest_listen_notify is True
 
     def test_enum_values_normalized(self):
         # Mixed case / surrounding whitespace is normalized before validation.


### PR DESCRIPTION
## Why

The procrastinate ingest worker runs with **LISTEN/NOTIFY on by default** (near-instant job pickup via a long-lived `LISTEN` connection). That's **incompatible with a transaction-mode connection pooler** (PgBouncer transaction mode): the `LISTEN` registration is dropped when the backend returns to the pool, so notifications are missed and jobs stall.

This is the **worker-side prerequisite** for routing per-tenant ingest workers through the shared-postgres **PgBouncer pooler** to stop onboarding-storm connection exhaustion (gitops Deck #424 — concurrent multi-tenant onboarding spins up many workers, each opening pool + LISTEN connections straight at `max_connections=100`). Workers must be poll-capable **before** their `DATABASE_URL` is pointed at the transaction pooler.

## What

One config knob, threaded into the worker:

- `config.py`: `ingest_listen_notify: bool = True` (env **`INGEST_LISTEN_NOTIFY`**) — added to the defaults dict, the `Settings` dataclass, and the env-var map, mirroring `ingest_delete_succeeded_jobs`.
- `cli.py`: pass `listen_notify=settings.ingest_listen_notify` to `run_worker_async(...)` (procrastinate 3.8 natively supports this — the worker only `LISTEN`s `if listen_notify`, else falls back to `fetch_job_polling_interval`). Startup log now records the mode.

**Default `true` → no behaviour change** for existing deployments (session-mode pools / direct connections keep instant LISTEN pickup). Set **`INGEST_LISTEN_NOTIFY=false`** to run poll-only when `DATABASE_URL` routes through a transaction-mode pooler; job queries still multiplex through the pooler, pickup latency rises to the polling interval (a few seconds — fine for ingest).

## Tests

`tests/unit/test_decomposition_config.py`: default stays `True` (monolith parity) + a toggle test. `ruff`, `ty-check`, commitizen, and the 24 config tests pass.

## Rollout (cross-repo)

1. **This PR** → release a new image with the knob.
2. **astrolabe-cloud-gitops**: set `INGEST_LISTEN_NOTIFY=false` on tenant workers + bump the image (workers go poll-only, still on the direct host — safe).
3. **astrolabe-cloud-gitops / astrolabe-cloud-website**: point `TENANT_DATABASE_HOST` at `shared-postgres-pooler…` + reprovision existing tenants' SM DSNs → workers now route through the pooler with no LISTEN/NOTIFY breakage.

---

_This PR was generated with the help of AI, and reviewed by a Human_