### PR TITLE
fix(ingest): make stalled-job reclaim resilient to queueing_lock collisions

### DIFF
--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -47,8 +47,8 @@ from procrastinate import (
     RetryDecision,
 )
 from procrastinate.connector import BaseConnector
-from procrastinate.exceptions import AlreadyEnqueued
-from procrastinate.jobs import Job
+from procrastinate.exceptions import AlreadyEnqueued, UniqueViolation
+from procrastinate.jobs import Job, Status
 
 from ...config import get_procrastinate_conninfo, get_settings
 from ..scanner import DocumentTask
@@ -233,17 +233,47 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
     )
     stalled_after = settings.ingest_stalled_job_seconds
     reclaimed = 0
+    discarded = 0
+    errored = 0
     # queue=None sweeps every queue, so an orphaned job on any tier queue is
     # reclaimed regardless of which tier's worker happens to run this periodic.
     # retry_job_by_id_async keeps the job on its own queue, so a stalled ``ocr``
     # job re-runs on ``ingest-ocr`` (the ocr fleet), not the reclaiming worker's.
+    #
+    # Each job is isolated: the retry UPDATE sets status='todo', which trips the
+    # partial-unique ``queueing_lock`` index if the scanner already re-queued the
+    # doc while it sat orphaned in ``doing`` (a fresh ``todo`` sibling holds the
+    # lock). Without per-job isolation the FIRST such UniqueViolation aborted the
+    # whole sweep, so every later orphan stayed in ``doing`` forever.
     for job in await manager.get_stalled_jobs(seconds_since_heartbeat=stalled_after):
         if job.id is None:
             continue
-        await manager.retry_job_by_id_async(job_id=job.id, retry_at=retry_at)
-        reclaimed += 1
-    if reclaimed:
-        logger.warning("ingest.reclaimed_stalled_jobs count=%d", reclaimed)
+        try:
+            await manager.retry_job_by_id_async(job_id=job.id, retry_at=retry_at)
+            reclaimed += 1
+        except UniqueViolation:
+            # A live ``todo`` sibling with the same queueing_lock already exists
+            # (the scanner re-queued this doc), so the orphan is redundant: drop
+            # it (delete_job) to free it from ``doing`` and let the sibling run.
+            try:
+                await manager.finish_job_by_id_async(
+                    job_id=job.id, status=Status.FAILED, delete_job=True
+                )
+                discarded += 1
+            except Exception:
+                logger.exception("ingest.reclaim_discard_failed job_id=%s", job.id)
+                errored += 1
+        except Exception:
+            # Never let one bad job abort the sweep; the rest still get reclaimed.
+            logger.exception("ingest.reclaim_retry_failed job_id=%s", job.id)
+            errored += 1
+    if reclaimed or discarded or errored:
+        logger.warning(
+            "ingest.reclaimed_stalled_jobs reclaimed=%d discarded=%d errored=%d",
+            reclaimed,
+            discarded,
+            errored,
+        )
     else:
         # Visible heartbeat under verbose logging when debugging a suspected
         # reclaim failure, without noising up production logs.

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -49,6 +49,7 @@ from procrastinate import (
 from procrastinate.connector import BaseConnector
 from procrastinate.exceptions import AlreadyEnqueued, UniqueViolation
 from procrastinate.jobs import Job, Status
+from procrastinate.manager import QUEUEING_LOCK_CONSTRAINT
 
 from ...config import get_procrastinate_conninfo, get_settings
 from ..scanner import DocumentTask
@@ -251,7 +252,16 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
         try:
             await manager.retry_job_by_id_async(job_id=job.id, retry_at=retry_at)
             reclaimed += 1
-        except UniqueViolation:
+        except UniqueViolation as exc:
+            if exc.constraint_name != QUEUEING_LOCK_CONSTRAINT:
+                # Only a queueing_lock collision proves a live duplicate that's
+                # safe to discard. The retry UPDATE can't trip any OTHER unique
+                # constraint today, but guard the assumption explicitly rather
+                # than deleting an unrelated job if procrastinate ever adds one:
+                # log + count it like any unexpected per-job error, don't delete.
+                logger.exception("ingest.reclaim_retry_failed job_id=%s", job.id)
+                errored += 1
+                continue
             # A live ``todo`` sibling with the same queueing_lock already exists
             # (the scanner re-queued this doc), so the orphan is redundant: drop
             # it (delete_job) to free it from ``doing`` and let the sibling run.

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -255,9 +255,15 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
             # A live ``todo`` sibling with the same queueing_lock already exists
             # (the scanner re-queued this doc), so the orphan is redundant: drop
             # it (delete_job) to free it from ``doing`` and let the sibling run.
+            # ``delete_job=True`` DELETEs the row, so the end_status is only
+            # validated, never persisted — no ``failed`` job/gauge inflation. We
+            # pass ABORTED (not FAILED) to name the intent honestly: this is an
+            # intentional dedup discard, not a genuine failure. (CANCELLED is not
+            # a valid finish_job end_status in procrastinate — only succeeded /
+            # failed / aborted.)
             try:
                 await manager.finish_job_by_id_async(
-                    job_id=job.id, status=Status.FAILED, delete_job=True
+                    job_id=job.id, status=Status.ABORTED, delete_job=True
                 )
                 discarded += 1
             except Exception:

--- a/tests/integration/test_ingest_queue_postgres.py
+++ b/tests/integration/test_ingest_queue_postgres.py
@@ -16,17 +16,22 @@ from __future__ import annotations
 
 import os
 import socket
+import types
+from typing import cast
 from urllib.parse import urlparse
 
 import pytest
+from procrastinate import JobContext
 
 import nextcloud_mcp_server.config as config_module
+import nextcloud_mcp_server.vector.queue.procrastinate as pq
 from nextcloud_mcp_server.vector.queue.procrastinate import (
     INGEST_QUEUE_NAME,
     ProcrastinateTaskProducer,
     apply_ingest_queue_schema,
     build_app_for_url,
     get_ingest_job_counts,
+    reclaim_stalled_ingest_jobs,
 )
 from nextcloud_mcp_server.vector.scanner import DocumentTask
 
@@ -137,3 +142,58 @@ async def test_ingest_queue_end_to_end(fresh_app):
             queue=INGEST_QUEUE_NAME, seconds_since_heartbeat=0
         )
         assert list(stalled) == []
