### PR TITLE
fix(ocr): re-queue on transient OCR-backend outage instead of dead-lettering (Deck #523)

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -60,6 +60,38 @@ _OCR_CONNECT_TIMEOUT_SECONDS = 10.0
 OCR_BATCH_PENDING_KEY = "ocr_batch_pending"
 OCR_BATCH_RETRY_IN_KEY = "ocr_batch_retry_in"
 
+# Substrings (matched case-insensitively) on a FAILED batch OCR job's error that
+# mark a TRANSIENT OCR-backend/infra outage — the OCR service (GPU / gateway) was
+# unreachable or not yet ready — as opposed to a genuine per-document parse error.
+# A backend outage MUST NOT dead-letter the document: retrying once the backend is
+# back succeeds, whereas a real parse error never improves on retry. Treating a GPU
+# outage as terminal permanently dropped scanned docs from the index (Deck #523 —
+# "surya OCR unavailable: GPU did not become ready within 1800s" → dead-lettered).
+_TRANSIENT_OCR_BACKEND_MARKERS: tuple[str, ...] = (
+    "did not become ready",  # gateway GPU boot-wait expired: GPU offline/booting/slow
+    "ocr unavailable",  # surya provider: backend not ready/reachable
+    "unavailable",  # service/backend/temporarily unavailable (incl. HTTP 503)
+    "not ready",
+    "connection refused",
+    "connection error",
+    "connection reset",
+    "bad gateway",  # HTTP 502
+    "gateway timeout",  # HTTP 504
+    "read timeout",  # httpx transport timeout reaching the gateway/GPU
+)
+
+
+def _is_transient_ocr_backend_error(error: str | None) -> bool:
+    """Whether a failed batch OCR job's error is a TRANSIENT backend/infra outage
+    (GPU offline/booting, gateway unreachable) rather than a genuine per-document
+    parse failure. Transient errors must re-queue (never dead-letter) so the
+    document waits for the OCR backend to recover (Deck #523)."""
+    if not error:
+        return False
+    haystack = error.lower()
+    return any(marker in haystack for marker in _TRANSIENT_OCR_BACKEND_MARKERS)
+
+
 # Metadata key carrying per-block geometry from a layout-aware OCR backend (surya
 # via the gateway). A list of ``{"page", "bbox", "start_offset", "end_offset"}``:
 # the block's normalized [0,1] ``bbox`` plus its char span in the document text,
@@ -865,15 +897,30 @@ class OcrProcessor(DocumentProcessor):
         # Terminal — drop the tracking row either way.
         await store.delete(user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag)
         if result.is_failed:
-            logger.warning(
-                "batch OCR job %s failed: %s", job.job_id, result.error or "unknown"
-            )
+            err = result.error or "unknown"
+            if _is_transient_ocr_backend_error(result.error):
+                # A TRANSIENT OCR-backend/infra outage (GPU offline/booting, gateway
+                # unreachable) is NOT a document failure — terminalizing it here lets
+                # the processor dead-letter a perfectly parseable scan, permanently
+                # dropping it from every future re-index (Deck #523). The tracking
+                # row is already dropped above, so return the pending sentinel: the
+                # doc re-queues and re-submits a fresh job next cycle, staying queued
+                # until the OCR backend recovers. Only GENUINE per-document parse
+                # errors fall through to the terminal failure below.
+                logger.warning(
+                    "batch OCR job %s hit a transient OCR-backend outage (%s); "
+                    "re-queuing (NOT dead-lettering) until the backend recovers",
+                    job.job_id,
+                    err,
+                )
+                return self._pending(poll_seconds)
+            logger.warning("batch OCR job %s failed: %s", job.job_id, err)
             return ProcessingResult(
                 text="",
                 metadata={"parse_failed_reason": "error"},
                 processor=self.name,
                 success=False,
-                error=f"batch OCR failed: {result.error or 'unknown'}",
+                error=f"batch OCR failed: {err}",
             )
         if not result.is_succeeded:
             # Defensive: poll() maps anything that isn't "succeeded" to its raw

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -792,6 +792,56 @@ async def test_batch_failed_marks_parse_error(monkeypatch):
     assert ("u1", "d1", "file", "v1") in store.deleted
 
 
+async def test_batch_failed_transient_backend_requeues(monkeypatch):
+    # A batch job that FAILED because the OCR backend was transiently unavailable
+    # (GPU offline/booting, gateway unreachable) must NOT terminalize — it returns
+    # the pending sentinel so the document re-queues and stays queued until the
+    # backend recovers, instead of being dead-lettered + permanently dropped from
+    # every future re-index (Deck #523).
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(
+            status="failed",
+            pages=[],
+            error="surya OCR unavailable: GPU did not become ready within 1800s",
+        )
+    )
+    store = _FakeStore(preset=preset)
+    _wire_batch(monkeypatch, client=client, store=store)
+
+    r = await ocr.OcrProcessor().process(
+        b"%PDF", "application/pdf", options=dict(_IDENTITY)
+    )
+
+    # Pending sentinel (re-queue), NOT a terminal parse failure → no dead-letter.
+    assert r.success is False
+    assert r.metadata.get(ocr.OCR_BATCH_PENDING_KEY) is True
+    assert "parse_failed_reason" not in r.metadata
+    # Tracking row is dropped either way, so the next cycle re-submits a fresh job.
+    assert ("u1", "d1", "file", "v1") in store.deleted
+
+
+@pytest.mark.parametrize(
+    "error, transient",
+    [
+        ("surya OCR unavailable: GPU did not become ready within 1800s", True),
+        ("OCR unavailable", True),
+        ("503 Service Unavailable", True),
+        ("Connection refused", True),
+        ("502 Bad Gateway", True),
+        ("gateway timeout", True),
+        ("read timeout", True),
+        (None, False),
+        ("", False),
+        ("invalid PDF: xref table broken", False),
+        ("unsupported image colorspace", False),
+        ("x", False),
+    ],
+)
+def test_is_transient_ocr_backend_error(error, transient):
+    assert ocr._is_transient_ocr_backend_error(error) is transient
+
+
 async def test_batch_unexpected_status_marks_failed_not_empty_success(monkeypatch):
     # A terminal status that isn't succeeded/failed (gateway skew) must NOT
     # produce a 0-chunk "success" that silently indexes empty text + loops.


