### PR TITLE
feat(api): reject explicit unsupported search algorithm with 422 (ADR-030)

### DIFF
--- a/docs/ADR-030-keyword-only-search-mode.md
+++ b/docs/ADR-030-keyword-only-search-mode.md
@@ -123,15 +123,39 @@ single constant `SUPPORTED_SEARCH_ALGORITHMS`, reused by the
 `/api/v1/vector-viz/search` validation so the advertised set and the accepted
 set cannot drift.
 
-Astrolabe is the **consumer** of `/api/v1/status` and this server is the
-**provider** (ADR-029). The contract is pinned both ways: a contract-first
-consumer pact (`tests/contract/test_mcp_status_search_types_consumer.py`,
-written to the unpublished `provider_contracts/` dir) and the matching
-provider-state handlers in `tests/contract/test_mcp_provider_verification.py`
-(`the server advertises hybrid search support` /
-`… keyword-only search support`). The real response is verified per mode by
-`tests/unit/test_management_status_endpoint.py`. A follow-up astrolabe PR
-consumes `supported_search_types` to gate its query-type picker.
+#### Strict rejection of an explicit unsupported algorithm
+
+Advertising is only half the contract — the search endpoints enforce it. When a
+client sends an **explicit** `algorithm` that is not in `supported_search_types`
+(the paradigm case: `algorithm: "semantic"` while `SEARCH_MODE=keyword`), both
+`/api/v1/search` and `/api/v1/vector-viz/search` return **HTTP 422**:
+
+```json
+{ "error": "unsupported_search_type", "requested": "semantic",
+  "supported_search_types": ["bm25"] }
+```
+
+This is deliberately stricter than the earlier behaviour (which silently coerced
+`semantic` → `bm25`). A silent downgrade returns lexical results dressed up as a
+semantic answer; a 422 lets astrolabe *and* any other client fail loud and
+self-correct from the advertised set. The strictness applies only to an
+**explicit** request: a call that omits `algorithm` still defaults gracefully
+across modes. `api/management.py` splits the two paths — `select_search_algorithm`
+(explicit → raise `UnsupportedSearchType`; absent → default) wraps the retained
+`resolve_search_algorithm` (the lenient default-coercion helper).
+
+Astrolabe is the **consumer** of `/api/v1/status` and `/api/v1/search`, and this
+server is the **provider** (ADR-029). The contract is pinned both ways: a
+contract-first consumer pact
+(`tests/contract/test_mcp_status_search_types_consumer.py`, written to the
+unpublished `provider_contracts/` dir) covering the status advertisement in each
+mode **and** the keyword-mode 422, plus the matching provider-state handlers in
+`tests/contract/test_mcp_provider_verification.py` (`the server advertises hybrid
+search support` / `… keyword-only search support`). The real status response is
+verified per mode by `tests/unit/test_management_status_endpoint.py`, and the
+`select_search_algorithm` gate is unit-tested there too. The astrolabe PR
+consumes `supported_search_types` to gate its query-type picker client-side and
+surfaces the 422 as its server-side backstop.
 
 ## Consequences
 

--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -100,12 +100,23 @@ def select_search_algorithm(requested: str | None, settings: Settings) -> str:
       :class:`UnsupportedSearchType` (→ 422). This is the strict half of the
       contract that /api/v1/status advertises; the lenient
       :func:`resolve_search_algorithm` remains for the implicit-default path.
