### PR TITLE
fix(ingest): disable psycopg prepared statements behind the pgbouncer pooler

### DIFF
--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -501,12 +501,29 @@ def build_app(connector: BaseConnector) -> App:
     return app
 
 
+# psycopg3 auto-prepares statements as server-side NAMED statements (``_pg3_N``, a
+# per-client counter). Behind a pgbouncer TRANSACTION-mode pooler (Deck #424) many
+# clients share the same backend server connections, so those names collide across
+# clients (``DuplicatePreparedStatement``, or a param-count ``ProtocolViolation``).
+# The failed statement aborts its transaction, and in transaction pooling an
+# aborted-but-open transaction never releases its server connection — the tenant's
+# small server pool fills with stuck ``idle in transaction (aborted)`` backends and
+# a new worker's pool init then times out (``psycopg_pool.PoolTimeout``). Disabling
+# auto-prepare (``prepare_threshold=None`` → psycopg uses unnamed statements) is the
+# standard fix. Applied UNCONDITIONALLY: harmless connecting direct (a negligible
+# re-parse cost for this poll-heavy workload) and it removes the footgun of pointing
+# a worker at a transaction-mode pooler without it — exactly how #424 regressed
+# (LISTEN/NOTIFY was disabled for the pooler, but prepared statements were not).
+# Passed to psycopg via the pool's per-connection ``kwargs`` (PsycopgConnector
+# forwards ``**kwargs`` to ``psycopg_pool.AsyncConnectionPool``).
+def _psycopg_connector(conninfo: str) -> PsycopgConnector:
+    return PsycopgConnector(conninfo=conninfo, kwargs={"prepare_threshold": None})
+
+
 def build_app_for_url(database_url: str) -> App:
     """Build an App bound to an explicit Postgres URL (for the CLI, which may
     target a ``--database-url`` that differs from the ``DATABASE_URL`` env)."""
-    return build_app(
-        PsycopgConnector(conninfo=get_procrastinate_conninfo(database_url))
-    )
+    return build_app(_psycopg_connector(get_procrastinate_conninfo(database_url)))
 
 
 _app: App | None = None
@@ -516,7 +533,7 @@ def get_procrastinate_app() -> App:
     """Process-wide procrastinate App bound to the Postgres app database."""
     global _app
     if _app is None:
-        _app = build_app(PsycopgConnector(conninfo=get_procrastinate_conninfo()))
+        _app = build_app(_psycopg_connector(get_procrastinate_conninfo()))
     return _app
 
 

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -5,7 +5,7 @@ Uses procrastinate's in-memory connector so no live Postgres is required.
 
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from procrastinate import App, JobContext, testing
@@ -394,3 +394,25 @@ class TestGetIngestJobCounts:
         assert set(by_queue) == {"ingest-fast", "ingest-ocr"}
         assert by_queue["ingest-fast"]["todo"] == 3
         assert by_queue["ingest-ocr"]["failed"] == 2
+
+
+def test_build_app_for_url_disables_psycopg_prepared_statements():
+    """The procrastinate connector MUST disable psycopg auto-prepared statements
+    (``prepare_threshold=None``) so it is safe behind the pgbouncer transaction-mode
+    pooler (Deck #424): per-client ``_pg3_N`` statement names otherwise collide over
+    the shared server connections, abort transactions, and exhaust the server pool."""
+    with patch.object(pq, "PsycopgConnector") as mock_conn:
+        pq.build_app_for_url("postgresql+psycopg://u:p@h:5432/db")
+    mock_conn.assert_called_once()
+    assert mock_conn.call_args.kwargs["kwargs"] == {"prepare_threshold": None}
+
+
+def test_get_procrastinate_app_disables_psycopg_prepared_statements(monkeypatch):
+    """The process-wide App builds the same prepared-statement-safe connector."""
+    monkeypatch.setattr(pq, "_app", None)  # reset the module singleton before/after
+    monkeypatch.setattr(pq, "get_procrastinate_conninfo", lambda: "host=h dbname=db")
+    with patch.object(pq, "PsycopgConnector") as mock_conn:
+        pq.get_procrastinate_app()
+    monkeypatch.setattr(pq, "_app", None)  # don't leak a mock-backed singleton
+    mock_conn.assert_called_once()
+    assert mock_conn.call_args.kwargs["kwargs"] == {"prepare_threshold": None}


### PR DESCRIPTION
## Problem

After the Deck #424 rollout repointed tenant ingest workers at the shared-postgres **PgBouncer pooler (transaction mode)**, the fast workers **CrashLoopBackOff** on:

```
psycopg_pool.PoolTimeout: pool initialization incomplete after 30.0 sec
```

## Root cause (reproduced + validated from a live tenant pod)

psycopg3 auto-prepares statements as **server-side NAMED statements** (`_pg3_0`, `_pg3_1`… — a **per-client** counter). Under **transaction pooling**, many client connections share the same backend server connections, so two clients each create their own `_pg3_0` on the same backend:

```
DuplicatePreparedStatement: prepared statement "_pg3_0" already exists
ProtocolViolation: bind message supplies 2 parameters, but prepared statement "_pg3_0" requires 1
```

Each error **aborts the transaction**. In transaction pooling, an aborted-but-open transaction **never releases its server connection** (it sits `idle in transaction (aborted)`), so the tenant's small server pool (`default_pool_size=6` / `max_db_connections=12`) fills with stuck connections → a new worker's pool-init query can't get a server connection → `PoolTimeout` → crashloop.

This is why it works **direct** (each client owns its server connection; names never collide) but fails **through the pooler**. #424 correctly disabled `LISTEN/NOTIFY` for transaction pooling but **missed prepared statements** — the second thing psycopg needs behind pgbouncer transaction mode.

Reproduction from a pod (8 clients × 25 prepared execs):

| Target | Result |
|---|---|
| Pooler, auto-prepare on (current) | **8/8 fail** (`DuplicatePreparedStatement`) |
| Pooler, `prepare_threshold=None` | **0 errors** |
| Direct postgres | 0 errors |

## Fix

Set **`prepare_threshold=None`** on the procrastinate `PsycopgConnector` (via the pool's per-connection `kwargs`), so psycopg uses **unnamed** statements — safe under transaction pooling. Applied **unconditionally**: it's harmless connecting direct (a negligible re-parse cost for this poll-heavy workload) and it removes the footgun of pointing a worker at a transaction-mode pooler without it.

- `vector/queue/procrastinate.py`: new `_psycopg_connector()` helper used by both `build_app_for_url()` and `get_procrastinate_app()`.
- Tests assert both build paths pass `kwargs={"prepare_threshold": None}`.
- ruff + ty + unit tests green.

## Follow-up

Belt-and-suspenders: enable pgbouncer `max_prepared_statements` on `shared-postgres-pooler` (gitops) so named statements are safe pooler-wide even for other apps.

Deck: board 7 #538 (repo:nextcloud-mcp-server), follow-up to #424.

---

_This PR was generated with the help of AI, and reviewed by a Human_