### PR TITLE
test(mail): GreenMail integration harness + fix Mail 5.x API bugs it surfaced

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
             wait-port: 8000
             mcp-internal-url: "http://mcp:8000"
             needs-playwright: false
+            # Also start GreenMail (SMTP/IMAP) so the Mail integration tests have
+            # a real backend; the Mail account is provisioned in a step below.
+            extra-compose-profiles: "--profile mail"
             extra-args: >-
               --ignore=tests/integration/test_qdrant_collection_creation.py
               --ignore=tests/rag_evaluation/
@@ -169,7 +172,7 @@ jobs:
         uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
         with:
           compose-file: "./docker-compose.yml"
-          compose-flags: "--profile ${{ matrix.profile }}"
+          compose-flags: "--profile ${{ matrix.profile }} ${{ matrix.extra-compose-profiles }}"
           up-flags: "--build"
         env:
           MCP_SERVER_URL: ${{ matrix.mcp-internal-url }}
@@ -201,6 +204,12 @@ jobs:
             sleep 5
           done
           echo "Nextcloud is ready."
+
+      # Provision a GreenMail-backed Mail account for the Mail integration tests
+      # (single-user lane only; the `mail` profile started GreenMail above).
+      - name: Provision GreenMail mail account
+        if: matrix.mode == 'single-user'
+        run: bash scripts/provision-greenmail-account.sh admin admin@example.org
 
       # Wait for the MCP service to be healthy
       - name: Wait for MCP service (${{ matrix.mode }})

--- a/app-hooks/post-installation/10-install-mail-app.sh
+++ b/app-hooks/post-installation/10-install-mail-app.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euox pipefail
+
+echo "Installing and configuring mail app for testing..."
+
+# The Mail account (pointing at the GreenMail service) is provisioned later by
+# the test harness, once GreenMail is reachable — see
+# scripts/provision-greenmail-account.sh / the mail integration fixtures. Here
+# we only need the app installed and enabled.
+if [ -d /var/www/html/custom_apps/mail ]; then
+    echo "mail app directory found in apps (already installed)"
+    php /var/www/html/occ app:enable mail
+else
+    echo "mail app not found, installing from app store..."
+    php /var/www/html/occ app:install mail
+    php /var/www/html/occ app:enable mail
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -410,6 +410,32 @@ services:
     profiles:
       - postgres
 
+  # GreenMail: standalone SMTP/IMAP test server for exercising the Nextcloud
+  # Mail app end-to-end (#965 follow-up). `greenmail.auth.disabled` makes any
+  # login succeed and auto-creates the mailbox, so the Nextcloud Mail account
+  # provisioned by the post-installation hook can connect without seeding users.
+  # SMTP 3025 / IMAP 3143 are the plaintext ports (ssl-mode "none").
+  greenmail:
+    image: docker.io/greenmail/standalone:2.1.9@sha256:3ac5a83dd6727cf95e4d50e18907fb8ee7bbf5f67e8534714dee2fb1b5b2e1d4
+    restart: always
+    environment:
+      - GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose
+    ports:
+      # Plaintext SMTP/IMAP + the management REST API (8080 → 8085 to avoid the
+      # host 8080 already taken by the `app` service).
+      - 127.0.0.1:3025:3025
+      - 127.0.0.1:3143:3143
+      - 127.0.0.1:8085:8080
+    healthcheck:
+      # The slim JRE base has no curl/wget, but the Ubuntu base ships bash, so
+      # probe the IMAP port directly (open once `setup.test.all` has bound it).
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/3143"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    profiles:
+      - mail
+
 volumes:
   nextcloud:
   db:

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -85,15 +85,11 @@ class MailClient:
     # Direct API endpoints — CSRF-exempt via the OCS-APIRequest header.
     API_BASE = "/index.php/apps/mail/api"
 
-    _OCS_HEADERS = {
+    # The OCS-APIRequest header authenticates the OCS routes and exempts the
+    # direct routes from CSRF, so both families use the same headers.
+    _API_HEADERS = {
         "OCS-APIRequest": "true",
         "Accept": "application/json",
-    }
-
-    # The OCS-APIRequest header is what exempts these direct routes from CSRF.
-    _DIRECT_HEADERS = {
-        "Accept": "application/json",
-        "OCS-APIRequest": "true",
     }
 
     app_name = "mail"
@@ -139,7 +135,7 @@ class MailClient:
             "GET",
             f"{self.OCS_BASE}{path}",
             params=query,
-            headers=self._OCS_HEADERS,
+            headers=self._API_HEADERS,
         )
         response.raise_for_status()
         return _ocs_response(response)
@@ -158,7 +154,7 @@ class MailClient:
             "GET",
             f"{self.API_BASE}{path}",
             params=params,
-            headers=self._DIRECT_HEADERS,
+            headers=self._API_HEADERS,
         )
         response.raise_for_status()
         return response.json()
@@ -179,10 +175,12 @@ class MailClient:
             "POST",
             f"{self.API_BASE}{path}",
             json=json_data,
-            headers={"Content-Type": "application/json", **self._DIRECT_HEADERS},
+            headers={"Content-Type": "application/json", **self._API_HEADERS},
         )
         response.raise_for_status()
-        return response.json()
+        # The outbox send step can legitimately return an empty body (e.g. 204);
+        # don't choke trying to JSON-decode it.
+        return response.json() if response.content else {}
 
     # ------------------------------------------------------------------
     # Public API methods

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -74,9 +74,9 @@ def _ocs_response(response: Response) -> Any:
 class MailClient:
     """Client for the Nextcloud Mail app API.
 
-    Uses a combination of OCS, direct, and API v1 routes to cover the full
-    mail workflow (list accounts → browse mailboxes → list messages → read
-    message → send reply) with the correct authentication for each endpoint.
+    Uses a combination of OCS and direct routes to cover the full mail workflow
+    (list accounts → browse mailboxes → list messages → read message → send
+    reply) with the correct authentication for each endpoint.
     """
 
     # OCS endpoints — work with Basic Auth + OCS‑APIRequest header alone.
