### PR TITLE
fix: detect truncated WebDAV downloads + NEXTCLOUD_HTTP_KEEPALIVE knob (#965)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ NEXTCLOUD_VERIFY_SSL=false
 |----------|----------|---------|-------------|
 | `NEXTCLOUD_VERIFY_SSL` | ⚠️ Optional | `true` | Set to `false` to disable TLS certificate verification |
 | `NEXTCLOUD_CA_BUNDLE` | ⚠️ Optional | - | Path to a PEM CA bundle file for custom certificate authorities |
+| `NEXTCLOUD_HTTP_KEEPALIVE` | ⚠️ Optional | `true` | Reuse pooled keep-alive connections for the Nextcloud httpx client. Set to `false` to open a fresh connection per request (`max_keepalive_connections=0`). Recommended for deployments behind a flaky CDN/WAN path where a truncated response can poison a pooled connection and cause later reads to silently return empty bytes — see [#965](https://github.com/cbcoutinho/nextcloud-mcp-server/issues/965). Mirrors the `DATABASE_POOL_SIZE`→`NullPool` precedent at the HTTP layer. Trade-off: a TLS handshake per request. |
 
 ### Scope
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,7 +242,18 @@ NEXTCLOUD_VERIFY_SSL=false
 |----------|----------|---------|-------------|
 | `NEXTCLOUD_VERIFY_SSL` | ⚠️ Optional | `true` | Set to `false` to disable TLS certificate verification |
 | `NEXTCLOUD_CA_BUNDLE` | ⚠️ Optional | - | Path to a PEM CA bundle file for custom certificate authorities |
-| `NEXTCLOUD_HTTP_KEEPALIVE` | ⚠️ Optional | `true` | Reuse pooled keep-alive connections for the Nextcloud httpx client. Set to `false` to open a fresh connection per request (`max_keepalive_connections=0`). Recommended for deployments behind a flaky CDN/WAN path where a truncated response can poison a pooled connection and cause later reads to silently return empty bytes — see [#965](https://github.com/cbcoutinho/nextcloud-mcp-server/issues/965). Mirrors the `DATABASE_POOL_SIZE`→`NullPool` precedent at the HTTP layer. Trade-off: a TLS handshake per request. |
+| `NEXTCLOUD_HTTP_KEEPALIVE` | ⚠️ Optional | `true` | Reuse pooled keep-alive connections for the Nextcloud httpx client. Set to `false` to open a fresh connection per request. See the note below. |
+
+> **`NEXTCLOUD_HTTP_KEEPALIVE`** — With the default (`true`) the httpx client pools
+> and reuses connections. Setting it to `false` builds the transport with
+> `max_keepalive_connections=0`, so every request opens (and closes) its own
+> connection. This is recommended for deployments behind a flaky CDN/WAN path,
+> where a truncated/interrupted response can poison a pooled connection and make
+> later reads silently return empty bytes — see
+> [#965](https://github.com/cbcoutinho/nextcloud-mcp-server/issues/965). It
+> mirrors the `DATABASE_POOL_SIZE`→`NullPool` precedent at the HTTP layer. The
+> trade-off is a TLS handshake per request, which is negligible for a background
+> indexer.
 
 ### Scope
 

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -8,13 +8,53 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, unquote
 from xml.sax.saxutils import escape as xml_escape
 
-from httpx import HTTPStatusError
+from httpx import HTTPStatusError, RemoteProtocolError, Response
 
-from nextcloud_mcp_server.observability.metrics import document_scan_truncated_total
+from nextcloud_mcp_server.observability.metrics import (
+    document_download_truncated_total,
+    document_scan_truncated_total,
+)
 
 from .base import BaseNextcloudClient
 
 logger = logging.getLogger(__name__)
+
+
+def _read_complete_body(response: Response, label: str) -> bytes:
+    """Return the response body, raising on a short read vs ``Content-Length``.
+
+    A truncated/desynced response on a pooled keep-alive connection can hand
+    back an empty/short body that the document parser then reads as ``0 chars``
+    and the vector-sync processor permanently dead-letters (#965). Compare the
+    received byte count against the declared ``Content-Length`` and raise a
+    retryable :class:`httpx.RemoteProtocolError` on a mismatch: the processor
+    retries/re-queues a raised transport error instead of dead-lettering the
+    document, so a healthy file recovers on the next scan. (httpx already
+    raises on most genuine truncations during the read; this is the
+    belt-and-suspenders guard for the cases it returns intact. The robust
+    mitigation for connection poisoning is ``NEXTCLOUD_HTTP_KEEPALIVE=false``.)
+    A missing or malformed header (e.g. ``Transfer-Encoding: chunked``) skips
+    the check so legitimately header-less responses never raise.
+    """
+    content = response.content
+    declared = response.headers.get("content-length")
+    if declared is None:
+        return content
+    try:
+        expected = int(declared)
+    except ValueError:
+        # Malformed header — nothing reliable to compare against, so don't
+        # raise spuriously; let the (possibly fine) body through.
+        return content
+    if len(content) != expected:
+        document_download_truncated_total.inc()
+        raise RemoteProtocolError(
+            f"Truncated download for {label!r}: expected {expected} bytes, "
+            f"got {len(content)} (poisoned keep-alive connection? see #965)",
+            request=response.request,
+        )
+    return content
+
 
 # Paging defaults for WebDAV SEARCH. Nextcloud's SEARCH returns a server-default
 # page (~100 results) when no ``<d:nresults>`` is sent, silently truncating large
@@ -252,7 +292,7 @@ class WebDAVClient(BaseNextcloudClient):
             response = await self._make_request("GET", attachment_path)
             response.raise_for_status()
 
-            content = response.content
+            content = _read_complete_body(response, filename)
             mime_type = response.headers.get("content-type", "application/octet-stream")
 
             logger.debug(
@@ -392,7 +432,7 @@ class WebDAVClient(BaseNextcloudClient):
             response = await self._make_request("GET", webdav_path)
             response.raise_for_status()
 
-            content = response.content
+            content = _read_complete_body(response, path)
             content_type = response.headers.get(
                 "content-type", "application/octet-stream"
             )

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -46,8 +46,23 @@ def _read_complete_body(response: Response, label: str) -> bytes:
         # Malformed header — nothing reliable to compare against, so don't
         # raise spuriously; let the (possibly fine) body through.
         return content
+    if expected < 0:
+        # Degenerate header (negative length) — can't be a real short-read
+        # signal and would always trip the check below; ignore it.
+        return content
     if len(content) != expected:
         document_download_truncated_total.inc()
+        # Log here, not just in the message: both callers funnel this through a
+        # generic ``except Exception`` that would otherwise report it as an
+        # opaque "Unexpected error reading file".
+        logger.warning(
+            "Truncated download for %r: expected %d bytes, got %d "
+            "(poisoned keep-alive connection? set NEXTCLOUD_HTTP_KEEPALIVE=false "
+            "— see #965)",
+            label,
+            expected,
+            len(content),
+        )
         raise RemoteProtocolError(
             f"Truncated download for {label!r}: expected {expected} bytes, "
             f"got {len(content)} (poisoned keep-alive connection? see #965)",

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -999,6 +999,16 @@ class Settings:
                 )
             logger.info("Using custom CA bundle: %s", self.nextcloud_ca_bundle)
 
+        # Surface the keep-alive opt-out at startup so an operator who set it to
+        # work around #965 gets confirmation it took effect.
+        if not self.nextcloud_http_keepalive:
+            logger.info(
+                "NEXTCLOUD_HTTP_KEEPALIVE is disabled. The Nextcloud HTTP client "
+                "will open a fresh connection per request (no pooled keep-alive "
+                "reuse) — a TLS handshake per call in exchange for immunity to "
+                "poisoned/desynced pooled connections (#965)."
+            )
+
         # Validate Postgres backend TLS configuration (ADR-026)
         if self.database_verify_ssl is False:
             logger.warning(

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -31,6 +31,7 @@ _DEFAULTS: dict[str, Any] = {
     "nextcloud_app_password": None,
     "nextcloud_verify_ssl": True,
     "nextcloud_ca_bundle": None,
+    "nextcloud_http_keepalive": True,
     "nextcloud_mcp_server_url": None,
     "nextcloud_resource_uri": None,
     "nextcloud_public_issuer_url": None,
@@ -720,6 +721,14 @@ class Settings:
     # Nextcloud SSL/TLS settings
     nextcloud_verify_ssl: bool = True
     nextcloud_ca_bundle: str | None = None
+
+    # Reuse pooled keep-alive connections for the Nextcloud httpx client.
+    # Default True preserves low-latency interactive traffic. Set
+    # NEXTCLOUD_HTTP_KEEPALIVE=false to force a fresh connection per request
+    # (max_keepalive_connections=0) — mirrors the DATABASE_POOL_SIZE→NullPool
+    # precedent and prevents a truncated/desynced response from poisoning a
+    # pooled connection on flaky CDN/WAN paths (see #965).
+    nextcloud_http_keepalive: bool = True
 
     # Postgres backend TLS settings (ADR-026). Default verify_ssl is None,
     # not True: when DATABASE_URL is unset there's nothing to verify, and
@@ -1493,6 +1502,7 @@ def get_settings() -> Settings:
         # Nextcloud SSL/TLS settings
         "nextcloud_verify_ssl": "NEXTCLOUD_VERIFY_SSL",
         "nextcloud_ca_bundle": "NEXTCLOUD_CA_BUNDLE",
+        "nextcloud_http_keepalive": "NEXTCLOUD_HTTP_KEEPALIVE",
         # Postgres backend TLS (ADR-026)
         "database_verify_ssl": "DATABASE_VERIFY_SSL",
         "database_ca_bundle": "DATABASE_CA_BUNDLE",
@@ -1641,6 +1651,17 @@ def get_nextcloud_ssl_verify() -> bool | ssl.SSLContext:
         ctx = ssl.create_default_context(cafile=settings.nextcloud_ca_bundle)
         return ctx
     return True
+
+
+def get_nextcloud_http_keepalive() -> bool:
+    """Return whether the Nextcloud httpx client may reuse pooled connections.
+
+    Returns:
+        - False if NEXTCLOUD_HTTP_KEEPALIVE=false (fresh connection per
+          request; mitigates the poisoned-keep-alive truncation in #965).
+        - True otherwise (default pooled keep-alive behavior).
+    """
+    return get_settings().nextcloud_http_keepalive
 
 
 def get_database_ssl() -> bool | ssl.SSLContext | None:

--- a/nextcloud_mcp_server/http.py
+++ b/nextcloud_mcp_server/http.py
@@ -42,6 +42,11 @@ def nextcloud_httpx_transport(**kwargs: Any) -> httpx.AsyncHTTPTransport:
     silently returning empty bytes on later reads (see #965). A
     caller-supplied ``limits`` kwarg takes precedence.
 
+    Both ``get_nextcloud_ssl_verify()`` and ``get_nextcloud_http_keepalive()``
+    are read eagerly here. That is correct because a transport is built once per
+    client lifetime; a future refactor that builds transports per-request would
+    turn these into per-request ``get_settings()`` calls and should cache them.
+
     Args:
         **kwargs: Forwarded to ``httpx.AsyncHTTPTransport()``.
 

--- a/nextcloud_mcp_server/http.py
+++ b/nextcloud_mcp_server/http.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import httpx
 
-from .config import get_nextcloud_ssl_verify
+from .config import get_nextcloud_http_keepalive, get_nextcloud_ssl_verify
 
 
 def nextcloud_httpx_client(**kwargs: Any) -> httpx.AsyncClient:
@@ -35,6 +35,13 @@ def nextcloud_httpx_transport(**kwargs: Any) -> httpx.AsyncHTTPTransport:
     Used by ``NextcloudClient`` which wraps the transport in
     ``AsyncDisableCookieTransport``.
 
+    When ``NEXTCLOUD_HTTP_KEEPALIVE=false`` the transport is built with
+    ``Limits(max_keepalive_connections=0)`` so every request opens a fresh
+    connection instead of reusing a pooled keep-alive one. This prevents a
+    truncated/desynced response from poisoning a pooled connection and
+    silently returning empty bytes on later reads (see #965). A
+    caller-supplied ``limits`` kwarg takes precedence.
+
     Args:
         **kwargs: Forwarded to ``httpx.AsyncHTTPTransport()``.
 
@@ -42,4 +49,6 @@ def nextcloud_httpx_transport(**kwargs: Any) -> httpx.AsyncHTTPTransport:
         Configured ``httpx.AsyncHTTPTransport``.
     """
     kwargs.setdefault("verify", get_nextcloud_ssl_verify())
+    if not get_nextcloud_http_keepalive():
+        kwargs.setdefault("limits", httpx.Limits(max_keepalive_connections=0))
     return httpx.AsyncHTTPTransport(**kwargs)

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -439,6 +439,12 @@ document_scan_truncated_total = Counter(
     "Times a folder-expansion SEARCH hit the result ceiling (coverage truncated)",
 )
 
+document_download_truncated_total = Counter(
+    "astrolabe_document_download_truncated_total",
+    "Times a WebDAV GET returned fewer bytes than Content-Length (truncated/"
+    "poisoned connection; raised as a retryable transport error, see #965)",
+)
+
 # =============================================================================
 # Database Metrics
 # =============================================================================

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -1,4 +1,18 @@
-"""Unit tests for MailClient API methods."""
+"""Unit tests for MailClient API methods.
+
+Mail 5.x exposes two route families (see ``~/Software/mail/appinfo/routes.php``
+and the module docstring of ``client/mail.py``):
+
+- **Direct REST resource routes** under ``/index.php/apps/mail/api`` —
+  ``/accounts``, ``/mailboxes``, ``/messages``, ``/outbox`` — return the payload
+  *unwrapped* (plain JSON list/dict) and require a CSRF ``requesttoken`` header.
+- **OCS routes** under ``/ocs/v2.php/apps/mail`` — ``/message/{id}``,
+  ``/message/{id}/attachment/{id}``, ``/message/{id}/raw`` — return the standard
+  OCS envelope and work with Basic Auth alone.
+
+The ``_api_*`` tests therefore feed plain JSON and stub the CSRF round-trip; the
+OCS tests feed an enveloped payload.
+"""
 
 import logging
 from typing import Any
@@ -16,7 +30,7 @@ pytestmark = pytest.mark.unit
 
 
 def _ocs_response(data: Any, status_code: int = 200) -> httpx.Response:
-    """Wrap a payload in the standard OCS envelope."""
+    """Wrap a payload in the standard OCS envelope (for OCS-route tests)."""
     return create_mock_response(
         status_code=status_code,
         json_data={
@@ -28,10 +42,22 @@ def _ocs_response(data: Any, status_code: int = 200) -> httpx.Response:
     )
 
 
-async def test_list_accounts_unwraps_ocs_envelope(mocker):
-    """list_accounts returns the ocs.data payload."""
-    mock_response = _ocs_response(
-        [
+def _stub_csrf(mocker, client: MailClient) -> None:
+    """Bypass the CSRF round-trip for direct-API tests.
+
+    The direct REST routes call ``_ensure_csrf`` (a live GET to
+    ``/index.php/csrftoken`` via the raw http client) before each request. Unit
+    tests patch ``_make_request`` only, so stub the token acquisition out and
+    pre-seed a token so the ``requesttoken`` header is populated.
+    """
+    mocker.patch.object(MailClient, "_ensure_csrf", new=mocker.AsyncMock())
+    client._request_token = "test-token"
+
+
+async def test_list_accounts_unwraps_direct_payload(mocker):
+    """list_accounts returns the plain JSON list from the direct REST route."""
+    mock_response = create_mock_response(
+        json_data=[
             {"id": 1, "email": "alice@example.com", "isDelegated": False},
             {"id": 2, "email": "bob@example.com", "isDelegated": False},
         ]
@@ -42,23 +68,23 @@ async def test_list_accounts_unwraps_ocs_envelope(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
+    _stub_csrf(mocker, client)
     accounts = await client.list_accounts()
 
     assert len(accounts) == 2
     assert accounts[0]["id"] == 1
     assert accounts[0]["email"] == "alice@example.com"
 
-    # Correct URL, OCS header, and format=json param.
+    # Direct resource route + CSRF header.
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/api/account/list")
-    assert kwargs["headers"]["OCS-APIRequest"] == "true"
-    assert kwargs["params"]["format"] == "json"
+    assert args == ("GET", "/index.php/apps/mail/api/accounts")
+    assert kwargs["headers"]["requesttoken"] == "test-token"
 
 
 async def test_get_mailboxes_passes_account_id(mocker):
     """get_mailboxes sends accountId and unwraps the list."""
-    mock_response = _ocs_response(
-        [
+    mock_response = create_mock_response(
+        json_data=[
             {
                 "databaseId": 10,
                 "id": "SU5CT1g=",
@@ -76,6 +102,7 @@ async def test_get_mailboxes_passes_account_id(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
+    _stub_csrf(mocker, client)
     mailboxes = await client.get_mailboxes(account_id=1)
 
     assert len(mailboxes) == 1
@@ -83,14 +110,14 @@ async def test_get_mailboxes_passes_account_id(mocker):
     assert mailboxes[0]["specialUse"] == ["inbox"]
 
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/api/mailboxes")
+    assert args == ("GET", "/index.php/apps/mail/api/mailboxes")
     assert kwargs["params"]["accountId"] == 1
 
 
 async def test_list_messages_builds_params(mocker):
-    """list_messages forwards limit/cursor/filter/view query params."""
-    mock_response = _ocs_response(
-        [
+    """list_messages forwards mailboxId/limit/cursor/filter/view query params."""
+    mock_response = create_mock_response(
+        json_data=[
             {
                 "databaseId": 100,
                 "subject": "Hello",
@@ -107,6 +134,7 @@ async def test_list_messages_builds_params(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
+    _stub_csrf(mocker, client)
     messages = await client.list_messages(
         10, cursor=42, search_filter="hello", limit=50, view="threaded"
     )
@@ -115,7 +143,8 @@ async def test_list_messages_builds_params(mocker):
     assert messages[0]["databaseId"] == 100
 
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/api/mailboxes/10/messages")
+    assert args == ("GET", "/index.php/apps/mail/api/messages")
+    assert kwargs["params"]["mailboxId"] == 10
     assert kwargs["params"]["limit"] == 50
     assert kwargs["params"]["cursor"] == 42
     assert kwargs["params"]["filter"] == "hello"
@@ -123,18 +152,20 @@ async def test_list_messages_builds_params(mocker):
 
 
 async def test_list_messages_omits_optional_params(mocker):
-    """Optional params are omitted when not supplied; limit always present."""
-    mock_response = _ocs_response([])
+    """Optional params are omitted when not supplied; mailboxId/limit always present."""
+    mock_response = create_mock_response(json_data=[])
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
     mock_make_request = mocker.patch.object(
         MailClient, "_make_request", return_value=mock_response
     )
 
     client = MailClient(mock_client, "testuser")
+    _stub_csrf(mocker, client)
     await client.list_messages(10)
 
     _, kwargs = mock_make_request.call_args
     params = kwargs["params"]
+    assert params["mailboxId"] == 10
     assert params["limit"] == 20  # default
     assert "cursor" not in params
     assert "filter" not in params
@@ -142,7 +173,7 @@ async def test_list_messages_omits_optional_params(mocker):
 
 
 async def test_get_message_unwraps_full_message(mocker):
-    """get_message returns the full message dict."""
+    """get_message returns the full message dict from the OCS route."""
     mock_response = _ocs_response(
         {
             "id": 100,
@@ -173,11 +204,11 @@ async def test_get_message_unwraps_full_message(mocker):
     assert message["attachments"][0]["fileName"] == "doc.pdf"
 
     args, _ = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/api/message/100")
+    assert args == ("GET", "/ocs/v2.php/apps/mail/message/100")
 
 
 async def test_get_attachment_unwraps_json(mocker):
-    """get_attachment returns the JSON attachment object (not a binary download)."""
+    """get_attachment returns the JSON attachment object from the OCS route."""
     mock_response = _ocs_response(
         {"name": "doc.pdf", "mime": "application/pdf", "size": 1024, "content": "abc"}
     )
@@ -193,7 +224,7 @@ async def test_get_attachment_unwraps_json(mocker):
     assert attachment["content"] == "abc"
 
     args, _ = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/api/message/100/attachment/1.2")
+    assert args == ("GET", "/ocs/v2.php/apps/mail/message/100/attachment/1.2")
 
 
 async def test_get_attachment_url_encodes_attachment_id(mocker):
@@ -211,17 +242,18 @@ async def test_get_attachment_url_encodes_attachment_id(mocker):
     # The "/" and ".." are encoded, so they can't escape the attachment path.
     assert args == (
         "GET",
-        "/ocs/v2.php/apps/mail/api/message/100/attachment/..%2F..%2Fevil",
+        "/ocs/v2.php/apps/mail/message/100/attachment/..%2F..%2Fevil",
     )
 
 
 async def test_empty_data_returns_empty_list(mocker):
-    """A null ocs.data payload degrades to an empty list for list endpoints."""
-    mock_response = _ocs_response(None)
+    """A non-list direct payload degrades to an empty list for list endpoints."""
+    mock_response = create_mock_response(json_data={})
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
     mocker.patch.object(MailClient, "_make_request", return_value=mock_response)
 
     client = MailClient(mock_client, "testuser")
+    _stub_csrf(mocker, client)
     assert await client.list_accounts() == []
 
 
@@ -250,7 +282,7 @@ async def test_ocs_meta_failure_raises_httpstatuserror(mocker):
 
 
 async def test_non_json_response_raises_requesterror(mocker):
-    """A non-JSON 200 body (e.g. Mail app absent) raises a RequestError."""
+    """A non-JSON 200 body on an OCS route (Mail app absent) raises RequestError."""
     mock_response = create_mock_response(
         status_code=200, content=b"<html>not found</html>"
     )
@@ -259,4 +291,4 @@ async def test_non_json_response_raises_requesterror(mocker):
 
     client = MailClient(mock_client, "testuser")
     with pytest.raises(httpx.RequestError):
-        await client.list_accounts()
+        await client.get_message(100)

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -603,6 +603,71 @@ async def test_read_file_ascii_path_unchanged(mocker):
 
 
 @pytest.mark.unit
+async def test_read_file_raises_on_truncated_body(mocker):
+    """A body shorter than Content-Length is a poisoned/truncated download (#965).
+
+    httpx can hand back empty/short bytes on a healthy-looking 200 when a pooled
+    keep-alive connection is desynced. read_file must raise a retryable transport
+    error (so the vector-sync processor retries/re-queues instead of parsing the
+    empty bytes and dead-lettering the file), not return the truncated content.
+    """
+    from httpx import RemoteProtocolError
+
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    mock_response = AsyncMock()
+    mock_response.content = b""  # poisoned connection delivered nothing
+    mock_response.headers = {
+        "content-type": "application/pdf",
+        "content-length": "187564",
+    }
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(RemoteProtocolError, match="Truncated download"):
+        await client.read_file("Active-Personal/fw9-filled.pdf")
+
+
+@pytest.mark.unit
+async def test_read_file_accepts_matching_content_length(mocker):
+    """A body matching Content-Length is returned unchanged."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    body = b"%PDF-1.7 full body"
+    mock_response = AsyncMock()
+    mock_response.content = body
+    mock_response.headers = {
+        "content-type": "application/pdf",
+        "content-length": str(len(body)),
+    }
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    content, content_type = await client.read_file("Documents/report.pdf")
+    assert content == body
+    assert content_type == "application/pdf"
+
+
+@pytest.mark.unit
+async def test_read_file_skips_check_without_content_length(mocker):
+    """A header-less (e.g. chunked) response must not raise — nothing to compare."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    body = b"chunked body of unknown declared length"
+    mock_response = AsyncMock()
+    mock_response.content = body
+    mock_response.headers = {"content-type": "text/plain"}  # no content-length
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    content, _ = await client.read_file("Documents/stream.txt")
+    assert content == body
+
+
+@pytest.mark.unit
 async def test_move_resource_encodes_destination_header(mocker):
     """The MOVE Destination header must be percent-encoded too (card 309)."""
     mock_http_client = AsyncMock()

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -668,6 +668,27 @@ async def test_read_file_skips_check_without_content_length(mocker):
 
 
 @pytest.mark.unit
+async def test_get_note_attachment_raises_on_truncated_body(mocker):
+    """get_note_attachment shares the short-read guard with read_file (#965)."""
+    from httpx import RemoteProtocolError
+
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    mock_response = AsyncMock()
+    mock_response.content = b"abc"  # 3 bytes
+    mock_response.headers = {
+        "content-type": "application/pdf",
+        "content-length": "2048",
+    }
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(RemoteProtocolError, match="Truncated download"):
+        await client.get_note_attachment(123, "doc.pdf")
+
+
+@pytest.mark.unit
 async def test_move_resource_encodes_destination_header(mocker):
     """The MOVE Destination header must be percent-encoded too (card 309)."""
     mock_http_client = AsyncMock()

--- a/tests/unit/test_ssl_config.py
+++ b/tests/unit/test_ssl_config.py
@@ -202,7 +202,13 @@ class TestHTTPClientFactory:
 
 
 class TestHTTPKeepalive:
-    """NEXTCLOUD_HTTP_KEEPALIVE wiring into the Nextcloud httpx transport (#965)."""
+    """NEXTCLOUD_HTTP_KEEPALIVE wiring into the Nextcloud httpx transport (#965).
+
+    The assertions reach into ``transport._pool._max_keepalive_connections`` —
+    a private httpcore attribute. It is the most direct way to verify the limit
+    actually reached the pool; httpx/httpcore is pinned, so the breakage risk on
+    a rename is low and would be caught immediately by these tests.
+    """
 
     def test_default_keeps_pooled_connections(self):
         """Default (keep-alive enabled) leaves httpx's default pool limits."""

--- a/tests/unit/test_ssl_config.py
+++ b/tests/unit/test_ssl_config.py
@@ -25,6 +25,7 @@ from nextcloud_mcp_server.config import (
     Settings,
     _reload_config,
     get_database_ssl,
+    get_nextcloud_http_keepalive,
     get_nextcloud_ssl_verify,
     get_settings,
 )
@@ -198,6 +199,51 @@ class TestHTTPClientFactory:
         ):
             client = nextcloud_httpx_client(timeout=5.0, follow_redirects=True)
             assert isinstance(client, httpx.AsyncClient)
+
+
+class TestHTTPKeepalive:
+    """NEXTCLOUD_HTTP_KEEPALIVE wiring into the Nextcloud httpx transport (#965)."""
+
+    def test_default_keeps_pooled_connections(self):
+        """Default (keep-alive enabled) leaves httpx's default pool limits."""
+        with patch(
+            "nextcloud_mcp_server.http.get_nextcloud_http_keepalive", return_value=True
+        ):
+            transport = nextcloud_httpx_transport()
+            assert transport._pool._max_keepalive_connections == 20
+
+    def test_disabled_forces_fresh_connection_per_request(self):
+        """NEXTCLOUD_HTTP_KEEPALIVE=false → max_keepalive_connections=0."""
+        with patch(
+            "nextcloud_mcp_server.http.get_nextcloud_http_keepalive", return_value=False
+        ):
+            transport = nextcloud_httpx_transport()
+            assert transport._pool._max_keepalive_connections == 0
+
+    def test_caller_supplied_limits_take_precedence(self):
+        """An explicit limits kwarg is not overridden even when keep-alive is off."""
+        with patch(
+            "nextcloud_mcp_server.http.get_nextcloud_http_keepalive", return_value=False
+        ):
+            transport = nextcloud_httpx_transport(
+                limits=httpx.Limits(max_keepalive_connections=7)
+            )
+            assert transport._pool._max_keepalive_connections == 7
+
+
+class TestGetNextcloudHTTPKeepalive:
+    """get_nextcloud_http_keepalive() reads NEXTCLOUD_HTTP_KEEPALIVE."""
+
+    def test_default_true(self):
+        assert Settings().nextcloud_http_keepalive is True
+
+    def test_env_false(self):
+        with patch.dict(os.environ, {"NEXTCLOUD_HTTP_KEEPALIVE": "false"}):
+            _reload_config()
+            try:
+                assert get_nextcloud_http_keepalive() is False
+            finally:
+                _reload_config()
 
 
 class TestDatabaseSSLSettings:


### PR DESCRIPTION
## Summary

Fixes #965 — during background vector-sync indexing a single truncated/desynced WebDAV response could poison the long-lived pooled `httpx.AsyncClient`, so later `webdav.read_file` calls returned empty/truncated bytes on a healthy `200`. The empty PDF raised `PDFium: Data format error`, which the processor treated as a **terminal parse failure and dead-lettered by etag** — permanently skipping a valid file until the MCP container was restarted. The reporter saw only ~350 of 3500 PDFs indexed.

## Approach (detection + operator knob; dead-letter logic unchanged)

1. **Detect short reads** (`client/webdav.py`): `read_file` / `get_note_attachment` now validate the downloaded body length against the `Content-Length` header and raise a retryable `httpx.RemoteProtocolError` on a mismatch. The processor's existing retry/re-queue loop handles a *raised* transport error without marking the doc failed, so a healthy file recovers on the next scan instead of being dead-lettered. (httpx already raises on most genuine truncations; this is the belt-and-suspenders guard.)
2. **Operator knob** (`config.py` + `http.py`): `NEXTCLOUD_HTTP_KEEPALIVE` (default `true`). Set `false` to open a fresh connection per request (`max_keepalive_connections=0`) — the **robust mitigation** for connection poisoning on flaky CDN/WAN paths, mirroring the `DATABASE_POOL_SIZE`→`NullPool` precedent. Recommended for deployments hitting this issue.
3. **Metric**: `astrolabe_document_download_truncated_total`.
4. **Docs**: `docs/configuration.md` documents the knob.

> Note: the always-on Content-Length guard primarily hardens *clean* truncation. For the desync/poisoning class, the reliable fix is `NEXTCLOUD_HTTP_KEEPALIVE=false`.

## Also in this PR — mail unit test fixes

The Mail 5.x route changes (#963 + the outbox two-step send) updated `client/mail.py` but left `tests/client/mail/test_mail_api.py` asserting the old routes/shapes (failing in CI). Updated to match: the direct REST resource routes (`/index.php/apps/mail/api/{accounts,mailboxes,messages}`) return **unwrapped JSON** and require a **CSRF** token, while `message` / `attachment` / `raw` stay on **OCS** routes. Verified against `~/Software/mail/appinfo/routes.php`.

## Testing

- `uv run ruff check && uv run ruff format --check && uv run ty check -- nextcloud_mcp_server` — clean
- `uv run pytest tests/unit/ -q` — 1890 passed, 1 skipped
- `uv run pytest tests/client/mail/ tests/unit/client/test_webdav.py tests/unit/test_ssl_config.py -q` — all green
- New tests: short-read raises / matching length OK / header-less (chunked) OK; keepalive knob sets `max_keepalive_connections=0` (+ caller override + env→setting)

---

_This PR was generated with the help of AI, and reviewed by a Human_