+
+
+async def test_reclaim_discards_real_queueing_lock_collision(fresh_app, monkeypatch):
+    """The reclaim fix, end-to-end against real Postgres (PR #999).
+
+    Confirms the exact production path the unit test can only simulate: that
+    ``retry_job_by_id_async``'s UPDATE raises ``procrastinate.exceptions.
+    UniqueViolation`` (not a bare ``psycopg`` error that would slip past the
+    ``except UniqueViolation`` branch) when a reclaimed orphan collides with a
+    live ``todo`` sibling — and that the orphan is then discarded, not stranded.
+    """
+    # Threshold 0 so the manually-orphaned ``doing`` job is immediately stalled;
+    # reclaim only reads these two settings.
+    monkeypatch.setattr(
+        pq,
+        "get_settings",
+        lambda: types.SimpleNamespace(
+            ingest_stalled_job_seconds=0, ingest_reclaim_retry_delay_seconds=0
+        ),
+    )
+
+    async with fresh_app.open_async():
+        producer = ProcrastinateTaskProducer(fresh_app)
+
+        # Job A for doc "1" → todo, then orphan it into ``doing`` (worker crashed
+        # mid-job) so its queueing_lock no longer occupies the todo partial-index.
+        await producer.send(_task("1"))
+        await fresh_app.connector.execute_query_async(
+            "UPDATE procrastinate_jobs SET status = 'doing' WHERE queue_name = %(q)s",
+            q=INGEST_QUEUE_NAME,
+        )
+        # The scanner re-queues the same doc → fresh todo sibling B holding the
+        # identical queueing_lock (allowed: A is 'doing', not 'todo').
+        await producer.send(_task("1"))
+
+        by_status = {
+            r["status"]: r["n"]
+            for r in await fresh_app.connector.execute_query_all_async(
+                "SELECT status, count(*) AS n FROM procrastinate_jobs GROUP BY status"
+            )
+        }
+        assert by_status == {"doing": 1, "todo": 1}  # A doing + B todo, same lock
+
+        # Reclaim: retry(A) → 'todo' collides with B → UniqueViolation → A is
+        # discarded (deleted). Must not raise, and must leave exactly B as todo.
+        ctx = cast(JobContext, types.SimpleNamespace(app=fresh_app))
+        await reclaim_stalled_ingest_jobs(ctx, timestamp=0)
+
+        by_status = {
+            r["status"]: r["n"]
+            for r in await fresh_app.connector.execute_query_all_async(
+                "SELECT status, count(*) AS n FROM procrastinate_jobs GROUP BY status"
+            )
+        }
+        assert by_status == {"todo": 1}  # orphan gone; the live sibling survives

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -225,6 +225,52 @@ class TestReclaimStalledJobs:
         # retried at now(), so a systemic outage doesn't thundering-herd.
         assert all((ra - before).total_seconds() >= 25 for ra in retry_ats)
 