@@ -302,7 +302,6 @@ class MailClient:
     async def send_message(
         self,
         account_id: int,
-        from_email: str,
         to: list[dict[str, str]],
         subject: str,
         body: str,
@@ -313,13 +312,17 @@ class MailClient:
     ) -> dict[str, Any]:
         """Send an email via the Mail 5.x outbox API.
 
-        Mail 5.x uses a two-step outbox flow:
-        1. POST ``/api/outbox`` to stage the message (needs CSRF token)
-        2. POST ``/api/outbox/{id}`` to send it (needs CSRF token)
+        Mail 5.x uses a two-step outbox flow (both CSRF-exempt via the
+        OCS-APIRequest header):
+        1. POST ``/api/outbox`` to stage the message
+        2. POST ``/api/outbox/{id}`` to send it
+
+        The ``From:`` identity is derived by the Mail app from ``account_id``
+        (``OutboxController::create`` has no from/email field), so it is not
+        sent here.
 
         Args:
             account_id: The mail account ID to send from.
-            from_email: The ``From:`` address (may be an alias).
             to: List of recipients ``[{"label": "...", "email": "..."}]``.
             subject: Subject line.
             body: Message body (plain text or HTML depending on ``is_html``).

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -1,19 +1,18 @@
 """Client for the Nextcloud Mail app API.
 
-Uses three endpoint types:
+Uses two endpoint types:
 
 1. **OCS routes** — ``/ocs/v2.php/apps/mail/message/...`` — for reading full messages
    and attachments. Works with Basic Auth (App Password) via the OCS-APIRequest header.
    These routes are registered in the ``'ocs'`` section of the Mail app's ``routes.php``.
 
 2. **Direct app routes** — ``/index.php/apps/mail/api/...`` — for listing accounts,
-   mailboxes, and messages. These are REST resource routes (from ``'resources'`` in
-   ``routes.php``). They **require** a ``requesttoken`` CSRF header obtained from the
-   ``/index.php/csrftoken`` endpoint.
-
-3. **API v1 routes** — ``/index.php/apps/mail/api/v1/...`` — for sending messages.
-   Registered via ``#[ApiRoute]`` attributes in ``MessageApiController``. These have
-   both ``#[NoAdminRequired]`` and ``#[NoCSRFRequired]``, so Basic Auth works directly.
+   mailboxes, and messages, and for the two-step outbox send. These REST resource
+   routes (from ``'resources'`` in ``routes.php``) are CSRF-gated for browser
+   sessions, but Nextcloud exempts any request carrying the ``OCS-APIRequest: true``
+   header from the CSRF check — so Basic Auth (App Password) + that header is
+   sufficient. No ``requesttoken`` round-trip is needed (verified end-to-end against
+   a live Mail 5.x backend; see the GreenMail integration tests).
 """
 
 import logging
@@ -83,17 +82,15 @@ class MailClient:
     # OCS endpoints — work with Basic Auth + OCS‑APIRequest header alone.
     OCS_BASE = "/ocs/v2.php/apps/mail"
 
-    # Direct API endpoints — need a CSRF token (obtained lazily).
+    # Direct API endpoints — CSRF-exempt via the OCS-APIRequest header.
     API_BASE = "/index.php/apps/mail/api"
-
-    # API v1 endpoints — ``#[NoCSRFRequired]`` + ``#[NoAdminRequired]``, Basic Auth.
-    API_V1_BASE = "/index.php/apps/mail/api/v1"
 
     _OCS_HEADERS = {
         "OCS-APIRequest": "true",
         "Accept": "application/json",
     }
 
+    # The OCS-APIRequest header is what exempts these direct routes from CSRF.
     _DIRECT_HEADERS = {
         "Accept": "application/json",
         "OCS-APIRequest": "true",
@@ -104,7 +101,6 @@ class MailClient:
     def __init__(self, http_client: AsyncClient, username: str) -> None:
         self._client = http_client
         self.username = username
-        self._request_token: str | None = None
 
     # ------------------------------------------------------------------
     # Low‑level request helpers
@@ -124,31 +120,6 @@ class MailClient:
         """
         logger.debug("MailClient %s %s", method, url)
         return await self._client.request(method, url, **kwargs)
-
-    async def _ensure_csrf(self) -> None:
-        """Obtain a CSRF token from the Nextcloud server if not yet cached.
-
-        The token is fetched with Basic Auth (App Password) from
-        ``/index.php/csrftoken`` and stored for the lifetime of this client
-        instance.
-        """
-        if self._request_token is not None:
-            return
-
-        logger.debug("Obtaining CSRF token")
-        response = await self._client.request(
-            "GET",
-            "/index.php/csrftoken",
-            headers={"Accept": "application/json"},
-        )
-        response.raise_for_status()
-        data = response.json()
-        self._request_token = data.get("token")
-
-        if not self._request_token:
-            raise RequestError("Could not obtain CSRF token from Nextcloud")
-
-        logger.debug("CSRF token obtained successfully")
 
     async def _ocs_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         """GET an OCS endpoint and unwrap its envelope.
@@ -174,7 +145,7 @@ class MailClient:
         return _ocs_response(response)
 
     async def _api_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
-        """GET a direct API endpoint (needs CSRF token).
+        """GET a direct API endpoint (CSRF-exempt via the OCS-APIRequest header).
 
         Args:
             path: Path relative to :attr:`API_BASE` (e.g. ``/accounts``).
@@ -183,35 +154,11 @@ class MailClient:
         Returns:
             The parsed JSON response body.
         """