+
+    Caveat: an explicit JSON ``"algorithm": null`` is indistinguishable from an
+    omitted key (both surface as ``None`` from ``body.get``), so it takes the
+    graceful-default path rather than being rejected.
     """
     if requested is None:
         return resolve_search_algorithm("hybrid", settings)
     supported = supported_search_types(settings)
     if requested in supported:
         return requested
+    # Log the hard reject (mirrors resolve_search_algorithm's coercion log) so
+    # operators can see why an explicit algorithm got a 422 rather than results.
+    logger.debug(
+        "select_search_algorithm: rejecting explicit %r (supported=%r)",
+        requested,
+        supported,
+    )
     raise UnsupportedSearchType(requested, supported)
 
 

--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -64,6 +64,51 @@ def supported_search_types(settings: Settings) -> list[str]:
     return ["bm25"]
 
 
+class UnsupportedSearchType(Exception):
+    """A client *explicitly* asked for a search algorithm this server can't serve.
+
+    Raised by :func:`select_search_algorithm` and translated by the search
+    endpoints into **HTTP 422** carrying the advertised ``supported_search_types``
+    (ADR-030), so a client (astrolabe) that requests ``semantic`` against a
+    keyword-only server gets a hard, self-correcting error instead of silent BM25
+    results. Only *explicit* requests are strict — an absent ``algorithm`` still
+    defaults gracefully via :func:`resolve_search_algorithm`.
+    """
+
+    def __init__(self, requested: str, supported: list[str]) -> None:
+        self.requested = requested
+        self.supported = supported
+        super().__init__(
+            f"search algorithm {requested!r} is not supported by this server "
+            f"(supported: {supported or 'none'})"
+        )
+
+
+def select_search_algorithm(requested: str | None, settings: Settings) -> str:
+    """Pick the algorithm to run for a search request (ADR-030, strict variant).
+
+    The search endpoints (`/api/v1/search`, `/api/v1/vector-viz/search`) call this
+    with the raw ``body.get("algorithm")`` — ``None`` when the client sent no
+    ``algorithm`` field:
+
+    - ``requested is None`` → graceful default via
+      :func:`resolve_search_algorithm` (coerces the historical ``hybrid`` default
+      to a serviceable type, e.g. ``bm25`` in keyword mode). Callers that don't
+      pin an algorithm keep working across modes.
+    - explicit ``requested`` in ``supported_search_types`` → returned unchanged.
+    - explicit ``requested`` NOT in ``supported_search_types`` → raise
+      :class:`UnsupportedSearchType` (→ 422). This is the strict half of the
+      contract that /api/v1/status advertises; the lenient
+      :func:`resolve_search_algorithm` remains for the implicit-default path.
+    """
+    if requested is None:
+        return resolve_search_algorithm("hybrid", settings)
+    supported = supported_search_types(settings)
+    if requested in supported:
+        return requested
+    raise UnsupportedSearchType(requested, supported)
+
+
 def resolve_search_algorithm(algorithm: str, settings: Settings) -> str:
     """Coerce a requested search algorithm to one this server can serve now.
 
