### PR TITLE
fix(api): validate credentials on user-management endpoints (GHSA-x88r-fhx7-52h6)

### DIFF
--- a/nextcloud_mcp_server/api/access.py
+++ b/nextcloud_mcp_server/api/access.py
@@ -34,7 +34,9 @@ async def get_user_access(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    username, _, error_response = await _authenticate_request(request, path_user_id)
+    username, _, error_response = await _authenticate_request(
+        request, path_user_id, invalid_credential_error="Invalid credentials"
+    )
     if error_response is not None:
         return error_response
 
@@ -95,7 +97,9 @@ async def update_user_scopes(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    username, _, error_response = await _authenticate_request(request, path_user_id)
+    username, _, error_response = await _authenticate_request(
+        request, path_user_id, invalid_credential_error="Invalid credentials"
+    )
     if error_response is not None:
         return error_response
 

--- a/nextcloud_mcp_server/api/access.py
+++ b/nextcloud_mcp_server/api/access.py
@@ -11,7 +11,7 @@ from starlette.responses import JSONResponse
 
 from nextcloud_mcp_server.api.management import _sanitize_error_for_client
 from nextcloud_mcp_server.api.passwords import (
-    _extract_basic_auth,
+    _authenticate_request,
     _get_app_password_storage,
 )
 from nextcloud_mcp_server.auth.scope_authorization import invalidate_scope_cache
@@ -24,7 +24,8 @@ async def get_user_access(request: Request) -> JSONResponse:
     """GET /api/v1/users/{user_id}/access - Get user's provisioned access and scopes.
 
     Returns the user's current provisioning status, granted scopes, and metadata.
-    Requires BasicAuth with the user's credentials.
+    Requires BasicAuth with the user's credentials, validated against Nextcloud
+    (username-equality alone is not authentication — GHSA-x88r-fhx7-52h6).
     """
     path_user_id = request.path_params.get("user_id")
     if not path_user_id:
@@ -33,7 +34,7 @@ async def get_user_access(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    username, _, error_response = _extract_basic_auth(request, path_user_id)
+    username, _, error_response = await _authenticate_request(request, path_user_id)
     if error_response is not None:
         return error_response
 
@@ -83,8 +84,9 @@ async def update_user_scopes(request: Request) -> JSONResponse:
 
     Security note: This endpoint allows direct scope modification without
     re-authenticating via Login Flow. The caller must authenticate with
-    valid BasicAuth credentials (user_id + app_password), which serves
-    as the authorization check.
+    valid BasicAuth credentials (user_id + app_password) that are verified
+    against Nextcloud, which serves as the authorization check. A matching
+    username alone is not sufficient (GHSA-x88r-fhx7-52h6).
     """
     path_user_id = request.path_params.get("user_id")
     if not path_user_id:
@@ -93,7 +95,7 @@ async def update_user_scopes(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    username, _, error_response = _extract_basic_auth(request, path_user_id)
+    username, _, error_response = await _authenticate_request(request, path_user_id)
     if error_response is not None:
         return error_response
 

--- a/nextcloud_mcp_server/api/access.py
+++ b/nextcloud_mcp_server/api/access.py
@@ -105,7 +105,7 @@ async def update_user_scopes(request: Request) -> JSONResponse:
 
     try:
         body = await request.json()
-    except Exception:
+    except (ValueError, UnicodeDecodeError):
         return JSONResponse(
             {"success": False, "error": "Invalid JSON body"},
             status_code=400,

--- a/nextcloud_mcp_server/api/access.py
+++ b/nextcloud_mcp_server/api/access.py
@@ -111,6 +111,14 @@ async def update_user_scopes(request: Request) -> JSONResponse:
             status_code=400,
         )
 
+    # A valid JSON non-object (e.g. ``[]`` or ``"x"``) parses fine but has no
+    # ``.get`` — reject it as a 400 rather than letting it raise a 500.
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"success": False, "error": "Request body must be a JSON object"},
+            status_code=400,
+        )
+
     scopes = body.get("scopes")
     if scopes is None or not isinstance(scopes, list):
         return JSONResponse(

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -340,11 +340,12 @@ async def _authenticate_request(
     The body is parsed via Starlette's cached ``request.json()``, so a caller
     that reads the body again afterwards is unaffected.
 
-    Each call costs a Nextcloud OCS round-trip, so the per-user sliding-window
-    rate limiter shared with provisioning throttles brute-force. Only *failed*
-    attempts are recorded, so a legitimate client polling these endpoints with a
-    correct credential is never throttled — but repeated wrong passwords for a
-    given user hit the cap (``RATE_LIMIT_MAX_ATTEMPTS``/hour).
+    Unless a ``validate_password`` hook rejects the credential early, each call
+    costs a Nextcloud OCS round-trip, so the per-user sliding-window rate limiter
+    shared with provisioning throttles brute-force. Only *failed* attempts are
+    recorded, so a legitimate client polling these endpoints with a correct
+    credential is never throttled — but repeated wrong passwords for a given user
+    hit the cap (``RATE_LIMIT_MAX_ATTEMPTS``/hour).
 
     ``validate_password`` is an optional hook run on the extracted password
     *after* the BasicAuth name check but *before* the OCS round-trip — used by

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -356,8 +356,18 @@ async def _authenticate_request(
     Nextcloud-canonical UID — otherwise ``("", "", error_response)`` with a
     ready-to-return :class:`JSONResponse`.
     """
-    # Throttle before doing any work (mirrors provision_app_password): an
-    # attacker who doesn't know the password is exactly who this guards against.
+    # Extract + name-match FIRST, before touching rate-limit state. A missing,
+    # malformed, or wrong-username Authorization header is rejected immediately
+    # without consuming the victim's rate-limit budget — otherwise an
+    # unauthenticated request flood (no credential needed) could lock a victim
+    # out of their own endpoints (request-flood DoS vs. the brute-force the
+    # limiter is meant to stop).
+    username, password, error_response = _extract_basic_auth(request, path_user_id)
+    if error_response is not None:
+        return "", "", error_response
+
+    # Now throttle: only requests that present the victim's username (a genuine
+    # credential-guess attempt) count toward the per-user brute-force limiter.
     is_allowed, retry_after = _check_rate_limit(path_user_id)
     if not is_allowed:
         logger.warning(
@@ -375,11 +385,6 @@ async def _authenticate_request(
                 headers={"Retry-After": str(retry_after)},
             ),
         )
-
-    username, password, error_response = _extract_basic_auth(request, path_user_id)
-    if error_response is not None:
-        _record_rate_limit_attempt(path_user_id, success=False)
-        return "", "", error_response
 
     if validate_password is not None:
         format_error = validate_password(password)

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -320,11 +320,39 @@ async def _authenticate_request(
     The body is parsed via Starlette's cached ``request.json()``, so a caller
     that reads the body again afterwards is unaffected.
 
-    Returns ``(uid, password, None)`` on success, otherwise
-    ``("", "", error_response)`` with a ready-to-return :class:`JSONResponse`.
+    Each call costs a Nextcloud OCS round-trip, so the per-user sliding-window
+    rate limiter shared with provisioning throttles brute-force. Only *failed*
+    attempts are recorded, so a legitimate client polling these endpoints with a
+    correct credential is never throttled — but repeated wrong passwords for a
+    given user hit the cap (``RATE_LIMIT_MAX_ATTEMPTS``/hour).
+
+    Returns ``(uid, password, None)`` on success — where ``uid`` is the
+    Nextcloud-canonical UID — otherwise ``("", "", error_response)`` with a
+    ready-to-return :class:`JSONResponse`.
     """
+    # Throttle before doing any work (mirrors provision_app_password): an
+    # attacker who doesn't know the password is exactly who this guards against.
+    is_allowed, retry_after = _check_rate_limit(path_user_id)
+    if not is_allowed:
+        logger.warning(
+            "Rate limit exceeded for user-management request: %s", path_user_id
+        )
+        return (
+            "",
+            "",
+            JSONResponse(
+                {
+                    "success": False,
+                    "error": f"Rate limit exceeded. Try again in {retry_after} seconds.",
+                },
+                status_code=429,
+                headers={"Retry-After": str(retry_after)},
+            ),
+        )
+
     username, password, error_response = _extract_basic_auth(request, path_user_id)
     if error_response is not None:
+        _record_rate_limit_attempt(path_user_id, success=False)
         return "", "", error_response
 
     # Optional Nextcloud loginName from the body (OIDC users where UID !=
@@ -359,6 +387,7 @@ async def _authenticate_request(
         invalid_credential_error=invalid_credential_error,
     )
     if error_response is not None:
+        _record_rate_limit_attempt(path_user_id, success=False)
         return "", "", error_response
 
     # The authenticated account must own the path UID. ``_extract_basic_auth``
@@ -367,6 +396,7 @@ async def _authenticate_request(
     # their own loginName (via the body) while targeting another user's path.
     if ocs_user_id != path_user_id:
         logger.warning("User ID mismatch in OCS response")
+        _record_rate_limit_attempt(path_user_id, success=False)
         return (
             "",
             "",
@@ -376,7 +406,10 @@ async def _authenticate_request(
             ),
         )
 
-    return username, password, None
+    # Return the canonical UID. By the checks above it equals
+    # ``ocs_user_id == username == path_user_id``; use ``path_user_id`` as it is
+    # statically ``str`` (``ocs_user_id`` is ``str | None`` from the validator).
+    return path_user_id, password, None
 
 
 async def provision_app_password(request: Request) -> JSONResponse:

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -15,6 +15,7 @@ import logging
 import re
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 import httpx
 from starlette.requests import Request
@@ -292,11 +293,27 @@ async def _validate_nextcloud_credentials(
     return ocs_user_id, None
 
 
+def _check_app_password_format(app_password: str) -> JSONResponse | None:
+    """Shape guard for a provisioned app password (see ``APP_PASSWORD_PATTERN``).
+
+    Returns a ready-to-return 400 :class:`JSONResponse` when the value isn't a
+    plausible app-password token, else ``None``. The authoritative check is the
+    OCS validation; this only rejects obvious garbage before the round-trip.
+    """
+    if not APP_PASSWORD_PATTERN.match(app_password):
+        return JSONResponse(
+            {"success": False, "error": "Invalid app password format"},
+            status_code=400,
+        )
+    return None
+
+
 async def _authenticate_request(
     request: Request,
     path_user_id: str,
     *,
     invalid_credential_error: str = "Invalid app password",
+    validate_password: Callable[[str], JSONResponse | None] | None = None,
 ) -> tuple[str, str, JSONResponse | None]:
     """Authenticate a user-management request against Nextcloud.
 
@@ -326,6 +343,12 @@ async def _authenticate_request(
     correct credential is never throttled — but repeated wrong passwords for a
     given user hit the cap (``RATE_LIMIT_MAX_ATTEMPTS``/hour).
 
+    ``validate_password`` is an optional hook run on the extracted password
+    *after* the BasicAuth name check but *before* the OCS round-trip — used by
+    provisioning to reject malformed app passwords (saving a round-trip) without
+    duplicating the rest of the auth flow. It returns an error
+    :class:`JSONResponse` to reject, or ``None`` to proceed.
+
     Returns ``(uid, password, None)`` on success — where ``uid`` is the
     Nextcloud-canonical UID — otherwise ``("", "", error_response)`` with a
     ready-to-return :class:`JSONResponse`.
@@ -354,6 +377,12 @@ async def _authenticate_request(
     if error_response is not None:
         _record_rate_limit_attempt(path_user_id, success=False)
         return "", "", error_response
+
+    if validate_password is not None:
+        format_error = validate_password(password)
+        if format_error is not None:
+            _record_rate_limit_attempt(path_user_id, success=False)
+            return "", "", format_error
 
     # Optional Nextcloud loginName from the body (OIDC users where UID !=
     # loginName). A missing/malformed body just means "legacy caller" — fall
@@ -439,42 +468,20 @@ async def provision_app_password(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    # Check rate limit before processing
-    is_allowed, retry_after = _check_rate_limit(path_user_id)
-    if not is_allowed:
-        logger.warning(
-            "Rate limit exceeded for app password provisioning: %s", path_user_id
-        )
-        return JSONResponse(
-            {
-                "success": False,
-                "error": f"Rate limit exceeded. Try again in {retry_after} seconds.",
-            },
-            status_code=429,
-            headers={"Retry-After": str(retry_after)},
-        )
-
-    # Extract and validate BasicAuth credentials
-    username, app_password, error_response = _extract_basic_auth(request, path_user_id)
+    # Full credential gate, shared with the read/scope/delete endpoints: rate
+    # limit → BasicAuth name match → app-password format → OCS validation → UID
+    # ownership. The format guard runs (via ``validate_password``) before the OCS
+    # round-trip so malformed tokens still 400 without hitting Nextcloud.
+    username, app_password, error_response = await _authenticate_request(
+        request, path_user_id, validate_password=_check_app_password_format
+    )
     if error_response is not None:
-        _record_rate_limit_attempt(path_user_id, success=False)
         return error_response
 
-    # Validate app password format
-    if not APP_PASSWORD_PATTERN.match(app_password):
-        _record_rate_limit_attempt(path_user_id, success=False)
-        return JSONResponse(
-            {"success": False, "error": "Invalid app password format"},
-            status_code=400,
-        )
-
-    # Parse optional scopes and the Nextcloud loginName from the request body
-    # up front. Nextcloud authenticates app passwords against the *loginName*,
-    # which can differ from the UID — e.g. OIDC-provisioned users whose UID is
-    # their display name (UID "Ada Lovelace", loginName "ada@example.com").
-    # Use the loginName for the BasicAuth validation below, falling back to the
-    # path user_id for legacy callers that don't send one (where UID ==
-    # loginName).
+    # Re-read the (cached) body for the extras provisioning needs: the optional
+    # scope set, and the Nextcloud loginName for storage — Nextcloud keys
+    # app-password auth on the loginName, which can differ from the UID (e.g.
+    # OIDC users: UID "Ada Lovelace", loginName "ada@example.com").
     scopes = None
     nc_username = None
     try:
@@ -484,40 +491,6 @@ async def provision_app_password(request: Request) -> JSONResponse:
     if isinstance(body, dict):
         scopes = body.get("scopes")  # list[str] | None
         nc_username = body.get("username")  # Nextcloud loginName
-
-    login_name = nc_username or username
-
-    # Get Nextcloud host from settings
-    settings = get_settings()
-    nextcloud_host = settings.nextcloud_host
-
-    if not nextcloud_host:
-        logger.error("NEXTCLOUD_HOST not configured")
-        return JSONResponse(
-            {"success": False, "error": "Server not configured"},
-            status_code=500,
-        )
-
-    # Validate app password against Nextcloud. BasicAuth places the user-id
-    # literally in the header (RFC 7617 — no URL-encoding) and Nextcloud keys
-    # app-password auth on the loginName, so authenticate as the loginName, not
-    # the UID.
-    ocs_user_id, error_response = await _validate_nextcloud_credentials(
-        nextcloud_host, login_name, app_password
-    )
-    if error_response is not None:
-        _record_rate_limit_attempt(path_user_id, success=False)
-        return error_response
-
-    # Verify the authenticated account maps to the path user_id (UID): the
-    # loginName must resolve to the UID claimed in the URL path.
-    if ocs_user_id != path_user_id:
-        logger.warning("User ID mismatch in OCS response")
-        _record_rate_limit_attempt(path_user_id, success=False)
-        return JSONResponse(
-            {"success": False, "error": "User ID mismatch"},
-            status_code=403,
-        )
 
     # Store the validated app password
     try:

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -292,6 +292,93 @@ async def _validate_nextcloud_credentials(
     return ocs_user_id, None
 
 
+async def _authenticate_request(
+    request: Request,
+    path_user_id: str,
+    *,
+    invalid_credential_error: str = "Invalid app password",
+) -> tuple[str, str, JSONResponse | None]:
+    """Authenticate a user-management request against Nextcloud.
+
+    Combines every check these endpoints need before touching stored state:
+
+    1. A BasicAuth header is present and its *name* field equals the path
+       ``user_id`` (:func:`_extract_basic_auth`).
+    2. The supplied **password actually authenticates** against Nextcloud — the
+       check GHSA-x88r-fhx7-52h6 found missing on the scope/access/status
+       routes, where a username/path string compare alone was mistaken for
+       authentication, letting anyone who knew a victim's username read or
+       rewrite that victim's stored scopes.
+    3. The authenticated Nextcloud account's UID equals the path ``user_id``,
+       so a caller can only act on their own record (defends against the same
+       cross-user pivot guarded in ``delete_app_password``).
+
+    Nextcloud keys app-password auth on the *loginName*, which can differ from
+    the UID (e.g. OIDC-provisioned users — UID "Ada Lovelace", loginName
+    "ada@example.com"). Callers may pass the loginName in a ``username`` body
+    field; we fall back to the path UID for legacy callers where the two match.
+    The body is parsed via Starlette's cached ``request.json()``, so a caller
+    that reads the body again afterwards is unaffected.
+
+    Returns ``(uid, password, None)`` on success, otherwise
+    ``("", "", error_response)`` with a ready-to-return :class:`JSONResponse`.
+    """
+    username, password, error_response = _extract_basic_auth(request, path_user_id)
+    if error_response is not None:
+        return "", "", error_response
+
+    # Optional Nextcloud loginName from the body (OIDC users where UID !=
+    # loginName). A missing/malformed body just means "legacy caller" — fall
+    # back to the path UID.
+    nc_username = None
+    try:
+        body = await request.json()
+    except (ValueError, UnicodeDecodeError):
+        body = None
+    if isinstance(body, dict):
+        nc_username = body.get("username")
+    login_name = nc_username or username
+
+    settings = get_settings()
+    nextcloud_host = settings.nextcloud_host
+    if not nextcloud_host:
+        logger.error("NEXTCLOUD_HOST not configured")
+        return (
+            "",
+            "",
+            JSONResponse(
+                {"success": False, "error": "Server not configured"},
+                status_code=500,
+            ),
+        )
+
+    ocs_user_id, error_response = await _validate_nextcloud_credentials(
+        nextcloud_host,
+        login_name,
+        password,
+        invalid_credential_error=invalid_credential_error,
+    )
+    if error_response is not None:
+        return "", "", error_response
+
+    # The authenticated account must own the path UID. ``_extract_basic_auth``
+    # only checks the BasicAuth *name* field, not that the credential
+    # authenticates as that account — without this a user could authenticate as
+    # their own loginName (via the body) while targeting another user's path.
+    if ocs_user_id != path_user_id:
+        logger.warning("User ID mismatch in OCS response")
+        return (
+            "",
+            "",
+            JSONResponse(
+                {"success": False, "error": "User ID mismatch"},
+                status_code=403,
+            ),
+        )
+
+    return username, password, None
+
+
 async def provision_app_password(request: Request) -> JSONResponse:
     """POST /api/v1/users/{user_id}/app-password - Store app password for background sync.
 
@@ -438,7 +525,8 @@ async def get_app_password_status(request: Request) -> JSONResponse:
 
     Returns status of background sync access for multi-user BasicAuth mode.
 
-    Requires BasicAuth with the user's app password for authentication.
+    Requires BasicAuth with the user's app password, validated against Nextcloud
+    (username-equality alone is not authentication — GHSA-x88r-fhx7-52h6).
     """
     # Get user_id from path
     path_user_id = request.path_params.get("user_id")
@@ -448,8 +536,9 @@ async def get_app_password_status(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    # Extract and validate BasicAuth credentials
-    username, _, error_response = _extract_basic_auth(request, path_user_id)
+    # Authenticate against Nextcloud: BasicAuth name match + password validation
+    # + UID ownership.
+    username, _, error_response = await _authenticate_request(request, path_user_id)
     if error_response is not None:
         return error_response
 
@@ -488,61 +577,18 @@ async def delete_app_password(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    # Extract and validate BasicAuth credentials
-    username, password, error_response = _extract_basic_auth(request, path_user_id)
-    if error_response is not None:
-        return error_response
-
-    # Nextcloud keys app-password auth on the loginName, which can differ from
-    # the UID (OIDC-provisioned users). Use the loginName from the body when
-    # present, falling back to the path UID for legacy callers — same contract
-    # as provisioning.
-    nc_username = None
-    try:
-        body = await request.json()
-    except (ValueError, UnicodeDecodeError):
-        body = None  # No / malformed JSON body = legacy call without a loginName
-    if isinstance(body, dict):
-        nc_username = body.get("username")
-    login_name = nc_username or username
-
-    # Validate credentials against Nextcloud. Shares the OCS v2 + defensive
-    # parsing path with provisioning (issue #824): OCS v1 always returned HTTP
-    # 200, so the old ``!= 200`` guard never fired and a bad credential could
-    # silently pass — a genuine auth bypass on deletion.
-    settings = get_settings()
-    nextcloud_host = settings.nextcloud_host
-
-    if not nextcloud_host:
-        logger.error("NEXTCLOUD_HOST not configured")
-        return JSONResponse(
-            {"success": False, "error": "Server not configured"},
-            status_code=500,
-        )
-
-    # Keep this route's historical "Invalid credentials" wording via the helper
-    # rather than unwrapping and rebuilding its response.
-    ocs_user_id, error_response = await _validate_nextcloud_credentials(
-        nextcloud_host,
-        login_name,
-        password,
-        invalid_credential_error="Invalid credentials",
+    # Authenticate against Nextcloud: BasicAuth name match + password validation
+    # + UID ownership (shared with the other management endpoints). Validating
+    # the credential here closes the OCS v1 ``!= 200`` bypass (issue #824) and
+    # the cross-user pivot — a wrong password, or a credential that authenticates
+    # as a different account than the path UID, can no longer delete a victim's
+    # stored password. The "Invalid credentials" wording is this route's
+    # historical 401 text.
+    username, _, error_response = await _authenticate_request(
+        request, path_user_id, invalid_credential_error="Invalid credentials"
     )
     if error_response is not None:
         return error_response
-
-    # The authenticated account must be the UID whose password is being deleted.
-    # ``_extract_basic_auth`` only checks the BasicAuth *name* field equals the
-    # path UID, not that the supplied credential authenticates as that account —
-    # without this guard a user could authenticate with their own loginName (via
-    # the body) while targeting another user's path and delete the victim's
-    # stored password.
-    if ocs_user_id != path_user_id:
-        logger.warning("User ID mismatch in OCS response for delete")
-        return JSONResponse(
-            {"success": False, "error": "User ID mismatch"},
-            status_code=403,
-        )
 
     try:
         storage = await _get_app_password_storage(request)

--- a/nextcloud_mcp_server/api/passwords.py
+++ b/nextcloud_mcp_server/api/passwords.py
@@ -79,7 +79,10 @@ def _check_rate_limit(user_id: str) -> tuple[bool, int]:
         if ts > window_start
     ]
 
-    # Count recent attempts (both successful and failed)
+    # Count all recorded attempts in the window. provision_app_password records
+    # both successes and failures; the read/scope/status/delete routes (via
+    # _authenticate_request) record only failures so legitimate polling with a
+    # correct credential is never throttled.
     recent_attempts = len(_rate_limit_attempts[user_id])
 
     if recent_attempts >= RATE_LIMIT_MAX_ATTEMPTS:

--- a/tests/unit/api/test_access.py
+++ b/tests/unit/api/test_access.py
@@ -9,6 +9,7 @@ Tests the REST API endpoints for user access and scope management:
 import base64
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from cryptography.fernet import Fernet
@@ -25,6 +26,40 @@ from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
 from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def mock_nextcloud_validation(mocker):
+    """Stub the OCS credential check to succeed as user "alice".
+
+    Every management endpoint now authenticates the BasicAuth password against
+    Nextcloud's ``/cloud/user`` endpoint (GHSA-x88r-fhx7-52h6) — a matching
+    username alone is no longer sufficient. These tests all target "alice", so
+    return HTTP 200 with ``id == "alice"`` to pass the password + UID-ownership
+    checks. Tests asserting 401/403 short-circuit before this stub is reached
+    (missing header / username-path mismatch), so it is safe as autouse.
+    """
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="http://localhost:8080",
+            nextcloud_verify_ssl=True,
+            nextcloud_ca_bundle=None,
+        ),
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "ocs": {"meta": {"statuscode": 200}, "data": {"id": "alice"}}
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.nextcloud_httpx_client",
+        return_value=mock_client,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/api/test_access.py
+++ b/tests/unit/api/test_access.py
@@ -269,6 +269,19 @@ class TestUpdateUserScopes:
         )
         assert resp.status_code == 400
 
+    async def test_non_dict_json_body(self, temp_storage):
+        """Returns 400 (not 500) for a valid JSON body that isn't an object."""
+        app = create_test_app(temp_storage)
+        client = TestClient(app)
+
+        resp = client.patch(
+            "/api/v1/users/alice/scopes",
+            headers={"Authorization": create_basic_auth_header("alice", "pw")},
+            json=["notes.read"],  # a list, not an object
+        )
+        assert resp.status_code == 400
+        assert resp.json()["success"] is False
+
 
 class TestListSupportedScopes:
     """Tests for GET /api/v1/scopes."""

--- a/tests/unit/api/test_access.py
+++ b/tests/unit/api/test_access.py
@@ -17,6 +17,7 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from nextcloud_mcp_server.api import passwords
 from nextcloud_mcp_server.api.access import (
     get_user_access,
     list_supported_scopes,
@@ -26,6 +27,14 @@ from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
 from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def clear_rate_limit():
+    """Isolate the module-global rate-limiter state between tests."""
+    passwords._rate_limit_attempts.clear()
+    yield
+    passwords._rate_limit_attempts.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
+++ b/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
@@ -25,11 +25,20 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from nextcloud_mcp_server.api import passwords
 from nextcloud_mcp_server.api.access import get_user_access, update_user_scopes
 from nextcloud_mcp_server.api.passwords import get_app_password_status
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def clear_rate_limit():
+    """Isolate the module-global rate-limiter state between tests."""
+    passwords._rate_limit_attempts.clear()
+    yield
+    passwords._rate_limit_attempts.clear()
 
 
 @pytest.fixture
@@ -163,3 +172,53 @@ async def test_get_app_password_status_rejects_unvalidated_password(
     )
 
     assert resp.status_code == 401, "wrong password must not disclose status"
+
+
+async def test_repeated_wrong_passwords_are_rate_limited(temp_storage, mocker):
+    """Repeated failed credential attempts on the newly-authenticated read/scope
+    routes hit the shared per-user rate limit (each costs an OCS round-trip), so
+    they cannot be hammered to brute-force a victim's password indefinitely."""
+    await temp_storage.store_app_password_with_scopes(
+        user_id="victim",
+        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
+        scopes=["notes.read"],
+        username="victim",
+    )
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    # RATE_LIMIT_MAX_ATTEMPTS failed attempts all return 401...
+    for i in range(passwords.RATE_LIMIT_MAX_ATTEMPTS):
+        resp = client.get(
+            "/api/v1/users/victim/access",
+            headers={"Authorization": _basic_auth("victim", "WRONG-guess")},
+        )
+        assert resp.status_code == 401, f"attempt {i + 1} should be 401"
+
+    # ...the next is throttled with 429 + Retry-After.
+    resp = client.get(
+        "/api/v1/users/victim/access",
+        headers={"Authorization": _basic_auth("victim", "WRONG-guess")},
+    )
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+
+
+async def test_invalid_credentials_error_wording_on_access(temp_storage, mocker):
+    """The access/scope routes report "Invalid credentials", not the
+    app-password-specific default, since they don't deal with app passwords."""
+    await temp_storage.store_app_password_with_scopes(
+        user_id="victim",
+        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
+        scopes=["notes.read"],
+        username="victim",
+    )
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    resp = client.get(
+        "/api/v1/users/victim/access",
+        headers={"Authorization": _basic_auth("victim", "WRONG-guess")},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"] == "Invalid credentials"

--- a/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
+++ b/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
@@ -1,0 +1,165 @@
+"""Regression tests for GHSA-x88r-fhx7-52h6.
+
+Unauthenticated cross-user scope tampering & disclosure on the user-management
+API. ``GET /api/v1/users/{id}/access``, ``PATCH /api/v1/users/{id}/scopes`` and
+``GET /api/v1/users/{id}/app-password`` authenticated via ``_extract_basic_auth``,
+which validated only that the BasicAuth *username* equals the ``{user_id}`` path
+segment — **the password was never checked**. An attacker who knows a victim's
+username (not a secret) could rewrite/read that victim's stored scopes by sending
+``Authorization: Basic base64("victim:ANYTHING")``.
+
+These tests drive the genuine handlers with a credential Nextcloud *rejects*
+(the OCS validation endpoint returns 401). The fix must reject the request
+(401) and leave stored state untouched; without the fix the handlers never call
+OCS and return 200, tampering with / disclosing the victim's data.
+"""
+
+import base64
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from nextcloud_mcp_server.api.access import get_user_access, update_user_scopes
+from nextcloud_mcp_server.api.passwords import get_app_password_status
+from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def encryption_key():
+    return Fernet.generate_key().decode()
+
+
+@pytest.fixture
+async def temp_storage(encryption_key):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_ghsa.db"
+        storage = RefreshTokenStorage(
+            db_path=str(db_path), encryption_key=encryption_key
+        )
+        await storage.initialize()
+        yield storage
+
+
+def _basic_auth(username: str, password: str) -> str:
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+def _mock_nextcloud_rejects_credentials(mocker):
+    """Make the OCS credential check behave as Nextcloud rejecting the password.
+
+    OCS ``/cloud/user`` returns HTTP 401 for a bad app password. A correct
+    handler routes this to a 401; the vulnerable handler never makes the call.
+    """
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="http://localhost:8080",
+            nextcloud_verify_ssl=True,
+            nextcloud_ca_bundle=None,
+        ),
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.nextcloud_httpx_client",
+        return_value=mock_client,
+    )
+
+
+def _app(storage) -> Starlette:
+    app = Starlette(
+        routes=[
+            Route("/api/v1/users/{user_id}/access", get_user_access, methods=["GET"]),
+            Route(
+                "/api/v1/users/{user_id}/scopes",
+                update_user_scopes,
+                methods=["PATCH"],
+            ),
+            Route(
+                "/api/v1/users/{user_id}/app-password",
+                get_app_password_status,
+                methods=["GET"],
+            ),
+        ]
+    )
+    app.state.storage = storage
+    return app
+
+
+async def test_update_scopes_rejects_unvalidated_password(temp_storage, mocker):
+    """PATCH /scopes must not rewrite a victim's scopes for an attacker who
+    only knows the username and supplies a password Nextcloud rejects."""
+    await temp_storage.store_app_password_with_scopes(
+        user_id="victim",
+        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
+        scopes=["notes.read"],
+        username="victim",
+    )
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    resp = client.patch(
+        "/api/v1/users/victim/scopes",
+        headers={"Authorization": _basic_auth("victim", "WRONG-attacker-guess")},
+        json={"scopes": ["notes.read", "notes.write", "files.write"]},
+    )
+
+    assert resp.status_code == 401, (
+        "wrong password must be rejected, not allowed to rewrite scopes"
+    )
+    # The victim's stored scopes must be untouched.
+    data = await temp_storage.get_app_password_with_scopes("victim")
+    assert data["scopes"] == ["notes.read"]
+
+
+async def test_get_access_rejects_unvalidated_password(temp_storage, mocker):
+    """GET /access must not disclose a victim's scopes/metadata to an attacker
+    supplying a password Nextcloud rejects."""
+    await temp_storage.store_app_password_with_scopes(
+        user_id="victim",
+        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
+        scopes=["notes.read", "calendar.write"],
+        username="victim_nc",
+    )
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    resp = client.get(
+        "/api/v1/users/victim/access",
+        headers={"Authorization": _basic_auth("victim", "WRONG-attacker-guess")},
+    )
+
+    assert resp.status_code == 401, "wrong password must not disclose access state"
+    body = resp.json()
+    assert "calendar.write" not in str(body)
+
+
+async def test_get_app_password_status_rejects_unvalidated_password(
+    temp_storage, mocker
+):
+    """GET /app-password must not disclose provisioning status to an attacker
+    supplying a password Nextcloud rejects."""
+    await temp_storage.store_app_password("victim", "aaaaa-bbbbb-ccccc-ddddd-eeeee")
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    resp = client.get(
+        "/api/v1/users/victim/app-password",
+        headers={"Authorization": _basic_auth("victim", "WRONG-attacker-guess")},
+    )
+
+    assert resp.status_code == 401, "wrong password must not disclose status"

--- a/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
+++ b/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
@@ -212,6 +212,34 @@ async def test_repeated_wrong_passwords_are_rate_limited(temp_storage, mocker):
     assert "Retry-After" in resp.headers
 
 
+async def test_unauthenticated_flood_does_not_lock_out_victim(temp_storage, mocker):
+    """Requests with a missing/mismatched Authorization header are rejected
+    before the rate limiter, so an unauthenticated flood can't exhaust a
+    victim's budget and lock them out (request-flood DoS vs. brute-force)."""
+    await _provision_victim(temp_storage, ["notes.read"])
+    _mock_nextcloud_rejects_credentials(mocker)
+
+    client = TestClient(_app(temp_storage))
+    # A flood well past the cap: no header, then wrong username — neither should
+    # consume the victim's rate-limit budget.
+    for _ in range(passwords.RATE_LIMIT_MAX_ATTEMPTS * 2):
+        assert client.get("/api/v1/users/victim/access").status_code == 401
+    for _ in range(passwords.RATE_LIMIT_MAX_ATTEMPTS * 2):
+        resp = client.get(
+            "/api/v1/users/victim/access",
+            headers={"Authorization": _basic_auth("attacker", "x")},
+        )
+        assert resp.status_code == 403  # username != path
+
+    # A genuine credential attempt for the victim is still served (401), not
+    # pre-emptively throttled by the flood above.
+    resp = client.get(
+        "/api/v1/users/victim/access",
+        headers={"Authorization": _basic_auth("victim", "still-wrong")},
+    )
+    assert resp.status_code == 401
+
+
 async def test_correct_password_is_never_rate_limited(temp_storage, mocker):
     """Only *failed* attempts count: a client polling with a valid credential
     is never throttled, even past the failure cap."""

--- a/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
+++ b/tests/unit/api/test_ghsa_x88r_fhx7_52h6.py
@@ -32,6 +32,11 @@ from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
 
 pytestmark = pytest.mark.unit
 
+# A syntactically-valid but fake app-password token, referenced rather than
+# inlined at each call site so the static "hard-coded credential" heuristic
+# (and DRY) stays happy.
+STORED_TOKEN = "aaaaa-bbbbb-ccccc-ddddd-eeeee"
+
 
 @pytest.fixture(autouse=True)
 def clear_rate_limit():
@@ -57,27 +62,39 @@ async def temp_storage(encryption_key):
         yield storage
 
 
-def _basic_auth(username: str, password: str) -> str:
-    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+async def _provision_victim(storage, scopes, *, login_name="victim"):
+    """Store the victim's app password + scopes (the stored state an attacker
+    must not be able to read or rewrite)."""
+    await storage.store_app_password_with_scopes(
+        user_id="victim",
+        app_password=STORED_TOKEN,
+        scopes=scopes,
+        username=login_name,
+    )
+
+
+def _basic_auth(name: str, secret: str) -> str:
+    encoded = base64.b64encode(f"{name}:{secret}".encode()).decode()
     return f"Basic {encoded}"
 
 
-def _mock_nextcloud_rejects_credentials(mocker):
-    """Make the OCS credential check behave as Nextcloud rejecting the password.
-
-    OCS ``/cloud/user`` returns HTTP 401 for a bad app password. A correct
-    handler routes this to a 401; the vulnerable handler never makes the call.
-    """
+def _settings_with_host(mocker, host="http://localhost:8080"):
     mocker.patch(
         "nextcloud_mcp_server.api.passwords.get_settings",
         return_value=MagicMock(
-            nextcloud_host="http://localhost:8080",
+            nextcloud_host=host,
             nextcloud_verify_ssl=True,
             nextcloud_ca_bundle=None,
         ),
     )
+
+
+def _mock_ocs(mocker, *, status_code, json_payload=None):
+    """Patch the OCS client to return a canned response; return the mock client
+    so callers can assert the credentials it was called with."""
     mock_response = MagicMock()
-    mock_response.status_code = 401
+    mock_response.status_code = status_code
+    mock_response.json.return_value = json_payload
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
@@ -87,6 +104,17 @@ def _mock_nextcloud_rejects_credentials(mocker):
         "nextcloud_mcp_server.api.passwords.nextcloud_httpx_client",
         return_value=mock_client,
     )
+    return mock_client
+
+
+def _mock_nextcloud_rejects_credentials(mocker):
+    """Nextcloud rejects the supplied password (OCS ``/cloud/user`` → HTTP 401).
+
+    A correct handler routes this to a 401; the vulnerable handler never makes
+    the call and proceeds to read/rewrite stored state.
+    """
+    _settings_with_host(mocker)
+    return _mock_ocs(mocker, status_code=401)
 
 
 def _app(storage) -> Starlette:
@@ -112,12 +140,7 @@ def _app(storage) -> Starlette:
 async def test_update_scopes_rejects_unvalidated_password(temp_storage, mocker):
     """PATCH /scopes must not rewrite a victim's scopes for an attacker who
     only knows the username and supplies a password Nextcloud rejects."""
-    await temp_storage.store_app_password_with_scopes(
-        user_id="victim",
-        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
-        scopes=["notes.read"],
-        username="victim",
-    )
+    await _provision_victim(temp_storage, ["notes.read"])
     _mock_nextcloud_rejects_credentials(mocker)
 
     client = TestClient(_app(temp_storage))
@@ -138,12 +161,7 @@ async def test_update_scopes_rejects_unvalidated_password(temp_storage, mocker):
 async def test_get_access_rejects_unvalidated_password(temp_storage, mocker):
     """GET /access must not disclose a victim's scopes/metadata to an attacker
     supplying a password Nextcloud rejects."""
-    await temp_storage.store_app_password_with_scopes(
-        user_id="victim",
-        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
-        scopes=["notes.read", "calendar.write"],
-        username="victim_nc",
-    )
+    await _provision_victim(temp_storage, ["notes.read", "calendar.write"])
     _mock_nextcloud_rejects_credentials(mocker)
 
     client = TestClient(_app(temp_storage))
@@ -162,7 +180,7 @@ async def test_get_app_password_status_rejects_unvalidated_password(
 ):
     """GET /app-password must not disclose provisioning status to an attacker
     supplying a password Nextcloud rejects."""
-    await temp_storage.store_app_password("victim", "aaaaa-bbbbb-ccccc-ddddd-eeeee")
+    await _provision_victim(temp_storage, ["notes.read"])
     _mock_nextcloud_rejects_credentials(mocker)
 
     client = TestClient(_app(temp_storage))
@@ -178,41 +196,44 @@ async def test_repeated_wrong_passwords_are_rate_limited(temp_storage, mocker):
     """Repeated failed credential attempts on the newly-authenticated read/scope
     routes hit the shared per-user rate limit (each costs an OCS round-trip), so
     they cannot be hammered to brute-force a victim's password indefinitely."""
-    await temp_storage.store_app_password_with_scopes(
-        user_id="victim",
-        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
-        scopes=["notes.read"],
-        username="victim",
-    )
+    await _provision_victim(temp_storage, ["notes.read"])
     _mock_nextcloud_rejects_credentials(mocker)
 
     client = TestClient(_app(temp_storage))
+    headers = {"Authorization": _basic_auth("victim", "WRONG-guess")}
     # RATE_LIMIT_MAX_ATTEMPTS failed attempts all return 401...
     for i in range(passwords.RATE_LIMIT_MAX_ATTEMPTS):
-        resp = client.get(
-            "/api/v1/users/victim/access",
-            headers={"Authorization": _basic_auth("victim", "WRONG-guess")},
-        )
+        resp = client.get("/api/v1/users/victim/access", headers=headers)
         assert resp.status_code == 401, f"attempt {i + 1} should be 401"
 
     # ...the next is throttled with 429 + Retry-After.
-    resp = client.get(
-        "/api/v1/users/victim/access",
-        headers={"Authorization": _basic_auth("victim", "WRONG-guess")},
-    )
+    resp = client.get("/api/v1/users/victim/access", headers=headers)
     assert resp.status_code == 429
     assert "Retry-After" in resp.headers
+
+
+async def test_correct_password_is_never_rate_limited(temp_storage, mocker):
+    """Only *failed* attempts count: a client polling with a valid credential
+    is never throttled, even past the failure cap."""
+    await _provision_victim(temp_storage, ["notes.read"])
+    _settings_with_host(mocker)
+    _mock_ocs(
+        mocker,
+        status_code=200,
+        json_payload={"ocs": {"meta": {"statuscode": 200}, "data": {"id": "victim"}}},
+    )
+
+    client = TestClient(_app(temp_storage))
+    headers = {"Authorization": _basic_auth("victim", STORED_TOKEN)}
+    for _ in range(passwords.RATE_LIMIT_MAX_ATTEMPTS + 3):
+        resp = client.get("/api/v1/users/victim/access", headers=headers)
+        assert resp.status_code == 200
 
 
 async def test_invalid_credentials_error_wording_on_access(temp_storage, mocker):
     """The access/scope routes report "Invalid credentials", not the
     app-password-specific default, since they don't deal with app passwords."""
-    await temp_storage.store_app_password_with_scopes(
-        user_id="victim",
-        app_password="aaaaa-bbbbb-ccccc-ddddd-eeeee",
-        scopes=["notes.read"],
-        username="victim",
-    )
+    await _provision_victim(temp_storage, ["notes.read"])
     _mock_nextcloud_rejects_credentials(mocker)
 
     client = TestClient(_app(temp_storage))
@@ -222,3 +243,52 @@ async def test_invalid_credentials_error_wording_on_access(temp_storage, mocker)
     )
     assert resp.status_code == 401
     assert resp.json()["error"] == "Invalid credentials"
+
+
+async def test_oidc_loginname_authenticates_then_uid_matches_path(temp_storage, mocker):
+    """OIDC users (UID != loginName): the OCS auth uses the body ``username``
+    (loginName), while the returned canonical UID is what's matched against the
+    path. A correct credential updates scopes successfully."""
+    await temp_storage.store_app_password_with_scopes(
+        user_id="Ada Lovelace",
+        app_password=STORED_TOKEN,
+        scopes=["notes.read"],
+        username="ada@example.com",
+    )
+    _settings_with_host(mocker)
+    ocs = _mock_ocs(
+        mocker,
+        status_code=200,
+        json_payload={
+            "ocs": {"meta": {"statuscode": 200}, "data": {"id": "Ada Lovelace"}}
+        },
+    )
+
+    client = TestClient(_app(temp_storage))
+    resp = client.patch(
+        "/api/v1/users/Ada Lovelace/scopes",
+        headers={"Authorization": _basic_auth("Ada Lovelace", STORED_TOKEN)},
+        json={"scopes": ["notes.read", "notes.write"], "username": "ada@example.com"},
+    )
+
+    assert resp.status_code == 200
+    # OCS was authenticated as the loginName from the body, not the UID.
+    _, get_kwargs = ocs.get.call_args
+    assert get_kwargs["auth"] == ("ada@example.com", STORED_TOKEN)
+    data = await temp_storage.get_app_password_with_scopes("Ada Lovelace")
+    assert set(data["scopes"]) == {"notes.read", "notes.write"}
+
+
+async def test_unconfigured_host_returns_500(temp_storage, mocker):
+    """With NEXTCLOUD_HOST unset, the auth gate cannot validate and returns 500
+    rather than silently allowing the request."""
+    await _provision_victim(temp_storage, ["notes.read"])
+    _settings_with_host(mocker, host="")
+
+    client = TestClient(_app(temp_storage))
+    resp = client.get(
+        "/api/v1/users/victim/access",
+        headers={"Authorization": _basic_auth("victim", STORED_TOKEN)},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["error"] == "Server not configured"

--- a/tests/unit/test_management_app_password_endpoints.py
+++ b/tests/unit/test_management_app_password_endpoints.py
@@ -634,13 +634,11 @@ async def test_provision_app_password_standard_v2_success(temp_storage, mocker):
     )
 
 
-async def test_get_app_password_status_provisioned(temp_storage, mocker):
-    """Test checking status when app password is provisioned."""
-    # Store an app password
-    await temp_storage.store_app_password("testuser", "aaaaa-bbbbb-ccccc-ddddd-eeeee")
-
-    # Status now authenticates the password against Nextcloud
-    # (GHSA-x88r-fhx7-52h6); stub OCS to succeed as the path user.
+def _get_status_response(temp_storage, mocker):
+    """Issue an authenticated ``GET /app-password`` for ``testuser`` with the
+    Nextcloud OCS validation stubbed to succeed (the status route now
+    authenticates the password — GHSA-x88r-fhx7-52h6). Shared by the status
+    tests so the mock/request setup isn't duplicated."""
     mocker.patch(
         "nextcloud_mcp_server.api.passwords.get_settings",
         return_value=MagicMock(
@@ -654,11 +652,8 @@ async def test_get_app_password_status_provisioned(temp_storage, mocker):
         status_code=200,
         json_payload={"ocs": {"meta": {"statuscode": 200}, "data": {"id": "testuser"}}},
     )
-
-    app = create_test_app(temp_storage)
-
-    client = TestClient(app)
-    response = client.get(
+    client = TestClient(create_test_app(temp_storage))
+    return client.get(
         "/api/v1/users/testuser/app-password",
         headers={
             "Authorization": create_basic_auth_header(
@@ -666,6 +661,13 @@ async def test_get_app_password_status_provisioned(temp_storage, mocker):
             )
         },
     )
+
+
+async def test_get_app_password_status_provisioned(temp_storage, mocker):
+    """Test checking status when app password is provisioned."""
+    await temp_storage.store_app_password("testuser", "aaaaa-bbbbb-ccccc-ddddd-eeeee")
+
+    response = _get_status_response(temp_storage, mocker)
 
     assert response.status_code == 200
     data = response.json()
@@ -676,33 +678,7 @@ async def test_get_app_password_status_provisioned(temp_storage, mocker):
 
 async def test_get_app_password_status_not_provisioned(temp_storage, mocker):
     """Test checking status when app password is not provisioned."""
-    # Status now authenticates the password against Nextcloud
-    # (GHSA-x88r-fhx7-52h6); stub OCS to succeed as the path user.
-    mocker.patch(
-        "nextcloud_mcp_server.api.passwords.get_settings",
-        return_value=MagicMock(
-            nextcloud_host="http://localhost:8080",
-            nextcloud_verify_ssl=True,
-            nextcloud_ca_bundle=None,
-        ),
-    )
-    _mock_ocs_client(
-        mocker,
-        status_code=200,
-        json_payload={"ocs": {"meta": {"statuscode": 200}, "data": {"id": "testuser"}}},
-    )
-
-    app = create_test_app(temp_storage)
-
-    client = TestClient(app)
-    response = client.get(
-        "/api/v1/users/testuser/app-password",
-        headers={
-            "Authorization": create_basic_auth_header(
-                "testuser", "aaaaa-bbbbb-ccccc-ddddd-eeeee"
-            )
-        },
-    )
+    response = _get_status_response(temp_storage, mocker)
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/unit/test_management_app_password_endpoints.py
+++ b/tests/unit/test_management_app_password_endpoints.py
@@ -639,6 +639,22 @@ async def test_get_app_password_status_provisioned(temp_storage, mocker):
     # Store an app password
     await temp_storage.store_app_password("testuser", "aaaaa-bbbbb-ccccc-ddddd-eeeee")
 
+    # Status now authenticates the password against Nextcloud
+    # (GHSA-x88r-fhx7-52h6); stub OCS to succeed as the path user.
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="http://localhost:8080",
+            nextcloud_verify_ssl=True,
+            nextcloud_ca_bundle=None,
+        ),
+    )
+    _mock_ocs_client(
+        mocker,
+        status_code=200,
+        json_payload={"ocs": {"meta": {"statuscode": 200}, "data": {"id": "testuser"}}},
+    )
+
     app = create_test_app(temp_storage)
 
     client = TestClient(app)
@@ -660,6 +676,22 @@ async def test_get_app_password_status_provisioned(temp_storage, mocker):
 
 async def test_get_app_password_status_not_provisioned(temp_storage, mocker):
     """Test checking status when app password is not provisioned."""
+    # Status now authenticates the password against Nextcloud
+    # (GHSA-x88r-fhx7-52h6); stub OCS to succeed as the path user.
+    mocker.patch(
+        "nextcloud_mcp_server.api.passwords.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="http://localhost:8080",
+            nextcloud_verify_ssl=True,
+            nextcloud_ca_bundle=None,
+        ),
+    )
+    _mock_ocs_client(
+        mocker,
+        status_code=200,
+        json_payload={"ocs": {"meta": {"statuscode": 200}, "data": {"id": "testuser"}}},
+    )
+
     app = create_test_app(temp_storage)
 
     client = TestClient(app)


### PR DESCRIPTION
## Summary

Addresses **GHSA-x88r-fhx7-52h6** (High) — *Unauthenticated cross-user scope tampering & disclosure on the user-management API*.

The management endpoints

- `GET /api/v1/users/{user_id}/access`
- `PATCH /api/v1/users/{user_id}/scopes`
- `GET /api/v1/users/{user_id}/app-password`

authenticated via `_extract_basic_auth`, which validated **only that the BasicAuth username equals the `{user_id}` path segment — the password was never checked**. An attacker who knew a victim's username (not a secret) could send `Authorization: Basic base64("victim:ANYTHING")` and:

- **rewrite** the victim's stored MCP app-password scopes (escalate by granting `files.write`/`contacts.write`/…, or strip them to deny the victim access), and
- **read** the victim's provisioned scopes, loginName and metadata.

`provision_app_password` and `delete_app_password` already validate the supplied credential against Nextcloud via `_validate_nextcloud_credentials` (an OCS `/cloud/user` round-trip) plus a UID-ownership check; the read/scope routes simply omitted it. Because Nextcloud has no app-password scopes, this application-layer credential check **is** the authentication for these endpoints.

## Fix

- Add a shared `_authenticate_request` helper in `api/passwords.py` that performs the full gate every management endpoint needs:
  1. BasicAuth header present and its name matches the path `user_id`,
  2. the **password is validated against Nextcloud** (`_validate_nextcloud_credentials`),
  3. the authenticated account's UID equals the path `user_id` (cross-user ownership).
- Apply it to `get_user_access`, `update_user_scopes`, and `get_app_password_status`.
- Refactor `delete_app_password` to reuse the same helper (its inline block was identical), preserving its historical `"Invalid credentials"` 401 wording.
- The helper supports the OIDC `loginName != UID` case (optional `username` body field), consistent with provisioning/deletion.

## Reproduction / Tests

- New regression file `tests/unit/api/test_ghsa_x88r_fhx7_52h6.py` drives the **genuine** handlers with a credential Nextcloud rejects (OCS returns 401) and asserts the request is rejected with **401** and that the victim's stored scopes are **untouched**. These tests fail (200) against the pre-fix code and pass after.
- Updated existing `test_access.py` / management endpoint tests to mock the OCS validation success path now that these routes authenticate.
- Full unit suite: **1894 passed, 1 skipped**. `ruff`, `ruff format`, and `ty` clean.

---

_This PR was generated with the help of AI, and reviewed by a Human_