-        await self._ensure_csrf()
-
         response = await self._make_request(
             "GET",
             f"{self.API_BASE}{path}",
             params=params,
-            headers={
-                "requesttoken": self._request_token,
-                **self._DIRECT_HEADERS,
-            },
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def _api_v1_post(self, path: str, data: dict[str, Any] | None = None) -> Any:
-        """POST to an API v1 endpoint (``#[NoCSRFRequired]``, Basic Auth works).
-
-        Args:
-            path: Path relative to :attr:`API_V1_BASE` (e.g. ``/message/send``).
-            data: Form data to send.
-
-        Returns:
-            The parsed JSON response body.
-        """
-        response = await self._make_request(
-            "POST",
-            f"{self.API_V1_BASE}{path}",
-            data=data,
-            headers={"Accept": "application/json"},
+            headers=self._DIRECT_HEADERS,
         )
         response.raise_for_status()
         return response.json()
@@ -219,7 +166,7 @@ class MailClient:
     async def _api_post(
         self, path: str, json_data: dict[str, Any] | None = None
     ) -> Any:
-        """POST to a direct API endpoint (needs CSRF token).
+        """POST to a direct API endpoint (CSRF-exempt via the OCS-APIRequest header).
 
         Args:
             path: Path relative to :attr:`API_BASE` (e.g. ``/outbox``).
@@ -228,17 +175,11 @@ class MailClient:
         Returns:
             The parsed JSON response body.
         """
-        await self._ensure_csrf()
-
         response = await self._make_request(
             "POST",
             f"{self.API_BASE}{path}",
             json=json_data,
-            headers={
-                "requesttoken": self._request_token,
-                "Content-Type": "application/json",
-                **self._DIRECT_HEADERS,
-            },
+            headers={"Content-Type": "application/json", **self._DIRECT_HEADERS},
         )
         response.raise_for_status()
         return response.json()
@@ -263,6 +204,10 @@ class MailClient:
 
         Uses ``GET /index.php/apps/mail/api/mailboxes?accountId=X``.
 
+        Mail 5.x wraps the folders in an account envelope —
+        ``{"id", "email", "mailboxes": [...], "delimiter"}`` — so the list is
+        nested under ``mailboxes`` rather than returned at the top level.
+
         Args:
             account_id: The account ID.
 
@@ -270,6 +215,10 @@ class MailClient:
             List of mailbox dicts.
         """
         data = await self._api_get("/mailboxes", params={"accountId": account_id})
+        if isinstance(data, dict):
+            mailboxes = data.get("mailboxes", [])
+            return mailboxes if isinstance(mailboxes, list) else []
+        # Defensive: tolerate a bare list if a future/older version returns one.
         return data if isinstance(data, list) else []
 
     async def list_messages(

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -194,7 +194,9 @@ class MailClient:
         Uses ``GET /index.php/apps/mail/api/accounts`` (direct resource route).
 
         Returns:
-            List of account dicts with keys ``id``, ``email``, ``isDelegated``.
+            List of raw account dicts. Mail 5.x keys the address as
+            ``emailAddress`` (the server layer maps it onto ``MailAccount.email``
+            via the field alias).
         """
         data = await self._api_get("/accounts")
         return data if isinstance(data, list) else []

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -175,7 +175,7 @@ class MailClient:
             "POST",
             f"{self.API_BASE}{path}",
             json=json_data,
-            headers={"Content-Type": "application/json", **self._API_HEADERS},
+            headers={**self._API_HEADERS, "Content-Type": "application/json"},
         )
         response.raise_for_status()
         # The outbox send step can legitimately return an empty body (e.g. 204);
@@ -354,10 +354,12 @@ class MailClient:
         create_result = await self._api_post("/outbox", json_data=create_data)
         outbox_id = create_result.get("data", {}).get("id")
         if not outbox_id:
-            return {
-                "error": "Failed to create outbox message",
-                "response": create_result,
-            }
+            # Raise (don't return an error dict) so the server tool's
+            # ``except RequestError`` surfaces it — otherwise the discarded
+            # return value would let the tool report success on a covert failure.
+            raise RequestError(
+                f"Outbox create returned no id; response: {create_result!r}"
+            )
 
         send_result = await self._api_post(f"/outbox/{outbox_id}", json_data={})
 

--- a/nextcloud_mcp_server/models/mail.py
+++ b/nextcloud_mcp_server/models/mail.py
@@ -15,12 +15,14 @@ class MailAddress(BaseModel):
 
 
 class MailAccount(BaseModel):
-    """A configured mail account (from the account/list endpoint)."""
+    """A configured mail account (from the ``/api/accounts`` endpoint)."""
 
     model_config = ConfigDict(populate_by_name=True)
 
     id: int = Field(description="Account ID")
-    email: str = Field(description="Account email address")
+    # Mail 5.x's /api/accounts returns the address as ``emailAddress`` (not
+    # ``email``); ``populate_by_name`` keeps the field accessible as ``email``.
+    email: str = Field(alias="emailAddress", description="Account email address")
     is_delegated: bool = Field(
         False, alias="isDelegated", description="Whether this is a delegated account"
     )

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -227,7 +227,10 @@ def configure_mail_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Send Mail Message",
-        annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(
+            idempotentHint=False,  # Stages a new outbox entry each call (ADR-017)
+            openWorldHint=True,
+        ),
     )
     @require_scopes("mail.send")
     @instrument_tool

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -268,7 +268,7 @@ def configure_mail_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         try:
-            to_list = json.loads(to) if isinstance(to, str) else to
+            to_list = json.loads(to)  # `to` is a required JSON-array string
             cc_list = json.loads(cc) if isinstance(cc, str) else (cc or [])
             bcc_list = json.loads(bcc) if isinstance(bcc, str) else (bcc or [])
 

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -233,7 +233,6 @@ def configure_mail_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_mail_send_message(
         account_id: int,
-        from_email: str,
         to: str,
         subject: str,
         body: str,
@@ -245,6 +244,7 @@ def configure_mail_tools(mcp: FastMCP):
     ) -> SendMessageResponse:
         """Send an email through a configured Nextcloud Mail account (requires mail.send scope).
 
+        The ``From:`` identity is derived by the Mail app from ``account_id``.
         Recipients are specified as JSON arrays of ``{"label": "...", "email": "..."}``
         objects.  Example for ``to``::
 
@@ -252,7 +252,6 @@ def configure_mail_tools(mcp: FastMCP):
 
         Args:
             account_id: Mail account ID to send from (from nc_mail_list_accounts)
-            from_email: The ``From:`` email address (must match the account or an alias)
             to: JSON array of To recipients
             subject: Email subject
             body: Email body (plain text unless is_html is true)
@@ -272,7 +271,6 @@ def configure_mail_tools(mcp: FastMCP):
 
             await client.mail.send_message(
                 account_id=account_id,
-                from_email=from_email,
                 to=to_list,
                 subject=subject,
                 body=body,

--- a/scripts/provision-greenmail-account.sh
+++ b/scripts/provision-greenmail-account.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Provision a GreenMail-backed Nextcloud Mail account for the single-user test
+# user so the mail integration tests have a real account to exercise.
+#
+# GreenMail runs with `-Dgreenmail.auth.disabled`, so any IMAP/SMTP login
+# succeeds and the mailbox is auto-created — the password below is arbitrary.
+# Plaintext ports: IMAP 3143, SMTP 3025 (ssl-mode "none"). Idempotent: skips if
+# the user already has a mail account.
+#
+# Usage: scripts/provision-greenmail-account.sh [user_id] [email]
+set -euo pipefail
+
+USER_ID="${1:-admin}"
+EMAIL="${2:-${USER_ID}@example.org}"
+GREENMAIL_READINESS_URL="${GREENMAIL_READINESS_URL:-http://localhost:8085/api/service/readiness}"
+
+echo "Waiting for GreenMail readiness at ${GREENMAIL_READINESS_URL} ..."
+for _ in $(seq 1 30); do
+    if curl -fsS "${GREENMAIL_READINESS_URL}" >/dev/null 2>&1; then
+        echo "GreenMail is ready"
+        break
+    fi
+    sleep 2
+done
+
+# Idempotency: mail:account:export prints a human-readable "Account N:" block
+# per existing account (and nothing matching when the user has none).
+if docker compose exec -T app php occ mail:account:export "${USER_ID}" 2>/dev/null | grep -qiE '^Account [0-9]+:'; then
+    echo "Mail account already exists for ${USER_ID}; skipping provisioning"
+    exit 0
+fi
+
+echo "Creating GreenMail mail account for ${USER_ID} (${EMAIL}) ..."
+docker compose exec -T app php occ mail:account:create \
+    "${USER_ID}" "${USER_ID} (GreenMail)" "${EMAIL}" \
+    greenmail 3143 none "${EMAIL}" greenmail-test-pw \
+    greenmail 3025 none "${EMAIL}" greenmail-test-pw
+
+echo "Provisioned GreenMail mail account for ${USER_ID}"

--- a/scripts/provision-greenmail-account.sh
+++ b/scripts/provision-greenmail-account.sh
@@ -16,13 +16,19 @@ EMAIL="${2:-${USER_ID}@example.org}"
 GREENMAIL_READINESS_URL="${GREENMAIL_READINESS_URL:-http://localhost:8085/api/service/readiness}"
 
 echo "Waiting for GreenMail readiness at ${GREENMAIL_READINESS_URL} ..."
+ready=0
 for _ in $(seq 1 30); do
     if curl -fsS "${GREENMAIL_READINESS_URL}" >/dev/null 2>&1; then
         echo "GreenMail is ready"
+        ready=1
         break
     fi
     sleep 2
 done
+if [ "${ready}" -ne 1 ]; then
+    echo "WARNING: GreenMail did not become ready in time; mail:account:create" \
+         "may fail to reach the IMAP/SMTP server." >&2
+fi
 
 # Idempotency: mail:account:export prints a human-readable "Account N:" block
 # per existing account (and nothing matching when the user has none).

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -4,14 +4,16 @@ Mail 5.x exposes two route families (see ``~/Software/mail/appinfo/routes.php``
 and the module docstring of ``client/mail.py``):
 
 - **Direct REST resource routes** under ``/index.php/apps/mail/api`` —
-  ``/accounts``, ``/mailboxes``, ``/messages``, ``/outbox`` — return the payload
-  *unwrapped* (plain JSON list/dict) and require a CSRF ``requesttoken`` header.
+  ``/accounts``, ``/mailboxes``, ``/messages``, ``/outbox`` — return plain JSON
+  (a list, or an account envelope for ``/mailboxes``) and are CSRF-exempt via the
+  ``OCS-APIRequest: true`` header (no ``requesttoken`` round-trip needed).
 - **OCS routes** under ``/ocs/v2.php/apps/mail`` — ``/message/{id}``,
   ``/message/{id}/attachment/{id}``, ``/message/{id}/raw`` — return the standard
   OCS envelope and work with Basic Auth alone.
 
-The ``_api_*`` tests therefore feed plain JSON and stub the CSRF round-trip; the
-OCS tests feed an enveloped payload.
+The ``_api_*`` tests therefore feed plain JSON; the OCS tests feed an enveloped
+payload. Shapes are the real ones verified against a live Mail 5.x backend via
+the GreenMail integration suite.
 """
 
 import logging
@@ -42,24 +44,17 @@ def _ocs_response(data: Any, status_code: int = 200) -> httpx.Response:
     )
 
 
-def _stub_csrf(mocker, client: MailClient) -> None:
-    """Bypass the CSRF round-trip for direct-API tests.
-
-    The direct REST routes call ``_ensure_csrf`` (a live GET to
-    ``/index.php/csrftoken`` via the raw http client) before each request. Unit
-    tests patch ``_make_request`` only, so stub the token acquisition out and
-    pre-seed a token so the ``requesttoken`` header is populated.
-    """
-    mocker.patch.object(MailClient, "_ensure_csrf", new=mocker.AsyncMock())
-    client._request_token = "test-token"
-
-
 async def test_list_accounts_unwraps_direct_payload(mocker):
-    """list_accounts returns the plain JSON list from the direct REST route."""
+    """list_accounts returns the plain JSON list from the direct REST route.
+
+    Mail 5.x's ``/api/accounts`` returns the address as ``emailAddress`` (the
+    real shape verified against a live backend); the client returns the raw
+    dicts and the server layer maps them onto ``MailAccount``.
+    """
     mock_response = create_mock_response(
         json_data=[
-            {"id": 1, "email": "alice@example.com", "isDelegated": False},
-            {"id": 2, "email": "bob@example.com", "isDelegated": False},
+            {"id": 1, "emailAddress": "alice@example.com", "isDelegated": False},
+            {"id": 2, "emailAddress": "bob@example.com", "isDelegated": False},
         ]
     )
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
@@ -68,33 +63,42 @@ async def test_list_accounts_unwraps_direct_payload(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
-    _stub_csrf(mocker, client)
     accounts = await client.list_accounts()
 
     assert len(accounts) == 2
     assert accounts[0]["id"] == 1
-    assert accounts[0]["email"] == "alice@example.com"
+    assert accounts[0]["emailAddress"] == "alice@example.com"
 
-    # Direct resource route + CSRF header.
+    # Direct resource route; CSRF-exempt via the OCS-APIRequest header (no token).
     args, kwargs = mock_make_request.call_args
     assert args == ("GET", "/index.php/apps/mail/api/accounts")
-    assert kwargs["headers"]["requesttoken"] == "test-token"
+    assert kwargs["headers"]["OCS-APIRequest"] == "true"
+    assert "requesttoken" not in kwargs["headers"]
 
 
-async def test_get_mailboxes_passes_account_id(mocker):
-    """get_mailboxes sends accountId and unwraps the list."""
+async def test_get_mailboxes_unwraps_account_envelope(mocker):
+    """get_mailboxes unwraps the ``{...,"mailboxes":[...]}`` account envelope.
+
+    Mail 5.x's ``/api/mailboxes`` returns the folders nested under a
+    ``mailboxes`` key (not a bare list); the client must unwrap them.
+    """
     mock_response = create_mock_response(
-        json_data=[
-            {
-                "databaseId": 10,
-                "id": "SU5CT1g=",
-                "name": "INBOX",
-                "displayName": "INBOX",
-                "accountId": 1,
-                "specialUse": ["inbox"],
-                "unread": 3,
-            }
-        ]
+        json_data={
+            "id": 1,
+            "email": "alice@example.com",
+            "delimiter": ".",
+            "mailboxes": [
+                {
+                    "databaseId": 10,
+                    "id": "SU5CT1g=",
+                    "name": "INBOX",
+                    "displayName": "INBOX",
+                    "accountId": 1,
+                    "specialUse": ["inbox"],
+                    "unread": 3,
+                }
+            ],
+        }
     )
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
     mock_make_request = mocker.patch.object(
@@ -102,7 +106,6 @@ async def test_get_mailboxes_passes_account_id(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
-    _stub_csrf(mocker, client)
     mailboxes = await client.get_mailboxes(account_id=1)
 
     assert len(mailboxes) == 1
@@ -134,7 +137,6 @@ async def test_list_messages_builds_params(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
-    _stub_csrf(mocker, client)
     messages = await client.list_messages(
         10, cursor=42, search_filter="hello", limit=50, view="threaded"
     )
@@ -160,7 +162,6 @@ async def test_list_messages_omits_optional_params(mocker):
     )
 
     client = MailClient(mock_client, "testuser")
-    _stub_csrf(mocker, client)
     await client.list_messages(10)
 
     _, kwargs = mock_make_request.call_args
@@ -253,7 +254,6 @@ async def test_empty_data_returns_empty_list(mocker):
     mocker.patch.object(MailClient, "_make_request", return_value=mock_response)
 
     client = MailClient(mock_client, "testuser")
-    _stub_csrf(mocker, client)
     assert await client.list_accounts() == []
 
 

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -292,3 +292,41 @@ async def test_non_json_response_raises_requesterror(mocker):
     client = MailClient(mock_client, "testuser")
     with pytest.raises(httpx.RequestError):
         await client.get_message(100)
+
+
+async def test_send_message_two_step_flow(mocker):
+    """send_message stages via POST /outbox then sends via POST /outbox/{id}.
+
+    Guards the create-response shape assumption (``data.id``) and the two-step
+    flow that the integration suite can only xfail (the GreenMail outbox send
+    fails before the success path).
+    """
+    create_response = create_mock_response(json_data={"data": {"id": 42}})
+    send_response = create_mock_response(status_code=204, content=b"")
+    mock_make_request = mocker.patch.object(
+        MailClient, "_make_request", side_effect=[create_response, send_response]
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    result = await client.send_message(
+        1, [{"email": "a@b.com", "label": "A"}], "Hi", "body"
+    )
+
+    assert result["success"] is True
+    assert result["outbox_id"] == 42
+
+    calls = mock_make_request.call_args_list
+    assert calls[0].args == ("POST", "/index.php/apps/mail/api/outbox")
+    assert calls[1].args == ("POST", "/index.php/apps/mail/api/outbox/42")
+
+
+async def test_send_message_missing_outbox_id_returns_error(mocker):
+    """A create response without ``data.id`` yields an error dict, not a crash."""
+    create_response = create_mock_response(json_data={"unexpected": "shape"})
+    mocker.patch.object(MailClient, "_make_request", return_value=create_response)
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    result = await client.send_message(
+        1, [{"email": "a@b.com", "label": "A"}], "Hi", "body"
+    )
+    assert "error" in result

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -320,13 +320,15 @@ async def test_send_message_two_step_flow(mocker):
     assert calls[1].args == ("POST", "/index.php/apps/mail/api/outbox/42")
 
 
-async def test_send_message_missing_outbox_id_returns_error(mocker):
-    """A create response without ``data.id`` yields an error dict, not a crash."""
+async def test_send_message_missing_outbox_id_raises(mocker):
+    """A create response without ``data.id`` raises (so the server reports an error).
+
+    Returning an error dict here would be discarded by the server tool, which
+    would then report ``success=True`` on a covert failure.
+    """
     create_response = create_mock_response(json_data={"unexpected": "shape"})
     mocker.patch.object(MailClient, "_make_request", return_value=create_response)
 
     client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
-    result = await client.send_message(
-        1, [{"email": "a@b.com", "label": "A"}], "Hi", "body"
-    )
-    assert "error" in result
+    with pytest.raises(httpx.RequestError):
+        await client.send_message(1, [{"email": "a@b.com", "label": "A"}], "Hi", "body")

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -109,7 +109,7 @@ def _seed_message_with_attachment(
 
 def _sync_mail_account(account_id: int) -> None:
     """Force Nextcloud Mail to sync the IMAP account so seeded mail is visible."""
-    subprocess.run(
+    proc = subprocess.run(
         [
             "docker",
             "compose",
@@ -125,6 +125,12 @@ def _sync_mail_account(account_id: int) -> None:
         capture_output=True,
         text=True,
     )
+    if proc.returncode != 0:
+        # Surface a sync failure so a later "message not found" assertion reads
+        # as a sync problem, not a client bug.
+        print(
+            f"WARNING: mail:account:sync failed (rc={proc.returncode}): {proc.stderr}"
+        )
 
 
 async def _first_account_id(nc_mcp_client) -> int:

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -234,14 +234,14 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
     )
     assert fetched["name"] == "note.txt"
     # The Mail OCS get-attachment endpoint returns text attachments as raw text
-    # and binary ones base64-encoded; accept either for the seeded text file.
+    # and binary ones base64-encoded. Decode if it's base64, else keep the raw
+    # text, so the assertion covers both shapes.
     content = fetched["content"]
-    decoded = content
     try:
         decoded = base64.b64decode(content).decode("utf-8")
     except (ValueError, UnicodeDecodeError):
-        pass
-    assert payload.decode("utf-8").strip() in (content + decoded)
+        decoded = content
+    assert payload.decode("utf-8").strip() in decoded
 
 
 @pytest.mark.xfail(

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -177,6 +177,8 @@ async def test_list_and_get_message_roundtrip(nc_mcp_client, provisioned_mail_ac
     )["results"]
     inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
 
+    # Newest-first ordering means the just-seeded message is on the first page,
+    # so limit=20 finds it even on a persistent INBOX with >20 older messages.
     messages = _tool_payload(
         await nc_mcp_client.call_tool(
             "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -222,7 +222,10 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
             "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
         )
     )["results"]
-    match = next(m for m in messages if m["subject"] == subject)
+    match = next((m for m in messages if m["subject"] == subject), None)
+    assert match is not None, (
+        f"seeded attachment message {subject!r} not found in {messages}"
+    )
 
     full = _tool_payload(
         await nc_mcp_client.call_tool(

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -256,13 +256,12 @@ async def test_send_message_via_outbox(nc_mcp_client, provisioned_mail_account):
     """Send a message through the Mail outbox (create succeeds; SMTP send is env-limited)."""
     account_id = await _first_account_id(nc_mcp_client)
     subject = "Sent from MCP via outbox"
-    # The tool takes `from_email` and `to` as a JSON-array string.
+    # The tool takes `to` as a JSON-array string; From is derived from account_id.
     data = _tool_payload(
         await nc_mcp_client.call_tool(
             "nc_mail_send_message",
             {
                 "account_id": account_id,
-                "from_email": ADMIN_EMAIL,
                 "to": json.dumps(
                     [{"email": "recipient@example.org", "label": "Recipient"}]
                 ),

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -19,6 +19,7 @@ Requires the `mail` + `single-user` compose profiles:
     uv run pytest -m integration tests/integration/test_mail_greenmail.py -v
 """
 
+import base64
 import json
 import smtplib
 import subprocess
@@ -87,6 +88,21 @@ def _seed_inbox_message(subject: str, body: str) -> None:
     msg["Subject"] = subject
     msg.set_content(body)
     msg.add_alternative(f"<p>{body}</p>", subtype="html")
+    with smtplib.SMTP("localhost", 3025, timeout=15) as smtp:
+        smtp.send_message(msg)
+
+
+def _seed_message_with_attachment(
+    subject: str, attachment: bytes, filename: str
+) -> None:
+    """Deliver a multipart/mixed message carrying a file attachment via SMTP."""
+    msg = EmailMessage()
+    msg["From"] = "sender@example.org"
+    msg["To"] = ADMIN_EMAIL
+    msg["Subject"] = subject
+    msg.set_content("see attached")
+    msg.add_alternative("<p>see attached</p>", subtype="html")
+    msg.add_attachment(attachment, maintype="text", subtype="plain", filename=filename)
     with smtplib.SMTP("localhost", 3025, timeout=15) as smtp:
         smtp.send_message(msg)
 
@@ -175,6 +191,57 @@ async def test_list_and_get_message_roundtrip(nc_mcp_client, provisioned_mail_ac
         )
     )["message"]
     assert full["subject"] == subject
+
+
+async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account):
+    """Seed a message with a file attachment, then fetch it through the MCP tools."""
+    subject = "Attachment integration probe"
+    payload = b"hello attachment contents\n"
+    _seed_message_with_attachment(subject, payload, "note.txt")
+
+    account_id = await _first_account_id(nc_mcp_client)
+    _sync_mail_account(account_id)
+
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+
+    messages = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+        )
+    )["results"]
+    match = next(m for m in messages if m["subject"] == subject)
+
+    full = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_message", {"message_id": match["databaseId"]}
+        )
+    )["message"]
+    attachments = full["attachments"]
+    assert attachments, f"no attachments on message {full}"
+    att = attachments[0]
+    assert att["fileName"] == "note.txt"
+
+    fetched = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_attachment",
+            {"message_id": match["databaseId"], "attachment_id": att["id"]},
+        )
+    )
+    assert fetched["name"] == "note.txt"
+    # The Mail OCS get-attachment endpoint returns text attachments as raw text
+    # and binary ones base64-encoded; accept either for the seeded text file.
+    content = fetched["content"]
+    decoded = content
+    try:
+        decoded = base64.b64decode(content).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        pass
+    assert payload.decode("utf-8").strip() in (content + decoded)
 
 
 @pytest.mark.xfail(

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -140,6 +140,38 @@ async def _first_account_id(nc_mcp_client) -> int:
     return accounts[0]["id"]
 
 
+async def _sync_and_fetch_message(nc_mcp_client, subject: str) -> dict:
+    """Sync the account, locate the seeded message by subject, return its full body.
+
+    Drives list_mailboxes → list_messages → get_message through the MCP tools.
+    """
+    account_id = await _first_account_id(nc_mcp_client)
+    _sync_mail_account(account_id)
+
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+
+    # Newest-first ordering means the just-seeded message is on the first page,
+    # so limit=20 finds it even on a persistent INBOX with >20 older messages.
+    messages = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+        )
+    )["results"]
+    match = next((m for m in messages if m["subject"] == subject), None)
+    assert match is not None, f"seeded message {subject!r} not found in {messages}"
+
+    return _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_message", {"message_id": match["databaseId"]}
+        )
+    )["message"]
+
+
 async def test_list_accounts_returns_provisioned_account(
     nc_mcp_client, provisioned_mail_account
 ):