@@ -71,9 +116,11 @@ def resolve_search_algorithm(algorithm: str, settings: Settings) -> str:
     unavailable in the current SEARCH_MODE (ADR-030) — notably ``semantic`` while
     ``SEARCH_MODE=keyword``, which would otherwise route a dense query at a
     sparse-only index and fail. Prefers ``hybrid`` when available (the historical
-    default), else the first supported type. Keeps the search endpoints lenient
-    (no new 4xx) while keeping the accepted set in lockstep with the
-    ``supported_search_types`` that /api/v1/status advertises.
+    default), else the first supported type. Backs the **implicit-default** path
+    (no ``algorithm`` in the request); an *explicit* unsupported algorithm is
+    rejected by :func:`select_search_algorithm` (422) rather than coerced, keeping
+    the accepted set in lockstep with the ``supported_search_types`` that
+    /api/v1/status advertises.
     """
     supported = supported_search_types(settings)
     if algorithm in supported:

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -19,11 +19,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from nextcloud_mcp_server.api.management import (
+    UnsupportedSearchType,
     _parse_float_param,
     _parse_int_param,
     _sanitize_error_for_client,
     _validate_query_string,
-    resolve_search_algorithm,
+    select_search_algorithm,
     validate_token_and_get_user,
 )
 from nextcloud_mcp_server.config import get_settings
@@ -228,7 +229,7 @@ async def unified_search(request: Request) -> JSONResponse:
         except ValueError as e:
             return JSONResponse({"error": str(e)}, status_code=400)
 
-        algorithm = body.get("algorithm", "hybrid")
+        requested_algorithm = body.get("algorithm")  # None ⇒ graceful default
         fusion = body.get("fusion", "rrf")
         include_pca = body.get("include_pca", False)
         include_chunks = body.get("include_chunks", True)
@@ -248,11 +249,22 @@ async def unified_search(request: Request) -> JSONResponse:
         if not query:
             return JSONResponse({"results": [], "total_found": 0})
 
-        # Coerce to an algorithm this server can actually serve in its current
-        # SEARCH_MODE (ADR-030): in keyword mode "semantic" would route a dense
-        # query at a sparse-only index, so it falls back to "bm25". Keeps the
-        # accepted set in lockstep with what /api/v1/status advertises.
-        algorithm = resolve_search_algorithm(algorithm, settings)
+        # Pick the algorithm to run (ADR-030, strict variant): an *explicit*
+        # unsupported request (e.g. "semantic" while SEARCH_MODE=keyword) is
+        # rejected with 422 carrying the advertised supported_search_types, so
+        # the client can correct it rather than silently receive BM25 results. An
+        # absent algorithm still defaults gracefully across modes.
+        try:
+            algorithm = select_search_algorithm(requested_algorithm, settings)
+        except UnsupportedSearchType as e:
+            return JSONResponse(
+                {
+                    "error": "unsupported_search_type",
+                    "requested": e.requested,
+                    "supported_search_types": e.supported,
+                },
+                status_code=422,
+            )
 
         # Validate fusion method
         valid_fusions = {"rrf", "dbsf"}
@@ -456,7 +468,7 @@ async def vector_search(request: Request) -> JSONResponse:
         # Parse request body
         body = await request.json()
         query = body.get("query", "")
-        algorithm = body.get("algorithm", "hybrid")
+        requested_algorithm = body.get("algorithm")  # None ⇒ graceful default
         fusion = body.get("fusion", "rrf")
         score_threshold = body.get("score_threshold", 0.0)
         limit = min(body.get("limit", 10), 50)  # Enforce max limit
@@ -501,11 +513,22 @@ async def vector_search(request: Request) -> JSONResponse:
                 status_code=400,
             )
 
-        # Coerce to an algorithm this server can actually serve in its current
-        # SEARCH_MODE (ADR-030): in keyword mode "semantic" would route a dense
-        # query at a sparse-only index, so it falls back to "bm25". Keeps the
-        # accepted set in lockstep with what /api/v1/status advertises.
-        algorithm = resolve_search_algorithm(algorithm, settings)
+        # Pick the algorithm to run (ADR-030, strict variant): an *explicit*
+        # unsupported request (e.g. "semantic" while SEARCH_MODE=keyword) is
+        # rejected with 422 carrying the advertised supported_search_types, so
+        # the client can correct it rather than silently receive BM25 results. An
+        # absent algorithm still defaults gracefully across modes.
+        try:
+            algorithm = select_search_algorithm(requested_algorithm, settings)
+        except UnsupportedSearchType as e:
+            return JSONResponse(
+                {
+                    "error": "unsupported_search_type",
+                    "requested": e.requested,
+                    "supported_search_types": e.supported,
+                },
+                status_code=422,
+            )
 
         # Validate fusion method
         valid_fusions = {"rrf", "dbsf"}

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -57,6 +57,22 @@ logger = logging.getLogger(__name__)
 _NEXTCLOUD_HOST_NOT_CONFIGURED = "Nextcloud host not configured"
 
 
+def _unsupported_search_type_response(e: UnsupportedSearchType) -> JSONResponse:
+    """Uniform 422 for an explicit unsupported search algorithm (ADR-030).
+
+    Shared by both search endpoints so the ``unsupported_search_type`` payload
+    shape (error / requested / supported_search_types) can't drift between them.
+    """
+    return JSONResponse(
+        {
+            "error": "unsupported_search_type",
+            "requested": e.requested,
+            "supported_search_types": e.supported,
+        },
+        status_code=422,
+    )
+
+
 async def _search_with_acl(
     request: Request,
     user_id: str,
@@ -257,14 +273,7 @@ async def unified_search(request: Request) -> JSONResponse:
         try:
             algorithm = select_search_algorithm(requested_algorithm, settings)
         except UnsupportedSearchType as e:
-            return JSONResponse(
-                {
-                    "error": "unsupported_search_type",
-                    "requested": e.requested,
-                    "supported_search_types": e.supported,
-                },
-                status_code=422,
-            )
+            return _unsupported_search_type_response(e)
 
         # Validate fusion method
         valid_fusions = {"rrf", "dbsf"}
@@ -521,14 +530,7 @@ async def vector_search(request: Request) -> JSONResponse:
         try:
             algorithm = select_search_algorithm(requested_algorithm, settings)
         except UnsupportedSearchType as e:
-            return JSONResponse(
-                {
-                    "error": "unsupported_search_type",
-                    "requested": e.requested,
-                    "supported_search_types": e.supported,
-                },
-                status_code=422,
-            )
+            return _unsupported_search_type_response(e)
 
         # Validate fusion method
         valid_fusions = {"rrf", "dbsf"}

--- a/tests/contract/test_mcp_status_search_types_consumer.py
+++ b/tests/contract/test_mcp_status_search_types_consumer.py
@@ -115,3 +115,54 @@ async def test_status_advertises_bm25_only_in_keyword_mode(status_pact):
         types = await _fetch_supported_search_types(str(srv.url))
 
     assert types == ["bm25"]
+
+
+async def _post_search_algorithm(base_url: str, algorithm: str) -> httpx.Response:
+    """Stand-in for astrolabe's McpServerClient.search(): POST /api/v1/search with
+    an explicit ``algorithm``. Returns the raw response so the caller can assert
+    on the (strict, ADR-030) 422 the server sends for an unsupported algorithm."""
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        return await client.post(
+            "/api/v1/search",
+            json={"query": "torch leadership award", "algorithm": algorithm},
+        )
+
+
+async def test_search_rejects_unsupported_algorithm_in_keyword_mode(status_pact):
+    """Explicitly requesting ``semantic`` on a keyword-only server → 422 (ADR-030).
+
+    This is the strict half of the contract: rather than silently degrading a
+    ``semantic`` request to BM25, the server rejects it with the advertised
+    ``supported_search_types`` so astrolabe can surface/guard the error. astrolabe
+    also gates the request client-side from ``/api/v1/status``, but this pins the
+    server-side backstop the client relies on.
+    """
+    (
+        status_pact.upon_receiving(
+            "a semantic search request when the server is in keyword mode"
+        )
+        .given("the server advertises keyword-only search support")
+        .with_request("POST", "/api/v1/search")
+        .with_body(
+            {"query": "torch leadership award", "algorithm": "semantic"},
+            content_type="application/json",
+        )
+        .will_respond_with(422)
+        .with_body(
+            {
+                "error": "unsupported_search_type",
+                "requested": "semantic",
+                "supported_search_types": ["bm25"],
+            },
+            content_type="application/json",
+        )
+    )
+
+    with status_pact.serve() as srv:
+        resp = await _post_search_algorithm(str(srv.url), "semantic")
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"] == "unsupported_search_type"
+    assert body["requested"] == "semantic"
+    assert body["supported_search_types"] == ["bm25"]

--- a/tests/unit/test_management_status_endpoint.py
+++ b/tests/unit/test_management_status_endpoint.py
@@ -484,11 +484,13 @@ class TestSelectSearchAlgorithm:
         )
 
         s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
-        with pytest.raises(UnsupportedSearchType) as excinfo:
-            select_search_algorithm("semantic", s)
-        # Error carries the request + the advertised set for a self-correcting 422.
-        assert excinfo.value.requested == "semantic"
-        assert excinfo.value.supported == ["bm25"]
+        # Both dense-requiring algorithms are unsupported in keyword mode.
+        for algo in ("semantic", "hybrid"):
+            with pytest.raises(UnsupportedSearchType) as excinfo:
+                select_search_algorithm(algo, s)
+            # Error carries the request + advertised set for a self-correcting 422.
+            assert excinfo.value.requested == algo
+            assert excinfo.value.supported == ["bm25"]
         # bm25 is still accepted in keyword mode.
         assert select_search_algorithm("bm25", s) == "bm25"
 

--- a/tests/unit/test_management_status_endpoint.py
+++ b/tests/unit/test_management_status_endpoint.py
@@ -451,6 +451,59 @@ class TestResolveSearchAlgorithm:
         assert resolve_search_algorithm("semantic", s) == "hybrid"
 
 
+class TestSelectSearchAlgorithm:
+    """select_search_algorithm is the strict variant backing the search
+    endpoints (ADR-030): an *explicit* unsupported algorithm raises
+    UnsupportedSearchType (→ 422); an absent algorithm defaults gracefully."""
+
+    def test_none_defaults_gracefully_in_hybrid(self):
+        from nextcloud_mcp_server.api.management import select_search_algorithm
+
+        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        # No explicit algorithm → historical "hybrid" default.
+        assert select_search_algorithm(None, s) == "hybrid"
+
+    def test_none_defaults_to_bm25_in_keyword_mode(self):
+        from nextcloud_mcp_server.api.management import select_search_algorithm
+
+        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
+        # No explicit algorithm → coerced to the one serviceable type.
+        assert select_search_algorithm(None, s) == "bm25"
+
+    def test_explicit_supported_passes_through(self):
+        from nextcloud_mcp_server.api.management import select_search_algorithm
+
+        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        for algo in ("semantic", "bm25", "hybrid"):
+            assert select_search_algorithm(algo, s) == algo
+
+    def test_explicit_semantic_in_keyword_mode_raises(self):
+        from nextcloud_mcp_server.api.management import (
+            UnsupportedSearchType,
+            select_search_algorithm,
+        )
+
+        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
+        with pytest.raises(UnsupportedSearchType) as excinfo:
+            select_search_algorithm("semantic", s)
+        # Error carries the request + the advertised set for a self-correcting 422.
+        assert excinfo.value.requested == "semantic"
+        assert excinfo.value.supported == ["bm25"]
+        # bm25 is still accepted in keyword mode.
+        assert select_search_algorithm("bm25", s) == "bm25"
+
+    def test_explicit_unknown_algorithm_raises(self):
+        from nextcloud_mcp_server.api.management import (
+            UnsupportedSearchType,
+            select_search_algorithm,
+        )
+
+        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        # Unknown values are a client bug — fail loud rather than coerce.
+        with pytest.raises(UnsupportedSearchType):
+            select_search_algorithm("nonsense", s)
+
+
 class TestStatusEndpointSearchTypes:
     """The /api/v1/status response advertises supported_search_types so the
     astrolabe UI can gate its query-type picker (ADR-030)."""

--- a/tests/unit/test_search_endpoint_algorithm_gate.py
+++ b/tests/unit/test_search_endpoint_algorithm_gate.py
@@ -1,0 +1,90 @@
+"""Endpoint wiring for the strict search-algorithm gate (ADR-030).
+
+The pure ``select_search_algorithm`` helper is unit-tested in
+``test_management_status_endpoint.py``; these tests drive the real Starlette
+handlers (``unified_search`` → /api/v1/search, ``vector_search`` →
+/api/v1/vector-viz/search) through a TestClient so the actual
+``try/except UnsupportedSearchType → 422`` wiring — and the shared
+``_unsupported_search_type_response`` payload — is covered locally, not only by
+the provider-verification job.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from nextcloud_mcp_server.api.visualization import unified_search, vector_search
+
+pytestmark = pytest.mark.unit
+
+
+def _keyword_mode_settings() -> MagicMock:
+    """Vector sync on, dense off → SEARCH_MODE=keyword advertises only ["bm25"]."""
+    settings = MagicMock()
+    settings.vector_sync_enabled = True
+    settings.dense_enabled = False
+    return settings
+
+
+def _app() -> Starlette:
+    return Starlette(
+        routes=[
+            Route("/api/v1/search", unified_search, methods=["POST"]),
+            Route("/api/v1/vector-viz/search", vector_search, methods=["POST"]),
+        ]
+    )
+
+
+@pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
+def test_explicit_semantic_in_keyword_mode_returns_422(path: str):
+    """An explicit unsupported algorithm is rejected before any Qdrant call."""
+    with (
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_settings",
+            return_value=_keyword_mode_settings(),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+            new=AsyncMock(return_value=("alice", {})),
+        ),
+    ):
+        client = TestClient(_app())
+        resp = client.post(
+            path, json={"query": "torch leadership award", "algorithm": "semantic"}
+        )
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"] == "unsupported_search_type"
+    assert body["requested"] == "semantic"
+    assert body["supported_search_types"] == ["bm25"]
+
+
+@pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
+def test_supported_bm25_in_keyword_mode_is_not_rejected(path: str):
+    """A supported algorithm passes the gate (it fails later, at the real search,
+    which is patched out here — the point is it is NOT a 422 gate rejection)."""
+    with (
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_settings",
+            return_value=_keyword_mode_settings(),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+            new=AsyncMock(return_value=("alice", {})),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.BM25HybridSearchAlgorithm",
+            side_effect=RuntimeError("stop after the gate"),
+        ),
+    ):
+        client = TestClient(_app())
+        resp = client.post(
+            path, json={"query": "leadership award", "algorithm": "bm25"}
+        )
+
+    # Not a 422 from the algorithm gate — the request got past it to the search.
+    assert resp.status_code != 422

