### PR TITLE
fix(ocr): re-submit batch OCR job on gateway 404 instead of polling a dead id forever

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -737,8 +737,29 @@ class OcrProcessor(DocumentProcessor):
             )
             return self._pending(poll_seconds)
 
-        # Existing job — poll the gateway.
-        result = await client.poll(job.job_id)
+        # Existing job — poll the gateway. Lazy import (mirrors the client import
+        # above) to keep document_processors off the embedding import path.
+        from ..embedding import gateway_batch_client as _gbc  # noqa: PLC0415
+
+        try:
+            result = await client.poll(job.job_id)
+        except _gbc.OcrBatchJobNotFound:
+            # The gateway lost this job — its row was purged (retention) or
+            # orphaned by a gateway pod move. Polling it 404s forever. Drop our
+            # tracking row so the NEXT cycle re-submits a fresh job (store.get →
+            # None → new submission) instead of looping on a dead id. Bounded by
+            # the same document_ocr_batch_max_wait budget as any submit; a genuine
+            # poison-pill still terminalises via the failed/timeout paths below and
+            # is dead-lettered by the scanner (incident 2026-07-03).
+            logger.warning(
+                "batch OCR job %s not found on gateway (404); re-submitting %s",
+                job.job_id,
+                filename or doc_id,
+            )
+            await store.delete(
+                user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
+            )
+            return self._pending(poll_seconds)
         if result.is_pending:
             elapsed = int(time.time()) - job.submitted_at
             if elapsed >= settings.document_ocr_batch_max_wait_seconds:

--- a/nextcloud_mcp_server/embedding/gateway_batch_client.py
+++ b/nextcloud_mcp_server/embedding/gateway_batch_client.py
@@ -151,8 +151,10 @@ class GatewayBatchOcrClient:
         return job_id
 
     async def poll(self, job_id: str) -> BatchPollResult:
-        """Poll a batch job. Raises on transport / non-2xx; maps a terminal job's
-        single-document result into :class:`BatchPollResult`.
+        """Poll a batch job. Maps a terminal job's single-document result into
+        :class:`BatchPollResult`. A ``404`` (the gateway has no record of this job —
+        row purged/orphaned) raises :class:`OcrBatchJobNotFound` so the caller can
+        re-submit; any other non-2xx / transport error propagates as a hard failure.
 
         ``job_id`` is the gateway's namespaced id (``<provider>/<batch_job_id>``),
         so it embeds a ``/`` and the request path is multi-segment

--- a/nextcloud_mcp_server/embedding/gateway_batch_client.py
+++ b/nextcloud_mcp_server/embedding/gateway_batch_client.py
@@ -46,6 +46,19 @@ _SUCCEEDED = "succeeded"
 _FAILED = "failed"
 
 
