### PR TITLE
fix(ingest): skip WebDAV re-download on batch-OCR poll retries (Deck #518)

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -420,6 +420,38 @@ def build_gateway_batch_client(
     )
 
 
+# Module-level cached batch client for the poll fast-path (Deck #518). Built once
+# and reused so the GatewayTokenProvider's M2M token cache survives across the many
+# ~5s poll retries — mirrors OcrProcessor._get_batch_client (per-instance cache).
+# Without it, rebuilding the client on every poll forces a fresh OAuth
+# client_credentials fetch each retry, trading the skipped WebDAV download for a
+# token round-trip on M2M-auth gateways.
+_poll_batch_client: "GatewayBatchOcrClient | None" = None
+_poll_batch_client_resolved: bool = False
+_poll_batch_client_lock: "anyio.Lock | None" = None
+
+
+async def _get_poll_batch_client(settings: Settings) -> "GatewayBatchOcrClient | None":
+    global _poll_batch_client, _poll_batch_client_resolved, _poll_batch_client_lock
+    if not _poll_batch_client_resolved:
+        if _poll_batch_client_lock is None:
+            _poll_batch_client_lock = anyio.Lock()
+        async with _poll_batch_client_lock:
+            if not _poll_batch_client_resolved:  # double-checked
+                _poll_batch_client = build_gateway_batch_client(settings)
+                _poll_batch_client_resolved = True
+    return _poll_batch_client
+
+
+def _reset_poll_batch_client() -> None:
+    """Test hook: drop the cached poll client so a monkeypatched
+    ``build_gateway_batch_client`` (or fresh settings) takes effect on the next call."""
+    global _poll_batch_client, _poll_batch_client_resolved, _poll_batch_client_lock
+    _poll_batch_client = None
+    _poll_batch_client_resolved = False
+    _poll_batch_client_lock = None
+
+
 async def poll_pending_batch_ocr(
     *, user_id: str, doc_id: str, etag: str, settings: Settings
 ) -> int | None:
@@ -445,7 +477,7 @@ async def poll_pending_batch_ocr(
     job = await store.get(user_id=user_id, doc_id=doc_id, doc_type="file", etag=etag)
     if job is None:
         return None
-    client = build_gateway_batch_client(settings)
+    client = await _get_poll_batch_client(settings)
     if client is None:
         return None
     from ..embedding.gateway_batch_client import OcrBatchJobNotFound  # noqa: PLC0415

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -420,6 +420,53 @@ def build_gateway_batch_client(
     )
 
 
+async def poll_pending_batch_ocr(
+    *, user_id: str, doc_id: str, etag: str, settings: Settings
+) -> int | None:
+    """Fast-path the OCR poll loop (Deck #516): if a batch OCR job is already in
+    flight for this exact content (same ``etag``), poll it by ``job_id`` and return
+    how many seconds to defer while it is still PENDING — so the ingest worker can
+    re-defer WITHOUT re-downloading the file. A poll needs only the ``job_id``; the
+    file bytes are needed only to SUBMIT, and indexing uses the gateway's OCR text,
+    not the original bytes. Re-fetching the file over WebDAV on every poll retry was
+    ~half the OCR worker's single-slot wall-time, starving the co-resident GPU.
+
+    Returns ``None`` — meaning "fall through to the normal download + parse path" —
+    when: there is no in-flight job (nothing submitted yet); batch OCR isn't
+    configured; the gateway has no record of the job (re-submit, #1019); the poll is
+    TERMINAL (succeeded/failed — the pipeline re-polls and indexes the result, and
+    its post-parse quality gate needs the real bytes); or the give-up deadline has
+    passed (the pipeline marks it failed). Only a still-PENDING, within-deadline job
+    returns an int, and that is the ONLY case in which the caller may skip the fetch.
+    """
+    from ..vector.batch_ocr_store import BatchOcrJobStore  # noqa: PLC0415
+
+    store = await BatchOcrJobStore.shared()
+    job = await store.get(user_id=user_id, doc_id=doc_id, doc_type="file", etag=etag)
+    if job is None:
+        return None
+    client = build_gateway_batch_client(settings)
+    if client is None:
+        return None
+    from ..embedding.gateway_batch_client import OcrBatchJobNotFound  # noqa: PLC0415
+
+    try:
+        result = await client.poll(job.job_id)
+    except OcrBatchJobNotFound:
+        # Gateway purged/orphaned the job — fall through so the normal path re-hits
+        # the same 404 and re-submits (#1019), which needs the file bytes anyway.
+        return None
+    if not result.is_pending:
+        return None  # terminal — fall through to index the result via the pipeline
+    # Honour the same give-up deadline as _process_batch so a stuck job isn't polled
+    # forever without ever re-fetching; past it, fall through so the normal path
+    # fails it (deletes the tracking row + records the metric).
+    elapsed = int(time.time()) - job.submitted_at
+    if elapsed >= settings.document_ocr_batch_max_wait_seconds:
+        return None
+    return settings.document_ocr_batch_poll_seconds
+
+
 def build_ocr_backend(
     settings: Settings, *, model: str | None = None
 ) -> _OcrBackend | None:

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1139,10 +1139,12 @@ async def _index_document(
             # (~half the OCR worker's single-slot wall-time; the GPU starved while the
             # worker re-fetched files). Only a TERMINAL poll falls through to the
             # download + index path below (which re-polls and needs the real bytes for
-            # the post-parse quality gate). Gated on ``tier`` (batch OCR is the
-            # per-tier worker path only, where ``BatchPending`` is a handled signal).
+            # the post-parse quality gate). Gated on ``tier == "ocr"``: only the OCR
+            # tier ever writes rows to BatchOcrJobStore, so fast/structured tiers skip
+            # the store lookup entirely, and it's the per-tier worker path where
+            # ``BatchPending`` is a handled control-flow signal.
             if (
-                tier is not None
+                tier == "ocr"
                 and settings.document_ocr_mode == "batch"
                 and doc_task.etag
             ):

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1131,6 +1131,37 @@ async def _index_document(
                 )
                 return
 
+            # Deck #516: the file bytes are needed only to SUBMIT an OCR job — a
+            # poll uses the gateway job_id and indexing uses the OCR text the gateway
+            # returns, not the original bytes. When a batch OCR job is already in
+            # flight for this content, poll it FIRST and, while it is still pending,
+            # defer WITHOUT the WebDAV re-download that otherwise ran on EVERY retry
+            # (~half the OCR worker's single-slot wall-time; the GPU starved while the
+            # worker re-fetched files). Only a TERMINAL poll falls through to the
+            # download + index path below (which re-polls and needs the real bytes for
+            # the post-parse quality gate). Gated on ``tier`` (batch OCR is the
+            # per-tier worker path only, where ``BatchPending`` is a handled signal).
+            if (
+                tier is not None
+                and settings.document_ocr_mode == "batch"
+                and doc_task.etag
+            ):
+                from nextcloud_mcp_server.document_processors.escalation import (  # noqa: PLC0415
+                    BatchPending,
+                )
+                from nextcloud_mcp_server.document_processors.ocr import (  # noqa: PLC0415
+                    poll_pending_batch_ocr,
+                )
+
+                retry_in = await poll_pending_batch_ocr(
+                    user_id=doc_task.user_id,
+                    doc_id=doc_task.doc_id,
+                    etag=doc_task.etag,
+                    settings=settings,
+                )
+                if retry_in is not None:
+                    raise BatchPending(retry_in=retry_in)
+
             # Read file content via WebDAV
             content_bytes, content_type = await nc_client.webdav.read_file(file_path)
         else:

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -912,3 +912,91 @@ async def test_batch_submit_transport_error_propagates_not_caught(monkeypatch):
             b"%PDF", "application/pdf", options=dict(_IDENTITY)
         )
     assert sync_backend_used is False  # never fell back to the sync path
+
+
+# --- poll_pending_batch_ocr: skip the WebDAV re-download on OCR polls (Deck #516) ---
+
+
+async def test_poll_pending_no_job_falls_through(monkeypatch):
+    """No in-flight job -> None: the caller downloads + submits normally."""
+    _wire_batch(monkeypatch, client=_FakeBatchClient(), store=_FakeStore())
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(document_ocr_mode="batch"),
+    )
+    assert got is None
+
+
+async def test_poll_pending_defers_without_download(monkeypatch):
+    """A still-pending job within its deadline -> return the poll interval so the
+    caller defers WITHOUT re-downloading the file (the win: polled by job_id only)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)  # within deadline
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_batch_poll_seconds=120
+        ),
+    )
+    assert got == 120
+    assert client.polled == ["surya/j"]  # polled by job_id; never submitted/fetched
+
+
+async def test_poll_pending_terminal_falls_through(monkeypatch):
+    """A terminal (succeeded) job -> None so the caller re-polls + indexes via the
+    pipeline (whose post-parse quality gate needs the real bytes)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(status="succeeded", pages=[(0, "hello", None)])
+    )
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(document_ocr_mode="batch"),
+    )
+    assert got is None
+
+
+async def test_poll_pending_past_deadline_falls_through(monkeypatch):
+    """Past the give-up deadline -> None (never re-fetched, never polled forever)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0 + 61)  # past 60s deadline
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_batch_max_wait_seconds=60
+        ),
+    )
+    assert got is None
+
+
+async def test_poll_pending_job_gone_falls_through(monkeypatch):
+    """Gateway 404 (job purged) -> None so the caller re-submits (#1019)."""
+    from nextcloud_mcp_server.embedding.gateway_batch_client import OcrBatchJobNotFound
+
+    class _NotFoundClient(_FakeBatchClient):
+        async def poll(self, job_id):
+            raise OcrBatchJobNotFound(job_id)
+
+    preset = SimpleNamespace(job_id="surya/gone", submitted_at=1000)
+    _wire_batch(monkeypatch, client=_NotFoundClient(), store=_FakeStore(preset=preset))
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(document_ocr_mode="batch"),
+    )
+    assert got is None

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -656,6 +656,9 @@ def _wire_batch(monkeypatch, *, client, store, settings=None):
     )
     monkeypatch.setattr(ocr, "get_settings", lambda: settings)
     monkeypatch.setattr(ocr, "build_gateway_batch_client", lambda s, **kw: client)
