### PR TITLE
feat(documents): opt-in docling VLM pipeline (DOCLING_PIPELINE/DOCLING_VLM_PRESET)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,5 @@ repos:
       name: ty-check
       language: system
       types: [python]
-      entry: uv run ty check
+      pass_filenames: false
+      entry: uv run ty check -- nextcloud_mcp_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,11 @@ services:
       - ENABLE_DOCLING=${ENABLE_DOCLING:-false}
       - DOCLING_API_URL=${DOCLING_API_URL:-}
       - DOCLING_TIMEOUT=${DOCLING_TIMEOUT:-120}
+      # Opt-in VLM pipeline (ADR-032): point docling-serve at its VLM presets
+      # instead of classic OCR. Default "standard" is byte-identical to the
+      # pre-VLM request. VLM needs a much larger DOCLING_TIMEOUT (600-900s).
+      - DOCLING_PIPELINE=${DOCLING_PIPELINE:-standard}
+      - DOCLING_VLM_PRESET=${DOCLING_VLM_PRESET:-}
     profiles:
       - single-user
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,9 +193,15 @@ services:
       - DOCLING_TIMEOUT=${DOCLING_TIMEOUT:-120}
       # Opt-in VLM pipeline (ADR-032): point docling-serve at its VLM presets
       # instead of classic OCR. Default "standard" is byte-identical to the
-      # pre-VLM request. VLM needs a much larger DOCLING_TIMEOUT (600-900s).
+      # pre-VLM request. VLM is slow (~90-200s/page): for bulk indexing use the
+      # async ingest path (DOCUMENT_OCR_PROVIDER=docling) and raise
+      # DOCUMENT_OCR_TIMEOUT_SECONDS -- do NOT inflate DOCLING_TIMEOUT (interactive).
       - DOCLING_PIPELINE=${DOCLING_PIPELINE:-standard}
       - DOCLING_VLM_PRESET=${DOCLING_VLM_PRESET:-}
+      # Opt-in cap on the synchronous nc_webdav_read_file parse; empty = disabled.
+      # A client-friendly bound (e.g. 45-60) makes a slow VLM/OCR read fall back to
+      # base64 fast instead of blocking past the MCP client's own timeout.
+      - DOCUMENT_READ_TIMEOUT_SECONDS=${DOCUMENT_READ_TIMEOUT_SECONDS:-}
     profiles:
       - single-user
 

--- a/docs/ADR-032-docling-vlm-pipeline.md
+++ b/docs/ADR-032-docling-vlm-pipeline.md
@@ -49,10 +49,14 @@ emits exactly the pre-VLM request — the default path is byte-for-byte unchange
 - **D2 — omit `do_ocr`/`ocr_lang` under `vlm`.** They belong to the classic OCR
   pipeline and are inert for VLM; sending them would be misleading.
 - **D3 — do not override the timeout; warn instead.** VLM inference is far slower
-  than classic OCR (typically 600–900s vs. the 120s default). Silently bumping the
-  timeout would hide a mis-provisioned deployment, so the default is left as-is and
-  the server logs a warning when `pipeline=vlm` is set with a timeout below 300s
-  (checked on both touchpoints).
+  than classic OCR (a quick A30 benchmark of Granite-Vision on docling's default
+  inline-transformers engine ran ~90–200s/page, vs. a few s/page for classic OCR).
+  Silently bumping a timeout would hide a mis-provisioned deployment, so defaults are
+  left as-is and the server warns. **Which timeout to raise depends on the path** (see
+  "Interactive reads vs. async ingest" below): raise `DOCUMENT_OCR_TIMEOUT_SECONDS`
+  for the async ingest/OCR path (where a long budget is appropriate); do **not**
+  inflate `DOCLING_TIMEOUT`, which only lengthens how long the interactive
+  `nc_webdav_read_file` tool blocks.
 - **D4 — send `image_export_mode=placeholder` under `vlm`.** VLM output does not
   need embedded page images; `placeholder` keeps the response lean.
 - **D5 — record the pipeline in metadata, keep `parsing_method`.** The result's
@@ -63,19 +67,58 @@ emits exactly the pre-VLM request — the default path is byte-for-byte unchange
   already maps to `ProcessorError`, so client-side validation would only add a
   brittle, deployment-specific allowlist.
 
+## Interactive reads vs. async ingest
+
+VLM widens the blast radius of a subtlety that predates this ADR: the two docling
+touchpoints run in very different execution contexts, and each has its **own,
+independent** timeout.
+
+- **Async ingest (bulk, out-of-band).** When `DOCUMENT_OCR_PROVIDER=docling`, scanned
+  PDFs are transcribed by the OCR tier on the **background ingest pipeline**
+  (`vector/scanner.py` → the `ingest-ocr` procrastinate queue → `vector/processor.py`,
+  running under `mcp_role=worker`), and the result is written to Qdrant for semantic
+  search. This path is governed by **`DOCUMENT_OCR_TIMEOUT_SECONDS`** and never blocks
+  a tool call. **This is the right home for VLM at any volume** — raise
+  `DOCUMENT_OCR_TIMEOUT_SECONDS` here freely.
+- **Interactive read (on-demand, synchronous).** `nc_webdav_read_file` parses inline
+  (`await parse_document(...)`), so an image (auto-routed to `DoclingProcessor`) or a
+  `force_processor="docling"` PDF makes a **blocking** POST to docling-serve for up to
+  **`DOCLING_TIMEOUT`**. Under VLM (~90–200s/page) this call blocks for minutes.
+
+**Explicit callout (the operative constraint):** raising `DOCLING_TIMEOUT` for VLM
+directly increases how long `nc_webdav_read_file` blocks, and MCP clients typically
+enforce a much shorter per-tool timeout (~30–60s). The client will usually kill the
+call before docling responds, so the user sees a client-side timeout rather than the
+tool's base64 fallback. Interactive VLM (multi-minute) and short MCP client timeouts
+are fundamentally incompatible; VLM is best paired with the async/ingest path, not
+interactive reads. **Images are interactive-only** — the ingest scanner is PDF-only,
+so images are never indexed; interactive VLM image reads inherently block.
+
+**Mitigation — `DOCUMENT_READ_TIMEOUT_SECONDS` (opt-in).** A new setting caps the
+synchronous parse *inside* `nc_webdav_read_file` (via `anyio.fail_after`), independent
+of `DOCLING_TIMEOUT` and of the worker path. When the cap trips, the tool returns
+base64 **quickly** instead of hanging until the client times out. Default is `None`
+(disabled) to avoid silently regressing existing ADR-031 interactive scanned-PDF reads
+(and the interactive-VLM user who deliberately accepts long calls); operators who care
+about client-timeout safety set it to a client-friendly bound (e.g. 45–60s). It never
+applies to the async ingest/worker path, which keeps its full `DOCUMENT_OCR_TIMEOUT_SECONDS`
+budget.
+
 ## Consequences
 
 - New env: `DOCLING_PIPELINE`, `DOCLING_VLM_PRESET`; `docling_pipeline` added to the
   validated enum (`{standard, vlm}`). Both flow through the config dual-surface
-  (the Dynaconf image path and the `Settings`-dataclass OCR-backend path).
+  (the Dynaconf image path and the `Settings`-dataclass OCR-backend path). Plus
+  `DOCUMENT_READ_TIMEOUT_SECONDS` (opt-in interactive read cap, default off).
 - **Fully backward compatible.** With `DOCLING_PIPELINE` unset (default `standard`)
   the request is identical to the ADR-031 client; nothing changes for existing
-  deployments.
+  deployments. `DOCUMENT_READ_TIMEOUT_SECONDS` unset = no behavioral change.
 - **Operational note:** VLM needs a VLM-capable docling-serve (a preset backed by a
   real inference engine). The CI `docling` lane uses the CPU image with no VLM
   engine, so the VLM round-trip is covered by an **opt-in** integration test gated
   on `DOCLING_PIPELINE=vlm`; unit tests assert the request schema (that
   `pipeline=vlm` and the preset are actually sent) without needing an engine.
