### PR TITLE
fix(mail): download attachments via direct route, not OCS (#989)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Mark tests appropriately**: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.oauth`, `@pytest.mark.smoke`
 
 ### Architectural Patterns
-- **Base classes**: `BaseNextcloudClient` for all API clients
+- **Base classes**: **All app API clients MUST extend `BaseNextcloudClient`** and
+  issue requests through its `_make_request`. That method centralizes `_resolve_url`
+  (prepends `/index.php` to bare `/apps/...` paths — the universal entry point that
+  works without pretty-URL rewriting, issue #732), `@retry_on_429`, tracing, and
+  `raise_for_status`. Consequences:
+  - **Write bare `/apps/<app>/...` paths — never hardcode `/index.php`.** The base
+    class adds it; `/ocs/...` and `/remote.php/dav/...` paths pass through unchanged.
+  - Don't reimplement `_make_request` in a subclass — a private copy silently skips
+    `_resolve_url`/retry/tracing (and, if it omits `raise_for_status`, breaks 429
+    retry). Override only for a genuinely different transport.
+  - **Known exception**: `CalendarClient` talks CalDAV via its own `caldav` session,
+    not the shared Nextcloud HTTP client, so it does not extend `BaseNextcloudClient`.
+    This is intentional — do not "fix" it.
 - **Pydantic responses**: All MCP tools return Pydantic models inheriting from `BaseResponse`
 - **Decorators**: `@require_scopes`, `@require_provisioning` for access control
 - **Context pattern**: `await get_client(ctx)` to access authenticated NextcloudClient (async!)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For Kubernetes, see [cbcoutinho/helm-charts](https://github.com/cbcoutinho/helm-
 | **Tables** | 5 | Row operations on Nextcloud Tables |
 | **Sharing** | 10+ | Create and manage shares |
 | **News** | 8 | Feeds, folders, items, feed health monitoring |
-| **Mail** | 5 | Read-only: accounts, mailboxes, messages, attachments (via Mail app's OCS API) |
+| **Mail** | 5 | Read-only: accounts, mailboxes, messages, attachments (via Mail app's REST API) |
 | **Collectives** | 16 | Full CRUD on collectives, pages, and tags |
 | **Talk (spreed)** | 6 | List conversations, read/post messages, mark as read, list participants |
 | **Semantic Search** | 2+ | Vector search for Notes, Files, News items, Deck cards, and Mail messages (experimental, opt-in, requires infrastructure) |

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -131,7 +131,8 @@ class MailClient(BaseNextcloudClient):
             params=query,
             headers=self._API_HEADERS,
         )
-        response.raise_for_status()
+        # ``_make_request`` (base) already raised on any non-2xx status; an OCS
+        # meta failure arrives as HTTP 200 and is handled by ``_ocs_response``.
         return _ocs_response(response)
 
     async def _api_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
@@ -150,7 +151,7 @@ class MailClient(BaseNextcloudClient):
             params=params,
             headers=self._API_HEADERS,
         )
-        response.raise_for_status()
+        # ``_make_request`` (base) already raised on any non-2xx status.
         return response.json()
 
     async def _api_post(
@@ -171,8 +172,8 @@ class MailClient(BaseNextcloudClient):
             json=json_data,
             headers={**self._API_HEADERS, "Content-Type": "application/json"},
         )
-        response.raise_for_status()
-        # The outbox send step can legitimately return an empty body (e.g. 204);
+        # ``_make_request`` (base) already raised on any non-2xx status. The
+        # outbox send step can legitimately return an empty body (e.g. 204);
         # don't choke trying to JSON-decode it.
         return response.json() if response.content else {}
 
@@ -297,8 +298,7 @@ class MailClient(BaseNextcloudClient):
             f"{self.API_BASE}/messages/{message_id}/attachment/{safe_id}",
             headers=self._API_HEADERS,
         )
-        response.raise_for_status()
-
+        # ``_make_request`` (base) already raised on any non-2xx status.
         raw = response.content
         ctype = (response.headers.get("content-type", "") or "").split(";")[0].strip()
 

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -3,27 +3,33 @@
 Uses two endpoint types:
 
 1. **OCS routes** — ``/ocs/v2.php/apps/mail/message/...`` — for reading full messages
-   and attachments. Works with Basic Auth (App Password) via the OCS-APIRequest header.
-   These routes are registered in the ``'ocs'`` section of the Mail app's ``routes.php``.
+   (body + metadata) and the raw RFC 2822 source. Works with Basic Auth (App
+   Password) via the OCS-APIRequest header. These routes are registered in the
+   ``'ocs'`` section of the Mail app's ``routes.php``.
 
 2. **Direct app routes** — ``/index.php/apps/mail/api/...`` — for listing accounts,
-   mailboxes, and messages, and for the two-step outbox send. These REST resource
-   routes (from ``'resources'`` in ``routes.php``) are CSRF-gated for browser
-   sessions, but Nextcloud exempts any request carrying the ``OCS-APIRequest: true``
-   header from the CSRF check — so Basic Auth (App Password) + that header is
-   sufficient. No ``requesttoken`` round-trip is needed (verified end-to-end against
-   a live Mail 5.x backend; see the GreenMail integration tests).
+   mailboxes, and messages, downloading attachments, and the two-step outbox send.
+   These REST resource routes (from ``'resources'`` in ``routes.php``) are
+   CSRF-gated for browser sessions, but Nextcloud exempts any request carrying the
+   ``OCS-APIRequest: true`` header from the CSRF check — so Basic Auth (App
+   Password) + that header is sufficient. No ``requesttoken`` round-trip is needed
+   (verified end-to-end against a live Mail 5.x backend; see the GreenMail
+   integration tests).
+
+Attachment downloads use the direct route ``/api/messages/{id}/attachment/{id}``,
+which returns the raw file bytes (via core's ``DownloadResponse``). The OCS
+``/message/{id}/attachment/{id}`` route is unreliable across Mail versions — on
+some setups it returns HTTP 200 with an empty, non-JSON body (see GH #989).
 """
 
-import logging
+import base64
+from email.message import Message
 from typing import Any
 from urllib.parse import quote
 
-from httpx import AsyncClient, HTTPStatusError, RequestError, Response
+from httpx import HTTPStatusError, RequestError, Response
 
-from nextcloud_mcp_server.client.base import retry_on_429
-
-logger = logging.getLogger(__name__)
+from nextcloud_mcp_server.client.base import BaseNextcloudClient
 
 
 def _ocs_response(response: Response) -> Any:
@@ -71,19 +77,26 @@ def _ocs_response(response: Response) -> Any:
     return ocs.get("data")
 
 
-class MailClient:
+class MailClient(BaseNextcloudClient):
     """Client for the Nextcloud Mail app API.
 
     Uses a combination of OCS and direct routes to cover the full mail workflow
     (list accounts → browse mailboxes → list messages → read message → send
     reply) with the correct authentication for each endpoint.
+
+    Requests go through :meth:`BaseNextcloudClient._make_request`, which routes
+    bare ``/apps/...`` paths through ``_resolve_url`` (prepending ``/index.php``,
+    the universal entry point that works without pretty-URL rewriting — issue
+    #732), applies 429 retry, tracing, and ``raise_for_status``. ``/ocs/...``
+    paths pass through ``_resolve_url`` unchanged.
     """
 
     # OCS endpoints — work with Basic Auth + OCS‑APIRequest header alone.
     OCS_BASE = "/ocs/v2.php/apps/mail"
 
-    # Direct API endpoints — CSRF-exempt via the OCS-APIRequest header.
-    API_BASE = "/index.php/apps/mail/api"
+    # Direct API endpoints — CSRF-exempt via the OCS-APIRequest header. Written
+    # as bare ``/apps/...`` paths (``_resolve_url`` prepends ``/index.php``).
+    API_BASE = "/apps/mail/api"
 
     # The OCS-APIRequest header authenticates the OCS routes and exempts the
     # direct routes from CSRF, so both families use the same headers.
@@ -94,28 +107,9 @@ class MailClient:
 
     app_name = "mail"
 
-    def __init__(self, http_client: AsyncClient, username: str) -> None:
-        self._client = http_client
-        self.username = username
-
     # ------------------------------------------------------------------
     # Low‑level request helpers
     # ------------------------------------------------------------------
-
-    @retry_on_429
-    async def _make_request(self, method: str, url: str, **kwargs: Any) -> Response:
-        """Make an HTTP request with retry logic for 429 responses.
-
-        Args:
-            method: HTTP method (GET, POST, PUT, …).
-            url: Full URL path (e.g. ``/ocs/v2.php/apps/mail/message/1``).
-            **kwargs: Extra arguments forwarded to ``httpx.AsyncClient.request()``.
-
-        Returns:
-            The httpx Response object.
-        """
-        logger.debug("MailClient %s %s", method, url)
-        return await self._client.request(method, url, **kwargs)
 
     async def _ocs_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         """GET an OCS endpoint and unwrap its envelope.
@@ -280,8 +274,12 @@ class MailClient:
     ) -> dict[str, Any]:
         """Get an attachment's content from a message.
 
-        Uses the OCS route ``GET /ocs/v2.php/apps/mail/message/{id}/attachment/{id}``
-        which works with Basic Auth (App Password).
+        Uses the direct route
+        ``GET /index.php/apps/mail/api/messages/{id}/attachment/{id}``
+        (CSRF-exempt via the OCS-APIRequest header), which returns the raw file
+        bytes. The OCS ``/message/{id}/attachment/{id}`` route is unreliable
+        across Mail versions — on some setups it returns HTTP 200 with an empty,
+        non-JSON body (GH #989).
 
         The ``attachment_id`` is URL‑encoded to prevent path traversal.
 
@@ -291,11 +289,47 @@ class MailClient:
 
         Returns:
             Attachment dict with keys ``name``, ``mime``, ``size``, ``content``.
+            ``content`` is the raw attachment bytes base64-encoded.
         """
-
         safe_id = quote(attachment_id, safe="")
-        data = await self._ocs_get(f"/message/{message_id}/attachment/{safe_id}")
-        return data if isinstance(data, dict) else {}
+        response = await self._make_request(
+            "GET",
+            f"{self.API_BASE}/messages/{message_id}/attachment/{safe_id}",
+            headers=self._API_HEADERS,
+        )
+        response.raise_for_status()
+
+        raw = response.content
+        ctype = (response.headers.get("content-type", "") or "").split(";")[0].strip()
+
+        # Recover the real filename from the Content-Disposition header (core's
+        # DownloadResponse sets ``attachment; filename="..."``); fall back to a
+        # synthetic name when the header is absent or has no filename.
+        name = (
+            self._filename_from_disposition(response.headers.get("content-disposition"))
+            or f"attachment_{message_id}_{attachment_id}"
+        )
+
+        return {
+            "name": name,
+            "mime": ctype or "application/octet-stream",
+            "size": len(raw),
+            "content": base64.b64encode(raw).decode("ascii"),
+        }
+
+    @staticmethod
+    def _filename_from_disposition(header: str | None) -> str | None:
+        """Extract the filename from a Content-Disposition header, if present.
+
+        Uses ``email.message.Message`` so quoted and RFC 2231-encoded filenames
+        are handled without the deprecated ``cgi`` module. Returns ``None`` when
+        the header is missing or carries no filename.
+        """
+        if not header:
+            return None
+        msg = Message()
+        msg["content-disposition"] = header
+        return msg.get_filename()
 
     async def send_message(
         self,

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -293,10 +293,13 @@ class MailClient(BaseNextcloudClient):
             ``content`` is the raw attachment bytes base64-encoded.
         """
         safe_id = quote(attachment_id, safe="")
+        # Binary download: unlike the JSON helpers, don't send
+        # ``Accept: application/json`` (mirrors ``DeckClient.get_attachment_file``).
+        # The ``OCS-APIRequest`` header still CSRF-exempts this direct route.
         response = await self._make_request(
             "GET",
             f"{self.API_BASE}/messages/{message_id}/attachment/{safe_id}",
-            headers=self._API_HEADERS,
+            headers={"OCS-APIRequest": "true"},
         )
         # ``_make_request`` (base) already raised on any non-2xx status.
         raw = response.content

--- a/nextcloud_mcp_server/client/tables.py
+++ b/nextcloud_mcp_server/client/tables.py
@@ -27,7 +27,7 @@ class TablesClient(BaseNextcloudClient):
         """Get the schema/structure of a specific table including columns and views."""
         # Using v1 API as v2 schema endpoint had issues during testing
         response = await self._make_request(
-            "GET", f"/index.php/apps/tables/api/1/tables/{table_id}/scheme"
+            "GET", f"/apps/tables/api/1/tables/{table_id}/scheme"
         )
         return response.json()
 
@@ -42,7 +42,7 @@ class TablesClient(BaseNextcloudClient):
             params["offset"] = offset
 
         response = await self._make_request(
-            "GET", f"/index.php/apps/tables/api/1/tables/{table_id}/rows", params=params
+            "GET", f"/apps/tables/api/1/tables/{table_id}/rows", params=params
         )
         return response.json()
 
@@ -77,7 +77,7 @@ class TablesClient(BaseNextcloudClient):
 
         response = await self._make_request(
             "PUT",
-            f"/index.php/apps/tables/api/1/rows/{row_id}",
+            f"/apps/tables/api/1/rows/{row_id}",
             json={"data": api_data},
         )
         return response.json()
@@ -85,7 +85,7 @@ class TablesClient(BaseNextcloudClient):
     async def delete_row(self, row_id: int) -> Dict[str, Any]:
         """Delete a row from a table."""
         response = await self._make_request(
-            "DELETE", f"/index.php/apps/tables/api/1/rows/{row_id}"
+            "DELETE", f"/apps/tables/api/1/rows/{row_id}"
         )
         return response.json()
 

--- a/nextcloud_mcp_server/models/mail.py
+++ b/nextcloud_mcp_server/models/mail.py
@@ -190,13 +190,13 @@ class SendMessageResponse(BaseResponse):
 class GetAttachmentResponse(BaseResponse):
     """Response model for getting a single attachment.
 
-    Intentionally does NOT nest ``MailAttachment``: the Mail OCS *get-attachment*
-    endpoint returns a different shape (``name``/``mime``/``size``/``content``)
-    than the attachment entries on a message listing, which ``MailAttachment``
-    models (``id``/``fileName``/``cid``/``disposition``, and no ``content``).
+    Intentionally does NOT nest ``MailAttachment``: the get-attachment path
+    returns a different shape (``name``/``mime``/``size``/``content``) than the
+    attachment entries on a message listing, which ``MailAttachment`` models
+    (``id``/``fileName``/``cid``/``disposition``, and no ``content``).
     """
 
     name: str | None = Field(None, description="Attachment file name")
     mime: str | None = Field(None, description="MIME type")
     size: int | None = Field(None, description="Size in bytes")
-    content: str | None = Field(None, description="Attachment content")
+    content: str | None = Field(None, description="Attachment content, base64-encoded")

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -31,14 +31,20 @@ logger = logging.getLogger(__name__)
 # fit in the host LLM's context window; replace anything larger with a sentinel
 # so a 20 MB design file can't blow up the MCP response. Callers can still see
 # the real size via the message's attachment list.
+#
+# NOTE: the cap is deliberately measured against the *base64-encoded* string —
+# that encoded footprint (~1.33x the raw file) is exactly what lands in the MCP
+# response, which is the thing we're bounding. Sizing off the raw byte count
+# would let a correspondingly larger payload through into the response.
 MAX_ATTACHMENT_CONTENT_BYTES = 5 * 1024 * 1024
 
 
 def _cap_attachment_content(content: str | None) -> str | None:
     """Replace oversized attachment content with a size sentinel.
 
-    Measures UTF-8 byte length (what actually lands in the MCP response/LLM
-    context), not character count. Non-string content is returned unchanged.
+    Measures the UTF-8 byte length of the (base64-encoded) content — i.e. the
+    footprint that actually lands in the MCP response / LLM context — not the
+    raw file size or character count. Non-string content is returned unchanged.
     """
     if not isinstance(content, str):
         return content

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -26,11 +26,11 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
 
-# Hard cap on inlined attachment content. The Mail OCS API returns the full
-# attachment body in the JSON response, which then has to fit in the host LLM's
-# context window; replace anything larger with a sentinel so a 20 MB design file
-# can't blow up the MCP response. Callers can still see the real size via the
-# message's attachment list.
+# Hard cap on inlined attachment content. The Mail attachment endpoint returns
+# the full attachment body (base64-encoded) in the response, which then has to
+# fit in the host LLM's context window; replace anything larger with a sentinel
+# so a 20 MB design file can't blow up the MCP response. Callers can still see
+# the real size via the message's attachment list.
 MAX_ATTACHMENT_CONTENT_BYTES = 5 * 1024 * 1024
 
 
@@ -319,9 +319,9 @@ def configure_mail_tools(mcp: FastMCP):
 
         Returns:
             GetAttachmentResponse with name, mime, size, and content. ``content``
-            is the attachment body as returned by the Mail OCS API; large
-            attachments produce a correspondingly large response, so prefer the
-            ``size`` from the message's attachment list before fetching.
+            is the attachment body base64-encoded; large attachments produce a
+            correspondingly large response, so prefer the ``size`` from the
+            message's attachment list before fetching.
         """
         client = await get_client(ctx)
         try:

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -22,6 +22,7 @@ payload. Shapes are the real ones verified against a live Mail 5.x backend via
 the GreenMail integration suite.
 """
 
+import base64
 import logging
 from typing import Any
 
@@ -220,8 +221,6 @@ async def test_get_attachment_returns_base64_bytes(mocker):
     The filename is recovered from the Content-Disposition header, the mime from
     Content-Type, and the size from the byte length (GH #989).
     """
-    import base64
-
     raw = b"%PDF-1.4 fake pdf bytes"
     mock_response = create_mock_response(
         content=raw,

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -3,13 +3,19 @@
 Mail 5.x exposes two route families (see ``~/Software/mail/appinfo/routes.php``
 and the module docstring of ``client/mail.py``):
 
-- **Direct REST resource routes** under ``/index.php/apps/mail/api`` —
-  ``/accounts``, ``/mailboxes``, ``/messages``, ``/outbox`` — return plain JSON
-  (a list, or an account envelope for ``/mailboxes``) and are CSRF-exempt via the
-  ``OCS-APIRequest: true`` header (no ``requesttoken`` round-trip needed).
-- **OCS routes** under ``/ocs/v2.php/apps/mail`` — ``/message/{id}``,
-  ``/message/{id}/attachment/{id}``, ``/message/{id}/raw`` — return the standard
-  OCS envelope and work with Basic Auth alone.
+- **Direct REST resource routes** under ``/apps/mail/api`` — ``/accounts``,
+  ``/mailboxes``, ``/messages``, ``/messages/{id}/attachment/{id}``, ``/outbox``
+  — return plain JSON or raw bytes and are CSRF-exempt via the
+  ``OCS-APIRequest: true`` header (no ``requesttoken`` round-trip needed). These
+  bare ``/apps/...`` paths are normalised to ``/index.php/apps/...`` by
+  ``BaseNextcloudClient._resolve_url`` inside ``MailClient._make_request`` (which
+  the assertions below capture pre-normalisation, since ``_make_request`` is
+  mocked).
+- **OCS routes** under ``/ocs/v2.php/apps/mail`` — ``/message/{id}`` and
+  ``/message/{id}/raw`` — return the standard OCS envelope and work with Basic
+  Auth alone. (Attachment downloads use the direct ``/api/messages/{id}/attachment/{id}``
+  route, which returns raw file bytes; the OCS attachment route is unreliable —
+  see GH #989.)
 
 The ``_api_*`` tests therefore feed plain JSON; the OCS tests feed an enveloped
 payload. Shapes are the real ones verified against a live Mail 5.x backend via
@@ -71,7 +77,7 @@ async def test_list_accounts_unwraps_direct_payload(mocker):
 
     # Direct resource route; CSRF-exempt via the OCS-APIRequest header (no token).
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/index.php/apps/mail/api/accounts")
+    assert args == ("GET", "/apps/mail/api/accounts")
     assert kwargs["headers"]["OCS-APIRequest"] == "true"
     assert "requesttoken" not in kwargs["headers"]
 
@@ -113,7 +119,7 @@ async def test_get_mailboxes_unwraps_account_envelope(mocker):
     assert mailboxes[0]["specialUse"] == ["inbox"]
 
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/index.php/apps/mail/api/mailboxes")
+    assert args == ("GET", "/apps/mail/api/mailboxes")
     assert kwargs["params"]["accountId"] == 1
 
 
@@ -145,7 +151,7 @@ async def test_list_messages_builds_params(mocker):
     assert messages[0]["databaseId"] == 100
 
     args, kwargs = mock_make_request.call_args
-    assert args == ("GET", "/index.php/apps/mail/api/messages")
+    assert args == ("GET", "/apps/mail/api/messages")
     assert kwargs["params"]["mailboxId"] == 10
     assert kwargs["params"]["limit"] == 50
     assert kwargs["params"]["cursor"] == 42
@@ -208,10 +214,21 @@ async def test_get_message_unwraps_full_message(mocker):
     assert args == ("GET", "/ocs/v2.php/apps/mail/message/100")
 
 
-async def test_get_attachment_unwraps_json(mocker):
-    """get_attachment returns the JSON attachment object from the OCS route."""
-    mock_response = _ocs_response(
-        {"name": "doc.pdf", "mime": "application/pdf", "size": 1024, "content": "abc"}
+async def test_get_attachment_returns_base64_bytes(mocker):
+    """get_attachment fetches the direct route and base64-encodes the raw bytes.
+
+    The filename is recovered from the Content-Disposition header, the mime from
+    Content-Type, and the size from the byte length (GH #989).
+    """
+    import base64
+
+    raw = b"%PDF-1.4 fake pdf bytes"
+    mock_response = create_mock_response(
+        content=raw,
+        headers={
+            "content-type": "application/pdf; charset=binary",
+            "content-disposition": 'attachment; filename="doc.pdf"',
+        },
     )
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
     mock_make_request = mocker.patch.object(
@@ -222,15 +239,34 @@ async def test_get_attachment_unwraps_json(mocker):
     attachment = await client.get_attachment(100, "1.2")
 
     assert attachment["name"] == "doc.pdf"
-    assert attachment["content"] == "abc"
+    assert attachment["mime"] == "application/pdf"
+    assert attachment["size"] == len(raw)
+    assert attachment["content"] == base64.b64encode(raw).decode("ascii")
+    assert base64.b64decode(attachment["content"]) == raw
 
     args, _ = mock_make_request.call_args
-    assert args == ("GET", "/ocs/v2.php/apps/mail/message/100/attachment/1.2")
+    assert args == ("GET", "/apps/mail/api/messages/100/attachment/1.2")
+
+
+async def test_get_attachment_synthesizes_name_without_disposition(mocker):
+    """Without a Content-Disposition filename, a synthetic name is used."""
+    mock_response = create_mock_response(
+        content=b"data",
+        headers={"content-type": "application/octet-stream"},
+    )
+    mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    mocker.patch.object(MailClient, "_make_request", return_value=mock_response)
+
+    client = MailClient(mock_client, "testuser")
+    attachment = await client.get_attachment(100, "1.2")
+
+    assert attachment["name"] == "attachment_100_1.2"
+    assert attachment["mime"] == "application/octet-stream"
 
 
 async def test_get_attachment_url_encodes_attachment_id(mocker):
     """A traversal-style attachment_id is percent-encoded in the URL path."""
-    mock_response = _ocs_response({"name": "x", "content": "y"})
+    mock_response = create_mock_response(content=b"y")
     mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
     mock_make_request = mocker.patch.object(
         MailClient, "_make_request", return_value=mock_response
@@ -243,7 +279,7 @@ async def test_get_attachment_url_encodes_attachment_id(mocker):
     # The "/" and ".." are encoded, so they can't escape the attachment path.
     assert args == (
         "GET",
-        "/ocs/v2.php/apps/mail/message/100/attachment/..%2F..%2Fevil",
+        "/apps/mail/api/messages/100/attachment/..%2F..%2Fevil",
     )
 
 
@@ -316,8 +352,8 @@ async def test_send_message_two_step_flow(mocker):
     assert result["outbox_id"] == 42
 
     calls = mock_make_request.call_args_list
-    assert calls[0].args == ("POST", "/index.php/apps/mail/api/outbox")
-    assert calls[1].args == ("POST", "/index.php/apps/mail/api/outbox/42")
+    assert calls[0].args == ("POST", "/apps/mail/api/outbox")
+    assert calls[1].args == ("POST", "/apps/mail/api/outbox/42")
 
 
 async def test_send_message_missing_outbox_id_raises(mocker):

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -93,18 +93,55 @@ def _seed_inbox_message(subject: str, body: str) -> None:
 
 
 def _seed_message_with_attachment(
-    subject: str, attachment: bytes, filename: str
+    subject: str,
+    attachment: bytes,
+    filename: str,
+    *,
+    maintype: str = "text",
+    subtype: str = "plain",
 ) -> None:
-    """Deliver a multipart/mixed message carrying a file attachment via SMTP."""
+    """Deliver a multipart/mixed message carrying a file attachment via SMTP.
+
+    ``maintype``/``subtype`` default to ``text/plain``; pass e.g.
+    ``application``/``pdf`` to attach a binary file.
+    """
     msg = EmailMessage()
     msg["From"] = "sender@example.org"
     msg["To"] = ADMIN_EMAIL
     msg["Subject"] = subject
     msg.set_content("see attached")
     msg.add_alternative("<p>see attached</p>", subtype="html")
-    msg.add_attachment(attachment, maintype="text", subtype="plain", filename=filename)
+    msg.add_attachment(
+        attachment, maintype=maintype, subtype=subtype, filename=filename
+    )
     with smtplib.SMTP("localhost", 3025, timeout=15) as smtp:
         smtp.send_message(msg)
+
+
+def _minimal_pdf_bytes() -> bytes:
+    """A tiny but structurally valid single-page PDF (with a ``%PDF`` signature).
+
+    Built inline (no fixture file) so the binary-attachment roundtrip test is
+    self-contained. Exercises the non-text path that base64-encodes raw bytes.
+    """
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n",
+    ]
+    pdf = b"%PDF-1.4\n"
+    offsets = []
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf += obj
+    xref_pos = len(pdf)
+    pdf += b"xref\n0 %d\n" % (len(objects) + 1)
+    pdf += b"0000000000 65535 f \n"
+    for off in offsets:
+        pdf += b"%010d 00000 n \n" % off
+    pdf += b"trailer\n<< /Size %d /Root 1 0 R >>\n" % (len(objects) + 1)
+    pdf += b"startxref\n%d\n%%%%EOF\n" % xref_pos
+    return pdf
 
 
 def _sync_mail_account(account_id: int) -> None:
@@ -232,6 +269,43 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
     # base64-encodes (GH #989), so decode the base64 to recover the payload.
     decoded = base64.b64decode(fetched["content"]).decode("utf-8")
     assert payload.decode("utf-8").strip() in decoded
+
+
+async def test_get_pdf_attachment_roundtrip(nc_mcp_client, provisioned_mail_account):
+    """Fetch a binary (PDF) attachment end-to-end via the direct route (GH #989).
+
+    Complements the text-attachment test: PDF bytes are not valid UTF-8, so this
+    proves the direct route + base64 encoding round-trips arbitrary binary data
+    (not just text) and preserves it byte-for-byte, including the ``%PDF``
+    signature. Runs against the single-user / BasicAuth MCP server — the same
+    deployment mode as the original bug report.
+    """
+    subject = "PDF attachment integration probe"
+    payload = _minimal_pdf_bytes()
+    assert payload.startswith(b"%PDF")
+    _seed_message_with_attachment(
+        subject, payload, "sample.pdf", maintype="application", subtype="pdf"
+    )
+
+    full = await _sync_and_fetch_message(nc_mcp_client, subject)
+    attachments = full["attachments"]
+    assert attachments, f"no attachments on message {full}"
+    att = attachments[0]
+    assert att["fileName"] == "sample.pdf"
+
+    fetched = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_attachment",
+            {"message_id": full["id"], "attachment_id": att["id"]},
+        )
+    )
+    assert fetched["name"] == "sample.pdf"
+    assert (fetched["mime"] or "").lower() == "application/pdf"
+    # Decode base64 and confirm the raw bytes survived intact (binary-safe).
+    decoded = base64.b64decode(fetched["content"])
+    assert decoded == payload
+    assert decoded.startswith(b"%PDF")
+    assert fetched["size"] == len(payload)
 
 
 @pytest.mark.xfail(

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -228,14 +228,9 @@ async def test_get_attachment_roundtrip(nc_mcp_client, provisioned_mail_account)
         )
     )
     assert fetched["name"] == "note.txt"
-    # The Mail OCS get-attachment endpoint returns text attachments as raw text
-    # and binary ones base64-encoded. Decode if it's base64, else keep the raw
-    # text, so the assertion covers both shapes.
-    content = fetched["content"]
-    try:
-        decoded = base64.b64decode(content).decode("utf-8")
-    except (ValueError, UnicodeDecodeError):
-        decoded = content
+    # The direct attachment route returns raw bytes, which the client always
+    # base64-encodes (GH #989), so decode the base64 to recover the payload.
+    decoded = base64.b64decode(fetched["content"]).decode("utf-8")
     assert payload.decode("utf-8").strip() in decoded
 
 


### PR DESCRIPTION
## Summary

Fixes #989. `nc_mail_get_attachment` always failed with `Network error getting attachment: Response is not valid JSON:`.

`MailClient.get_attachment` fetched attachments via the Mail **OCS** route (`/ocs/v2.php/apps/mail/message/{id}/attachment/{id}`) and JSON-parsed the body. On some setups (Nextcloud 33.0.3 / Mail 5.8.1) that route returns HTTP 200 with an **empty, non-JSON body**, so `response.json()` raised (and `raise_for_status()` didn't fire on a 200).

## Fix

- Switch to the **direct route** the Mail web frontend uses — `/apps/mail/api/messages/{id}/attachment/{id}` — which returns the raw file bytes via core's `DownloadResponse` (mirrors `DeckClient.get_attachment_file`).
- Return the bytes **base64-encoded**; recover the filename from the `Content-Disposition` header (synthetic fallback `attachment_{message_id}_{attachment_id}`), the mime from `Content-Type`, and size from the byte length.

## Follow-on cleanup (per review discussion)

- Make **`MailClient` extend `BaseNextcloudClient`** so every request routes through its `_make_request` — centralising `_resolve_url` (the `/index.php` prefixing for portability, #732), `@retry_on_429`, tracing, and `raise_for_status` — instead of a private `_make_request` copy that silently skipped them (its 429 retry was a no-op).
- Client code now uses **bare `/apps/...` paths**; dropped the redundant hardcoded `/index.php` from `TablesClient` as well.
- Documented the "all app clients extend `BaseNextcloudClient` / write bare paths / never hardcode `/index.php`" convention in `CLAUDE.md`, noting `CalendarClient` (CalDAV) as the intentional exception.

## Testing

- `tests/client/mail/test_mail_api.py`: rewrote the attachment tests to mock a raw-bytes response with `Content-Type`/`Content-Disposition` and assert base64 content, mime, size, filename (+ synthetic fallback) and the direct-route URL; updated all direct-route assertions to bare `/apps/...` paths.
- `tests/integration/test_mail_greenmail.py`: attachment roundtrip now decodes base64 directly.
- `ruff check`, `ruff format`, `ty check`, and the unit suite all pass (2102 passed; the only errors are pre-existing live-server webdav tests unrelated to this change).

---

_This PR was generated with the help of AI, and reviewed by a Human_