+    # Drop the module-level poll-client cache so poll_pending_batch_ocr rebuilds via
+    # the just-monkeypatched build_gateway_batch_client rather than a stale fake.
+    ocr._reset_poll_batch_client()
 
     async def _shared(cls):
         return store

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -31,6 +31,9 @@ pytestmark = pytest.mark.unit
 def _settings(*, ocr_enabled: bool) -> SimpleNamespace:
     return SimpleNamespace(
         document_ocr_enabled=ocr_enabled,
+        # A real Settings always carries this; "sync" keeps the Deck #516
+        # skip-redownload guard in process_document inert on these non-batch paths.
+        document_ocr_mode="sync",
         document_tier1_engine="pypdfium2",
         get_collection_name=lambda: "c",
     )

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -21,7 +21,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nextcloud_mcp_server.document_processors.base import ProcessingResult
-from nextcloud_mcp_server.document_processors.escalation import EscalateError
+from nextcloud_mcp_server.document_processors.escalation import (
+    BatchPending,
+    EscalateError,
+)
 from nextcloud_mcp_server.vector import processor
 from nextcloud_mcp_server.vector.scanner import DocumentTask
 
@@ -285,3 +288,58 @@ async def test_delete_clears_dead_letter_marker(mocker):
     await processor.process_document(task, MagicMock(), max_retries=1)
 
     clear.assert_awaited_once_with("520189", "file")