-- Sync-only and the timeout implication carry over from ADR-031: a VLM run is a long
-  synchronous convert, hence the larger recommended `DOCLING_TIMEOUT`. Async
-  submit/poll remains future work.
+- Sync-only carries over from ADR-031: a VLM run is a long synchronous convert. For
+  bulk VLM raise `DOCUMENT_OCR_TIMEOUT_SECONDS` on the ingest path; keep
+  `DOCLING_TIMEOUT` client-friendly and use `DOCUMENT_READ_TIMEOUT_SECONDS` to bound
+  interactive reads. Async submit/poll for the interactive path remains future work.

--- a/docs/ADR-032-docling-vlm-pipeline.md
+++ b/docs/ADR-032-docling-vlm-pipeline.md
@@ -1,0 +1,81 @@
+# ADR-032: Docling VLM pipeline (client-selected)
+
+## Status
+
+Accepted — 2026-07-04 (extends ADR-031)
+
+## Context
+
+ADR-031 added docling-serve as an OCR-strong parsing backend at three touchpoints
+(images, scanned PDFs, on-demand force), all sharing one HTTP client,
+`document_processors/docling_serve.py`. That client calls
+`POST /v1/convert/file` and — critically — **never sends a `pipeline` field**, so
+docling-serve always runs its default **`standard`** pipeline: classic OCR
+(EasyOCR / RapidOCR / Tesseract).
+
+docling-serve also ships a **VLM** pipeline (`pipeline=vlm`) that transcribes with
+a vision-language model — often markedly better on handwriting, messy scans and
+complex layouts. A VLM run is selected by `pipeline=vlm` plus an optional
+`vlm_pipeline_preset` naming a server-defined preset (e.g. `glm_ocr` backed by a
+local Ollama). A real deployment runs docling-serve **VLM-only** with such a
+preset, but because the MCP client never sends `pipeline=vlm`, every request fell
+through to classic OCR and the VLM presets were never exercised. docling-serve has
+**no server-side "default pipeline" switch**, so the fix must be **client-side**.
+
+The request field names were verified live against docling-serve v1.26.0's
+`GET /openapi.json`: `/v1/convert/file` really accepts the form fields `pipeline`,
+`vlm_pipeline_preset` and `image_export_mode`. (A wrong field name would be
+silently ignored and fall back to `standard` — i.e. exactly the bug.)
+
+## Decision
+
+Add two opt-in operator settings, shared by **both** docling touchpoints that call
+`convert_file()` (the image `DoclingProcessor` and the scanned-PDF
+`_DoclingServeBackend`):
+
+- **`DOCLING_PIPELINE`** ∈ {`standard`, `vlm`}, default `standard`.
+- **`DOCLING_VLM_PRESET`** `str | None`, default `None` (→ docling-serve picks its
+  own default preset).
+
+`convert_file()` gains `pipeline` / `vlm_pipeline_preset` keyword arguments. When
+`pipeline == "vlm"` it sends `pipeline=vlm`, the preset (if set) and
+`image_export_mode=placeholder`, and **omits** `do_ocr`/`ocr_lang`. Otherwise it
+emits exactly the pre-VLM request — the default path is byte-for-byte unchanged.
+
+### Design decisions
+
+- **D1 — client-selected, two settings.** No server default exists, so the client
+  chooses. One pair of settings feeds both touchpoints (both call `convert_file()`).
+- **D2 — omit `do_ocr`/`ocr_lang` under `vlm`.** They belong to the classic OCR
+  pipeline and are inert for VLM; sending them would be misleading.
+- **D3 — do not override the timeout; warn instead.** VLM inference is far slower
+  than classic OCR (typically 600–900s vs. the 120s default). Silently bumping the
+  timeout would hide a mis-provisioned deployment, so the default is left as-is and
+  the server logs a warning when `pipeline=vlm` is set with a timeout below 300s
+  (checked on both touchpoints).
+- **D4 — send `image_export_mode=placeholder` under `vlm`.** VLM output does not
+  need embedded page images; `placeholder` keeps the response lean.
+- **D5 — record the pipeline in metadata, keep `parsing_method`.** The result's
+  `parsing_metadata` gains `docling_pipeline` (`standard`/`vlm`); `parsing_method`
+  stays `"docling"` because the pipeline is a docling sub-detail, not a new backend.
+- **D6 — do not validate preset names.** Presets are defined by the docling-serve
+  instance and vary by deployment. An unknown preset produces a docling error that
+  already maps to `ProcessorError`, so client-side validation would only add a
+  brittle, deployment-specific allowlist.
+
+## Consequences
+
+- New env: `DOCLING_PIPELINE`, `DOCLING_VLM_PRESET`; `docling_pipeline` added to the
+  validated enum (`{standard, vlm}`). Both flow through the config dual-surface
+  (the Dynaconf image path and the `Settings`-dataclass OCR-backend path).
+- **Fully backward compatible.** With `DOCLING_PIPELINE` unset (default `standard`)
+  the request is identical to the ADR-031 client; nothing changes for existing
+  deployments.
+- **Operational note:** VLM needs a VLM-capable docling-serve (a preset backed by a
+  real inference engine). The CI `docling` lane uses the CPU image with no VLM
+  engine, so the VLM round-trip is covered by an **opt-in** integration test gated
+  on `DOCLING_PIPELINE=vlm`; unit tests assert the request schema (that
+  `pipeline=vlm` and the preset are actually sent) without needing an engine.
+- Sync-only and the timeout implication carry over from ADR-031: a VLM run is a long
+  synchronous convert, hence the larger recommended `DOCLING_TIMEOUT`. Async
+  submit/poll remains future work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -695,6 +695,8 @@ DOCLING_API_URL=http://docling:5001   # docling-serve base URL (required)
 DOCLING_TIMEOUT=120                   # image/force conversion timeout (seconds)
 DOCLING_OCR_LANG=en,de                # engine-dependent codes (EasyOCR: en,de; Tesseract: eng,deu)
 DOCLING_DO_OCR=true                   # run OCR (vs. text-layer extraction only)
