### PR TITLE
fix(ocr): poll batch OCR jobs forever + honour gateway Retry-After (Deck #523)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -748,7 +748,6 @@ The OCR tier has two execution modes, selected by `DOCUMENT_OCR_MODE`:
 ```dotenv
 DOCUMENT_OCR_MODE=sync                 # "sync" (default) | "batch"
 DOCUMENT_OCR_BATCH_POLL_SECONDS=120    # re-poll cadence for a batch job (default: 120)
-DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS=86400  # give up + mark timeout after this (default: 24h)
 ```
 
 - **`sync`** (default) — transcribe the document inline via the backend's
@@ -773,11 +772,15 @@ there.
 
 Mechanics: the OCR tier submits the job, records its id in the `batch_ocr_jobs`
 app-DB table (keyed on the document + its etag), and raises a re-poll deferral so
-procrastinate re-runs the tier after `DOCUMENT_OCR_BATCH_POLL_SECONDS` — releasing
-the worker slot between polls (a long batch never pins a worker or is reclaimed as
-stalled). On completion the per-page markdown is indexed exactly like the sync
-path; a failure or a job exceeding `DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS` marks the
-document parse-failed. Each poll re-fetches + re-classifies the PDF (a known v1
+procrastinate re-runs the tier after `DOCUMENT_OCR_BATCH_POLL_SECONDS` (or the
+gateway's `Retry-After` when longer, so a large pending backlog can't storm it) —
+releasing the worker slot between polls (a long batch never pins a worker or is
+reclaimed as stalled). On completion the per-page markdown is indexed exactly like
+the sync path. A pending job is polled **indefinitely**: once the gateway accepts a
+document it owns the OCR lifecycle (Deck #523), so there is no worker-side give-up
+deadline — a transient backend/GPU outage only delays completion, never fails the
+document. Only a job-level failure (or a per-document error inside a succeeded job)
+marks the document parse-failed. Each poll re-fetches + re-classifies the PDF (a known v1
 inefficiency, bounded by the poll cadence); one batch job is submitted per
 document (coalescing many documents per job is a planned follow-up).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -773,7 +773,9 @@ there.
 Mechanics: the OCR tier submits the job, records its id in the `batch_ocr_jobs`
 app-DB table (keyed on the document + its etag), and raises a re-poll deferral so
 procrastinate re-runs the tier after `DOCUMENT_OCR_BATCH_POLL_SECONDS` (or the
-gateway's `Retry-After` when longer, so a large pending backlog can't storm it) —
+gateway's `Retry-After` when longer, so a large pending backlog can't storm it —
+capped at an internal 1h ceiling, `_BATCH_POLL_MAX_DEFER_SECONDS`, so a
+malformed/absurd header can't stall a poll unboundedly) —
 releasing the worker slot between polls (a long batch never pins a worker or is
 reclaimed as stalled). On completion the per-page markdown is indexed exactly like
 the sync path. A pending job is polled **indefinitely**: once the gateway accepts a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -774,8 +774,9 @@ Mechanics: the OCR tier submits the job, records its id in the `batch_ocr_jobs`
 app-DB table (keyed on the document + its etag), and raises a re-poll deferral so
 procrastinate re-runs the tier after `DOCUMENT_OCR_BATCH_POLL_SECONDS` (or the
 gateway's `Retry-After` when longer, so a large pending backlog can't storm it —
-capped at an internal 1h ceiling, `_BATCH_POLL_MAX_DEFER_SECONDS`, so a
-malformed/absurd header can't stall a poll unboundedly) —
+capped at an internal 1h ceiling, `_BATCH_POLL_MAX_DEFER_SECONDS`, or the poll
+interval if that is set higher, so a malformed/absurd header can't stall a poll
+unboundedly) —
 releasing the worker slot between polls (a long batch never pins a worker or is
 reclaimed as stalled). On completion the per-page markdown is indexed exactly like
 the sync path. A pending job is polled **indefinitely**: once the gateway accepts a

--- a/nextcloud_mcp_server/alembic/versions/20260615_1200_008_add_batch_ocr_jobs.py
+++ b/nextcloud_mcp_server/alembic/versions/20260615_1200_008_add_batch_ocr_jobs.py
@@ -4,8 +4,9 @@ Deck #332 / embedding-gateway batch OCR (astrolabe-cloud-website#372). When
 ``DOCUMENT_OCR_MODE=batch`` the OCR tier submits a document to the gateway's
 async ``POST /v1/ocr/batch`` and must re-poll ``GET /v1/ocr/batch/{job_id}``
 across procrastinate retries. procrastinate job args are immutable, so the
-gateway ``job_id`` (and submit time, for the poll deadline) are persisted here,
-keyed on the document + its content version (``etag``).
+gateway ``job_id`` (and submit time, for job-age observability) are persisted
+here, keyed on the document + its content version (``etag``). A pending job is
+polled indefinitely — no worker-side give-up deadline (Deck #523).
 
 One row per in-flight job; the row is deleted once the job reaches a terminal
 state. Empty + unused unless batch mode is enabled (gateway-only), so OSS/SQLite
@@ -48,8 +49,9 @@ def upgrade() -> None:
         # The gateway's namespaced batch job id ("<provider>/<batch_job_id>") —
         # the only handle for polling (the gateway is stateless).
         sa.Column("job_id", sa.Text(), nullable=False),
-        # Unix-epoch seconds. ``submitted_at`` anchors the poll deadline
-        # (DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS). No status/updated_at column: a row
+        # Unix-epoch seconds. ``submitted_at`` records when the job was submitted
+        # (observability / job age); a pending job is polled indefinitely, so it no
+        # longer anchors a give-up deadline (Deck #523). No status/updated_at column: a row
         # only ever exists in the pending state (terminal jobs are deleted), and
         # the live status always comes from a fresh poll — a stored mirror would
         # be permanently "pending" and carry no information.

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -223,10 +223,6 @@ _DEFAULTS: dict[str, Any] = {
     # Seconds between batch-job polls (the procrastinate re-enqueue delay). Each
     # poll re-runs the tier; keep it well above a few seconds.
     "document_ocr_batch_poll_seconds": 120,
-    # Hard deadline (seconds from submit) after which a still-pending batch job is
-    # abandoned and the document marked parse-failed (timeout). Matches the
-    # gateway's 24h Batch timeout default.
-    "document_ocr_batch_max_wait_seconds": 86400,
     # Observability
     "metrics_enabled": True,
     "metrics_port": 9090,
@@ -451,10 +447,8 @@ _dynaconf = Dynaconf(
         # Settings.__post_init__ via _enum_fields (case-insensitive, like
         # DOCUMENT_OCR_PROVIDER) — no strict dynaconf Validator here, so
         # "Batch"/"SYNC" normalise instead of erroring.
-        # Poll cadence well above a few seconds (each poll re-runs the tier);
-        # deadline at least one poll interval.
+        # Poll cadence well above a few seconds (each poll re-runs the tier).
         Validator("DOCUMENT_OCR_BATCH_POLL_SECONDS", gte=5),
-        Validator("DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS", gte=60),
         Validator("DOCUMENT_PARSE_MEM_LIMIT_MB", gte=128),
         # 0 disables the pre-parse PDF size cap; otherwise it must be positive.
         Validator("DOCUMENT_MAX_PDF_SIZE_MB", gte=0),
@@ -1031,9 +1025,10 @@ class Settings:
     # It requires a gateway: with no EMBEDDING_GATEWAY_URL, __post_init__ rejects
     # mode=batch at startup rather than silently downgrading to sync.
     document_ocr_mode: str = "sync"
-    # Batch-job poll cadence (procrastinate re-enqueue delay) and hard deadline.
+    # Batch-job poll cadence (procrastinate re-enqueue delay). A pending job is
+    # polled indefinitely — the gateway owns the OCR lifecycle (Deck #523), so
+    # there is no worker-side give-up deadline.
     document_ocr_batch_poll_seconds: int = 120
-    document_ocr_batch_max_wait_seconds: int = 86400
     # OCR escalation triggers (tier-0), per-tenant tunable. A page is OCR-worthy
     # if near-empty (< min_page_chars) OR low text-quality (< min_text_quality)
     # OR (when detect_scanned, image-analysis only runs when OCR is enabled)
@@ -1794,7 +1789,6 @@ def get_settings() -> Settings:
         "document_ocr_timeout_seconds": "DOCUMENT_OCR_TIMEOUT_SECONDS",
         "document_ocr_mode": "DOCUMENT_OCR_MODE",
         "document_ocr_batch_poll_seconds": "DOCUMENT_OCR_BATCH_POLL_SECONDS",
-        "document_ocr_batch_max_wait_seconds": "DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS",
         "document_ocr_min_text_quality": "DOCUMENT_OCR_MIN_TEXT_QUALITY",
         "document_ocr_page_fraction": "DOCUMENT_OCR_PAGE_FRACTION",
         "document_ocr_min_page_chars": "DOCUMENT_OCR_MIN_PAGE_CHARS",

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -29,7 +29,6 @@ import base64
 import html as _html
 import logging
 import re
-import time
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any
@@ -490,13 +489,13 @@ async def poll_pending_batch_ocr(
         return None
     if not result.is_pending:
         return None  # terminal — fall through to index the result via the pipeline
-    # Honour the same give-up deadline as _process_batch so a stuck job isn't polled
-    # forever without ever re-fetching; past it, fall through so the normal path
-    # fails it (deletes the tracking row + records the metric).
-    elapsed = int(time.time()) - job.submitted_at
-    if elapsed >= settings.document_ocr_batch_max_wait_seconds:
-        return None
-    return settings.document_ocr_batch_poll_seconds
+    # Poll forever: in batch mode the gateway owns the OCR lifecycle for an accepted
+    # document (Deck #523), so a pending job is NEVER abandoned on a worker-side
+    # deadline — it re-defers until the gateway completes it (the gateway never fails
+    # an item for a GPU outage). Back off by the gateway's Retry-After, floored at our
+    # poll interval so a tiny value can't busy-loop it; fall back when absent.
+    poll_seconds = settings.document_ocr_batch_poll_seconds
+    return max(result.retry_after or poll_seconds, poll_seconds)
 
 
 def build_ocr_backend(
@@ -826,10 +825,9 @@ class OcrProcessor(DocumentProcessor):
             # The gateway lost this job — its row was purged (retention) or
             # orphaned by a gateway pod move. Polling it 404s forever. Drop our
             # tracking row so the NEXT cycle re-submits a fresh job (store.get →
-            # None → new submission) instead of looping on a dead id. Bounded by
-            # the same document_ocr_batch_max_wait budget as any submit; a genuine
-            # poison-pill still terminalises via the failed/timeout paths below and
-            # is dead-lettered by the scanner (incident 2026-07-03).
+            # None → new submission) instead of looping on a dead id. A genuine
+            # poison-pill still terminalises via the failed paths below and is
+            # dead-lettered by the scanner (incident 2026-07-03).
             logger.warning(
                 "batch OCR job %s not found on gateway (404); re-submitting %s",
                 job.job_id,
@@ -840,27 +838,13 @@ class OcrProcessor(DocumentProcessor):
             )
             return self._pending(poll_seconds)
         if result.is_pending:
-            elapsed = int(time.time()) - job.submitted_at
-            if elapsed >= settings.document_ocr_batch_max_wait_seconds:
-                await store.delete(
-                    user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
-                )
-                # We don't cancel the gateway-side job (there's no cancel endpoint
-                # at this layer) — it keeps running and is reaped by the gateway's
-                # own file purge. Dropping the row just stops us polling it.
-                logger.warning(
-                    "batch OCR job %s exceeded max wait (%ss); marking failed",
-                    job.job_id,
-                    settings.document_ocr_batch_max_wait_seconds,
-                )
-                return ProcessingResult(
-                    text="",
-                    metadata={"parse_failed_reason": "timeout"},
-                    processor=self.name,
-                    success=False,
-                    error="batch OCR timed out",
-                )
-            return self._pending(poll_seconds)
+            # Poll forever: in batch mode the gateway owns the OCR lifecycle for an
+            # accepted document (Deck #523), so a pending job is NEVER abandoned on a
+            # worker-side deadline — it re-defers until the gateway completes it (the
+            # gateway never fails an item for a GPU outage). Back off by the gateway's
+            # Retry-After, floored at our poll interval so a tiny value can't busy-loop
+            # it; fall back to poll_seconds when absent.
+            return self._pending(max(result.retry_after or poll_seconds, poll_seconds))
 
         # Terminal — drop the tracking row either way.
         await store.delete(user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag)

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -73,6 +73,10 @@ def _batch_defer_seconds(poll_seconds: int, retry_after: int | None) -> int:
     ``_BATCH_POLL_MAX_DEFER_SECONDS`` (a malformed header can't stall a document absurdly
     long). No give-up — this only paces re-polls (Deck #523)."""
     raw = retry_after or poll_seconds
+    # ceiling = max(poll_seconds, cap): the cap must never clamp BELOW the operator's
+    # configured floor (poll_seconds has no upper-bound validator), else a re-poll
+    # could fire faster than they asked. So an interval above the 1h cap raises the
+    # effective ceiling to that interval — floor and ceiling coincide, still bounded.
     ceiling = max(poll_seconds, _BATCH_POLL_MAX_DEFER_SECONDS)
     return min(max(raw, poll_seconds), ceiling)
 

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -59,6 +59,24 @@ _OCR_CONNECT_TIMEOUT_SECONDS = 10.0
 OCR_BATCH_PENDING_KEY = "ocr_batch_pending"
 OCR_BATCH_RETRY_IN_KEY = "ocr_batch_retry_in"
 
+# Ceiling on how long one batch-OCR poll may defer. The gateway's Retry-After is
+# honoured (floored at the poll interval), but capped here so a malformed header
+# (e.g. an accidental extra zero) can't stall a document for an absurd duration.
+# This is NOT a give-up deadline — the job keeps polling forever, just never slower
+# than this ceiling (Deck #523).
+_BATCH_POLL_MAX_DEFER_SECONDS = 3600
+
+
+def _batch_defer_seconds(poll_seconds: int, retry_after: int | None) -> int:
+    """Seconds to wait before the next batch poll. Honour the gateway's ``Retry-After``,
+    floored at ``poll_seconds`` (a tiny value can't busy-loop the gateway) and capped at
+    ``_BATCH_POLL_MAX_DEFER_SECONDS`` (a malformed header can't stall a document absurdly
+    long). No give-up — this only paces re-polls (Deck #523)."""
+    raw = retry_after or poll_seconds
+    ceiling = max(poll_seconds, _BATCH_POLL_MAX_DEFER_SECONDS)
+    return min(max(raw, poll_seconds), ceiling)
+
+
 # Metadata key carrying per-block geometry from a layout-aware OCR backend (surya
 # via the gateway). A list of ``{"page", "bbox", "start_offset", "end_offset"}``:
 # the block's normalized [0,1] ``bbox`` plus its char span in the document text,
@@ -494,9 +512,10 @@ async def poll_pending_batch_ocr(
     # document (Deck #523), so a pending job is NEVER abandoned on a worker-side
     # deadline — it re-defers until the gateway completes it (the gateway never fails
     # an item for a GPU outage). Back off by the gateway's Retry-After, floored at our
-    # poll interval so a tiny value can't busy-loop it; fall back when absent.
-    poll_seconds = settings.document_ocr_batch_poll_seconds
-    return max(result.retry_after or poll_seconds, poll_seconds)
+    # poll interval (no busy-loop) and capped (no absurd stall); fall back when absent.
+    return _batch_defer_seconds(
+        settings.document_ocr_batch_poll_seconds, result.retry_after
+    )
 
 
 def build_ocr_backend(
@@ -843,9 +862,9 @@ class OcrProcessor(DocumentProcessor):
             # accepted document (Deck #523), so a pending job is NEVER abandoned on a
             # worker-side deadline — it re-defers until the gateway completes it (the
             # gateway never fails an item for a GPU outage). Back off by the gateway's
-            # Retry-After, floored at our poll interval so a tiny value can't busy-loop
-            # it; fall back to poll_seconds when absent.
-            return self._pending(max(result.retry_after or poll_seconds, poll_seconds))
+            # Retry-After, floored at our poll interval (no busy-loop) and capped (no
+            # absurd stall); fall back to poll_seconds when absent.
+            return self._pending(_batch_defer_seconds(poll_seconds, result.retry_after))
 
         # Terminal — drop the tracking row either way.
         await store.delete(user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag)

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -464,11 +464,12 @@ async def poll_pending_batch_ocr(
 
     Returns ``None`` — meaning "fall through to the normal download + parse path" —
     when: there is no in-flight job (nothing submitted yet); batch OCR isn't
-    configured; the gateway has no record of the job (re-submit, #1019); the poll is
-    TERMINAL (succeeded/failed — the pipeline re-polls and indexes the result, and
-    its post-parse quality gate needs the real bytes); or the give-up deadline has
-    passed (the pipeline marks it failed). Only a still-PENDING, within-deadline job
-    returns an int, and that is the ONLY case in which the caller may skip the fetch.
+    configured; the gateway has no record of the job (re-submit, #1019); or the poll
+    is TERMINAL (succeeded/failed — the pipeline re-polls and indexes the result, and
+    its post-parse quality gate needs the real bytes). A still-PENDING job ALWAYS
+    returns a positive int (Deck #523: no give-up deadline — the gateway owns the OCR
+    lifecycle and never fails an item for a GPU outage), and that is the ONLY case in
+    which the caller may skip the fetch.
     """
     from ..vector.batch_ocr_store import BatchOcrJobStore  # noqa: PLC0415
 

--- a/nextcloud_mcp_server/embedding/gateway_batch_client.py
+++ b/nextcloud_mcp_server/embedding/gateway_batch_client.py
@@ -77,6 +77,10 @@ class BatchPollResult:
     # which turns blocks into per-block char spans.
     pages: list[tuple[int, str, list[dict[str, Any]] | None]]
     error: str | None = None
+    # Seconds the gateway asked us to wait before polling again (its Retry-After on
+    # a pending 202). None if absent/unparseable; the caller falls back to its own
+    # configured poll interval and applies a floor. Deck #523.
+    retry_after: int | None = None
 
     @property
     def is_pending(self) -> bool:
@@ -89,6 +93,19 @@ class BatchPollResult:
     @property
     def is_failed(self) -> bool:
         return self.status == _FAILED
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse a Retry-After header as delta-seconds. The gateway sends an integer
+    number of seconds (never an HTTP-date), so a non-integer / non-positive / absent
+    value yields None and the caller falls back to its configured poll interval."""
+    if value is None:
+        return None
+    try:
+        seconds = int(value.strip())
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds > 0 else None
 
 
 class GatewayBatchOcrClient:
@@ -188,8 +205,16 @@ class GatewayBatchOcrClient:
                 status=_FAILED, pages=[], error="gateway returned no status"
             )
         if status != _SUCCEEDED:
-            # pending: nothing to read yet. failed: surface the job-level error.
-            return BatchPollResult(status=status, pages=[], error=body.get("error"))
+            # pending: nothing to read yet — honour the gateway's Retry-After so a
+            # large pending backlog doesn't storm it (Deck #523). failed: surface
+            # the job-level error. resp.headers stays valid after the client closes
+            # (the response is fully read).
+            return BatchPollResult(
+                status=status,
+                pages=[],
+                error=body.get("error"),
+                retry_after=_parse_retry_after(resp.headers.get("Retry-After")),
+            )
         return _result_from_success(body)
 
 

--- a/nextcloud_mcp_server/vector/batch_ocr_store.py
+++ b/nextcloud_mcp_server/vector/batch_ocr_store.py
@@ -2,9 +2,10 @@
 
 When ``DOCUMENT_OCR_MODE=batch`` the OCR tier submits a document to the gateway's
 async batch route and then re-polls across procrastinate retries. procrastinate
-job args are immutable, so the gateway ``job_id`` (and submit time, for the poll
-deadline) live in the ``batch_ocr_jobs`` app-DB table, keyed on the document +
-its content version (``etag``).
+job args are immutable, so the gateway ``job_id`` (and submit time, for job-age
+observability) live in the ``batch_ocr_jobs`` app-DB table, keyed on the document +
+its content version (``etag``). A pending job is polled indefinitely — the gateway
+owns the OCR lifecycle, so there is no worker-side give-up deadline (Deck #523).
 
 Engine reuse mirrors :class:`~nextcloud_mcp_server.usage.store.UsageEventStore`:
 rather than open its own engine this store borrows the process-wide
@@ -30,7 +31,9 @@ logger = logging.getLogger(__name__)
 class BatchOcrJob:
     """A tracked in-flight batch OCR job. A row exists only while pending (terminal
     jobs are deleted), so there's no stored status — the live status comes from a
-    fresh ``GatewayBatchOcrClient.poll``. ``submitted_at`` anchors the deadline."""
+    fresh ``GatewayBatchOcrClient.poll``. ``submitted_at`` records the submit time
+    (observability / job age); a pending job is polled indefinitely, so it no longer
+    anchors a give-up deadline (Deck #523)."""
 
     job_id: str
     submitted_at: int

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -413,10 +413,11 @@ class TieredEscalationStrategy(BaseRetryStrategy):
             # Batch OCR job still in flight (Deck #332): defer a re-poll on the
             # SAME queue after retry_in seconds. Deliberately exempt from the
             # transient cap below — a batch job can take minutes-hours, so the
-            # poll count is unbounded here; the OCR processor's own deadline
-            # (DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS) is what terminates a stuck job.
-            # Releasing the worker between polls keeps the job out of `doing`, so
-            # it's never stall-reclaimed.
+            # poll count is unbounded here. A pending job is polled indefinitely:
+            # once the gateway accepts a document it owns the OCR lifecycle (Deck
+            # #523), so there is no worker-side give-up deadline; only a job-level
+            # failure terminalises it. Releasing the worker between polls keeps the
+            # job out of `doing`, so it's never stall-reclaimed.
             return RetryDecision(retry_in={"seconds": exc.retry_in})
 
         if isinstance(exc, EscalateError):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -120,7 +120,6 @@ class TestGetSettings:
         {
             "DOCUMENT_OCR_MODE": "batch",
             "DOCUMENT_OCR_BATCH_POLL_SECONDS": "45",
-            "DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS": "3600",
             # batch routes through the gateway, so it requires a gateway URL
             # (validated in __post_init__).
             "EMBEDDING_GATEWAY_URL": "https://gw",
@@ -138,7 +137,6 @@ class TestGetSettings:
         settings = get_settings()
         assert settings.document_ocr_mode == "batch"
         assert settings.document_ocr_batch_poll_seconds == 45
-        assert settings.document_ocr_batch_max_wait_seconds == 3600
 
     @patch.dict(
         os.environ,

--- a/tests/unit/test_gateway_batch_client.py
+++ b/tests/unit/test_gateway_batch_client.py
@@ -109,12 +109,46 @@ async def test_poll_404_raises_job_not_found(monkeypatch):
 
 
 async def test_poll_pending(monkeypatch):
+    # No Retry-After header -> retry_after is None (caller falls back to its own
+    # configured poll interval).
     _patch_transport(
         monkeypatch,
         lambda r: httpx.Response(200, json={"status": "pending", "total": 1}),
     )
     result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
     assert result.is_pending and result.pages == []
+    assert result.retry_after is None
+
+
+async def test_poll_pending_parses_retry_after_header(monkeypatch):
+    # A pending poll carrying the gateway's Retry-After (delta-seconds) surfaces it
+    # on the result so the caller can back off (anti-storm, Deck #523). This is the
+    # layer doing the actual HTTP header parsing.
+    _patch_transport(
+        monkeypatch,
+        lambda r: httpx.Response(
+            202, json={"status": "pending"}, headers={"Retry-After": "30"}
+        ),
+    )
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
+    assert result.is_pending
+    assert result.retry_after == 30
+
+
+async def test_poll_pending_ignores_malformed_retry_after_header(monkeypatch):
+    # An HTTP-date-formatted Retry-After (which _parse_retry_after intentionally does
+    # NOT support) — or any non-integer — degrades to None rather than raising.
+    _patch_transport(
+        monkeypatch,
+        lambda r: httpx.Response(
+            202,
+            json={"status": "pending"},
+            headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        ),
+    )
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
+    assert result.is_pending
+    assert result.retry_after is None
 
 
 async def test_poll_succeeded_maps_pages(monkeypatch):
@@ -197,3 +231,20 @@ async def test_poll_raises_on_http_error(monkeypatch):
     )
     with pytest.raises(httpx.HTTPStatusError):
         await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/j")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("30", 30),
+        ("  45  ", 45),  # surrounding whitespace tolerated
+        (None, None),  # header absent
+        ("0", None),  # non-positive -> no back-off signal
+        ("-5", None),  # negative -> ignored
+        ("30.5", None),  # non-integer -> ignored (we send whole seconds)
+        ("soon", None),  # non-numeric -> ignored
+        ("Wed, 21 Oct 2026 07:28:00 GMT", None),  # HTTP-date form unsupported
+    ],
+)
+def test_parse_retry_after(raw, expected):
+    assert gbc._parse_retry_after(raw) == expected

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -698,6 +698,25 @@ async def test_batch_existing_pending_polls_and_defers(monkeypatch):
     assert client.submitted == []  # did NOT resubmit
 
 
+async def test_batch_existing_pending_honours_retry_after(monkeypatch):
+    # The submit/poll path (OcrProcessor.process -> _submit_and_poll) forwards the
+    # gateway's Retry-After into the pending sentinel's retry_in, same as the fast
+    # poll_pending path — 200 is above the 120s floor and below the cap (Deck #523).
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(status="pending", pages=[], retry_after=200)
+    )
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+
+    r = await ocr.OcrProcessor().process(
+        b"%PDF", "application/pdf", options=dict(_IDENTITY)
+    )
+
+    assert r.metadata[ocr.OCR_BATCH_PENDING_KEY] is True
+    assert r.metadata[ocr.OCR_BATCH_RETRY_IN_KEY] == 200
+    assert client.submitted == []  # polled the existing job, did NOT resubmit
+
+
 async def test_batch_poll_404_drops_row_and_resubmits(monkeypatch):
     # Incident 2026-07-03: a 404 on poll means the gateway lost the job (row purged
     # by retention or orphaned by a pod move). The processor must DROP its tracking
@@ -983,20 +1002,60 @@ async def test_poll_pending_polls_forever_no_deadline(monkeypatch):
 
 
 async def test_poll_pending_honours_retry_after(monkeypatch):
-    """The gateway's Retry-After sets the poll cadence (anti-storm), floored at the
-    configured interval (Deck #523)."""
+    """The gateway's Retry-After sets the poll cadence (anti-storm) when it's above
+    the configured floor — passed through, not clamped (Deck #523)."""
     preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
     client = _FakeBatchClient(
-        poll=BatchPollResult(status="pending", pages=[], retry_after=120)
+        poll=BatchPollResult(status="pending", pages=[], retry_after=200)
     )
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
     got = await ocr.poll_pending_batch_ocr(
         user_id="u1",
         doc_id="d1",
         etag="v1",
-        settings=_settings(document_ocr_mode="batch"),
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_batch_poll_seconds=120
+        ),
     )
-    assert got == 120  # honours Retry-After (well above the poll-interval floor)
+    assert got == 200  # honoured verbatim (above the 120s floor, below the cap)
+
+
+async def test_poll_pending_floors_retry_after(monkeypatch):
+    """A Retry-After BELOW the poll interval is raised to the floor so a tiny value
+    can't busy-loop the gateway (Deck #523)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(status="pending", pages=[], retry_after=5)
+    )
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_batch_poll_seconds=120
+        ),
+    )
+    assert got == 120  # floored up from 5
+
+
+async def test_poll_pending_caps_retry_after(monkeypatch):
+    """An absurd Retry-After (e.g. a malformed header with an extra zero) is capped
+    so one document can't stall for an absurd duration — still no give-up (Deck #523)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(status="pending", pages=[], retry_after=999_999)
+    )
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_batch_poll_seconds=120
+        ),
+    )
+    assert got == ocr._BATCH_POLL_MAX_DEFER_SECONDS  # capped at the ceiling
 
 
 async def test_poll_pending_job_gone_falls_through(monkeypatch):

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -22,7 +22,6 @@ def _settings(**kw) -> Any:  # a Settings stand-in (only the read fields matter)
         document_ocr_timeout_seconds=180.0,
         document_ocr_mode="sync",
         document_ocr_batch_poll_seconds=120,
-        document_ocr_batch_max_wait_seconds=86400,
         embedding_gateway_url=None,
         embedding_gateway_client_id=None,
         embedding_gateway_client_secret=None,
@@ -688,8 +687,6 @@ async def test_batch_existing_pending_polls_and_defers(monkeypatch):
     preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     store = _FakeStore(preset=preset)
-    # submitted just now -> deadline not reached
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)
     _wire_batch(monkeypatch, client=client, store=store)
 
     r = await ocr.OcrProcessor().process(
@@ -717,7 +714,6 @@ async def test_batch_poll_404_drops_row_and_resubmits(monkeypatch):
 
     client.poll = _poll_404  # type: ignore[method-assign]
     store = _FakeStore(preset=preset)
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)
     _wire_batch(monkeypatch, client=client, store=store)
 
     r = await ocr.OcrProcessor().process(
@@ -810,21 +806,25 @@ async def test_batch_unexpected_status_marks_failed_not_empty_success(monkeypatc
     assert ("u1", "d1", "file", "v1") in store.deleted
 
 
-async def test_batch_deadline_exceeded_marks_timeout(monkeypatch):
+async def test_batch_pending_polls_forever_no_deadline(monkeypatch):
+    # Deck #523: a pending batch job is NEVER abandoned on a worker-side deadline —
+    # even long past the old max-wait it stays pending (re-defers), because the
+    # gateway owns the lifecycle and never fails an item for a GPU outage.
     preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     store = _FakeStore(preset=preset)
-    # now far past submitted_at + max_wait (86400)
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0 + 90000)
     _wire_batch(monkeypatch, client=client, store=store)
 
     r = await ocr.OcrProcessor().process(
         b"%PDF", "application/pdf", options=dict(_IDENTITY)
     )
 
+    # Pending sentinel (re-queue), NOT a terminal timeout → no dead-letter.
     assert r.success is False
-    assert r.metadata["parse_failed_reason"] == "timeout"
-    assert ("u1", "d1", "file", "v1") in store.deleted
+    assert r.metadata.get(ocr.OCR_BATCH_PENDING_KEY) is True
+    assert "parse_failed_reason" not in r.metadata
+    # The tracking row is kept — the job keeps being polled, not abandoned.
+    assert ("u1", "d1", "file", "v1") not in store.deleted
 
 
 async def test_batch_raises_when_no_gateway(monkeypatch):
@@ -938,7 +938,6 @@ async def test_poll_pending_defers_without_download(monkeypatch):
     preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)  # within deadline
     got = await ocr.poll_pending_batch_ocr(
         user_id="u1",
         doc_id="d1",
@@ -959,7 +958,6 @@ async def test_poll_pending_terminal_falls_through(monkeypatch):
         poll=BatchPollResult(status="succeeded", pages=[(0, "hello", None)])
     )
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0)
     got = await ocr.poll_pending_batch_ocr(
         user_id="u1",
         doc_id="d1",
@@ -969,21 +967,36 @@ async def test_poll_pending_terminal_falls_through(monkeypatch):
     assert got is None
 
 
-async def test_poll_pending_past_deadline_falls_through(monkeypatch):
-    """Past the give-up deadline -> None (never re-fetched, never polled forever)."""
+async def test_poll_pending_polls_forever_no_deadline(monkeypatch):
+    """Deck #523: past the old deadline still re-defers (a positive retry_in), never
+    None — the gateway owns the lifecycle, so the worker polls forever."""
     preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
-    monkeypatch.setattr(ocr.time, "time", lambda: 1000.0 + 61)  # past 60s deadline
     got = await ocr.poll_pending_batch_ocr(
         user_id="u1",
         doc_id="d1",
         etag="v1",
-        settings=_settings(
-            document_ocr_mode="batch", document_ocr_batch_max_wait_seconds=60
-        ),
+        settings=_settings(document_ocr_mode="batch"),
     )
-    assert got is None
+    assert got is not None and got > 0
+
+
+async def test_poll_pending_honours_retry_after(monkeypatch):
+    """The gateway's Retry-After sets the poll cadence (anti-storm), floored at the
+    configured interval (Deck #523)."""
+    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    client = _FakeBatchClient(
+        poll=BatchPollResult(status="pending", pages=[], retry_after=120)
+    )
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(document_ocr_mode="batch"),
+    )
+    assert got == 120  # honours Retry-After (well above the poll-interval floor)
 
 
 async def test_poll_pending_job_gone_falls_through(monkeypatch):


### PR DESCRIPTION
## Problem

In **batch** OCR mode the embedding gateway owns the OCR lifecycle once it
accepts a document — it re-defers a pending item indefinitely and (as of
astrolabe-cloud-website#561) never fails it for a transient backend/GPU outage.
The worker still enforced a **client-side give-up deadline**
(`DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS`, default 24h). A job still *pending* past
that budget was terminalised as a timeout: the tracking row was deleted and the
document dead-lettered by the scanner — **permanent data-loss on a GPU that was
merely offline**. ~486 smoke-test documents were lost this way (previously
indexed 1.47k → 984 on a re-index while the burst GPU was down).

This is the leaky GPU abstraction the design forbids: GPU availability must
never reach the OCR worker in batch mode. If the gateway accepted the document,
the contract is met and the worker only polls.

## Change

- **`poll_pending_batch_ocr` / `_submit_and_poll`** — remove the max-wait
  deadline. A pending job now **always re-defers** (polls forever). Back-off is
  the gateway's `Retry-After`, floored at the configured poll interval, so a
  tiny value can't busy-loop the gateway and a large pending backlog can't storm
  it.
- **`gateway_batch_client`** — parse `Retry-After` (delta-seconds) on a pending
  poll into `BatchPollResult.retry_after` (`None` if absent/unparseable → caller
  falls back to its configured interval).
- Drop the now-dead `DOCUMENT_OCR_BATCH_MAX_WAIT_SECONDS` setting (field,
  default, env map, dynaconf validator) and refresh the docs/comments that
  described the deadline.

Only a genuine **job-level failure** (or a per-document error inside a succeeded
job) now marks a document parse-failed. A 404 (gateway lost the job) still drops
the row and re-submits, unchanged.

## Pairs with

- **astrolabe-cloud-website#561** — gateway stops failing a batch item on
  GPU-unavailable (re-defers forever) and sets `Retry-After` on the pending 202.

## Tests

- `test_batch_pending_polls_forever_no_deadline` / `test_poll_pending_polls_forever_no_deadline`
  — a pending job past the old budget re-defers (pending sentinel / positive
  retry_in), never terminalises; tracking row kept, no dead-letter.
- `test_poll_pending_honours_retry_after` — gateway `Retry-After` sets the poll
  cadence.
- Removed the deadline assertions from the config/regression tests.

Full unit suite: **2033 passed, 1 skipped**. `ruff` + `ty` clean.

---

_This PR was generated with the help of AI, and reviewed by a Human_