@@ -173,31 +205,7 @@ async def test_list_and_get_message_roundtrip(nc_mcp_client, provisioned_mail_ac
     subject = "GreenMail integration probe"
     _seed_inbox_message(subject, "hello from greenmail")
 
-    account_id = await _first_account_id(nc_mcp_client)
-    _sync_mail_account(account_id)
-
-    mailboxes = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_list_mailboxes", {"account_id": account_id}
-        )
-    )["results"]
-    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
-
-    # Newest-first ordering means the just-seeded message is on the first page,
-    # so limit=20 finds it even on a persistent INBOX with >20 older messages.
-    messages = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
-        )
-    )["results"]
-    match = next((m for m in messages if m["subject"] == subject), None)
-    assert match is not None, f"seeded message {subject!r} not found in {messages}"
-
-    full = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_get_message", {"message_id": match["databaseId"]}
-        )
-    )["message"]
+    full = await _sync_and_fetch_message(nc_mcp_client, subject)
     assert full["subject"] == subject
 
 
@@ -207,31 +215,7 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
     payload = b"hello attachment contents\n"
     _seed_message_with_attachment(subject, payload, "note.txt")
 
-    account_id = await _first_account_id(nc_mcp_client)
-    _sync_mail_account(account_id)
-
-    mailboxes = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_list_mailboxes", {"account_id": account_id}
-        )
-    )["results"]
-    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
-
-    messages = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
-        )
-    )["results"]
-    match = next((m for m in messages if m["subject"] == subject), None)
-    assert match is not None, (
-        f"seeded attachment message {subject!r} not found in {messages}"
-    )
-
-    full = _tool_payload(
-        await nc_mcp_client.call_tool(
-            "nc_mail_get_message", {"message_id": match["databaseId"]}
-        )
-    )["message"]
+    full = await _sync_and_fetch_message(nc_mcp_client, subject)
     attachments = full["attachments"]
     assert attachments, f"no attachments on message {full}"
     att = attachments[0]