+DOCLING_PIPELINE=standard             # "standard" (classic OCR) | "vlm" (vision-language model)
+DOCLING_VLM_PRESET=                   # VLM preset name when DOCLING_PIPELINE=vlm (unset = docling-serve default)
 ```
 
 **Required configuration per use case** (`auto` never selects docling — it needs
@@ -705,6 +707,7 @@ an explicit self-hosted URL):
 | Images auto-route to docling | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
 | Force docling on a text-layer PDF (`force_processor="docling"`) | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
 | Scanned / no-text-layer PDFs auto-OCR via docling | `DOCUMENT_OCR_ENABLED=true` + `DOCUMENT_OCR_PROVIDER=docling` + `DOCLING_API_URL` |
+| Drive docling-serve's **VLM** presets instead of classic OCR | any docling row above + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`, `DOCLING_TIMEOUT=600`–`900`) |
 
 The scanned-PDF row deliberately omits `ENABLE_DOCLING`/`ENABLE_DOCUMENT_PROCESSING`:
 that path rides the always-registered `ocr` tier during **indexing** (so it also
@@ -740,6 +743,22 @@ convert endpoint has an observed ~2 min practical ceiling (from our testing, not
 hard server-enforced limit), so a larger `DOCLING_TIMEOUT` (e.g. 300s for slow CPU
 OCR) simply lets a slow conversion finish; very large scans are future work (async
 submit/poll). See `docs/ADR-031-docling-document-parsing-backend.md`.
+
+**VLM pipeline (opt-in).** docling-serve can also transcribe with a
+vision-language model instead of classic OCR — often markedly better on messy
+scans, handwriting and complex layouts. The pipeline is **client-selected**: set
+`DOCLING_PIPELINE=vlm` and the docling client sends `pipeline=vlm` (plus
+`DOCLING_VLM_PRESET`, if set, and a lean `image_export_mode=placeholder`) on
+**both** the image and scanned-PDF touchpoints. Presets are defined by the
+docling-serve instance (e.g. `glm_ocr` backed by a local Ollama), so the client
+does not validate the name — an unknown preset surfaces as a docling error. Under
+`vlm` the classic `DOCLING_DO_OCR`/`DOCLING_OCR_LANG` knobs are inert and not sent.
+The default `standard` is byte-identical to the pre-VLM request, so leaving it
+unset changes nothing. **VLM inference is much slower than classic OCR** — raise
+`DOCLING_TIMEOUT` to 600–900s (the server warns if `vlm` is set with a timeout
+below 300s). The chosen pipeline is recorded in `parsing_metadata.docling_pipeline`
+while `parsing_method` stays `docling`. See
+`docs/ADR-032-docling-vlm-pipeline.md`.
 
 #### OCR execution mode: synchronous vs batch (Deck #332)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -692,11 +692,12 @@ HTTP — no ML dependencies are added to the server image. Run one via the
 ```dotenv
 ENABLE_DOCLING=false                  # master switch for the docling touchpoints
 DOCLING_API_URL=http://docling:5001   # docling-serve base URL (required)
-DOCLING_TIMEOUT=120                   # image/force conversion timeout (seconds)
+DOCLING_TIMEOUT=120                   # INTERACTIVE image/force read timeout (nc_webdav_read_file); keep client-friendly
 DOCLING_OCR_LANG=en,de                # engine-dependent codes (EasyOCR: en,de; Tesseract: eng,deu)
 DOCLING_DO_OCR=true                   # run OCR (vs. text-layer extraction only)
 DOCLING_PIPELINE=standard             # "standard" (classic OCR) | "vlm" (vision-language model)
 DOCLING_VLM_PRESET=                   # VLM preset name when DOCLING_PIPELINE=vlm (unset = docling-serve default)
+DOCUMENT_READ_TIMEOUT_SECONDS=        # opt-in cap on the interactive read parse; empty = disabled (see VLM note)
 ```
 
 **Required configuration per use case** (`auto` never selects docling — it needs
@@ -707,7 +708,8 @@ an explicit self-hosted URL):
 | Images auto-route to docling | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
 | Force docling on a text-layer PDF (`force_processor="docling"`) | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
 | Scanned / no-text-layer PDFs auto-OCR via docling | `DOCUMENT_OCR_ENABLED=true` + `DOCUMENT_OCR_PROVIDER=docling` + `DOCLING_API_URL` |
-| Drive docling-serve's **VLM** presets instead of classic OCR | any docling row above + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`, `DOCLING_TIMEOUT=600`–`900`) |
+| **VLM** for bulk PDF indexing (async, recommended) | scanned-PDF row + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`) + raise `DOCUMENT_OCR_TIMEOUT_SECONDS` (e.g. 600–900) |
+| **VLM** for interactive image/force reads | image/force row + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`); expect long blocking — see the VLM note below |
 
 The scanned-PDF row deliberately omits `ENABLE_DOCLING`/`ENABLE_DOCUMENT_PROCESSING`:
 that path rides the always-registered `ocr` tier during **indexing** (so it also
@@ -754,11 +756,34 @@ docling-serve instance (e.g. `glm_ocr` backed by a local Ollama), so the client
 does not validate the name — an unknown preset surfaces as a docling error. Under
 `vlm` the classic `DOCLING_DO_OCR`/`DOCLING_OCR_LANG` knobs are inert and not sent.
 The default `standard` is byte-identical to the pre-VLM request, so leaving it
-unset changes nothing. **VLM inference is much slower than classic OCR** — raise
-`DOCLING_TIMEOUT` to 600–900s (the server warns if `vlm` is set with a timeout
-below 300s). The chosen pipeline is recorded in `parsing_metadata.docling_pipeline`
-while `parsing_method` stays `docling`. See
-`docs/ADR-032-docling-vlm-pipeline.md`.
+unset changes nothing. The chosen pipeline is recorded in
+`parsing_metadata.docling_pipeline` while `parsing_method` stays `docling`.
+
+**VLM is much slower than classic OCR (~90–200s/page), so where you run it
+matters — and the two touchpoints have independent timeouts:**
+
+- **Bulk indexing (recommended for VLM):** with `DOCUMENT_OCR_PROVIDER=docling`,
+  scanned PDFs are transcribed on the **async ingest pipeline** (`mcp_role=worker`,
+  the `ingest-ocr` queue) and written to the search index. That path uses
+  **`DOCUMENT_OCR_TIMEOUT_SECONDS`** and never blocks a tool call — raise it freely
+  (e.g. 600–900s) for VLM.
+- **Interactive reads (`nc_webdav_read_file` on images / `force_processor="docling"`):**
+  these parse **synchronously** and block for up to **`DOCLING_TIMEOUT`**. Raising
+  `DOCLING_TIMEOUT` for VLM directly lengthens that block, and MCP clients usually
+  enforce a much shorter per-tool timeout (~30–60s) — so the client typically kills
+  the call before docling responds and you see a client timeout, not the tool's
+  base64 fallback. **Do not inflate `DOCLING_TIMEOUT` to force interactive VLM.**
+  Images are interactive-only (the ingest scanner is PDF-only), so interactive VLM
+  image reads inherently block.
+
+**`DOCUMENT_READ_TIMEOUT_SECONDS` (opt-in cap).** Set it to bound the synchronous
+parse inside `nc_webdav_read_file` (via `anyio.fail_after`), independent of
+`DOCLING_TIMEOUT` and of the worker path: when the cap trips, the tool returns
+base64 **fast** instead of hanging until the client times out. Default is empty
+(disabled) — no behavior change for existing reads. Set a client-friendly bound
+(e.g. 45–60s) if you want graceful fallback; leave it unset (and expect long calls)
+if you deliberately want interactive VLM with a tolerant client. It never affects
+the async ingest/worker path. See `docs/ADR-032-docling-vlm-pipeline.md`.
 
 #### OCR execution mode: synchronous vs batch (Deck #332)
 

--- a/env.sample
+++ b/env.sample
@@ -248,6 +248,13 @@ NEXTCLOUD_PASSWORD=
 #DOCLING_DO_OCR=true
 #DOCUMENT_OCR_ENABLED=false
 #DOCUMENT_OCR_PROVIDER=docling
+# Opt-in VLM pipeline (ADR-032). DOCLING_PIPELINE=vlm makes the docling client
+# drive docling-serve's VLM presets (e.g. glm_ocr via a local Ollama) instead of
+# classic OCR; DOCLING_VLM_PRESET names the preset (unset = docling-serve's own
+# default). do_ocr/ocr_lang are inert under vlm and are not sent. VLM is much
+# slower than classic OCR -- raise DOCLING_TIMEOUT to 600-900s.
+#DOCLING_PIPELINE=standard
+#DOCLING_VLM_PRESET=glm_ocr
 
 # ===== SSL/TLS =====
 # For Nextcloud behind reverse proxies with self-signed or private CA certificates

--- a/env.sample
+++ b/env.sample
@@ -243,6 +243,8 @@ NEXTCLOUD_PASSWORD=
 # a Tesseract-backed instance wants eng,deu).
 #ENABLE_DOCLING=false
 #DOCLING_API_URL=http://docling:5001
+# INTERACTIVE image/force read timeout (nc_webdav_read_file). Keep it client-friendly;
+# do NOT inflate it for VLM (see below) -- it only lengthens how long the tool blocks.
 #DOCLING_TIMEOUT=120
 #DOCLING_OCR_LANG=en,de
 #DOCLING_DO_OCR=true
@@ -252,9 +254,16 @@ NEXTCLOUD_PASSWORD=
 # drive docling-serve's VLM presets (e.g. glm_ocr via a local Ollama) instead of
 # classic OCR; DOCLING_VLM_PRESET names the preset (unset = docling-serve's own
 # default). do_ocr/ocr_lang are inert under vlm and are not sent. VLM is much
-# slower than classic OCR -- raise DOCLING_TIMEOUT to 600-900s.
+# slower than classic OCR (~90-200s/page): for bulk indexing use the ASYNC ingest
+# path (DOCUMENT_OCR_PROVIDER=docling + mcp_role=worker) and raise
+# DOCUMENT_OCR_TIMEOUT_SECONDS there -- it never blocks interactive reads.
 #DOCLING_PIPELINE=standard
 #DOCLING_VLM_PRESET=glm_ocr
+# Opt-in cap (seconds) on the SYNCHRONOUS parse inside nc_webdav_read_file. Unset =
+# disabled (interactive reads bounded only by DOCLING_TIMEOUT). Set a client-friendly
+# bound (e.g. 45-60) so a slow VLM/OCR read returns base64 fast instead of blocking
+# past your MCP client's own timeout. Never affects the async ingest path.
+#DOCUMENT_READ_TIMEOUT_SECONDS=60
 
 # ===== SSL/TLS =====
 # For Nextcloud behind reverse proxies with self-signed or private CA certificates

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -272,6 +272,8 @@ def initialize_document_processors():
                 timeout=docling_config["timeout"],
                 ocr_lang=docling_config["ocr_lang"],
                 do_ocr=docling_config["do_ocr"],
+                pipeline=docling_config.get("pipeline", "standard"),
+                vlm_preset=docling_config.get("vlm_preset"),
                 progress_interval=docling_config.get("progress_interval", 10),
             )
             registry.register(processor, priority=20)  # Above unstructured (10)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -169,6 +169,13 @@ _DEFAULTS: dict[str, Any] = {
     # PDF parse isolation (OOM guard)
     "document_pdf_graphics_limit": 1000,
     "document_parse_timeout_seconds": 120.0,