### PR DESCRIPTION
## Data-loss bug (go-live blocker)

When the on-demand OCR GPU is unavailable beyond the gateway's boot-wait (`SURYA_GPU_BOOT_MAX_WAIT_SECONDS=1800s`) — leaf.cloud reclaim, maintenance, slow boot, or an operator pinning it down — the embedding-gateway marks the batch OCR job **failed** with `surya OCR unavailable: GPU did not become ready within 1800s`. `document_processors/ocr.py` (`is_failed` branch) returned this as a **terminal** `ProcessingResult(success=False)`. Because `tier=ocr` has no escalation target, `vector/processor.py` **dead-lettered** the document with a **durable, content-addressed marker**, and `scanner.py` then **skipped re-queuing it on every future re-index** → the scan was **permanently dropped**.

**Impact:** the smoke-test tenant indexed **984 of ~1470** docs; ~486 OCR-tier scans (`/OHR-Bench/textbook/*.pdf`) were silently, permanently lost. In production, *any* GPU outage during ingest drops a tenant's scanned documents.

## Root cause
`ocr.py` did not distinguish a **transient backend/infra outage** (GPU offline/booting, gateway unreachable — retry later succeeds) from a **genuine per-document parse error** (retry never helps). Both terminalized → dead-letter.

## Fix
Classify a failed job's error: backend/infra markers (`did not become ready`, `*unavailable`, `not ready`, `connection refused/error/reset`, `bad gateway`, `gateway timeout`, `read timeout`) are **transient** → return the `_pending` sentinel (the tracking row is already dropped, so the doc re-queues and re-submits a fresh job next cycle) → it **stays queued until the OCR backend recovers** and is **never dead-lettered on infra**. Only genuine per-document parse errors terminalize.

## Tests
- `test_batch_failed_transient_backend_requeues` — a `failed` job with the GPU-not-ready error returns the pending sentinel (`OCR_BATCH_PENDING_KEY`), **no** `parse_failed_reason` → no dead-letter.
- `test_is_transient_ocr_backend_error` — parametrized transient-vs-genuine table.
- Existing `test_batch_failed_marks_parse_error` (genuine error → terminal) unchanged. Full `test_ocr_processor.py` + `test_processor_dead_letter.py`: **87 passed**; ruff + ty clean.

## Follow-ups (Deck #523)
- **Gateway-side:** don't mark a job `failed` on GPU-boot timeout — keep it pending/retryable (so it doesn't even round-trip through this classifier).
- **Recover already-lost docs:** clear the stale dead-letter markers written by past outages so a re-index re-attempts them.

Deck #523.