+class OcrBatchJobNotFound(Exception):
+    """The gateway returned ``404`` for a poll — it has no record of this batch
+    job. Its durable row was purged (retention) or lost/orphaned (e.g. a gateway
+    pod move mid-flight). Distinct from a transport/5xx error: the caller must
+    DROP the persisted job id and re-submit a fresh job, not keep polling a dead
+    id forever (incident 2026-07-03 — one doc polled a purged id from 2026-07-01
+    for ~2.5 days, flapping the burst GPU)."""
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(f"gateway has no record of batch OCR job {job_id!r}")
+        self.job_id = job_id
+
+
 @dataclass(frozen=True)
 class BatchPollResult:
     """One poll of a batch OCR job.
@@ -155,6 +168,12 @@ class GatewayBatchOcrClient:
             resp = await client.get(
                 f"{self._base}/ocr/batch/{job_id}", headers=await self._headers()
             )
+            if resp.status_code == 404:
+                # The gateway has no record of this job (a store-backed provider
+                # 404s an unknown id). Raise a typed error so the caller re-submits
+                # instead of treating it as a generic failure and re-polling the
+                # dead id forever.
+                raise OcrBatchJobNotFound(job_id)
             resp.raise_for_status()
             body = resp.json()
         status = body.get("status")

--- a/tests/unit/test_gateway_batch_client.py
+++ b/tests/unit/test_gateway_batch_client.py
@@ -95,6 +95,19 @@ async def test_poll_missing_status_is_failed(monkeypatch):
     assert result.is_failed
 
 
+async def test_poll_404_raises_job_not_found(monkeypatch):
+    # A 404 means the gateway has no record of this job (row purged by retention or
+    # orphaned by a pod move). Surface a TYPED OcrBatchJobNotFound — distinct from a
+    # transport/5xx — so the caller drops the id and re-submits instead of re-polling
+    # a dead id forever (incident 2026-07-03: a doc polled a purged id for ~2.5 days).
+    _patch_transport(
+        monkeypatch, lambda r: httpx.Response(404, json={"detail": "gone"})
+    )
+    with pytest.raises(gbc.OcrBatchJobNotFound) as exc:
+        await gbc.GatewayBatchOcrClient("https://gw", "m").poll("surya/deadbeef")
+    assert exc.value.job_id == "surya/deadbeef"
+
+
 async def test_poll_pending(monkeypatch):
     _patch_transport(
         monkeypatch,

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -698,6 +698,37 @@ async def test_batch_existing_pending_polls_and_defers(monkeypatch):
     assert client.submitted == []  # did NOT resubmit
 
 
+async def test_batch_poll_404_drops_row_and_resubmits(monkeypatch):
+    # Incident 2026-07-03: a 404 on poll means the gateway lost the job (row purged
+    # by retention or orphaned by a pod move). The processor must DROP its tracking
+    # row and return the pending sentinel so the NEXT cycle re-submits a fresh job —
+    # NOT re-poll the dead id forever (which flapped the burst GPU).
+    from nextcloud_mcp_server.embedding.gateway_batch_client import OcrBatchJobNotFound
+
+    preset = SimpleNamespace(job_id="surya/dead", submitted_at=1000)
+    client = _FakeBatchClient()
+
+    async def _poll_404(job_id):
+        client.polled.append(job_id)
+        raise OcrBatchJobNotFound(job_id)
+
+    client.poll = _poll_404  # type: ignore[method-assign]
+    store = _FakeStore(preset=preset)
+    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)
+    _wire_batch(monkeypatch, client=client, store=store)
+
+    r = await ocr.OcrProcessor().process(
+        b"%PDF", "application/pdf", options=dict(_IDENTITY)
+    )
+
+    assert client.polled == ["surya/dead"]
+    # tracking row dropped -> store.get is None next cycle -> fresh submit
+    assert ("u1", "d1", "file", "v1") in store.deleted
+    # returned the pending sentinel (re-poll → resubmit); did NOT resubmit inline
+    assert r.metadata[ocr.OCR_BATCH_PENDING_KEY] is True
+    assert client.submitted == []
+
+
 async def test_batch_succeeded_returns_indexed_result(monkeypatch):
     preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(


### PR DESCRIPTION
## Problem (incident 2026-07-03)
When the gateway returns **`404`** for a batch-OCR poll — its durable job row was purged by the 24 h retention sweep, or orphaned by a gateway pod move — the tenant worker propagated the raw `httpx.HTTPStatusError` and **re-polled the same persisted `job_id` every scan cycle, forever**.

One smoke-test doc (`5121`, an OHR-Bench page whose OCR sub-batch times out at 120 s) polled a job first submitted **2026-07-01 00:00:24** for **~2.5 days**, dropping a 1–2 job `ingest-ocr` blip each cycle that repeatedly booted the on-demand burst GPU (with `activationThreshold=0`, any blip → a boot).

## Fix
- **`gateway_batch_client.poll()`**: map a `404` to a typed **`OcrBatchJobNotFound`** (distinct from a transport/5xx error), rather than a generic `HTTPStatusError`.
- **`ocr._process_batch()`**: on `OcrBatchJobNotFound`, **drop the tracking row** and return the pending sentinel. The next cycle finds no row (`store.get → None`) and **re-submits a fresh job** instead of re-polling a dead id.

A genuine poison-pill (un-OCR-able doc) still terminalises via the existing `failed`/timeout paths and is dead-lettered by the scanner, so this cannot loop forever on a bad document — it only recovers a *lost* job.

## Tests
- `test_poll_404_raises_job_not_found` — client maps `404 → OcrBatchJobNotFound` (carries `job_id`).
- `test_batch_poll_404_drops_row_and_resubmits` — processor deletes the tracking row + returns the pending sentinel + does **not** resubmit inline (next cycle does).
- 75 unit tests pass; `ruff` + `ty` (source) green.

## Related
- **astrolabe-cloud-gitops#534** (embedding-gateway HA: 2 replicas + PDB + zero-gap rollout) removes the ~12-min pod-eviction churn that *causes* most of these 404s. This PR makes the tenant resilient to any that still occur (e.g. the legitimate 24 h-retention purge).
- Two poison-pill OHR-Bench pages (5121/4752) were dead-lettered operationally to stop the immediate GPU flapping.

---

_This PR was generated with the help of AI, and reviewed by a Human_