+    # Optional wall-clock cap (seconds) on the SYNCHRONOUS parse inside the
+    # nc_webdav_read_file MCP tool. None (default) = disabled: an interactive read
+    # is bounded only by the underlying processor timeout (DOCLING_TIMEOUT /
+    # DOCUMENT_OCR_TIMEOUT_SECONDS). Set a client-friendly bound (e.g. 45-60s) so a
+    # slow VLM/OCR convert returns base64 quickly instead of blocking past an MCP
+    # client's own timeout. Never applies to the async ingest/worker path (ADR-032).
+    "document_read_timeout_seconds": None,
     "document_parse_mem_limit_mb": 1536,
     # Pre-parse size cap (MB): PDFs larger than this fail fast with reason
     # "oversize" instead of burning the OCR timeout to 0 chars on a pathological
@@ -1013,6 +1020,13 @@ class Settings:
     # float so a fractional DOCUMENT_PARSE_TIMEOUT_SECONDS is honoured, matching
     # anyio.move_on_after's float seconds.
     document_parse_timeout_seconds: float = 120.0
+    # Optional cap (seconds) on the synchronous parse in the nc_webdav_read_file
+    # tool. None = disabled (bounded only by the processor timeout). When set,
+    # anyio.fail_after aborts a slow interactive convert and the tool returns
+    # base64 instead of blocking; it never affects the async ingest path (ADR-032).
+    # Distinct from document_parse_timeout_seconds, which caps the fast/structured
+    # PDF-parse subprocess, not the docling/OCR HTTP call.
+    document_read_timeout_seconds: float | None = None
     # Pre-parse PDF size cap (MB). A PDF larger than this fails fast with
     # parse_failed_reason="oversize" (placeholder marked "failed") rather than
     # being handed to the fast/OCR tiers, where a pathological large file burns
@@ -1290,6 +1304,29 @@ class Settings:
                 "routes through the embedding gateway); use DOCUMENT_OCR_MODE=sync "
                 "for the direct backend without a gateway"
             )
+        # Optional interactive read-parse cap (nc_webdav_read_file). Unset / empty =
+        # disabled; when set it must be a positive number of seconds. An empty string
+        # (a bare `DOCUMENT_READ_TIMEOUT_SECONDS=` from a compose passthrough) is
+        # treated as unset. Coerce so a dynaconf env string ("60") becomes a float for
+        # anyio.fail_after.
+        _read_cap = self.document_read_timeout_seconds
+        if isinstance(_read_cap, str):
+            _read_cap = _read_cap.strip() or None
+        if _read_cap is not None:
+            try:
+                _read_cap = float(_read_cap)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "DOCUMENT_READ_TIMEOUT_SECONDS must be a positive number of "
+                    "seconds (or unset to disable); got "
+                    f"{self.document_read_timeout_seconds!r}"
+                ) from None
+            if _read_cap < 1:
+                raise ValueError(
+                    "DOCUMENT_READ_TIMEOUT_SECONDS must be >= 1 second (or unset to "
+                    f"disable); got {_read_cap}"
+                )
+        self.document_read_timeout_seconds = _read_cap
         if (
             self.collection_metadata_source == "api"
             and not self.collection_metadata_api_url
@@ -1803,6 +1840,7 @@ def get_settings() -> Settings:
         "document_chunk_page_aware": "DOCUMENT_CHUNK_PAGE_AWARE",
         "document_pdf_graphics_limit": "DOCUMENT_PDF_GRAPHICS_LIMIT",
         "document_parse_timeout_seconds": "DOCUMENT_PARSE_TIMEOUT_SECONDS",
+        "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_classify_enabled": "DOCUMENT_CLASSIFY_ENABLED",

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -276,6 +276,13 @@ _DEFAULTS: dict[str, Any] = {
     # Run OCR on IMAGES routed to the DoclingProcessor (find_processor path). The
     # docling OCR *backend* (scanned PDFs) always OCRs regardless of this flag.
     "docling_do_ocr": True,
+    # Which docling-serve pipeline to request: "standard" (classic layout+OCR,
+    # default, unchanged) or "vlm" (Vision-LLM OCR). "vlm" needs a docling-serve
+    # instance configured with VLM presets (see ADR-032).
+    "docling_pipeline": "standard",
+    # VLM preset name sent when docling_pipeline == "vlm". None -> docling-serve
+    # picks its own DOCLING_SERVE_DEFAULT_VLM_PRESET. Preset names are server-defined.
+    "docling_vlm_preset": None,
     # Tag-based file exclusion (issue #710): comma-separated list of
     # Nextcloud system tag names. Files/folders carrying any of these tags
     # are hidden from WebDAV MCP tools. Empty = feature off.
@@ -752,6 +759,15 @@ def get_document_processor_config() -> dict[str, Any]:
                 "timeout": _dynaconf.get("DOCLING_TIMEOUT"),
                 "ocr_lang": [s.strip() for s in lang_str.split(",") if s.strip()],
                 "do_ocr": _dynaconf.get("DOCLING_DO_OCR"),
+                # Normalize like Settings.__post_init__ does (.strip().lower()) so the
+                # image path matches convert_file()'s ``pipeline == "vlm"`` check --
+                # otherwise DOCLING_PIPELINE=VLM would silently fall back to standard
+                # here while the OCR-backend path (Settings-validated) uses vlm.
+                # vlm_preset is server-defined and case-sensitive, so it stays raw.
+                "pipeline": (_dynaconf.get("DOCLING_PIPELINE") or "standard")
+                .strip()
+                .lower(),
+                "vlm_preset": _dynaconf.get("DOCLING_VLM_PRESET"),
                 "progress_interval": _dynaconf.get("PROGRESS_INTERVAL"),
             }
 
@@ -1053,6 +1069,8 @@ class Settings:
     # resolves to None (docling OCR off) and the image processor is not registered.
     docling_api_url: str | None = None
     docling_ocr_lang: str = "en,de"
+    docling_pipeline: str = "standard"
+    docling_vlm_preset: str | None = None
 
     # Observability settings
     metrics_enabled: bool = True
@@ -1223,6 +1241,7 @@ class Settings:
             "document_tier1_engine": {"pypdfium2", "pymupdf"},
             "document_ocr_provider": {"auto", "gateway", "mistral", "docling", "none"},
             "document_ocr_mode": {"sync", "batch"},
+            "docling_pipeline": {"standard", "vlm"},
         }
         for _field, _allowed in _enum_fields.items():
             _val = (getattr(self, _field) or "").strip().lower()