@@ -240,7 +224,7 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
     fetched = _tool_payload(
         await nc_mcp_client.call_tool(
             "nc_mail_get_attachment",
-            {"message_id": match["databaseId"], "attachment_id": att["id"]},
+            {"message_id": full["id"], "attachment_id": att["id"]},
         )
     )
     assert fetched["name"] == "note.txt"

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -1,0 +1,207 @@
+"""End-to-end Mail integration tests against a live GreenMail + Nextcloud stack.
+
+These exercise the mail MCP tools through the single-user `mcp` service
+(http://localhost:8000) against a real Nextcloud `app` with the Mail app
+installed and a GreenMail-backed account provisioned for the `admin` test user.
+
+Why this suite exists (#965 follow-up): the Mail 5.x *direct REST* routes
+(`/index.php/apps/mail/api/{accounts,mailboxes,messages,outbox}`) are CSRF-gated
+(regular non-OCS controllers, no `@NoCSRFRequired`), while `NextcloudClient`
+strips `Set-Cookie` (`AsyncDisableCookieTransport`) and authenticates per-request
+with an App Password — so it cannot maintain the session a CSRF `requesttoken`
+needs. This suite proves, end-to-end, whether the mail feature actually works
+from the MCP server before we decide to keep or remove it.
+
+Requires the `mail` + `single-user` compose profiles:
+
+    docker compose --profile mail --profile single-user up --build -d
+    scripts/provision-greenmail-account.sh admin admin@example.org
+    uv run pytest -m integration tests/integration/test_mail_greenmail.py -v
+"""
+
+import json
+import smtplib
+import subprocess
+from email.message import EmailMessage
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROVISION_SCRIPT = _REPO_ROOT / "scripts" / "provision-greenmail-account.sh"
+
+ADMIN_EMAIL = "admin@example.org"
+
+
+def _tool_payload(result) -> dict:
+    """Extract the JSON body returned by an MCP tool call.
+
+    Tools return a Pydantic ``BaseResponse`` serialized as the first text
+    content block; ``isError`` results raise so the test fails loudly with the
+    server-side error (which, for a CSRF rejection, is the evidence we want).
+    """
+    if getattr(result, "isError", False):
+        text = result.content[0].text if result.content else "<no content>"
+        raise AssertionError(f"MCP tool returned an error: {text}")
+    return json.loads(result.content[0].text)
+
+
+@pytest.fixture(scope="module")
+def provisioned_mail_account() -> str:
+    """Ensure a GreenMail-backed mail account exists for `admin`.
+
+    Skips the whole module if provisioning fails (e.g. the `mail`/`single-user`
+    profiles aren't running), so the suite is a no-op outside the mail CI lane.
+    """
+    if not _PROVISION_SCRIPT.exists():
+        pytest.skip("provision-greenmail-account.sh missing")
+    proc = subprocess.run(
+        ["bash", str(_PROVISION_SCRIPT), "admin", ADMIN_EMAIL],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(
+            "GreenMail mail account provisioning failed (mail/single-user "
+            f"profiles up?):\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return ADMIN_EMAIL
+
+
+def _seed_inbox_message(subject: str, body: str) -> None:
+    """Deliver a multipart message to the admin mailbox via GreenMail SMTP (3025).
+
+    The message is deliberately ``multipart/alternative`` (plain + HTML). GreenMail
+    2.1.x has a bug where an IMAP ``BODY`` fetch on a *non*-multipart (plain
+    text/plain) message throws ``ClassCastException`` (String → MimeMultipart),
+    which Nextcloud Mail surfaces as "Could not connect to IMAP server" on
+    ``get_message``. A multipart body sidesteps that GreenMail defect; real IMAP
+    servers handle either shape.
+    """
+    msg = EmailMessage()
+    msg["From"] = "sender@example.org"
+    msg["To"] = ADMIN_EMAIL
+    msg["Subject"] = subject
+    msg.set_content(body)
+    msg.add_alternative(f"<p>{body}</p>", subtype="html")
+    with smtplib.SMTP("localhost", 3025, timeout=15) as smtp:
+        smtp.send_message(msg)
+
+
+def _sync_mail_account(account_id: int) -> None:
+    """Force Nextcloud Mail to sync the IMAP account so seeded mail is visible."""
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "app",
+            "php",
+            "/var/www/html/occ",
+            "mail:account:sync",
+            str(account_id),
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+async def _first_account_id(nc_mcp_client) -> int:
+    data = _tool_payload(await nc_mcp_client.call_tool("nc_mail_list_accounts", {}))
+    accounts = data["results"]
+    assert accounts, "no mail accounts returned"
+    return accounts[0]["id"]
+
+
+async def test_list_accounts_returns_provisioned_account(
+    nc_mcp_client, provisioned_mail_account
+):
+    """The decisive CSRF test: list the provisioned account via the MCP server.
+
+    If the direct REST route is CSRF-gated for our cookieless App-Password
+    client, this call fails — which is the evidence that the mail feature does
+    not work from the MCP server.
+    """
+    data = _tool_payload(await nc_mcp_client.call_tool("nc_mail_list_accounts", {}))
+    # Responses serialize by alias (e.g. mailboxes expose ``databaseId``), so the
+    # account address comes back under the Mail API's ``emailAddress`` key.
+    emails = [a["emailAddress"] for a in data["results"]]
+    assert provisioned_mail_account in emails
+
+
+async def test_list_mailboxes(nc_mcp_client, provisioned_mail_account):
+    """List mailboxes for the provisioned account (expects at least INBOX)."""
+    account_id = await _first_account_id(nc_mcp_client)
+    data = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )
+    names = {m["name"].upper() for m in data["results"]}
+    assert "INBOX" in names
+
+
+async def test_list_and_get_message_roundtrip(nc_mcp_client, provisioned_mail_account):
+    """Seed a message via SMTP, sync, then list + fetch it through the MCP tools."""
+    subject = "GreenMail integration probe"
+    _seed_inbox_message(subject, "hello from greenmail")
+
+    account_id = await _first_account_id(nc_mcp_client)
+    _sync_mail_account(account_id)
+
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+
+    messages = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+        )
+    )["results"]
+    match = next((m for m in messages if m["subject"] == subject), None)
+    assert match is not None, f"seeded message {subject!r} not found in {messages}"
+
+    full = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_message", {"message_id": match["databaseId"]}
+        )
+    )["message"]
+    assert full["subject"] == subject
+
+
+@pytest.mark.xfail(
+    reason="Mail outbox send fails internally (HTTP 500, before any SMTP "
+    "connection) for a CLI-provisioned GreenMail account — the sender identity "
+    "isn't resolved (stored row has from:[]). This is a Mail-app/test-env "
+    "limitation, not the MCP client: the client implements the two-step "
+    "create+send per OutboxController::create, and the create step succeeds.",
+    strict=False,
+)
+async def test_send_message_via_outbox(nc_mcp_client, provisioned_mail_account):
+    """Send a message through the Mail outbox (create succeeds; SMTP send is env-limited)."""
+    account_id = await _first_account_id(nc_mcp_client)
+    subject = "Sent from MCP via outbox"
+    # The tool takes `from_email` and `to` as a JSON-array string.
+    data = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_send_message",
+            {
+                "account_id": account_id,
+                "from_email": ADMIN_EMAIL,
+                "to": json.dumps(
+                    [{"email": "recipient@example.org", "label": "Recipient"}]
+                ),
+                "subject": subject,
+                "body": "body sent through the Nextcloud Mail outbox API",
+            },
+        )
+    )
+    assert data["success"] is True


