### PR TITLE
fix(vector): keyword-mode content dedup (embedding-identity writer/reader agree)

### DIFF
--- a/nextcloud_mcp_server/vector/collection_metadata.py
+++ b/nextcloud_mcp_server/vector/collection_metadata.py
@@ -41,13 +41,33 @@ CHUNKING_CONFIG = "chunking_config"
 IS_SENTINEL = "is_sentinel"
 
 
-def build_embedding_identity(settings: Settings | None = None) -> str:
-    """The embedding identity for locally-produced vectors: the model name.
+# ADR-030 keyword-mode embedding identity. Keyword collections carry only BM25
+# sparse vectors, so the dense model name is a meaningless ``simple-{dim}``
+# fallback; a fixed marker is stamped instead. This MUST be produced identically
+# everywhere the identity is written OR compared — chunk points, the collection
+# sentinel, the admin backfill, and the cross-user dedup lookup. A keyword-mode
+# mismatch here (the chunk-point writer stamped this marker while the dedup lookup
+# compared the model name) made the dedup ALWAYS miss, so unchanged shared docs
+# were re-processed + re-OCR'd on every scan and the run never converged, pinning
+# the burst GPU (Deck #509).
+KEYWORD_EMBEDDING_IDENTITY = "bm25-keyword"
 
-    The gateway and query path route on this name; for the monolith it is the
-    active embedding model (matching the collection-name derivation).
+
+def build_embedding_identity(settings: Settings | None = None) -> str:
+    """The embedding identity for locally-produced vectors — the single source of
+    truth for the identity stamped on chunk points, the collection sentinel, the
+    admin backfill, and the cross-user dedup comparison, so all four agree.
+
+    - Hybrid mode: the active dense embedding model name. The gateway and query
+      path route on it, matching the collection-name derivation.
+    - Keyword mode (ADR-030, ``dense_enabled`` False): the fixed
+      ``KEYWORD_EMBEDDING_IDENTITY`` marker — the collection has no dense vectors
+      and ``get_embedding_model_name()`` would return the bogus ``simple-{dim}``
+      fallback. Using the marker keeps the dedup comparison correct (Deck #509).
     """
     s = settings or get_settings()
+    if not s.dense_enabled:
+        return KEYWORD_EMBEDDING_IDENTITY
     return s.get_embedding_model_name()
 
 

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -45,6 +45,7 @@ from nextcloud_mcp_server.usage import UsageEventStore
 from nextcloud_mcp_server.utils.validation import is_valid_nextcloud_doc_id
 from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector._errors import format_exception_group
+from nextcloud_mcp_server.vector.collection_metadata import build_embedding_identity
 from nextcloud_mcp_server.vector.dead_letter import (
     clear_dead_letter,
     mark_dead_letter,
@@ -1715,16 +1716,11 @@ async def _index_document(
     # PIPELINE_TIER is "fast"; ACL hash records at least the owner principal
     # (full share enumeration is a follow-up — a missing/partial acl_hash is
     # safe because the query-side pre-filter only applies when present + enabled).
-    # Keyword mode (ADR-030) writes no dense vector, so stamping a real
-    # embedding model name would be misleading (and in airgapped deployments it
-    # would be the bogus ``simple-{dim}`` fallback). Use a fixed sentinel so
-    # keyword-only points are self-describing and any mixed-mode contamination of
-    # a collection is auditable by scrolling this payload key.
-    _embedding_identity = (
-        settings.get_embedding_model_name()
-        if settings.dense_enabled
-        else "bm25-keyword"
-    )
+    # Embedding identity stamped on every chunk point. Via the shared helper so it
+    # is IDENTICAL to what the collection sentinel and the cross-user dedup lookup
+    # produce — keyword mode returns a fixed marker (not the bogus ``simple-{dim}``
+    # model-name fallback), which is what makes dedup match (Deck #509).
+    _embedding_identity = build_embedding_identity(settings)
     _acl_hash = compute_acl_hash([("user", doc_task.user_id)])
 
     # Observed-access ACL principals (computed once per document, not per chunk).

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -33,6 +33,7 @@ from qdrant_client.models import FieldCondition, Filter, MatchValue
 
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.vector import payload_keys
+from nextcloud_mcp_server.vector.collection_metadata import build_embedding_identity
 from nextcloud_mcp_server.vector.placeholder import get_placeholder_filter
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
@@ -244,7 +245,11 @@ async def claim_existing_index(
     after a confirmed hit is non-fatal (logged, not raised): verify-on-read still
     gates access and the user's next scan re-claims it.
     """
-    embedding_identity = get_settings().get_embedding_model_name()
+    # Must match what the chunk-point WRITER stamps (processor.py), which is the
+    # shared helper — NOT get_embedding_model_name(), whose ``simple-{dim}`` keyword
+    # fallback never equals the writer's ``bm25-keyword`` marker, so dedup would
+    # always miss and unchanged docs re-process every scan (Deck #509).
+    embedding_identity = build_embedding_identity(get_settings())
     try:
         existing = await find_indexed_content(
             doc_id, doc_type, etag, embedding_identity

--- a/tests/unit/vector/test_collection_metadata.py
+++ b/tests/unit/vector/test_collection_metadata.py
@@ -42,6 +42,26 @@ async def test_qdrant_error_falls_back_to_env(mocker):
     assert meta == cm.env_default_metadata(settings)
 
 
+def test_build_embedding_identity_hybrid_is_model_name():
+    # Hybrid mode: the identity is the active dense embedding model name.
+    settings = Settings()
+    assert settings.dense_enabled is True
+    assert cm.build_embedding_identity(settings) == settings.get_embedding_model_name()
+
+
+def test_build_embedding_identity_keyword_is_bm25_marker():
+    # Regression (Deck #509): keyword mode must return the fixed ``bm25-keyword``
+    # marker, NOT get_embedding_model_name()'s ``simple-{dim}`` fallback — the value
+    # the chunk-point writer stamps and the dedup lookup compares must agree, or an
+    # unchanged shared doc is re-processed + re-OCR'd every scan.
+    settings = Settings(search_mode="keyword")
+    assert settings.dense_enabled is False
+    assert cm.build_embedding_identity(settings) == cm.KEYWORD_EMBEDDING_IDENTITY
+    assert cm.build_embedding_identity(settings) == "bm25-keyword"
+    # The sentinel/env-fallback metadata carries the same marker.
+    assert cm.env_default_metadata(settings)["embedding_identity"] == "bm25-keyword"
+
+
 async def test_api_source(mocker):
     settings = Settings(
         collection_metadata_source="api",

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -27,11 +27,27 @@ _MODEL = "model-x"
 
 
 class _Settings:
+    # Hybrid mode: the dedup identity is the dense embedding model name.
+    dense_enabled = True
+
     def get_collection_name(self) -> str:
         return _COLLECTION
 
     def get_embedding_model_name(self) -> str:
         return _MODEL
+
+
+class _KeywordSettings:
+    # Keyword mode (ADR-030): no dense vectors. The dedup identity must be the
+    # fixed ``bm25-keyword`` marker, NOT the ``simple-{dim}`` model-name fallback,
+    # so it matches what the chunk-point writer stamps (Deck #509).
+    dense_enabled = False
+
+    def get_collection_name(self) -> str:
+        return _COLLECTION
+
+    def get_embedding_model_name(self) -> str:
+        return "simple-384"
 
 
 def _point(payload: dict) -> SimpleNamespace:
@@ -265,6 +281,30 @@ class TestClaimExistingIndex:
             None,
         )
         # alice already present -> claim still True (skip reprocess) but no write.
+        assert await ss.claim_existing_index("42", "file", "abc", "alice") is True
+        client.set_payload.assert_not_called()
+
+    async def test_keyword_mode_hit_matches_bm25_marker(
+        self, client, monkeypatch
+    ) -> None:
+        # Regression (Deck #509): in keyword mode the dedup identity is the fixed
+        # ``bm25-keyword`` marker the writer stamps — NOT get_embedding_model_name()'s
+        # ``simple-{dim}`` fallback. With the pre-fix code these disagreed, so the
+        # claim always missed and an unchanged shared doc was re-processed + re-OCR'd
+        # every scan. A point stamped ``bm25-keyword`` must register as a HIT.
+        monkeypatch.setattr(ss, "get_settings", lambda: _KeywordSettings())
+        client.scroll.return_value = (
+            [
+                _point(
+                    {
+                        payload_keys.EMBEDDING_IDENTITY: "bm25-keyword",
+                        ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+                    }
+                )
+            ],
+            None,
+        )
+        # alice already listed -> HIT (skip reprocess), no write.
         assert await ss.claim_existing_index("42", "file", "abc", "alice") is True
         client.set_payload.assert_not_called()
 


### PR DESCRIPTION
## Problem

In **keyword mode** (`SEARCH_MODE=keyword`, `dense_enabled=False`) the tenant-wide cross-user dedup (`sharing_state.claim_existing_index`) **always missed**, so unchanged, already-indexed shared documents were **re-processed and re-escalated to OCR on every scan cycle, per user**. The run never converged, keeping the on-demand leaf.cloud burst GPU pinned up and billing (Deck #509; diagnosed on `tenant-blackbox-demo` — one unchanged file was re-OCR'd 11+ times in 3h across 3 users, ~14k process-document calls/3h, **zero** dead-letters/errors).

## Root cause — writer/reader mismatch on `embedding_identity`

- **Writer** (`processor.py`): stamps the fixed `"bm25-keyword"` marker on every chunk point in keyword mode.
- **Reader** (`sharing_state.claim_existing_index`): compared against `get_embedding_model_name()`, which returns the meaningless `"simple-{dim}"` fallback in keyword mode.

`"bm25-keyword" != "simple-384"` → `find_indexed_content` returns `None` → `claim` is `False` → the doc is treated as never-indexed → re-escalated. Both skip-gates (`scanner`/`processor`) call the same broken claim, so neither fires. Every pass "succeeds" (points written, placeholder cleared, `clear_dead_letter` runs), so there are **no errors** — it just never converges. **Hybrid mode was unaffected** (writer and reader both used the model name).

## Fix

Make **`build_embedding_identity()`** (`collection_metadata.py`) the single source of truth — return the fixed `KEYWORD_EMBEDDING_IDENTITY` marker when `not dense_enabled`, else the model name — and route **both** the chunk-point writer (`processor.py`) and the dedup reader (`sharing_state.py`) through it. This also corrects the collection **sentinel point** and the **admin payload-backfill**, which previously stamped `simple-{dim}` on keyword collections.

**Safe:** keyword collections are name-isolated by the `-bm25-keyword` collection suffix (no cross-mode contamination), and `embedding_identity` is **not** consumed by query-time dense routing (verified: only the dedup comparison, the sentinel/fallback record, and the admin backfill read it).

## Tests

- **Keyword-mode regression** (`test_sharing_state.py`): a point stamped `bm25-keyword` with `dense_enabled=False` must `claim_existing_index` as a **HIT** — the guard that was missing. Also added `dense_enabled` to the settings stub.
- **Direct `build_embedding_identity` coverage** (`test_collection_metadata.py`): hybrid → model name; keyword → `bm25-keyword` (and the sentinel/env-default metadata carries the same marker).
- **211 vector unit tests pass; `ruff check` + `ruff format` + `ty check nextcloud_mcp_server` green.**

> Note: the pre-commit/pre-push `ty-check` hooks run ty over staged **test** files and surface **pre-existing** typing errors in the unrelated `test_api_source_uses_shared_http_client` (httpx monkeypatch), which the CI ty scope (`nextcloud_mcp_server` only) does not gate on — hence `--no-verify` on the commit/push. Worth a follow-up to align the hook scope with CI (or fix that test).

Deck #509. Related: #349 (dead-letter for terminally-failed shared files), #495 (keyword placeholder/dead-letter dense sizing, 0.128.1 — did **not** touch this path).

---

_This PR was generated with the help of AI, and reviewed by a Human_