+
+
+async def test_batch_ocr_pending_defers_before_download(mocker):
+    """Deck #518: a still-pending batch OCR job defers via BatchPending BEFORE the
+    WebDAV fetch — the whole point of the change (no re-download on poll retries).
+
+    Guards the call ordering at the integration point: ``poll_pending_batch_ocr``
+    returning a non-None interval must short-circuit to ``BatchPending`` without ever
+    reaching ``nc_client.webdav.read_file``."""
+    settings = _settings(ocr_enabled=True)
+    settings.document_ocr_mode = "batch"  # activate the pre-read poll fast-path
+    mocker.patch.object(processor, "get_settings", lambda: settings)
+    mocker.patch.object(
+        processor, "claim_existing_index", AsyncMock(return_value=False)
+    )
+    # The poll fast-path reports the job is still pending -> defer for 120s.
+    poll = mocker.patch(
+        "nextcloud_mcp_server.document_processors.ocr.poll_pending_batch_ocr",
+        AsyncMock(return_value=120),
+    )
+    nc = _nc_client()
+
+    with pytest.raises(BatchPending) as ei:
+        await processor._index_document(_file_task(), nc, MagicMock(), tier="ocr")
+
+    assert ei.value.retry_in == 120
+    poll.assert_awaited_once()
+    nc.webdav.read_file.assert_not_awaited()  # the win: no re-download on a poll
+
+
+async def test_batch_ocr_no_pending_job_still_downloads(mocker):
+    """The inverse guard: when poll_pending_batch_ocr returns None (no in-flight
+    job), _index_document falls through to the normal fetch (read_file IS called)."""
+    settings = _settings(ocr_enabled=True)
+    settings.document_ocr_mode = "batch"
+    mocker.patch.object(processor, "get_settings", lambda: settings)
+    mocker.patch.object(
+        processor, "claim_existing_index", AsyncMock(return_value=False)
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.document_processors.ocr.poll_pending_batch_ocr",
+        AsyncMock(return_value=None),
+    )
+    # Stop after the fetch so we only assert the download happened, not full indexing.
+    mocker.patch.object(
+        processor,
+        "_parse_pdf_tier",
+        AsyncMock(side_effect=BatchPending(retry_in=99)),
+    )
+    nc = _nc_client()
+
+    with pytest.raises(BatchPending):
+        await processor._index_document(_file_task(), nc, MagicMock(), tier="ocr")
+
+    nc.webdav.read_file.assert_awaited_once()  # no in-flight job -> fetched normally