@@ -1805,6 +1824,8 @@ def get_settings() -> Settings:
         # image processor only (the OCR backend always OCRs), like the unstructured_* keys.
         "docling_api_url": "DOCLING_API_URL",
         "docling_ocr_lang": "DOCLING_OCR_LANG",
+        "docling_pipeline": "DOCLING_PIPELINE",
+        "docling_vlm_preset": "DOCLING_VLM_PRESET",
         # Observability settings
         "metrics_enabled": "METRICS_ENABLED",
         "metrics_port": "METRICS_PORT",

--- a/nextcloud_mcp_server/document_processors/docling_serve.py
+++ b/nextcloud_mcp_server/document_processors/docling_serve.py
@@ -119,10 +119,17 @@ async def convert_file(
     to_formats: list[str],
     do_ocr: bool = True,
     ocr_lang: list[str] | None = None,
+    pipeline: str | None = None,
+    vlm_pipeline_preset: str | None = None,
     timeout: float = 120.0,
 ) -> dict[str, Any]:
     """POST one document to docling-serve ``/v1/convert/file`` and return its
     ``document`` payload (``md_content``/``text_content``/``json_content``/...).
+
+    ``pipeline="vlm"`` drives docling-serve's Vision-LLM pipeline (optionally with a
+    server-defined ``vlm_pipeline_preset``); the default (``None``/``"standard"``)
+    requests the classic layout+OCR pipeline with byte-identical form fields to the
+    pre-VLM client. The response shape is the same for both pipelines.
 
     Raises :class:`ProcessorError` on HTTP error, a non-usable ``status``
     (anything but success/partial_success), or empty output -- so callers get a
@@ -137,15 +144,25 @@ async def convert_file(
     }
     # docling-serve reads repeated multipart fields for list params; httpx emits a
     # part per list item. Booleans go as lowercase strings for FastAPI coercion.
-    data: dict[str, Any] = {
-        "to_formats": list(to_formats),
-        "do_ocr": "true" if do_ocr else "false",
-    }
+    data: dict[str, Any] = {"to_formats": list(to_formats)}
     from_format = _from_format_for_mime(content_type)
     if from_format:
         data["from_formats"] = [from_format]
-    if ocr_lang:
-        data["ocr_lang"] = list(ocr_lang)
+    if pipeline == "vlm":
+        # VLM pipeline: docling-serve defaults an absent ``pipeline`` to "standard",
+        # so it must be requested explicitly. The classic OCR engine isn't used, so
+        # do_ocr/ocr_lang are inert and omitted. Select the (server-defined) preset
+        # when given, and keep base64 page images out of the markdown for lean text.
+        data["pipeline"] = "vlm"
+        if vlm_pipeline_preset:
+            data["vlm_pipeline_preset"] = vlm_pipeline_preset
+        data["image_export_mode"] = "placeholder"
+    else:
+        # Standard pipeline (default): byte-identical to pre-VLM requests -- no
+        # ``pipeline`` field is emitted, so existing deployments are unaffected.
+        data["do_ocr"] = "true" if do_ocr else "false"
+        if ocr_lang:
+            data["ocr_lang"] = list(ocr_lang)
 
     url = f"{api_url.rstrip('/')}/v1/convert/file"
     try:
@@ -208,19 +225,32 @@ class DoclingProcessor(DocumentProcessor):
         timeout: int = 120,
         ocr_lang: list[str] | None = None,
         do_ocr: bool = True,
+        pipeline: str = "standard",
+        vlm_preset: str | None = None,
         progress_interval: int = 10,
     ) -> None:
         self.api_url = api_url
         self.timeout = timeout
         self.ocr_lang = ocr_lang or ["en", "de"]
         self.do_ocr = do_ocr
+        self.pipeline = pipeline
+        self.vlm_preset = vlm_preset
         self.progress_interval = progress_interval
         logger.info(
-            "Initialized DoclingProcessor: %s, ocr_lang=%s, do_ocr=%s",
+            "Initialized DoclingProcessor: %s, pipeline=%s, ocr_lang=%s, do_ocr=%s",
             api_url,
+            pipeline,
             self.ocr_lang,
             do_ocr,
         )
+        # VLM OCR is ~30-150s per page; the 120s default is often too low. Warn
+        # (don't override) so the operator raises DOCLING_TIMEOUT deliberately (D3).
+        if pipeline == "vlm" and timeout < 300:
+            logger.warning(
+                "DOCLING_PIPELINE=vlm but DOCLING_TIMEOUT=%ss is low for Vision-LLM "
+                "OCR; consider raising it (e.g. >= 600)",
+                timeout,
+            )
 
     @property
     def name(self) -> str:
@@ -248,6 +278,8 @@ class DoclingProcessor(DocumentProcessor):
             to_formats=["md"],
             do_ocr=self.do_ocr,
             ocr_lang=self.ocr_lang,
+            pipeline=self.pipeline,
+            vlm_pipeline_preset=self.vlm_preset,
             timeout=self.timeout,
         )
         text = _document_text(document)
@@ -255,6 +287,7 @@ class DoclingProcessor(DocumentProcessor):
             text=text,
             metadata={
                 "parsing_method": "docling",
+                "docling_pipeline": self.pipeline,
                 "text_length": len(text),
             },
             processor=self.name,

--- a/nextcloud_mcp_server/document_processors/docling_serve.py
+++ b/nextcloud_mcp_server/document_processors/docling_serve.py
@@ -243,12 +243,19 @@ class DoclingProcessor(DocumentProcessor):
             self.ocr_lang,
             do_ocr,
         )
-        # VLM OCR is ~30-150s per page; the 120s default is often too low. Warn
-        # (don't override) so the operator raises DOCLING_TIMEOUT deliberately (D3).
-        if pipeline == "vlm" and timeout < 300:
+        # DoclingProcessor is the INTERACTIVE path (nc_webdav_read_file on images /
+        # force_processor="docling"). Under VLM a convert is slow (~30-150s/page) and
+        # blocks the tool call for up to DOCLING_TIMEOUT, which can exceed an MCP
+        # client's own timeout. Don't inflate DOCLING_TIMEOUT to "fix" this: for bulk
+        # VLM use the async ingest path (DOCUMENT_OCR_PROVIDER=docling, its own
+        # DOCUMENT_OCR_TIMEOUT_SECONDS), and set DOCUMENT_READ_TIMEOUT_SECONDS for a
+        # graceful base64 fallback on interactive reads (ADR-032).
+        if pipeline == "vlm":
             logger.warning(
-                "DOCLING_PIPELINE=vlm but DOCLING_TIMEOUT=%ss is low for Vision-LLM "
-                "OCR; consider raising it (e.g. >= 600)",
+                "DOCLING_PIPELINE=vlm makes nc_webdav_read_file a slow synchronous "
+                "convert (VLM ~30-150s/page, up to DOCLING_TIMEOUT=%ss) that can "
+                "exceed MCP client timeouts; prefer the async ingest path for bulk "
+                "and set DOCUMENT_READ_TIMEOUT_SECONDS to bound interactive reads",
                 timeout,
             )
 

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -326,9 +326,17 @@ class _DoclingServeBackend(_OcrBackend):
     (``DOCLING_API_URL``), for self-hosters who prefer docling's OCR over the
     gateway/Mistral backends (esp. photographed/handwritten text)."""
 
-    def __init__(self, api_url: str, ocr_lang: list[str] | None) -> None:
+    def __init__(
+        self,
+        api_url: str,
+        ocr_lang: list[str] | None,
+        pipeline: str = "standard",
+        vlm_preset: str | None = None,
+    ) -> None:
         self._api_url = api_url
         self._ocr_lang = ocr_lang or None