### PR DESCRIPTION
## Summary

A follow-up to #965/#968. While fixing the mail unit tests there, the question arose whether the Mail feature actually works from the MCP server at all — the direct REST routes (`/index.php/apps/mail/api/*`) are CSRF-gated, and `NextcloudClient` strips `Set-Cookie`. Rather than remove the feature on a hunch, this PR stands up a **real GreenMail (SMTP/IMAP) integration lane** to test it end-to-end — and the answer is: it works, but the mocked unit tests had been hiding real schema bugs.

## What the integration testing proved

- **Not CSRF-broken.** Nextcloud exempts any request carrying `OCS-APIRequest: true` from CSRF (which `MailClient` already sends). The direct route returns `200` with the header, `412` without. The `_ensure_csrf`/`requesttoken` machinery was redundant dead weight.
- **Real bugs the mocked tests missed** (fixtures encoded wrong shapes):
  - `nc_mail_list_accounts` raised a validation error every call — Mail 5.x returns `emailAddress`, the model required `email`.
  - `nc_mail_list_mailboxes` always returned `[]` — the endpoint returns `{…,"mailboxes":[…]}`, but the client did `isinstance(data, list)`.

## Changes

**Harness**
- `docker-compose.yml`: `greenmail/standalone` service (`mail` profile, SMTP 3025 / IMAP 3143), digest-pinned.
- `app-hooks/post-installation/10-install-mail-app.sh`: install + enable Mail.
- `scripts/provision-greenmail-account.sh`: idempotent `mail:account:create` against GreenMail.
- `tests/integration/test_mail_greenmail.py`: drives the mail MCP tools through the single-user `mcp` service.
- `.github/workflows/test.yml`: starts the `mail` profile + provisions the account in the single-user integration lane.

**Fixes**
- `models/mail.py`: `MailAccount.email` aliased to `emailAddress`.
- `client/mail.py`: `get_mailboxes` unwraps the account envelope; removed the redundant `_ensure_csrf`/`requesttoken` round-trip and the dead `_api_v1_post`.
- `tests/client/mail/test_mail_api.py`: fixtures updated to the real shapes; CSRF stub removed.

## Test-environment limitations (documented, not product bugs)
- `get_message` needs a **multipart** seed message — GreenMail 2.1.x throws a `ClassCastException` on an IMAP `BODY` fetch of a plain `text/plain` message. Real IMAP servers are fine; the test seeds multipart and `get_message` returns 200.
- `send_message` (outbox) is **xfailed** — the Mail app fails internally (HTTP 500, before any SMTP connection) for a CLI-provisioned account (`from:[]`, sender identity unresolved). The client correctly implements the two-step outbox API per `OutboxController::create`.

## Verification
- `ruff` / `ruff format` / `ty` clean; `tests/unit/` 1901 passed, 1 skipped.
- Mail integration suite against a live stack: **3 passed, 1 xfailed**.

---

_This PR was generated with the help of AI, and reviewed by a Human_