+    async def test_queueing_lock_collision_discards_orphan_and_continues(self):
+        """A retry that trips the ``queueing_lock`` unique index (the scanner
+        already re-queued the doc) must NOT abort the sweep: the orphan is
+        dropped and the remaining stalled jobs are still reclaimed."""
+        from procrastinate.exceptions import UniqueViolation
+        from procrastinate.jobs import Status
+
+        retried: list[int] = []
+        finished: list[tuple[int, Status, bool]] = []
+
+        class Job:
+            def __init__(self, id):
+                self.id = id
+
+        class FakeManager:
+            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+                return [Job(1), Job(2), Job(3)]
+
+            async def retry_job_by_id_async(self, job_id, retry_at):
+                retried.append(job_id)
+                # Jobs 1 and 3 collide with a live todo sibling; 2 reclaims fine.
+                if job_id in (1, 3):
+                    raise UniqueViolation(
+                        constraint_name="procrastinate_jobs_queueing_lock_idx_v1",
+                        queueing_lock=f"user:file:{job_id}",
+                    )
+
+            async def finish_job_by_id_async(self, job_id, status, delete_job):
+                finished.append((job_id, status, delete_job))
+
+        class FakeApp:
+            job_manager = FakeManager()
+
+        class Ctx:
+            app = FakeApp()
+
+        # Must not raise even though two of three jobs collide.
+        await pq.reclaim_stalled_ingest_jobs(cast(JobContext, Ctx()), timestamp=0)
+
+        assert retried == [1, 2, 3]  # every job attempted; sweep never aborted
+        # Colliding orphans are deleted (delete_job=True) so they leave `doing`.
+        assert finished == [
+            (1, Status.FAILED, True),
+            (3, Status.FAILED, True),
+        ]
+
 
 class TestGetIngestJobCounts:
     async def test_aggregates_stats_rows(self):

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -265,10 +265,11 @@ class TestReclaimStalledJobs:
         await pq.reclaim_stalled_ingest_jobs(cast(JobContext, Ctx()), timestamp=0)
 
         assert retried == [1, 2, 3]  # every job attempted; sweep never aborted
-        # Colliding orphans are deleted (delete_job=True) so they leave `doing`.
+        # Colliding orphans are deleted (delete_job=True) so they leave `doing`;
+        # ABORTED names the intentional dedup discard (delete makes it non-persisted).
         assert finished == [
-            (1, Status.FAILED, True),
-            (3, Status.FAILED, True),
+            (1, Status.ABORTED, True),
+            (3, Status.ABORTED, True),
         ]
 
 

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -272,6 +272,72 @@ class TestReclaimStalledJobs:
             (3, Status.ABORTED, True),
         ]
 
