### PR TITLE
fix(calendar): resolve calendar-home-set against origin, not subpath base URL (#1007)

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import uuid
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import unquote, urlsplit, urlunsplit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import anyio
@@ -115,7 +115,15 @@ class CalendarClient:
         if not home_url:
             return None
         if home_url.startswith("/"):
-            home_url = f"{self.base_url}{home_url}"
+            # calendar-home-set returns an absolute path that already includes
+            # any subpath under which Nextcloud is served (e.g.
+            # ``/nextcloud/remote.php/dav/calendars/David/``). Resolve it
+            # against the *origin* (scheme + host) of ``base_url`` rather than
+            # the full ``base_url`` — concatenating onto a subpath base URL
+            # would double the subpath and produce a bogus, unroutable URL
+            # (issue #1007).
+            origin = urlsplit(self.base_url)
+            home_url = urlunsplit((origin.scheme, origin.netloc, home_url, "", ""))
         if not home_url.endswith("/"):
             home_url = f"{home_url}/"
         return home_url

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -163,6 +163,47 @@ def test_webcal_caching_header_enabled_on_client(mocker):
     assert headers["X-NC-CalDAV-Webcal-Caching"] == "On"
 
 
+# --- calendar-home-set absolute-path normalization (issue #1007) ---
+
+
+def test_home_set_absolute_path_resolves_against_origin_not_subpath(mocker):
+    """An absolute calendar-home-set path resolves against the origin.
+
+    When Nextcloud is served under a subpath, calendar-home-set returns an
+    absolute path that already includes that subpath (e.g.
+    ``/nextcloud/remote.php/dav/calendars/David/``). Resolving it against the
+    full base URL would double the subpath and yield an unroutable URL, which
+    then hits Apache's default routing and 405s with an HTML body that fails
+    CalDAV XML parsing (issue #1007). It must resolve against the origin only.
+    """
+    mocker.patch("nextcloud_mcp_server.client.calendar.AsyncDAVClient")
+
+    from nextcloud_mcp_server.client.calendar import CalendarClient
+
+    client = CalendarClient("https://host/nextcloud", "David", password="app-pw")
+
+    home_url = client._calendar_home_url_from_home_set(
+        "/nextcloud/remote.php/dav/calendars/David/"
+    )
+
+    assert home_url == "https://host/nextcloud/remote.php/dav/calendars/David/"
+
+
+def test_home_set_absolute_path_resolves_against_root_origin(mocker):
+    """Root-hosted deployments keep resolving absolute paths correctly."""
+    mocker.patch("nextcloud_mcp_server.client.calendar.AsyncDAVClient")
+
+    from nextcloud_mcp_server.client.calendar import CalendarClient
+
+    client = CalendarClient("https://cloud.example.org", "alice", password="app-pw")
+
+    home_url = client._calendar_home_url_from_home_set(
+        "/remote.php/dav/calendars/alice/"
+    )
+
+    assert home_url == "https://cloud.example.org/remote.php/dav/calendars/alice/"
+
+
 # --- list_calendars: regular + external subscription parsing (issue #830) ---
 
 # A multistatus body with the calendar home, one regular calendar, and one

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -180,7 +180,10 @@ def test_home_set_absolute_path_resolves_against_origin_not_subpath(mocker):
 
     from nextcloud_mcp_server.client.calendar import CalendarClient
 
-    client = CalendarClient("https://host/nextcloud", "David", password="app-pw")
+    # No credentials needed: the method under test derives the URL purely from
+    # base_url, and constructing without auth keeps this free of S2068 (hard-
+    # coded credential) noise.
+    client = CalendarClient("https://host/nextcloud", "David")
 
     home_url = client._calendar_home_url_from_home_set(
         "/nextcloud/remote.php/dav/calendars/David/"
@@ -195,7 +198,7 @@ def test_home_set_absolute_path_resolves_against_root_origin(mocker):
 
     from nextcloud_mcp_server.client.calendar import CalendarClient
 
-    client = CalendarClient("https://cloud.example.org", "alice", password="app-pw")
+    client = CalendarClient("https://cloud.example.org", "alice")
 
     home_url = client._calendar_home_url_from_home_set(
         "/remote.php/dav/calendars/alice/"


### PR DESCRIPTION
## Summary

Fixes #1007 — calendar tools fail with a confusing `lxml.etree.XMLSyntaxError` (hr/body tag mismatch) when Nextcloud is served under a URL subpath (e.g. `https://host/nextcloud`).

**Root cause:** `CalendarClient._calendar_home_url_from_home_set` concatenated a server-returned absolute path onto `self.base_url`. When Nextcloud is hosted at a subpath, `calendar-home-set` already returns an absolute path containing that subpath (e.g. `/nextcloud/remote.php/dav/calendars/David/`), so gluing it onto `base_url` (which also carries `/nextcloud`) produced a doubled path (`…/nextcloud/nextcloud/remote.php/…`). PROPFIND on that URL hits Apache's default routing and returns a 405 HTML page, which then fails CalDAV XML parsing.

**Fix:** resolve absolute home-set paths against the **origin** (scheme + host) of `base_url` via `urlsplit`/`urlunsplit`, so the subpath is not duplicated.

## Scope

This was specific to `CalendarClient` — the only client that bypasses the shared httpx client and manually concatenates a server-returned absolute path onto `base_url`. All other app clients pass **relative** paths through `httpx.AsyncClient(base_url=...)`, which concatenates paths and preserves a subpath correctly. WebDAV parses server hrefs but extracts only the relative portion, so it isn't affected.

## Tests

- Added `test_home_set_absolute_path_resolves_against_origin_not_subpath` (subpath deployment)
- Added `test_home_set_absolute_path_resolves_against_root_origin` (regression guard for root-hosted)
- Full unit suite: 1963 passed.

Credit to @DavidKoot for the report and root-cause analysis.

---

_This PR was generated with the help of AI, and reviewed by a Human_