+        self._pipeline = pipeline
+        self._vlm_preset = vlm_preset
 
     async def ocr(
         self, content: bytes, mime_type: str
@@ -346,8 +354,11 @@ class _DoclingServeBackend(_OcrBackend):
             to_formats=["md", "json"],
             # This IS the OCR tier -- always OCR. (DOCLING_DO_OCR tunes only the
             # image processor; honoring it here would silently no-OCR scanned PDFs.)
+            # In VLM mode do_ocr is inert -- convert_file omits it.
             do_ocr=True,
             ocr_lang=self._ocr_lang,
+            pipeline=self._pipeline,
+            vlm_pipeline_preset=self._vlm_preset,
             timeout=ocr_timeout,
         )
         pages = docling_pages(document.get("json_content"))
@@ -460,7 +471,23 @@ def build_ocr_backend(
         lang = [
             s.strip() for s in (settings.docling_ocr_lang or "").split(",") if s.strip()
         ]
-        return _DoclingServeBackend(settings.docling_api_url, lang or None)
+        # VLM OCR is ~30-150s per page; the default 180s OCR timeout is often too
+        # low. Warn (don't override) so the operator raises it deliberately (D3).
+        if (
+            settings.docling_pipeline == "vlm"
+            and settings.document_ocr_timeout_seconds < 300
+        ):
+            logger.warning(
+                "DOCLING_PIPELINE=vlm but DOCUMENT_OCR_TIMEOUT_SECONDS=%.0fs is low "
+                "for Vision-LLM OCR; consider raising it (e.g. >= 600)",
+                settings.document_ocr_timeout_seconds,
+            )
+        return _DoclingServeBackend(
+            settings.docling_api_url,
+            lang or None,
+            settings.docling_pipeline,
+            settings.docling_vlm_preset,
+        )
 
     # An EXPLICIT provider that's missing its config is an operator error -- warn
     # loudly (once, since the backend is resolved+cached) rather than silently

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -1,11 +1,14 @@
 import base64
+import contextlib
 import logging
 
+import anyio
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models import DirectoryListing, FileInfo, SearchFilesResponse
 from nextcloud_mcp_server.observability.metrics import instrument_tool
@@ -151,6 +154,17 @@ def configure_webdav_tools(mcp: FastMCP):
         # Parse when the type is auto-parseable OR the caller forced a processor.
         # is_parseable_document() also checks that document processing is enabled.
         if force_processor is not None or is_parseable_document(content_type):
+            # Optional interactive cap (ADR-032): bound the SYNCHRONOUS parse so a
+            # slow VLM/OCR convert returns base64 quickly instead of blocking past
+            # the MCP client's own timeout. Read lazily so test/env overrides apply.
+            # Disabled (None) -> nullcontext, i.e. unchanged behavior. Only wraps this
+            # interactive tool; the async ingest/worker path is never bounded here.
+            read_cap = get_settings().document_read_timeout_seconds
+            cap_ctx = (
+                anyio.fail_after(read_cap)
+                if read_cap is not None
+                else contextlib.nullcontext()
+            )
             try:
                 logger.info(
                     "Parsing document %r of type %r%s",
@@ -160,13 +174,14 @@ def configure_webdav_tools(mcp: FastMCP):
                     if force_processor
                     else "",
                 )
-                parsed_text, metadata = await parse_document(
-                    content,
-                    content_type,
-                    filename=path,
-                    progress_callback=ctx.report_progress,
-                    processor_name=force_processor,
-                )
+                with cap_ctx:
+                    parsed_text, metadata = await parse_document(
+                        content,
+                        content_type,
+                        filename=path,
+                        progress_callback=ctx.report_progress,
+                        processor_name=force_processor,
+                    )
                 return {
                     "path": path,
                     "content": parsed_text,
@@ -175,6 +190,25 @@ def configure_webdav_tools(mcp: FastMCP):
                     "parsed": True,
                     "parsing_metadata": metadata,
                 }
+            except TimeoutError as e:
+                # Caught before the generic Exception (subclass-first). When the cap
+                # is set this is our anyio.fail_after tripping; when it is None the
+                # TimeoutError bubbled from a backend's own anyio timeout (e.g. the
+                # Mistral OCR path) -- either way base64 is the right fallback.
+                if read_cap is not None:
+                    logger.warning(
+                        "Parsing document %r exceeded the interactive read cap "
+                        "(%ss), falling back to base64",
+                        path,
+                        read_cap,
+                    )
+                else:
+                    logger.warning(
+                        "Failed to parse document %r, falling back to base64: %s",
+                        path,
+                        e,
+                    )
+                # Fall through to base64 encoding on timeout
             except Exception as e:
                 logger.warning(
                     "Failed to parse document %r, falling back to base64: %s",

--- a/tests/integration/test_docling_api.py
+++ b/tests/integration/test_docling_api.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.integration, pytest.mark.docling]
 
 _DOCLING_ENABLED = os.getenv("ENABLE_DOCLING", "false").lower() == "true"
+# The VLM round-trip needs a VLM-capable docling-serve (a VLM preset backed by a
+# real inference engine, e.g. glm_ocr via Ollama). The CI docling-serve-cpu image
+# has no such engine, so the VLM test is opt-in: it runs only when the operator
+# has deployed the MCP service with DOCLING_PIPELINE=vlm against such an instance.
+_DOCLING_VLM = _DOCLING_ENABLED and os.getenv("DOCLING_PIPELINE", "").lower() == "vlm"
 
 
 @pytest.fixture
@@ -97,6 +102,41 @@ async def test_docling_image_parsing(
         content = result["content"]
         assert isinstance(content, str) and content
         # OCR is imperfect; assert on a distinctive substring rather than equality.
+        assert "docling" in content.lower()
+    finally:
+        try:
+            await nc_client.webdav.delete_resource(test_file)
+        except Exception:
+            pass
+
+
+@pytest.mark.skipif(
+    not _DOCLING_VLM,
+    reason="Docling VLM pipeline is not configured (DOCLING_PIPELINE=vlm)",
+)
+async def test_docling_vlm_image_parsing(
+    nc_client: NextcloudClient, test_base_path: str, nc_mcp_client: ClientSession
+):
+    """With DOCLING_PIPELINE=vlm the same image auto-routes to docling and the VLM
+    preset transcribes it. parsing_method stays "docling"; the pipeline surfaces in
+    parsing_metadata. Manual/opt-in: needs a VLM-capable docling-serve."""
+    test_file = f"{test_base_path}/docling_vlm_image.png"
+    marker = "DoclingVlmHello"
+    try:
+        await nc_client.webdav.write_file(
+            test_file, create_text_image(marker), content_type="image/png"
+        )
+        mcp_result = await nc_mcp_client.call_tool(
+            "nc_webdav_read_file", arguments={"path": test_file}
+        )
+        result = _read_result(mcp_result)
+
+        assert result.get("parsed") is True
+        metadata = result["parsing_metadata"]
+        assert metadata["parsing_method"] == "docling"
+        assert metadata.get("docling_pipeline") == "vlm"
+        content = result["content"]
+        assert isinstance(content, str) and content
         assert "docling" in content.lower()
     finally:
         try:

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -79,7 +79,7 @@ class TestEnumValidation:
             ("document_tier1_engine", "mupdf"),
             ("document_ocr_provider", "gatway"),
             ("search_mode", "fulltext"),
-            ("docling_pipeline", "vllm")
+            ("docling_pipeline", "vllm"),
         ],
     )
     def test_invalid_enum_rejected(self, field, value):

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -107,6 +107,37 @@ class TestEnumValidation:
         assert Settings(docling_pipeline="vlm").docling_pipeline == "vlm"
 
 