+    async def test_non_queueing_lock_unique_violation_is_not_discarded(self):
+        """A UniqueViolation from a DIFFERENT constraint is not a proven duplicate,
+        so the orphan must NOT be deleted — it's isolated + counted like any other
+        error, and the sweep continues."""
+        from procrastinate.exceptions import UniqueViolation
+
+        retried: list[int] = []
+        finished: list[int] = []
+
+        class Job:
+            def __init__(self, id):
+                self.id = id
+
+        class FakeManager:
+            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+                return [Job(1), Job(2)]
+
+            async def retry_job_by_id_async(self, job_id, retry_at):
+                retried.append(job_id)
+                if job_id == 1:
+                    raise UniqueViolation(
+                        constraint_name="some_other_constraint", queueing_lock=None
+                    )
+
+            async def finish_job_by_id_async(self, job_id, status, delete_job):
+                finished.append(job_id)
+
+        class FakeApp:
+            job_manager = FakeManager()
+
+        class Ctx:
+            app = FakeApp()
+
+        await pq.reclaim_stalled_ingest_jobs(cast(JobContext, Ctx()), timestamp=0)
+
+        assert retried == [1, 2]  # sweep continued past the unrelated violation
+        assert finished == []  # job 1 NOT deleted — its constraint wasn't the lock idx
+
+    async def test_generic_error_on_one_job_does_not_abort_sweep(self):
+        """An arbitrary per-job error (e.g. a transient connector error) is logged
+        and counted, never aborting the sweep or the other jobs' reclaim."""
+        retried: list[int] = []
+
+        class Job:
+            def __init__(self, id):
+                self.id = id
+
+        class FakeManager:
+            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+                return [Job(1), Job(2), Job(3)]
+
+            async def retry_job_by_id_async(self, job_id, retry_at):
+                retried.append(job_id)
+                if job_id == 2:
+                    raise RuntimeError("transient connector error")
+
+        class FakeApp:
+            job_manager = FakeManager()
+
+        class Ctx:
+            app = FakeApp()
+
+        # Must not raise; jobs 1 and 3 still get reclaimed despite 2 erroring.
+        await pq.reclaim_stalled_ingest_jobs(cast(JobContext, Ctx()), timestamp=0)
+        assert retried == [1, 2, 3]
+
 
 class TestGetIngestJobCounts:
     async def test_aggregates_stats_rows(self):


### PR DESCRIPTION
## Problem

On a full re-index, `mcp_vector_sync_pending_documents` climbs and never drains — jobs pile up orphaned in the `ingest-structured` `doing` state with no remediation. Observed on `tenant-blackbox-demo`: `ingest-structured doing`=142 (stranded up to ~18h) and `ingest-maintenance failed`=295 (≈ every `*/5` reclaim run failed for ~24h).

## Root cause

Workers get cycled mid-parse (KEDA scale-down / pod rotation), stranding their in-flight job in `doing`. The `reclaim_stalled_ingest_jobs` periodic is supposed to rescue these via `retry_job_by_id_async`, which `UPDATE`s the job to `status='todo'`. But that trips the partial-unique `procrastinate_jobs_queueing_lock_idx_v1` index whenever the **scanner already re-queued the same doc** while it sat orphaned (a fresh `todo` sibling holds the `queueing_lock`). The reclaim loop had **no per-job isolation**, so the *first* `UniqueViolation` aborted the entire sweep — every other orphan then stayed in `doing` forever.

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint
  "procrastinate_jobs_queueing_lock_idx_v1"
DETAIL:  Key (queueing_lock)=(Chris Coutinho:file:520189) already exists.
  → reclaim_stalled_ingest_jobs → manager.retry_job_by_id_async (procrastinate.py:243)
```

## Fix

Isolate each job in the sweep:
- On `UniqueViolation`, the orphan is a **proven duplicate** (a live `todo` sibling holds the lock), so discard it via `finish_job_by_id_async(status=FAILED, delete_job=True)` — it leaves `doing` and the sibling does the work.
- Any other per-job error is logged, never fatal.
- Summary log now reports `reclaimed/discarded/errored`.

Net: the reclaim sweep always completes, so stranded `doing` jobs drain (deleted-if-duplicate or retried), regardless of how often workers get cycled.

## Testing

- New unit test: collision on 2 of 3 stalled jobs → sweep completes, both orphans deleted with `delete_job=True`, no exception propagates.
- Existing reclaim test unchanged and passing.
- `uv run pytest tests/unit/vector/test_procrastinate_producer.py` → **11 passed**; `ruff` + `ty` clean.

## Scope / follow-ups (not in this PR)

- Worker churn that *strands* jobs in the first place (KEDA `terminationGracePeriod` vs the 120s parse) — gitops.
- The Surya wrapper host-RAM OOM (a separate ingest-OCR problem). Tracked on Deck #491 / #411 / #412 / #436.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)