### PR TITLE
fix(vector): keyword-mode tenant indexes nothing — placeholder/dead-letter dense vector sized from Mistral, not SIMPLE_EMBEDDING_DIMENSION

### DIFF
--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -106,7 +106,13 @@ async def mark_dead_letter(
     try:
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
-        dimension = get_embedding_service().get_dimension()
+        # Match the collection's dense slot; in keyword mode (dense_enabled=False)
+        # it's sized to SIMPLE_EMBEDDING_DIMENSION and there may be no embedding
+        # endpoint — so don't call the embedding service (mirrors placeholder.py).
+        if settings.dense_enabled:
+            dimension = get_embedding_service().get_dimension()
+        else:
+            dimension = settings.simple_embedding_dimension
 
         payload: dict[str, Any] = {
             "doc_id": doc_id,

--- a/nextcloud_mcp_server/vector/placeholder.py
+++ b/nextcloud_mcp_server/vector/placeholder.py
@@ -80,10 +80,20 @@ async def write_placeholder_point(
     try:
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
-        embedding_service = get_embedding_service()
 
-        # Get dimension dynamically (never hardcode)
-        dimension = embedding_service.get_dimension()
+        # Size the dense zero-vector to match the collection's dense slot. In
+        # keyword mode (SEARCH_MODE=keyword, dense_enabled=False) the collection's
+        # dense slot is created sized to SIMPLE_EMBEDDING_DIMENSION — NOT the
+        # embedding provider's dimension (see qdrant_client collection creation) —
+        # and the deployment may have no text-embedding endpoint at all. So gate on
+        # dense_enabled and never touch the embedding service in keyword mode;
+        # otherwise a Mistral-sized (e.g. 1024) placeholder vector is rejected by
+        # the 384-dim slot and the pre-enqueue placeholder write aborts the whole
+        # scan (no document ever gets indexed).
+        if settings.dense_enabled:
+            dimension = get_embedding_service().get_dimension()
+        else:
+            dimension = settings.simple_embedding_dimension
 
         # Create zero vectors
         zero_dense = [0.0] * dimension

--- a/tests/unit/vector/test_dead_letter.py
+++ b/tests/unit/vector/test_dead_letter.py
@@ -26,6 +26,10 @@ _COLLECTION = "test_collection"
 
 
 class _Settings:
+    # Hybrid mode by default (dense slot sized from the embedding provider).
+    dense_enabled = True
+    simple_embedding_dimension = 384
+
     def get_collection_name(self) -> str:
         return _COLLECTION
 
@@ -94,6 +98,32 @@ class TestMarkDeadLetter:
         assert payload["reason"] == "timeout"
         assert payload["doc_id"] == "520189"
         assert payload["file_path"] == "/Plans/big.pdf"
+        # Hybrid mode: dense slot sized from the embedding provider (dim=4 here).
+        assert len(point.vector["dense"]) == 4
+
+    async def test_keyword_mode_sizes_dense_from_simple_dimension(
+        self, client, monkeypatch
+    ) -> None:
+        """Regression (Deck #495): in keyword mode (dense_enabled=False) the dead-
+        letter marker's dense slot must be sized to simple_embedding_dimension and
+        the embedding service must NOT be built — mirrors the placeholder fix."""
+        kw = SimpleNamespace(
+            get_collection_name=lambda: _COLLECTION,
+            dense_enabled=False,
+            simple_embedding_dimension=384,
+        )
+        monkeypatch.setattr(dl, "get_settings", lambda: kw)
+
+        def _boom():
+            raise AssertionError("embedding service must not be built in keyword mode")
+
+        monkeypatch.setattr(dl, "get_embedding_service", _boom)
+
+        await dl.mark_dead_letter("520189", "file", "etag-1", "sig", "timeout")
+
+        client.upsert.assert_awaited_once()
+        point = client.upsert.await_args.kwargs["points"][0]
+        assert len(point.vector["dense"]) == 384
 
     async def test_failure_is_swallowed(self, client) -> None:
         client.upsert.side_effect = RuntimeError("qdrant down")

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -188,7 +188,11 @@ async def test_write_placeholder_payload_includes_instance_id(monkeypatch):
     monkeypatch.setattr(placeholder_module, "_INSTANCE_ID", "pod-pinned")
 
     fake_qdrant = AsyncMock()
-    fake_settings = SimpleNamespace(get_collection_name=lambda: "nextcloud_content")
+    fake_settings = SimpleNamespace(
+        get_collection_name=lambda: "nextcloud_content",
+        dense_enabled=True,
+        simple_embedding_dimension=384,
+    )
     fake_embedding = SimpleNamespace(get_dimension=lambda: 4)
 
     async def fake_get_qdrant_client():
@@ -214,3 +218,50 @@ async def test_write_placeholder_payload_includes_instance_id(monkeypatch):
     # Sanity: the other contract-pinning fields are still emitted.
     assert upserted_point.payload["is_placeholder"] is True
     assert upserted_point.payload["status"] == "pending"
+    # Hybrid mode: dense slot sized from the embedding provider (dim=4 here).
+    assert len(upserted_point.vector["dense"]) == 4
+
+
+@pytest.mark.unit
+async def test_keyword_mode_sizes_dense_from_simple_dimension_without_embedding(
+    monkeypatch,
+):
+    """Regression (Deck #495): in keyword mode (SEARCH_MODE=keyword,
+    dense_enabled=False) the collection's dense slot is sized to
+    SIMPLE_EMBEDDING_DIMENSION, not the provider dimension, and there may be no
+    embedding endpoint. ``write_placeholder_point`` MUST size its zero-vector to
+    simple_embedding_dimension and NEVER call the embedding service — otherwise a
+    Mistral-sized (1024) placeholder is rejected by the 384-dim slot and the
+    pre-enqueue placeholder write aborts the whole scan (keyword tenant indexes
+    NOTHING)."""
+    monkeypatch.setattr(placeholder_module, "_INSTANCE_ID", "pod-kw")
+
+    fake_qdrant = AsyncMock()
+    fake_settings = SimpleNamespace(
+        get_collection_name=lambda: "nextcloud_content",
+        dense_enabled=False,
+        simple_embedding_dimension=384,
+    )
+
+    async def fake_get_qdrant_client():
+        return fake_qdrant
+
+    def _boom():
+        raise AssertionError("embedding service must not be built in keyword mode")
+
+    monkeypatch.setattr(placeholder_module, "get_qdrant_client", fake_get_qdrant_client)
+    monkeypatch.setattr(placeholder_module, "get_settings", lambda: fake_settings)
+    monkeypatch.setattr(placeholder_module, "get_embedding_service", _boom)
+
+    await placeholder_module.write_placeholder_point(
+        doc_id="d-99",
+        doc_type="file",
+        user_id="alice",
+        modified_at=1700000000,
+        etag="xyz",
+    )
+
+    fake_qdrant.upsert.assert_awaited_once()
+    upserted_point = fake_qdrant.upsert.await_args.kwargs["points"][0]
+    # Sized to the keyword-mode dense slot (384), never the provider dimension.
+    assert len(upserted_point.vector["dense"]) == 384


### PR DESCRIPTION
## Problem

A **keyword-only** tenant (`SEARCH_MODE=keyword`, `dense_enabled=False`) failed to index **any** document (observed on `tenant-blackbox-demo`).

`write_placeholder_point` (`vector/placeholder.py`) and `mark_dead_letter` (`vector/dead_letter.py`) unconditionally sized their dense zero-vector from the embedding provider:

```python
embedding_service = get_embedding_service()      # constructs Mistral provider
dimension = embedding_service.get_dimension()    # → 1024 (mistral-embed)
zero_dense = [0.0] * dimension
```

But in keyword mode the collection's `dense` named-vector slot is created sized to **`SIMPLE_EMBEDDING_DIMENSION` (384)** — *not* the provider dimension (see `qdrant_client.py` collection creation). So the placeholder upserts a **1024-dim vector into a 384-dim slot → Qdrant rejects it**. The scanner `await`s `write_placeholder_point` **before enqueuing each document with no try/except**, and the function re-raises → **the scan aborts and no document is ever queued or indexed**.

This is a regression from the `SEARCH_MODE=keyword` feature (#484 / Deck): that PR added `settings.dense_enabled` guards to `processor.py` + `qdrant_client.py` but **missed these two other points-writers** (`git log` confirms neither file was touched).

## Fix

Gate both writers on `settings.dense_enabled`, mirroring the existing `qdrant_client.py` pattern — in keyword mode size the zero-vector to `simple_embedding_dimension` and **never build the embedding service** (a keyword/airgapped deployment may have no text-embedding endpoint at all):

```python
if settings.dense_enabled:
    dimension = get_embedding_service().get_dimension()
else:
    dimension = settings.simple_embedding_dimension
```

- `placeholder.py:write_placeholder_point` — primary fix (caused total indexing failure).
- `dead_letter.py:mark_dead_letter` — same guard (was fail-safe/wrapped, so not fatal on its own, but still wrong in keyword mode).

## Tests

- New keyword-mode regression for **both** writers: dense zero-vector sized to `simple_embedding_dimension` (384), and the embedding service asserted **never built** (monkeypatched to raise).
- Existing hybrid-mode tests updated to assert the provider dimension (dim=4) is still used.
- **208 vector unit tests pass**; ruff + ty + commitizen green.

Deck #495 (regression from #484 — SEARCH_MODE keyword). Surfaced during the blackbox-demo re-index (keyword-only tenant produced zero ingest jobs).

---

_This PR was generated with the help of AI, and reviewed by a Human_