+class TestReadTimeoutCap:
+    """Opt-in interactive read-parse cap (DOCUMENT_READ_TIMEOUT_SECONDS, ADR-032)."""
+
+    def test_default_is_disabled(self):
+        assert Settings().document_read_timeout_seconds is None
+
+    def test_numeric_string_coerced_to_float(self):
+        # dynaconf may hand the env value through as a string -> coerce for fail_after.
+        s = Settings(document_read_timeout_seconds="60")
+        assert s.document_read_timeout_seconds == pytest.approx(60.0)
+
+    def test_empty_string_disables(self):
+        # A bare DOCUMENT_READ_TIMEOUT_SECONDS= (compose passthrough) means "unset".
+        assert (
+            Settings(document_read_timeout_seconds="").document_read_timeout_seconds
+            is None
+        )
+        assert (
+            Settings(document_read_timeout_seconds="  ").document_read_timeout_seconds
+            is None
+        )
+
+    def test_below_one_rejected(self):
+        with pytest.raises(ValueError, match="DOCUMENT_READ_TIMEOUT_SECONDS"):
+            Settings(document_read_timeout_seconds=0)
+
+    def test_non_numeric_rejected(self):
+        with pytest.raises(ValueError, match="DOCUMENT_READ_TIMEOUT_SECONDS"):
+            Settings(document_read_timeout_seconds="abc")
+
+
 class TestIngestQueueResolution:
     def test_postgres_requires_postgres_url(self):
         # Explicit postgres against the default SQLite DATABASE_URL is a

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -85,6 +85,7 @@ class TestEnumValidation:
             ("document_tier1_engine", "mupdf"),
             ("document_ocr_provider", "gatway"),
             ("search_mode", "fulltext"),
+            ("docling_pipeline", "vllm"),
         ],
     )
     def test_invalid_enum_rejected(self, field, value):
@@ -100,6 +101,10 @@ class TestEnumValidation:
         assert (
             Settings(document_ocr_provider="docling").document_ocr_provider == "docling"
         )
+
+    def test_docling_pipeline_vlm_accepted(self):
+        # vlm is the opt-in pipeline that drives docling-serve's VLM presets, ADR-032.
+        assert Settings(docling_pipeline="vlm").docling_pipeline == "vlm"
 
 
 class TestIngestQueueResolution:

--- a/tests/unit/test_docling_processor.py
+++ b/tests/unit/test_docling_processor.py
@@ -89,6 +89,10 @@ async def test_convert_file_sends_multipart_options(mocker, monkeypatch):
     assert data["do_ocr"] == "true"
     assert data["ocr_lang"] == ["en", "de"]
     assert "files" in kwargs
+    # Backward-compat guard: no VLM fields on the default (standard) path.
+    assert "pipeline" not in data
+    assert "vlm_pipeline_preset" not in data
+    assert "image_export_mode" not in data
 
 
 async def test_convert_file_pdf_from_format(mocker, monkeypatch):
@@ -106,6 +110,53 @@ async def test_convert_file_pdf_from_format(mocker, monkeypatch):
     )
     _, kwargs = client.post.call_args
     assert kwargs["data"]["from_formats"] == ["pdf"]
+
+
+async def test_convert_file_vlm_pipeline(mocker, monkeypatch):
+    """pipeline='vlm' sends pipeline + preset + image_export_mode and OMITS the
+    classic do_ocr/ocr_lang (inert in VLM)."""
+    client = _mock_client(
+        mocker, json={"status": "success", "document": {"md_content": "vlm text"}}
+    )
+    monkeypatch.setattr(docling_serve.httpx, "AsyncClient", lambda *a, **k: client)
+
+    await docling_serve.convert_file(
+        "https://docling:5001",
+        b"\x89PNG",
+        "image/png",
+        to_formats=["md"],
+        do_ocr=True,
+        ocr_lang=["en", "de"],
+        pipeline="vlm",
+        vlm_pipeline_preset="glm_ocr",
+    )
+    data = client.post.call_args.kwargs["data"]
+    assert data["pipeline"] == "vlm"
+    assert data["vlm_pipeline_preset"] == "glm_ocr"
+    assert data["image_export_mode"] == "placeholder"
+    # classic-OCR fields are inert in VLM -> omitted
+    assert "do_ocr" not in data
+    assert "ocr_lang" not in data
+
+
+async def test_convert_file_vlm_without_preset(mocker, monkeypatch):
+    """pipeline='vlm' with no preset omits vlm_pipeline_preset (docling-serve picks
+    its own default)."""
+    client = _mock_client(
+        mocker, json={"status": "success", "document": {"md_content": "vlm text"}}
+    )
+    monkeypatch.setattr(docling_serve.httpx, "AsyncClient", lambda *a, **k: client)
+
+    await docling_serve.convert_file(
+        "https://docling:5001",
+        b"\x89PNG",
+        "image/png",
+        to_formats=["md"],
+        pipeline="vlm",
+    )
+    data = client.post.call_args.kwargs["data"]
+    assert data["pipeline"] == "vlm"
+    assert "vlm_pipeline_preset" not in data
 
 
 async def test_convert_file_http_error_raises_processor_error(mocker, monkeypatch):
@@ -199,6 +250,34 @@ async def test_process_image_returns_markdown(mocker, monkeypatch):
     assert result.processor == "docling"
     assert result.text == "handwritten text"
     assert result.metadata["parsing_method"] == "docling"
+    # Default (standard) pipeline is recorded in metadata; no VLM fields sent.
+    assert result.metadata["docling_pipeline"] == "standard"
+    data = client.post.call_args.kwargs["data"]
+    assert "pipeline" not in data
+
+
+async def test_process_image_vlm_pipeline(mocker, monkeypatch):
+    """A DoclingProcessor built with pipeline='vlm' forwards the VLM fields to
+    docling-serve and records the pipeline in parsing_metadata."""
+    client = _mock_client(
+        mocker,
+        json={"status": "success", "document": {"md_content": "vlm markdown"}},
+    )
+    monkeypatch.setattr(docling_serve.httpx, "AsyncClient", lambda *a, **k: client)
+
+    proc = DoclingProcessor(
+        "https://docling:5001", pipeline="vlm", vlm_preset="glm_ocr"
+    )
+    result = await proc.process(b"\x89PNG", "image/png", filename="note.png")
+    assert result.text == "vlm markdown"
+    assert result.metadata["docling_pipeline"] == "vlm"
+    # parsing_method stays "docling" -- pipeline is a sub-detail (D5).
+    assert result.metadata["parsing_method"] == "docling"
+    data = client.post.call_args.kwargs["data"]
+    assert data["pipeline"] == "vlm"
+    assert data["vlm_pipeline_preset"] == "glm_ocr"
+    assert data["image_export_mode"] == "placeholder"
+    assert "do_ocr" not in data
 
 
 async def test_process_pdf_when_forced(mocker, monkeypatch):

--- a/tests/unit/test_document_processor_config.py
+++ b/tests/unit/test_document_processor_config.py
@@ -116,6 +116,9 @@ class TestDocumentProcessorConfig:
             assert dcfg["ocr_lang"] == ["en", "de"]
             assert dcfg["timeout"] == 90
             assert dcfg["do_ocr"] is True
+            # VLM opt-in defaults: standard pipeline, no preset.
+            assert dcfg["pipeline"] == "standard"
+            assert dcfg["vlm_preset"] is None
         finally:
             for key in (
                 "ENABLE_DOCLING",
@@ -123,6 +126,32 @@ class TestDocumentProcessorConfig:
                 "DOCLING_OCR_LANG",
                 "DOCLING_TIMEOUT",
                 "DOCLING_DO_OCR",
+            ):
+                os.environ.pop(key, None)
+
+    def test_docling_vlm_pipeline_config(self):
+        """DOCLING_PIPELINE/DOCLING_VLM_PRESET flow into the docling processor
+        config so the image path can drive the VLM pipeline."""
+        os.environ["ENABLE_DOCLING"] = "true"
+        os.environ["DOCLING_API_URL"] = "https://docling:5001"
+        # Uppercase to prove the image path normalizes like Settings does; otherwise
+        # convert_file's `pipeline == "vlm"` check would silently use standard.
+        os.environ["DOCLING_PIPELINE"] = "VLM"
+        os.environ["DOCLING_VLM_PRESET"] = "glm_ocr"
+
+        try:
+            _reload_config()
+            config = get_document_processor_config()
+            dcfg = config["processors"]["docling"]
+            assert dcfg["pipeline"] == "vlm"
+            # Preset stays verbatim -- server-defined and case-sensitive (D6).
+            assert dcfg["vlm_preset"] == "glm_ocr"
+        finally:
+            for key in (
+                "ENABLE_DOCLING",
+                "DOCLING_API_URL",
+                "DOCLING_PIPELINE",
+                "DOCLING_VLM_PRESET",
             ):
                 os.environ.pop(key, None)
 

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -32,6 +32,8 @@ def _settings(**kw) -> Any:  # a Settings stand-in (only the read fields matter)
         mistral_base_url=None,
         docling_api_url=None,
         docling_ocr_lang="en,de",