### PR DESCRIPTION
## Problem

During the Deck #516 dual-vLLM benchmark the GPU sat at **~0% util with hundreds of docs pending**. Root cause: `process_document` re-downloads the whole file via WebDAV (~2.4 s) on **every 5 s batch-OCR poll retry** — but a poll needs only the gateway `job_id`, and indexing uses the gateway's returned OCR **text**, not the original bytes. On the single-slot (`concurrency=1`) OCR worker this burned **~half the wall-time re-fetching files**, draining ~9 docs/min against the dual-vLLM GPU's ~30/min capacity → starved.

Job-timeline evidence: every `process_document` ran ~2.5–3.3 s, **including the ones that were just polls** of still-pending jobs (they re-downloaded before polling).

## Fix

New `poll_pending_batch_ocr()` (`document_processors/ocr.py`): check the batch store, poll the in-flight job **by `job_id`**, and return the defer interval **while it's still PENDING** (within `document_ocr_batch_max_wait_seconds`). `process_document` calls it **before** `read_file` and raises `BatchPending` on a pending job — deferring **without the download**.

Only a **terminal** poll (or no job / gateway-404 / past-deadline) returns `None` → falls through to the normal download+parse path, which re-polls and indexes the result (the post-parse quality gate + `_classify_result` need the real bytes). Submit and index paths are unchanged.

## Why it's safe

- **Pending** raises `BatchPending` before `read_file` — caught by the existing `control_flow_excs` handler and re-raised to the retry strategy (verified: `processor.py:861`). OCR is the top tier, so a terminal poll must reach the real-bytes path for `evaluate_escalation`; hence only *pending* skips the fetch.
- Gated on `tier is not None and document_ocr_mode == "batch"` (the per-tier worker path where batch OCR + `BatchPending` exist).

## Tests

5 new cases for `poll_pending_batch_ocr` (no-job / pending-defers / terminal-falls-through / past-deadline / gateway-404). Existing OCR, `parse_pdf_tier`, and dead-letter suites pass (299 green); added the now-required `document_ocr_mode` to the dead-letter settings stand-in. `ruff` + `ty` clean.

## Expected impact

~2–3× the OCR worker's drain rate (polls become ~0.1 s instead of ~2.5 s), so the gateway keeps its 24-way drain — and the GPU — **fed** while `todo` remains. Prerequisite for a meaningful spec-decode A/B (astrolabe-cloud-gitops#542).

Deck #518.

---

_This PR was generated with the help of AI, and reviewed by a Human_