--- a/tests/unit/test_search_endpoint_algorithm_gate.py
+++ b/tests/unit/test_search_endpoint_algorithm_gate.py
@@ -39,7 +39,12 @@ def _app() -> Starlette:
 
 
 @pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
-def test_explicit_semantic_in_keyword_mode_returns_422(path: str):
+# Both dense-requiring algorithms are unsupported in keyword mode (supported is
+# ["bm25"]), so each must be rejected — not just "semantic".
+@pytest.mark.parametrize("algorithm", ["semantic", "hybrid"])
+def test_explicit_dense_algorithm_in_keyword_mode_returns_422(
+    path: str, algorithm: str
+):
     """An explicit unsupported algorithm is rejected before any Qdrant call."""
     with (
         patch(
@@ -53,13 +58,13 @@ def test_explicit_semantic_in_keyword_mode_returns_422(path: str):
     ):
         client = TestClient(_app())
         resp = client.post(
-            path, json={"query": "torch leadership award", "algorithm": "semantic"}
+            path, json={"query": "torch leadership award", "algorithm": algorithm}
         )
 
     assert resp.status_code == 422
     body = resp.json()
     assert body["error"] == "unsupported_search_type"
-    assert body["requested"] == "semantic"
+    assert body["requested"] == algorithm
     assert body["supported_search_types"] == ["bm25"]
 
 


### PR DESCRIPTION
## Summary

`GET /api/v1/status` already advertises `supported_search_types` (ADR-030). This makes the **enforcement** side strict: `/api/v1/search` and `/api/v1/vector-viz/search` now **reject an explicit unsupported `algorithm` with HTTP 422** instead of silently coercing it (e.g. `semantic` → `bm25` while `SEARCH_MODE=keyword`).

Motivation: a keyword-only tenant was still returning results for `semantic`/hybrid queries because the server coerced the algorithm — lexical results dressed up as a semantic answer. Now the client (astrolabe) fails loud and self-corrects from the advertised set.

```json
HTTP 422
{ "error": "unsupported_search_type", "requested": "semantic",
  "supported_search_types": ["bm25"] }
```

## Changes
- `api/management.py`: new `select_search_algorithm` (explicit → raise `UnsupportedSearchType`; absent → graceful default) wrapping the retained lenient `resolve_search_algorithm`; new `UnsupportedSearchType` exception.
- `api/visualization.py`: both search endpoints translate the exception to 422. Absent `algorithm` still defaults gracefully across modes.
- Tests: `TestSelectSearchAlgorithm` unit tests; contract-first pact gains the keyword-mode 422 interaction (provider state `the server advertises keyword-only search support`, already registered).
- `docs/ADR-030`: documents the strict rejection.

## Contract alignment
Paired with the astrolabe consumer PR (gates the algorithm client-side from `/api/v1/status` and surfaces this 422 as the backstop; adds the matching pact-php consumer interaction). Deck card #512.

## Test plan
- [x] `pytest tests/unit/test_management_status_endpoint.py` (26 passed)
- [x] `pytest -m contract tests/contract/test_mcp_status_search_types_consumer.py` (3 passed)
- [x] `ruff` + `ty-check` (pre-commit) clean
- [ ] Provider verification job replays astrolabe's published consumer pact (keyword-mode 422)

---

_This PR was generated with the help of AI, and reviewed by a Human_