+        docling_pipeline="standard",
+        docling_vlm_preset=None,
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -250,6 +252,25 @@ def test_build_backend_docling():
     assert isinstance(b, ocr._DoclingServeBackend)
     assert b._api_url == "https://docling:5001"
     assert b._ocr_lang == ["en", "de"]
+    # Default (standard) pipeline, no preset.
+    assert b._pipeline == "standard"
+    assert b._vlm_preset is None
+
+
+def test_build_backend_docling_vlm():
+    """DOCLING_PIPELINE=vlm + preset thread through to the OCR-backend (the scanned
+    -PDF path), so DOCUMENT_OCR_PROVIDER=docling can drive the VLM pipeline too."""
+    b = ocr.build_ocr_backend(
+        _settings(
+            document_ocr_provider="docling",
+            docling_api_url="https://docling:5001",
+            docling_pipeline="vlm",
+            docling_vlm_preset="glm_ocr",
+        )
+    )
+    assert isinstance(b, ocr._DoclingServeBackend)
+    assert b._pipeline == "vlm"
+    assert b._vlm_preset == "glm_ocr"
 
 
 def test_build_backend_docling_missing_url():

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -12,9 +12,11 @@ are transparent under our mocked ``Context`` (no ``access_token`` set →
 BasicAuth pass-through path).
 """
 
+import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import anyio
 import pytest
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
@@ -398,3 +400,78 @@ async def test_list_favorites_raises_when_scope_excluded(
         await fn(ctx=_mock_ctx(fake_client), scope="/Private")
 
     fake_client.webdav.list_favorites.assert_not_called()
+
+
+# ── Interactive read-parse cap (ADR-032) ────────────────────────────────
+
+
+async def test_read_file_interactive_cap_falls_back_to_base64(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """With DOCUMENT_READ_TIMEOUT_SECONDS set, a slow synchronous parse is aborted
+    at the cap and the tool returns base64 fast instead of blocking past the MCP
+    client's own timeout (ADR-032)."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.read_file = AsyncMock(return_value=(b"\x89PNG", "image/png"))
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(document_read_timeout_seconds=0.05),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.utils.document_parser.is_parseable_document",
+        return_value=True,
+    )
+
+    async def slow_parse(*_a, **_k):
+        await anyio.sleep(5)  # far beyond the 0.05s cap; fail_after cancels it
+
+    mocker.patch(
+        "nextcloud_mcp_server.utils.document_parser.parse_document",
+        side_effect=slow_parse,
+    )
+
+    ctx = _mock_ctx(fake_client)
+    ctx.report_progress = AsyncMock()
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/scan.png", ctx=ctx)
+
+    # Graceful base64 fallback, not the parsed-document shape.
+    assert result["encoding"] == "base64"
+    assert result["content"] == base64.b64encode(b"\x89PNG").decode("ascii")
+    assert "parsed" not in result
+
+
+async def test_read_file_no_cap_returns_parsed(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """With the cap disabled (None, the default), a normal parse is returned
+    unchanged -- the nullcontext path adds no behavior."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.read_file = AsyncMock(
+        return_value=(b"%PDF-1.7", "application/pdf")
+    )
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(document_read_timeout_seconds=None),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.utils.document_parser.is_parseable_document",
+        return_value=True,
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.utils.document_parser.parse_document",
+        return_value=("parsed text", {"parsing_method": "docling"}),
+    )
+
+    ctx = _mock_ctx(fake_client)
+    ctx.report_progress = AsyncMock()
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/doc.pdf", ctx=ctx)
+
+    assert result["parsed"] is True
+    assert result["content"] == "parsed text"
+    assert result["parsing_metadata"]["parsing_method"] == "docling"


### PR DESCRIPTION
## What & why

The merged docling integration (ADR-031, v0.128) only ever triggers docling-serve's
**standard** (classic OCR: EasyOCR/RapidOCR/Tesseract) pipeline — `convert_file()`
never sends a `pipeline` field, so docling-serve defaults to `standard`. A docling-serve
deployment running **VLM-only** (e.g. the `glm_ocr` preset backed by a local Ollama)
therefore never exercises its VLM presets: every request falls through to classic OCR.
docling-serve has **no server-side "default pipeline" switch**, so the fix needs to be client-side.

This adds two opt-in operator settings, shared by both docling touchpoints:

- `DOCLING_PIPELINE` ∈ `{standard, vlm}`, default `standard`.
- `DOCLING_VLM_PRESET` (`str | None`, default `None` → docling-serve picks its own default preset).

With `DOCLING_PIPELINE=vlm`, the client sends `pipeline=vlm`, the optional preset and a
lean `image_export_mode=placeholder`, and omits the inert classic `do_ocr`/`ocr_lang`
fields. The default `standard` request is **byte-identical** to the pre-VLM client, so
existing deployments are unaffected.

Field names (`pipeline`, `vlm_pipeline_preset`, `image_export_mode`) were verified live
against docling-serve v1.26.0's `/openapi.json` — a wrong name would be silently ignored
and fall back to `standard` (i.e. the bug).

## Design decisions

- **D1** Client-selected (no server default exists); one setting pair feeds both touchpoints.
- **D2** Omit `do_ocr`/`ocr_lang` under `vlm` — inert for VLM.
- **D3** Don't override the timeout; **warn** when `vlm` is set with a low timeout. VLM
  inference is far slower than classic OCR (~600–900s); silently bumping would hide a
  mis-provisioned deploy.
- **D4** Send `image_export_mode=placeholder` under `vlm` (lean output).
- **D5** Record `docling_pipeline` in `parsing_metadata`; `parsing_method` stays `docling`.
- **D6** Don't validate preset names — they're server-defined; an unknown preset already
  maps to `ProcessorError`.

## Changes

- `document_processors/docling_serve.py` — `convert_file()` gains `pipeline`/`vlm_pipeline_preset`;
  `DoclingProcessor` threads them through and warns on low `DOCLING_TIMEOUT`.
- `document_processors/ocr.py` — `_DoclingServeBackend` + `build_ocr_backend()` thread the
  settings through the scanned-PDF OCR path; warn on low `DOCUMENT_OCR_TIMEOUT_SECONDS`.
- `config.py` — both config surfaces (Dynaconf image path + `Settings` dataclass/env-map),
  `docling_pipeline` added to the validated enum. Image path lowercases to match `Settings`.
- Docs: **ADR-032** (extends ADR-031), `configuration.md` VLM section + use-case row.
- `env.sample` + `docker-compose.yml` mcp-service passthrough.

## Testing

- Unit: VLM request schema on both touchpoints (send vs. omit), a **backward-compat guard**
  asserting no `pipeline` field on the default path, config dual-surface (incl. uppercase
  normalization), enum accept/reject.
- Integration: an opt-in `test_docling_vlm_image_parsing` gated on `DOCLING_PIPELINE=vlm` —
  the CI docling-serve-cpu image has no VLM engine, so the round-trip is manual.

Fully backward compatible: unset `DOCLING_PIPELINE` → identical to the current client.