### PR TITLE
refactor(db): DATABASE_URL passthrough to psycopg; drop asyncpg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,7 +440,7 @@ services:
 
   # Centralized Postgres backend for token storage. Used by:
   #   1. Integration tests gated on @pytest.mark.postgres — they read
-  #      TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp.
+  #      TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp.
   #   2. Manual smoke testing of the HA (multi-replica) deployment story.
   # Bring up with:  docker compose --profile postgres up -d postgres-test
   # See ADR-026 for the pluggable-database-backend design.

--- a/docs/ADR-026-pluggable-database-backend.md
+++ b/docs/ADR-026-pluggable-database-backend.md
@@ -63,10 +63,14 @@ the fly. The seven `INSERT OR REPLACE` statements were rewritten as
 portable `INSERT ... ON CONFLICT (...) DO UPDATE` (SQLite ≥ 3.24, Postgres
 ≥ 9.5; we already require SQLite ≥ 3.35 elsewhere).
 
-### Distribution: asyncpg is an optional extra, bundled in Docker
+### Distribution: psycopg is an optional extra, bundled in Docker
 
-`asyncpg` carries a compiled C extension (~5 MB plus a build toolchain on
-source installs) — too heavy a default for the
+> **Amendment (Model A):** the backend now uses **psycopg3** for every
+> Postgres connection (app engine *and* the procrastinate queue); `asyncpg`
+> has been dropped. `DATABASE_URL` is consumed **verbatim** and TLS is
+> configured in the URL (`?sslmode=...`) — see the TLS section below.
+
+`psycopg[binary]` carries a compiled component — too heavy a default for the
 `pip install nextcloud-mcp-server` audience, the majority of whom run the
 SQLite path. It is shipped as a PyPI optional dependency::
 
@@ -74,11 +78,11 @@ SQLite path. It is shipped as a PyPI optional dependency::
 
 The published Docker image runs `uv sync --extra postgres` so the
 container always has the driver, matching the HA-deployment audience
-that exercises the Postgres backend. When `DATABASE_URL=postgresql+asyncpg://...`
+that exercises the Postgres backend. When `DATABASE_URL=postgresql+psycopg://...`
 is set on a venv without the extra installed, `RefreshTokenStorage`
 raises a clear actionable error before the engine is built — operators
 see "install with `[postgres]` extra" rather than a generic
-`ModuleNotFoundError: No module named 'asyncpg'`.
+`ModuleNotFoundError: No module named 'psycopg'`.
 
 ### Alembic env.py runs the async engine inside a worker thread
 
@@ -104,7 +108,7 @@ round-2 default) was: *isn't 1 connection enough for an MCP server?*
 This subsection records why a small pool is right, why 1 is not the
 target default, and what the workload actually looks like.
 
-**asyncpg connection semantics.** Each asyncpg connection is
+**psycopg connection semantics.** Each psycopg connection is
 **single-flight** — only one query can be in flight at a time on a
 given connection. SQLAlchemy serializes additional requests in the
 pool queue. So the question is never "how many requests does the MCP
@@ -162,33 +166,40 @@ sees the migrated schema. Covered by
 
 ### TLS for the Postgres backend
 
-Two settings mirror the existing `NEXTCLOUD_VERIFY_SSL` /
-`NEXTCLOUD_CA_BUNDLE` pattern: `DATABASE_VERIFY_SSL` and
-`DATABASE_CA_BUNDLE`. `get_database_ssl()` (in `nextcloud_mcp_server/config.py`)
-returns the value to pass to asyncpg via SQLAlchemy's `connect_args={"ssl": ...}`.
+> **Amendment (Model A):** TLS is configured **entirely in `DATABASE_URL`**
+> and read by libpq/psycopg. The earlier `DATABASE_VERIFY_SSL` /
+> `DATABASE_CA_BUNDLE` env vars and the `get_database_ssl()` helper have been
+> removed. The text below records the superseded design.
 
-The default is deliberately **less strict than the Nextcloud HTTPS
-default**: `DATABASE_VERIFY_SSL` defaults to `None` rather than `True`.
-When both env vars are unset we omit the `ssl` kwarg entirely and asyncpg's
-default (`prefer`) applies — TLS if the server offers it, no certificate
-validation. The reasoning:
+Because the server now uses psycopg3 (libpq) for both the app engine and the
+procrastinate connector and passes `DATABASE_URL` through verbatim, TLS is
+expressed with standard libpq query parameters on the URL:
 
-- Cluster-internal Postgres (CNPG via a Service, RDS over a private VPC,
-  PgBouncer sidecar) is the common HA pattern and frequently runs without
-  TLS or with cert hostnames asyncpg wouldn't match anyway.
-- The HTTPS analogy doesn't carry over: the Nextcloud client talks to
-  *external* hostnames over public networks where verify-full is the
-  right default. The database client talks to a controlled peer.
-- Just-shipped PR #798 had no TLS knobs and worked against cluster-local
-  Postgres-test; flipping the default to `True` here would break that
-  flow on upgrade.
+- `?sslmode=require` — encrypt, do not verify the certificate (the common
+  cluster-internal posture; matches the historical default below).
+- `?sslmode=verify-full&sslrootcert=/path/to/ca.pem` — verify against a
+  private CA (homelab / managed Postgres with a known CA).
+- Omit `sslmode` entirely → libpq's default (`prefer`): TLS if offered, no
+  verification.
 
-Operators in production with a managed Postgres opt in with
-`DATABASE_VERIFY_SSL=true`. Homelab operators with a private CA set
-`DATABASE_CA_BUNDLE=/path/to/ca.pem` (which implies `verify=true`).
-`DATABASE_VERIFY_SSL=false` is the escape hatch for incident response —
-it wins over `DATABASE_CA_BUNDLE` so an operator can quickly silence
-cert errors without editing the secret store.
+There is no separate env-var TLS mechanism and the server neither parses nor
+validates the URL — a bad value fails fast at the driver. This keeps a single
+source of truth (the DSN) shared by the app engine and the queue, and was the
+fix for the `Dropping DATABASE_URL query parameters ... sslmode` warning that
+the old decomposition emitted.
+
+<details><summary>Superseded env-var TLS design</summary>
+
+Two settings mirrored the existing `NEXTCLOUD_VERIFY_SSL` /
+`NEXTCLOUD_CA_BUNDLE` pattern: `DATABASE_VERIFY_SSL` and `DATABASE_CA_BUNDLE`,
+resolved by `get_database_ssl()` and passed to asyncpg via
+`connect_args={"ssl": ...}`. The default was deliberately less strict than the
+Nextcloud HTTPS default (`None`, i.e. asyncpg's `prefer`) because
+cluster-internal Postgres frequently ran without TLS. This mechanism was
+asyncpg-shaped and inert for the psycopg engine, so it was removed in favour of
+the in-URL `sslmode` above.
+
+</details>
 
 ### Encryption stays in Python (Fernet), not the DB
 
@@ -261,8 +272,9 @@ existing `--database-path / -d` (env `TOKEN_STORAGE_DB`). `-u` wins over
 
 - One more thing operators have to think about for HA deployments
   (Postgres connection string, credentials secret, network policies).
-- Adds SQLAlchemy + asyncpg to the runtime dependency set. SQLAlchemy was
-  already transitively present via Alembic; asyncpg is genuinely new.
+- Adds SQLAlchemy + psycopg to the runtime dependency set. SQLAlchemy was
+  already transitively present via Alembic; psycopg (also required by the
+  procrastinate queue) is the single Postgres driver.
 - The compatibility shim in `storage.py` is a small piece of bespoke code
   that future contributors need to understand. The alternative — rewriting
   every method body to SQLAlchemy idioms — was rejected as too risky for
@@ -287,7 +299,7 @@ existing `--database-path / -d` (env `TOKEN_STORAGE_DB`). `-u` wins over
 
 1. `uv run pytest tests/unit/` — SQLite path unchanged (1012 tests).
 2. `docker compose --profile postgres up -d postgres-test` then
-   `TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp uv run pytest tests/unit/test_app_password_storage.py tests/unit/test_webhook_storage.py`
+   `TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp uv run pytest tests/unit/test_app_password_storage.py tests/unit/test_webhook_storage.py`
    — every test runs once per backend.
 3. Manual end-to-end smoke against `mcp-login-flow` with a Postgres URL
    (commands in `/home/chris/.claude/plans/spicy-enchanting-flurry.md` →

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,21 +151,26 @@ database via `DATABASE_URL`.
 
 ```env
 # Centralized Postgres backend (HA k8s deployments)
-DATABASE_URL=postgresql+asyncpg://mcp:secret@postgres.svc.cluster.local:5432/mcp
+DATABASE_URL=postgresql+psycopg://mcp:secret@postgres.svc.cluster.local:5432/mcp?sslmode=require
 TOKEN_ENCRYPTION_KEY=<fernet-key>
 ```
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `DATABASE_URL` | Optional | SQLAlchemy async URL for any supported backend. When set, wins over `TOKEN_STORAGE_DB`. Primary supported targets: `postgresql+asyncpg://...` (recommended for HA) and `sqlite+aiosqlite:///...` (development). |
+| `DATABASE_URL` | Optional | SQLAlchemy async URL for any supported backend. When set, wins over `TOKEN_STORAGE_DB`. Primary supported targets: `postgresql+psycopg://...` (recommended for HA) and `sqlite+aiosqlite:///...` (development). **Passed through verbatim** — the server never rewrites it. |
 | `TOKEN_STORAGE_DB` | Optional | Legacy SQLite-only path. Used when `DATABASE_URL` is unset. Falls back to a per-process ephemeral tempfile when both are unset. |
-| `DATABASE_VERIFY_SSL` | Optional | TLS verification toggle for the Postgres backend. Unset (default) → asyncpg's `prefer` mode (TLS if offered, no verification — keeps cluster-internal Postgres working). `true` → full cert verification. `false` → silence cert errors (homelab / self-signed). |
-| `DATABASE_CA_BUNDLE` | Optional | Path to a PEM file containing a private CA. Implies `DATABASE_VERIFY_SSL=true`. Use this for self-hosted Postgres signed by your homelab CA instead of disabling verification. |
-| `DATABASE_POOL_SIZE` | Deprecated, no-op | Was per-pod SQLAlchemy pool size for the Postgres backend. The engine now uses `NullPool` (one fresh asyncpg connection per checkout) to avoid cross-event-loop crashes under anyio TaskGroups — see [ADR-026 § Connection pool](ADR-026-pluggable-database-backend.md) and [#799](https://github.com/cbcoutinho/nextcloud-mcp-server/pull/799). Still accepted for backward compatibility; setting it has no effect. |
+| `DATABASE_POOL_SIZE` | Deprecated, no-op | Was per-pod SQLAlchemy pool size for the Postgres backend. The engine now uses `NullPool` (one fresh psycopg connection per checkout) to avoid cross-event-loop crashes under anyio TaskGroups — see [ADR-026 § Connection pool](ADR-026-pluggable-database-backend.md) and [#799](https://github.com/cbcoutinho/nextcloud-mcp-server/pull/799). Still accepted for backward compatibility; setting it has no effect. |
 | `DATABASE_MAX_OVERFLOW` | Deprecated, no-op | Was per-pod burst connection cap on top of `DATABASE_POOL_SIZE`. Now ignored (see above). |
 
-The asyncpg engine is `NullPool`-only: each `engine.connect()` opens
-and tears down a fresh asyncpg connection in the caller's current
+**TLS is configured in the URL, not via env vars.** The server uses
+psycopg3 (libpq) for both the app engine and the procrastinate queue and
+hands `DATABASE_URL` through untouched, so add libpq parameters directly to
+the URL: `?sslmode=require` (encrypt), `?sslmode=verify-full&sslrootcert=/path/ca.pem`
+(verify against a private CA). Omitting `sslmode` leaves libpq's default
+(`prefer`). There are no `DATABASE_VERIFY_SSL` / `DATABASE_CA_BUNDLE` settings.
+
+The psycopg engine is `NullPool`-only: each `engine.connect()` opens
+and tears down a fresh psycopg connection in the caller's current
 event loop. On LAN-local Postgres the per-connection overhead is a
 single round-trip (~5 ms), so the throughput cost is negligible for
 the MCP server's traffic shape (low concurrency, bursty per-user
@@ -174,18 +179,17 @@ requests).
 Homelab example (self-signed Postgres with a private CA):
 
 ```env
-DATABASE_URL=postgresql+asyncpg://mcp:secret@pg.lan:5432/mcp
-DATABASE_CA_BUNDLE=/etc/ssl/certs/homelab-ca.pem
+DATABASE_URL=postgresql+psycopg://mcp:secret@pg.lan:5432/mcp?sslmode=verify-full&sslrootcert=/etc/ssl/certs/homelab-ca.pem
 TOKEN_ENCRYPTION_KEY=<fernet-key>
 ```
 
 Notes:
 
-- **PyPI extra required.** The `asyncpg` driver is an optional extra so
+- **PyPI extra required.** The `psycopg` driver is an optional extra so
   the default `pip install nextcloud-mcp-server` stays lean. Install
   with `pip install 'nextcloud-mcp-server[postgres]'` when using a
   Postgres URL. The Docker image bundles it by default. When
-  `DATABASE_URL=postgresql+asyncpg://...` is set without the extra,
+  `DATABASE_URL=postgresql+psycopg://...` is set without the extra,
   the server fails fast with a clear actionable error.
 - **Bring-your-own DB.** The MCP server doesn't provision the database;
   it just consumes the URL. Use CNPG, RDS, your existing Helm chart's
@@ -201,7 +205,7 @@ Notes:
   re-register on the next sync tick.
 - **Testing a Postgres backend locally:** `docker compose --profile
   postgres up -d postgres-test` then export
-  `DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp`.
+  `DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp`.
 
 See [ADR-026 Pluggable database backend](ADR-026-pluggable-database-backend.md)
 for the architecture rationale.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ database via `DATABASE_URL`.
 
 ```env
 # Centralized Postgres backend (HA k8s deployments)
-DATABASE_URL=postgresql+psycopg://mcp:secret@postgres.svc.cluster.local:5432/mcp?sslmode=require
+DATABASE_URL=postgresql+psycopg://mcp:secret@postgres.svc.cluster.local:5432/mcp?sslmode=require&connect_timeout=10
 TOKEN_ENCRYPTION_KEY=<fernet-key>
 ```
 
@@ -168,6 +168,12 @@ hands `DATABASE_URL` through untouched, so add libpq parameters directly to
 the URL: `?sslmode=require` (encrypt), `?sslmode=verify-full&sslrootcert=/path/ca.pem`
 (verify against a private CA). Omitting `sslmode` leaves libpq's default
 (`prefer`). There are no `DATABASE_VERIFY_SSL` / `DATABASE_CA_BUNDLE` settings.
+
+**Set `connect_timeout` for production.** Because the server passes
+`DATABASE_URL` through verbatim, it no longer injects a default connect
+timeout. Add `?...&connect_timeout=10` (seconds) to a production `DATABASE_URL`
+so worker/API startup fails fast against an unreachable Postgres instead of
+hanging indefinitely — libpq reads it directly (as it does `sslmode`).
 
 The psycopg engine is `NullPool`-only: each `engine.connect()` opens
 and tears down a fresh psycopg connection in the caller's current

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -941,7 +941,7 @@ async def app_lifespan_basic(server: FastMCP) -> AsyncIterator[AppContext]:
         logger.info("Shutting down BasicAuth session")
         if client is not None:
             await client.close()
-        # Dispose the storage engine so pooled asyncpg connections drain
+        # Dispose the storage engine so pooled psycopg connections drain
         # cleanly on SIGTERM (ADR-026, PR #798 round-4).
         try:
             await storage.close()
@@ -1652,7 +1652,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             finally:
                 logger.info("Shutting down MCP server")
                 # Dispose the RefreshTokenStorage engine so pooled
-                # asyncpg connections drain cleanly on SIGTERM instead
+                # psycopg connections drain cleanly on SIGTERM instead
                 # of leaking server-side slots until the Postgres
                 # idle-timeout fires (ADR-026, PR #798 round-4).
                 if refresh_token_storage is not None:

--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -4,7 +4,7 @@ Persistent Storage for MCP Server State
 This module provides SQL-backed storage for multiple concerns across both
 BasicAuth and OAuth authentication modes. The default backend is SQLite
 (file-based or per-process tempfile); set ``DATABASE_URL`` to a
-``postgresql+asyncpg://...`` URL for HA k8s deployments where pods need
+``postgresql+psycopg://...`` URL for HA k8s deployments where pods need
 to be stateless. See :doc:`ADR-026 </docs/ADR-026-pluggable-database-backend>`
 for the design.
 
@@ -53,7 +53,6 @@ from sqlalchemy.pool import NullPool
 
 from nextcloud_mcp_server.config import (
     cfg,
-    get_database_ssl,
     get_database_url,
     is_ephemeral_token_db,
     is_sqlite_url,
@@ -170,19 +169,6 @@ def _wrap_row(row) -> _Row | None:
     return _Row(tuple(row), dict(row._mapping))
 
 
-def _describe_ssl_arg(ssl_arg: object) -> str:
-    """Render the ``ssl`` value for the startup log line.
-
-    Split out of the engine factory to avoid a nested-ternary
-    SonarQube finding (``S3358``) and to make the cases readable.
-    """
-    if ssl_arg is False:
-        return "disabled"
-    if isinstance(ssl_arg, bool):
-        return "verify-full (system CAs)"
-    return "custom CA bundle"
-
-
 def _wrap_rows(rows) -> list[_Row]:
     """Wrap a list of SQLAlchemy rows; iterator never yields ``None``."""
     return [_Row(tuple(r), dict(r._mapping)) for r in rows]
@@ -198,7 +184,7 @@ class _Cursor:
 
     ``rowcount`` is captured eagerly at construction time. ``lastrowid`` is
     intentionally NOT exposed: accessing ``CursorResult.lastrowid`` on the
-    asyncpg dialect consumes the result buffer, which would silently turn
+    Postgres dialect consumes the result buffer, which would silently turn
     every subsequent ``fetchall()`` into an empty list (a real bug hit
     during the Postgres port).
     """
@@ -331,7 +317,7 @@ class RefreshTokenStorage:
 
         Args:
             database_url: SQLAlchemy URL (``sqlite+aiosqlite:///...`` or
-                ``postgresql+asyncpg://...``). When omitted, falls back to
+                ``postgresql+psycopg://...``). When omitted, falls back to
                 :func:`get_database_url` (honors ``DATABASE_URL`` env, then
                 ``TOKEN_STORAGE_DB``).
             encryption_key: Optional Fernet encryption key (32 bytes, base64-encoded).
@@ -371,7 +357,7 @@ class RefreshTokenStorage:
         Environment variables:
             DATABASE_URL: SQLAlchemy URL for any supported backend. Wins
                 over ``TOKEN_STORAGE_DB`` when set. Use
-                ``postgresql+asyncpg://user:pw@host/db`` for HA k8s
+                ``postgresql+psycopg://user:pw@host/db`` for HA k8s
                 deployments. See ADR-026.
             TOKEN_STORAGE_DB: Legacy SQLite-only path. If unset and
                 ``DATABASE_URL`` is also unset, a per-process tempfile is
@@ -535,11 +521,11 @@ class RefreshTokenStorage:
         under the SonarQube ``S3776`` threshold and so a future
         engine-arg unit test has a single seam to mock.
 
-        Uses :class:`NullPool` (one fresh asyncpg connection per
+        Uses :class:`NullPool` (one fresh psycopg connection per
         checkout, no caching). The original ADR-026 design used a
         small bounded ``QueuePool`` with ``pool_pre_ping=True``, but
         that combination is unsafe under the server's anyio task
-        layout: cached asyncpg connections are bound to the event
+        layout: cached connections are bound to the event
         loop they were opened on, and a checkout from a task running
         under a different anyio TaskGroup / loop triggers
         ``RuntimeError: got Future attached to a different loop`` on
@@ -550,8 +536,8 @@ class RefreshTokenStorage:
         and the request-path code paths share an engine across loops.
 
         NullPool sidesteps the entire class of bugs: every
-        ``engine.connect()`` opens a fresh asyncpg connection in the
-        caller's current loop, and disposes it on close. asyncpg
+        ``engine.connect()`` opens a fresh psycopg connection in the
+        caller's current loop, and disposes it on close. psycopg
         connection setup is cheap (~5 ms LAN, single round-trip when
         the server is local) so the throughput cost is negligible for
         the MCP server's traffic shape (low-concurrency, bursty).
@@ -560,35 +546,30 @@ class RefreshTokenStorage:
         the Postgres backend — they were never propagated to SQLite,
         which has always used NullPool.
         """
-        # asyncpg ships as an optional PyPI extra (`[postgres]`) so the
-        # default `pip install nextcloud-mcp-server` audience doesn't
-        # pull in the C extension. The Docker image bundles it. Surface
-        # a clear actionable error when the driver is missing rather
-        # than the generic ``ModuleNotFoundError`` SQLAlchemy emits.
-        if "+asyncpg" in self.database_url.lower() and (
-            importlib.util.find_spec("asyncpg") is None
+        # psycopg (psycopg3) ships as an optional PyPI extra
+        # (`[postgres]`) so the default `pip install nextcloud-mcp-server`
+        # audience doesn't pull it in. The Docker image bundles it.
+        # Surface a clear actionable error when the driver is missing
+        # rather than the generic ``ModuleNotFoundError`` SQLAlchemy emits.
+        if "+psycopg" in self.database_url.lower() and (
+            importlib.util.find_spec("psycopg") is None
         ):
             raise RuntimeError(
-                "DATABASE_URL points at Postgres via asyncpg but the "
-                "'asyncpg' driver is not installed. Install with "
+                "DATABASE_URL points at Postgres via psycopg but the "
+                "'psycopg' driver is not installed. Install with "
                 "`pip install nextcloud-mcp-server[postgres]` or use "
                 "the Docker image, which bundles it. See ADR-026."
             )
 
-        # Conditionally pass TLS config through to asyncpg. When
-        # ``get_database_ssl()`` returns None we omit ``ssl`` entirely
-        # so asyncpg's default (``prefer``) applies — keeps
+        # TLS is carried IN the DATABASE_URL (e.g. ``?sslmode=require``) and
+        # read by libpq/psycopg directly — the URL is passed through verbatim,
+        # never decomposed or rewritten. No TLS ``connect_args``: the server
+        # accepts the operator-supplied DSN as-is (ADR-026). When the URL omits
+        # ``sslmode`` libpq's default (``prefer``) applies, keeping
         # cluster-local Postgres without TLS working out of the box.
-        connect_args: dict[str, object] = {}
-        ssl_arg = get_database_ssl()
-        if ssl_arg is not None:
-            connect_args["ssl"] = ssl_arg
-            logger.info("Postgres backend TLS: %s", _describe_ssl_arg(ssl_arg))
-
         engine = create_async_engine(
             self.database_url,
             poolclass=NullPool,
-            connect_args=connect_args,
             future=True,
         )
         logger.info(
@@ -601,7 +582,7 @@ class RefreshTokenStorage:
         """Dispose the underlying AsyncEngine on shutdown.
 
         With ``NullPool`` the dispose call has no idle pool to drain,
-        but it still cleanly tears down any in-flight asyncpg
+        but it still cleanly tears down any in-flight psycopg
         connections held by active checkouts so shutdown hooks don't
         leave dangling transports behind. Idempotent: safe to call
         from any number of shutdown hooks.

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -363,7 +363,7 @@ def worker(concurrency: int | None, tier: str | None):
 
     \b
     Example:
-      $ export DATABASE_URL=postgresql+asyncpg://mcp:mcp@db/mcp
+      $ export DATABASE_URL=postgresql+psycopg://mcp:mcp@db/mcp
       $ nextcloud-mcp-server worker -c 4 --tier fast
     """
     import anyio  # noqa: PLC0415
@@ -525,7 +525,7 @@ def _db_target_options(fn):
         "-u",
         envvar="DATABASE_URL",
         default=None,
-        help="SQLAlchemy URL (e.g. postgresql+asyncpg://...). Wins over --database-path.",
+        help="SQLAlchemy URL (e.g. postgresql+psycopg://...). Wins over --database-path.",
     )(fn)
     return fn
 
@@ -548,7 +548,7 @@ def upgrade(database_url: str | None, database_path: str | None, revision: str):
       $ nextcloud-mcp-server db upgrade
 
       # Upgrade a Postgres backend
-      $ nextcloud-mcp-server db upgrade -u postgresql+asyncpg://mcp:mcp@db/mcp
+      $ nextcloud-mcp-server db upgrade -u postgresql+psycopg://mcp:mcp@db/mcp
 
       # Use custom SQLite path
       $ nextcloud-mcp-server db upgrade -d /path/to/tokens.db

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -1874,5 +1874,10 @@ def get_procrastinate_conninfo(database_url: str | None = None) -> str:
         )
 
     # Strip only the SQLAlchemy driver tag (``postgresql+psycopg`` →
-    # ``postgresql``); libpq consumes the rest of the URL unchanged.
-    return re.sub(r"^postgresql\+\w+://", "postgresql://", url, count=1)
+    # ``postgresql``); libpq consumes the rest of the URL unchanged. Match
+    # case-insensitively so the strip stays consistent with the scheme guard
+    # above (``url.lower().startswith``) — a ``Postgresql+psycopg://`` that
+    # passed the guard must not slip through unstripped into an invalid conninfo.
+    return re.sub(
+        r"^postgresql\+\w+://", "postgresql://", url, count=1, flags=re.IGNORECASE
+    )

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -2,6 +2,7 @@ import atexit
 import logging
 import logging.config
 import os
+import re
 import socket
 import ssl
 import tempfile
@@ -88,19 +89,14 @@ _DEFAULTS: dict[str, Any] = {
     # Set TOKEN_STORAGE_DB to persist tokens across restarts.
     "token_storage_db": None,
     # Centralized backend (any SQLAlchemy URL). Wins over TOKEN_STORAGE_DB
-    # when set. Use postgresql+asyncpg://user:pw@host/db for HA k8s
-    # deployments so pods can be stateless. See ADR-026.
+    # when set. Use postgresql+psycopg://user:pw@host/db for HA k8s
+    # deployments so pods can be stateless. The URL is passed through
+    # verbatim — TLS (e.g. ?sslmode=require) and every other parameter are
+    # read from it by libpq/psycopg; the server never rewrites it. See ADR-026.
     "database_url": None,
-    # TLS for the Postgres backend (mirror NEXTCLOUD_VERIFY_SSL pattern).
-    # Default is None — preserve asyncpg's `prefer` mode so cluster-local
-    # Postgres without TLS works out of the box. Set to True for full
-    # verification or False to silence cert errors against self-signed
-    # homelab servers. DATABASE_CA_BUNDLE points at a private-CA PEM.
-    "database_verify_ssl": None,
-    "database_ca_bundle": None,
     # Postgres connection pool sizing (ADR-026 → "Concurrency model and
     # pool sizing"). Per-pod defaults to 2 + 5 overflow = 7 max
-    # connections. asyncpg connections are single-flight, so the pool
+    # connections. psycopg connections are single-flight, so the pool
     # only needs to cover typical multi-user MCP burst — not every
     # potential in-flight tool call. Tune up with DATABASE_POOL_SIZE /
     # DATABASE_MAX_OVERFLOW for high-traffic prod fleets.
@@ -562,7 +558,7 @@ def get_database_url() -> str:
 
     Priority:
     1. ``DATABASE_URL`` if set — any SQLAlchemy URL is accepted; the primary
-       supported backends are ``postgresql+asyncpg://...`` for HA k8s
+       supported backends are ``postgresql+psycopg://...`` for HA k8s
        deployments and ``sqlite+aiosqlite:///...`` for development.
     2. Otherwise build ``sqlite+aiosqlite:///{get_token_db_path()}`` so the
        legacy ``TOKEN_STORAGE_DB`` env var and the ephemeral-tempfile
@@ -590,7 +586,7 @@ def mask_db_password(url: str) -> str:
     """Return a logger-safe rendering of a SQLAlchemy URL.
 
     DATABASE_URL routinely carries a password (e.g.
-    ``postgresql+asyncpg://mcp:secret@db/mcp``); logging it raw leaks the
+    ``postgresql+psycopg://mcp:secret@db/mcp``); logging it raw leaks the
     secret to stdout/stderr and any aggregator. SQLAlchemy's
     :func:`make_url` + ``render_as_string(hide_password=True)`` substitutes
     a fixed ``***`` placeholder while keeping the rest of the URL intact
@@ -837,15 +833,8 @@ class Settings:
     # pooled connection on flaky CDN/WAN paths (see #965).
     nextcloud_http_keepalive: bool = True
 
-    # Postgres backend TLS settings (ADR-026). Default verify_ssl is None,
-    # not True: when DATABASE_URL is unset there's nothing to verify, and
-    # when it is set we don't want to break cluster-internal Postgres that
-    # commonly runs without TLS. Operators opt in to verify-full with True
-    # or supply a private-CA bundle.
-    database_verify_ssl: bool | None = None
-    database_ca_bundle: str | None = None
     # Postgres connection pool sizing — DEPRECATED, retained for
-    # backward compatibility. The asyncpg engine switched to NullPool
+    # backward compatibility. The psycopg engine switched to NullPool
     # in #799 (cross-event-loop crashes under anyio TaskGroups made
     # the original QueuePool + pool_pre_ping setup unsafe). These
     # fields no longer affect the Postgres engine; the validators
@@ -1145,23 +1134,9 @@ class Settings:
                 "poisoned/desynced pooled connections (#965)."
             )
 
-        # Validate Postgres backend TLS configuration (ADR-026)
-        if self.database_verify_ssl is False:
-            logger.warning(
-                "DATABASE_VERIFY_SSL is disabled. "
-                "TLS certificate verification is turned off for the Postgres "
-                "backend. Only acceptable for homelab / self-signed setups; "
-                "prefer DATABASE_CA_BUNDLE for production."
-            )
-        if self.database_ca_bundle:
-            if not os.path.isfile(self.database_ca_bundle):
-                raise ValueError(
-                    f"DATABASE_CA_BUNDLE path does not exist: {self.database_ca_bundle}"
-                )
-            logger.info(
-                "Using custom CA bundle for Postgres backend: %s",
-                self.database_ca_bundle,
-            )
+        # Postgres backend TLS is configured entirely in DATABASE_URL (e.g.
+        # ?sslmode=require&sslrootcert=/path) and read by libpq/psycopg — the
+        # server neither parses nor validates it (ADR-026, Model A).
 
         # Pool sizing must be sensible — guard against operators accidentally
         # setting 0 / negative via env (would deadlock at first request).
@@ -1712,9 +1687,6 @@ def get_settings() -> Settings:
         "nextcloud_verify_ssl": "NEXTCLOUD_VERIFY_SSL",
         "nextcloud_ca_bundle": "NEXTCLOUD_CA_BUNDLE",
         "nextcloud_http_keepalive": "NEXTCLOUD_HTTP_KEEPALIVE",
-        # Postgres backend TLS (ADR-026)
-        "database_verify_ssl": "DATABASE_VERIFY_SSL",
-        "database_ca_bundle": "DATABASE_CA_BUNDLE",
         # Postgres backend pool sizing (ADR-026)
         "database_pool_size": "DATABASE_POOL_SIZE",
         "database_max_overflow": "DATABASE_MAX_OVERFLOW",
@@ -1878,143 +1850,29 @@ def get_nextcloud_http_keepalive() -> bool:
     return get_settings().nextcloud_http_keepalive
 
 
-def get_database_ssl() -> bool | ssl.SSLContext | None:
-    """Return the asyncpg ``ssl`` arg for the Postgres backend (ADR-026).
-
-    Returns:
-        - ``None`` when both DATABASE_VERIFY_SSL and DATABASE_CA_BUNDLE are
-          unset — caller skips passing ``ssl`` so asyncpg keeps its default
-          (``prefer``). Preserves PR #798 behavior for cluster-local
-          Postgres without TLS.
-        - ``False`` if DATABASE_VERIFY_SSL=false (silence cert errors).
-        - ``ssl.SSLContext`` if DATABASE_CA_BUNDLE is set (custom private
-          CA, implies verify-full).
-        - ``True`` if DATABASE_VERIFY_SSL=true and no bundle (verify-full
-          against system trust store).
-
-    DATABASE_VERIFY_SSL=false wins over DATABASE_CA_BUNDLE so an operator
-    can quickly silence cert errors during incident response without
-    having to delete the bundle path from their secret store. Matches the
-    Nextcloud-pattern precedence for symmetry with
-    :func:`get_nextcloud_ssl_verify`.
-    """
-    settings = get_settings()
-    if settings.database_verify_ssl is False:
-        # Operator-explicit opt-out (DATABASE_VERIFY_SSL=false) — semantics
-        # are documented in the docstring above and ADR-026 TLS section.
-        # Bare NOSONAR silences any cert-verification-required rule that
-        # may fire on this branch (defensive; no such rule fires today).
-        return False  # NOSONAR
-    if settings.database_ca_bundle:
-        # ``ssl.create_default_context()`` on Python 3.10+ already negotiates
-        # the strongest available protocol (TLS 1.2+ with secure ciphers);
-        # we pin Python 3.11+ in pyproject.toml. ``purpose=SERVER_AUTH`` is
-        # the default but spelt out here so the intent is visible to
-        # static analysers and human readers alike.
-        return ssl.create_default_context(  # NOSONAR
-            purpose=ssl.Purpose.SERVER_AUTH,
-            cafile=settings.database_ca_bundle,
-        )
-    if settings.database_verify_ssl is True:
-        return True
-    return None
-
-
-def _pg_ssl_params() -> dict[str, str]:
-    """Map the DATABASE_VERIFY_SSL / DATABASE_CA_BUNDLE settings to libpq
-    keyword params for psycopg3 (used by procrastinate, Deck #183).
-
-    psycopg/libpq takes ``sslmode`` (and ``sslrootcert``) rather than an
-    ``ssl.SSLContext`` like asyncpg, so we translate :func:`get_database_ssl`'s
-    intent into the equivalent libpq settings:
-
-    - ``None``  (both unset)        → ``{}`` (omit; libpq default ``prefer``,
-      matching the asyncpg default for cluster-local Postgres without TLS).
-    - ``False`` (DATABASE_VERIFY_SSL=false) → ``sslmode=require`` (encrypt but
-      do not verify the certificate).
-    - CA bundle set                → ``sslmode=verify-full`` + ``sslrootcert``.
-    - ``True``  (verify, no bundle) → ``sslmode=verify-full`` (system trust).
-    """
-    ssl_setting = get_database_ssl()
-    if ssl_setting is None:
-        return {}
-    if ssl_setting is False:
-        return {"sslmode": "require"}
-    settings = get_settings()
-    if settings.database_ca_bundle:
-        return {"sslmode": "verify-full", "sslrootcert": settings.database_ca_bundle}
-    return {"sslmode": "verify-full"}
-
-
 def get_procrastinate_conninfo(database_url: str | None = None) -> str:
-    """Build a libpq conninfo string for procrastinate's psycopg3 connector.
+    """Return the libpq conninfo for procrastinate's psycopg3 connector.
 
-    Derives the connection from ``DATABASE_URL`` (a SQLAlchemy URL such as
-    ``postgresql+asyncpg://user:pass@host/db``): the SQLAlchemy driver suffix
-    (``+asyncpg``/``+psycopg``) is stripped and the parts are rendered via
-    :func:`psycopg.conninfo.make_conninfo`, which quotes values correctly (never
-    f-string the password). TLS settings are appended from :func:`_pg_ssl_params`.
+    ``DATABASE_URL`` is passed through **verbatim** — never decomposed or
+    rewritten (ADR-026, Model A). procrastinate speaks raw libpq (psycopg3),
+    which wants the URL *without* SQLAlchemy's ``+psycopg`` driver tag, so the
+    only transform is a lossless strip of that tag. libpq then reads
+    ``sslmode``, ``connect_timeout``, the password, and every other parameter
+    straight from the URL. TLS therefore lives entirely in the DSN; there is no
+    separate env-var TLS mechanism.
 
-    This is driver-agnostic on purpose: procrastinate uses psycopg3 regardless of
-    which SQLAlchemy driver the app's own engine uses, so it works whether
-    ``DATABASE_URL`` carries ``+asyncpg`` or ``+psycopg``.
-
-    TODO(Deck #183 follow-up, out-of-tree): unify the app's SQLAlchemy engine on
-    psycopg3 too (``postgresql+psycopg://``) and drop asyncpg, so the deployment
-    ships a single Postgres driver. This belongs in the rendered Helm chart
-    (set ``DATABASE_URL`` to a ``+psycopg`` URL) rather than rewriting the driver
-    in code — see charts repo, not this repo.
-
-    Only the host/port/dbname/user/password components are forwarded, plus
-    ``connect_timeout`` (a libpq keyword) honored from the URL query string or
-    defaulted to 10s so a slow/unreachable DB can't hang worker/API startup
-    indefinitely. Any *other* ``?key=value`` query parameters are **dropped**
-    (TLS is set separately via :func:`_pg_ssl_params`, and SQLAlchemy-specific
-    options don't map cleanly to libpq keywords); a warning lists them.
-
-    Raises ``ValueError`` for a non-Postgres URL — procrastinate is Postgres-only.
+    Raises ``ValueError`` for a non-Postgres URL — procrastinate is
+    Postgres-only — rather than silently coercing it.
     """
-    from psycopg.conninfo import make_conninfo  # noqa: PLC0415
-    from sqlalchemy.engine.url import make_url  # noqa: PLC0415
-
-    url = make_url(database_url or get_database_url())
-    if not url.drivername.startswith("postgresql"):
+    url = database_url or get_database_url()
+    if not url.lower().startswith("postgresql"):
+        # Show only the scheme (no credentials) — the URL is not parsed.
+        scheme = url.split("://", 1)[0]
         raise ValueError(
             "get_procrastinate_conninfo requires a PostgreSQL DATABASE_URL; "
-            f"got driver {url.drivername!r}"
+            f"got driver {scheme!r}"
         )
 
-    # ``connect_timeout`` is forwarded (libpq keyword); everything else in the
-    # query string is dropped with a warning.
-    dropped = sorted(k for k in url.query if k != "connect_timeout")
-    if dropped:
-        logger.warning(
-            "Dropping DATABASE_URL query parameters not forwarded to the "
-            "procrastinate connector: %s",
-            ", ".join(dropped),
-        )
-
-    params: dict[str, str] = {}
-    if url.host:
-        params["host"] = url.host
-    if url.port:
-        params["port"] = str(url.port)
-    if url.database:
-        params["dbname"] = url.database
-    if url.username:
-        params["user"] = url.username
-    if url.password:
-        params["password"] = url.password
-    # Honor an operator-supplied connect_timeout, else default to 10s. (make_url
-    # query values are str or a tuple of strs when repeated; take the last.)
-    # ``connect_timeout=0`` (disable) is preserved — only a missing/empty value
-    # falls back to the default, and an explicit-but-empty value is flagged.
-    _ct = url.query.get("connect_timeout")
-    if isinstance(_ct, (list, tuple)):
-        _ct = _ct[-1] if _ct else None
-    if _ct == "":
-        logger.warning("DATABASE_URL has an empty connect_timeout=; using default 10s")
-    params["connect_timeout"] = _ct if _ct else "10"
-    params.update(_pg_ssl_params())
-
-    return make_conninfo(**params)
+    # Strip only the SQLAlchemy driver tag (``postgresql+psycopg`` →
+    # ``postgresql``); libpq consumes the rest of the URL unchanged.
+    return re.sub(r"^postgresql\+\w+://", "postgresql://", url, count=1)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -600,8 +600,6 @@ def mask_db_password(url: str) -> str:
         # If parsing fails (e.g. an explicit ssl-disable test URL with an
         # exotic shape), fall back to a regex that scrubs any
         # ``://user:password@`` pattern. Never raise from a logging path.
-        import re  # noqa: PLC0415
-
         return re.sub(r"(://[^:/]+):[^@]*@", r"\1:***@", url)
 
 

--- a/nextcloud_mcp_server/migrations.py
+++ b/nextcloud_mcp_server/migrations.py
@@ -5,7 +5,7 @@ programmatically. It enables automatic migration on application startup and
 provides CLI integration.
 
 All helpers accept a SQLAlchemy URL (``sqlite+aiosqlite:///...`` or
-``postgresql+asyncpg://...``). When called without an explicit URL they fall
+``postgresql+psycopg://...``). When called without an explicit URL they fall
 back to :func:`nextcloud_mcp_server.config.get_database_url`.
 """
 
@@ -35,36 +35,42 @@ def _coerce_url(database_url: str | Path | None) -> str:
     return database_url
 
 
-_KNOWN_ASYNC_DRIVERS = ("aiosqlite", "asyncpg")
+# Async-only drivers: strip the suffix so the sync engine falls back to the
+# backend's default sync driver (``+aiosqlite`` -> ``sqlite`` / pysqlite).
+_ASYNC_ONLY_DRIVERS = ("aiosqlite",)
+# Drivers that already work synchronously — psycopg3 supports both sync and
+# async, so the sync engine can use ``postgresql+psycopg://`` unchanged.
+_SYNC_CAPABLE_DRIVERS = ("psycopg",)
 
 
 def _to_sync_url(database_url: str) -> str:
     """Map an async driver URL to its sync equivalent for blocking inspection.
 
     SQLAlchemy's :func:`inspect` and :func:`create_engine` used below are
-    synchronous APIs. The runtime uses async drivers (``aiosqlite``,
-    ``asyncpg``) but Alembic and these utility queries don't need them.
+    synchronous APIs. ``+aiosqlite`` is async-only and gets stripped to the
+    sync pysqlite driver; ``+psycopg`` is sync-capable and passes through
+    unchanged (psycopg3 is a unified sync/async driver).
 
-    Emits a one-shot warning when the URL carries an async-driver
-    suffix we don't recognize — the sync engine creation downstream
-    will still fail, but with a clearer hint than SQLAlchemy's generic
-    "Can't load plugin" error.
+    Emits a one-shot warning when the URL carries some other unrecognized
+    driver suffix — the sync engine creation downstream will still fail, but
+    with a clearer hint than SQLAlchemy's generic "Can't load plugin" error.
     """
     out = database_url
-    for driver in _KNOWN_ASYNC_DRIVERS:
+    for driver in _ASYNC_ONLY_DRIVERS:
         out = out.replace(f"+{driver}", "")
     # Detect a leftover ``+<driver>`` token (we know the URL is
-    # ``scheme[+driver]://...``, so a remaining ``+`` before ``://``
-    # means an unrecognized async driver). Log once and pass through.
+    # ``scheme[+driver]://...``, so a remaining ``+`` before ``://`` means a
+    # driver we didn't strip). psycopg is sync-capable and expected; anything
+    # else is unrecognized — log once and pass through.
     head = out.split("://", 1)[0]
     if "+" in head:
-        unknown = head.split("+", 1)[1]
-        logger.warning(
-            "_to_sync_url: unrecognized driver %r in DATABASE_URL; "
-            "passing through unchanged. Supported async drivers: %s",
-            unknown,
-            ", ".join(_KNOWN_ASYNC_DRIVERS),
-        )
+        driver = head.split("+", 1)[1]
+        if driver not in _SYNC_CAPABLE_DRIVERS:
+            logger.warning(
+                "_to_sync_url: unrecognized driver %r in DATABASE_URL; "
+                "passing through unchanged.",
+                driver,
+            )
     return out
 
 

--- a/nextcloud_mcp_server/usage/store.py
+++ b/nextcloud_mcp_server/usage/store.py
@@ -35,14 +35,15 @@ from nextcloud_mcp_server.observability.metrics import record_db_operation
 logger = logging.getLogger(__name__)
 
 
-# Parameters bind untyped through the ``sa.text(...)`` shim; asyncpg infers
-# each placeholder's type from its target column. For ``occurred_at``
-# (TIMESTAMPTZ) it wants a real ``datetime`` (a string is rejected even with a
-# CAST), so we bind the aware datetime object on Postgres; SQLite's sqlite3
-# driver can't bind a ``datetime`` on Python 3.12+, so we bind an ISO string
-# there. ``metadata`` (JSONB) takes a JSON string on both — asyncpg's jsonb
-# codec accepts ``str`` directly, so no cast is needed. Same SQL both ways;
-# only the ``occurred_at`` bind value differs by dialect.
+# Parameters bind untyped through the ``sa.text(...)`` shim. psycopg3 dumps a
+# Python ``str`` with the libpq "unknown" OID, so Postgres infers each
+# placeholder's type from its target column. For ``occurred_at`` (TIMESTAMPTZ)
+# we bind the aware ``datetime`` object on Postgres — psycopg3 adapts it to
+# timestamptz directly; SQLite's sqlite3 driver can't bind a ``datetime`` on
+# Python 3.12+, so we bind an ISO string there. ``metadata`` (JSONB) takes a
+# JSON string on both: on Postgres the unknown-typed ``str`` is inferred as
+# jsonb and parsed server-side, so no explicit ``::jsonb`` cast is needed. Same
+# SQL both ways; only the ``occurred_at`` bind value differs by dialect.
 _INSERT_SQL = (
     "INSERT INTO usage_events (event_id, occurred_at, metric, value, metadata) "
     "VALUES (?, ?, ?, ?, ?) "
@@ -125,7 +126,7 @@ class UsageEventStore:
         try:
             event_id = event_id or str(uuid.uuid4())
             when = occurred_at or datetime.now(timezone.utc)
-            # asyncpg takes the datetime object directly; sqlite3 needs a string.
+            # psycopg takes the datetime object directly; sqlite3 needs a string.
             when_bind = (
                 when if self._storage.dialect == "postgresql" else when.isoformat()
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,6 @@ nextcloud-mcp-server = "nextcloud_mcp_server.cli:cli"
 
 [project.optional-dependencies]
 postgres = [
-    "asyncpg>=0.29",
     "procrastinate>=3.8",
     "psycopg[binary,pool]>=3.2",
 ]

--- a/tests/fixtures/storage_backend.py
+++ b/tests/fixtures/storage_backend.py
@@ -10,7 +10,7 @@ available in the current environment:
 
   and export the URL so the fixture picks it up::
 
-      export TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp
+      export TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp
 
   When ``TEST_DATABASE_URL`` is unset (or the host is unreachable), the
   Postgres parametrization is skipped automatically so the suite still runs
@@ -38,8 +38,8 @@ def _postgres_reachable(url: str) -> bool:
     """Return ``True`` if the configured Postgres accepts TCP connections.
 
     A lightweight socket probe is used rather than a full DB handshake so
-    we don't have to ship a sync Postgres driver (psycopg2) just for the
-    test gate — asyncpg only works inside an event loop.
+    we don't have to open a sync Postgres connection just for the test
+    gate — the async psycopg engine only works inside an event loop.
     """
     import socket
     from urllib.parse import urlparse
@@ -80,9 +80,9 @@ def storage_backend(request):
 
     async def reset() -> None:
         # Use a fresh async engine so we don't fight an async connection
-        # the test might still be holding open at teardown time. asyncpg
+        # the test might still be holding open at teardown time. psycopg3
         # is the only driver we ship for Postgres, so the reset path stays
-        # event-loop-only (no psycopg2 dependency required).
+        # event-loop-only.
         from sqlalchemy import text
         from sqlalchemy.ext.asyncio import create_async_engine
 

--- a/tests/integration/test_ingest_queue_postgres.py
+++ b/tests/integration/test_ingest_queue_postgres.py
@@ -6,7 +6,7 @@ Validates the queue mechanics the in-memory connector can't: real
 ``test_storage_postgres.py``::
 
     docker compose --profile postgres up -d postgres-test
-    export TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp
+    export TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp
     uv run pytest tests/integration/test_ingest_queue_postgres.py -v -m postgres
 
 Skipped when ``TEST_DATABASE_URL`` is unset or the service is unreachable.
@@ -23,7 +23,6 @@ from urllib.parse import urlparse
 import pytest
 from procrastinate import JobContext
 
-import nextcloud_mcp_server.config as config_module
 import nextcloud_mcp_server.vector.queue.procrastinate as pq
 from nextcloud_mcp_server.vector.queue.procrastinate import (
     INGEST_QUEUE_NAME,
@@ -60,7 +59,7 @@ def postgres_url() -> str:
         pytest.skip(
             "TEST_DATABASE_URL not set — run "
             "`docker compose --profile postgres up -d postgres-test` and export "
-            "TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp"
+            "TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp"
         )
     # pytest.skip raises, but ty doesn't model it as NoReturn — narrow explicitly.
     assert url is not None
@@ -70,7 +69,7 @@ def postgres_url() -> str:
 
 
 @pytest.fixture
-async def fresh_app(postgres_url: str, monkeypatch: pytest.MonkeyPatch):
+async def fresh_app(postgres_url: str):
     """Drop+recreate the public schema, then apply procrastinate's schema."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
@@ -83,10 +82,8 @@ async def fresh_app(postgres_url: str, monkeypatch: pytest.MonkeyPatch):
     finally:
         await engine.dispose()
 
-    # build_app_for_url passes the URL explicitly to get_procrastinate_conninfo,
-    # so only the ssl lookup (which reads settings) needs pinning here.
-    monkeypatch.setattr(config_module, "get_database_ssl", lambda: None)
-
+    # get_procrastinate_conninfo passes the URL through verbatim (only strips
+    # the +psycopg driver tag), so there is no settings/ssl lookup to pin.
     app = build_app_for_url(postgres_url)
     await apply_ingest_queue_schema(app)
     return app

--- a/tests/integration/test_storage_postgres.py
+++ b/tests/integration/test_storage_postgres.py
@@ -1,6 +1,6 @@
 """End-to-end Postgres backend smoke for RefreshTokenStorage (ADR-026).
 
-Exercises every storage method touched by the SQLAlchemy / asyncpg port
+Exercises every storage method touched by the SQLAlchemy / psycopg port
 against a fresh Postgres schema. The test is opt-in: it requires the
 ``postgres-test`` docker-compose service to be running and
 ``TEST_DATABASE_URL`` to be exported.
@@ -8,7 +8,7 @@ against a fresh Postgres schema. The test is opt-in: it requires the
 Bring up the dependency once::
 
     docker compose --profile postgres up -d postgres-test
-    export TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp
+    export TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp
 
 Then run::
 
@@ -54,8 +54,10 @@ def postgres_url() -> str:
         pytest.skip(
             "TEST_DATABASE_URL not set — run "
             "`docker compose --profile postgres up -d postgres-test` and export "
-            "TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp"
+            "TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp"
         )
+    # pytest.skip raises, but ty doesn't model it as NoReturn — narrow explicitly.
+    assert url is not None
     if not _reachable(url):
         pytest.skip(f"Postgres at {url} is not reachable")
     return url
@@ -238,7 +240,7 @@ async def test_browser_session_delete_returning(storage: RefreshTokenStorage):
     needed SQLite ≥ 3.35 specifically because of RETURNING. Bot review
     on PR #798 round 2 flagged that the existing cleanup test didn't
     actually exercise this path. Asserts both the present and absent
-    cases so the asyncpg result-handling for RETURNING is covered.
+    cases so the psycopg result-handling for RETURNING is covered.
     """
     await storage.create_browser_session(
         session_id="bs-returning", user_id="alice", ttl_seconds=600
@@ -254,7 +256,7 @@ async def test_browser_session_delete_returning(storage: RefreshTokenStorage):
 
 
 async def test_close_disposes_engine(postgres_url: str, reset_schema):
-    """``close()`` releases pooled asyncpg connections and is idempotent.
+    """``close()`` releases pooled psycopg connections and is idempotent.
 
     PR #798 round-4 review (bot #4): the engine wasn't being disposed on
     shutdown, leaking server-side connection slots until the Postgres
@@ -319,7 +321,9 @@ async def test_concurrent_initialize_serialized_by_advisory_lock(
     try:
         async with engine.connect() as conn:
             result = await conn.execute(text("SELECT count(*) FROM alembic_version"))
-            (count,) = result.fetchone()
+            row = result.fetchone()
+            assert row is not None
+            (count,) = row
             assert count == 1, f"expected 1 alembic_version row, got {count}"
     finally:
         await engine.dispose()

--- a/tests/unit/test_app_password_storage.py
+++ b/tests/unit/test_app_password_storage.py
@@ -7,7 +7,7 @@ BasicAuth mode background sync.
 These tests are parametrized over both supported backends so the storage
 layer is exercised against SQLite (default, always runs) and Postgres (gated
 on ``TEST_DATABASE_URL``; bring up ``docker compose --profile postgres up
--d postgres-test`` and export ``TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp``
+-d postgres-test`` and export ``TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp``
 to opt in).
 """
 
@@ -241,7 +241,7 @@ async def test_decryption_with_wrong_key(encryption_key):
         await storage1.store_app_password("testuser", "JHWzB-ZYgLZ-3qBDj-ZQe5o-LdKpB")
 
         # Try to read with different key
-        wrong_key = Fernet.generate_key().decode()
+        wrong_key = Fernet.generate_key()
         storage2 = RefreshTokenStorage(db_path=str(db_path), encryption_key=wrong_key)
         await storage2.initialize()
 

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -184,6 +184,19 @@ class TestProcrastinateConninfo:
         assert parsed["dbname"] == "mcp"
         assert parsed["sslmode"] == "require"
 
+    def test_conninfo_strips_driver_tag_case_insensitively(self, monkeypatch):
+        # The scheme guard is case-insensitive; the driver-tag strip must match,
+        # so an unconventional-cased scheme can't slip through unstripped.
+        monkeypatch.setattr(
+            config_module,
+            "get_database_url",
+            lambda: "Postgresql+psycopg://mcp:s@db/mcp?sslmode=require",
+        )
+        assert (
+            config_module.get_procrastinate_conninfo()
+            == "postgresql://mcp:s@db/mcp?sslmode=require"
+        )
+
     def test_conninfo_no_injected_connect_timeout(self, monkeypatch):
         # The server injects nothing — a URL without connect_timeout stays that
         # way (the CP/gitops-generated DSN owns the default, not the server).

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -115,7 +115,7 @@ class TestIngestQueueResolution:
         monkeypatch.setattr(
             config_module,
             "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:mcp@db/mcp",
+            lambda: "postgresql+psycopg://mcp:mcp@db/mcp",
         )
         assert Settings().ingest_queue == "memory"
 
@@ -124,7 +124,7 @@ class TestIngestQueueResolution:
         monkeypatch.setattr(
             config_module,
             "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:mcp@db/mcp",
+            lambda: "postgresql+psycopg://mcp:mcp@db/mcp",
         )
         assert Settings(ingest_queue="postgres").ingest_queue == "postgres"
 
@@ -132,7 +132,7 @@ class TestIngestQueueResolution:
         monkeypatch.setattr(
             config_module,
             "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:mcp@db/mcp",
+            lambda: "postgresql+psycopg://mcp:mcp@db/mcp",
         )
         assert Settings(ingest_queue="memory").ingest_queue == "memory"
 
@@ -159,68 +159,54 @@ class TestTenantId:
 
 
 class TestProcrastinateConninfo:
-    @pytest.mark.parametrize(
-        "url,expected_sslmode",
-        [
-            ("postgresql+asyncpg://mcp:p%40ss@db:5432/mcp", None),
-        ],
-    )
-    def test_conninfo_round_trips_password(self, monkeypatch, url, expected_sslmode):
+    """Model A (ADR-026): DATABASE_URL is passed through verbatim — the only
+    transform is stripping the SQLAlchemy ``+<driver>`` tag so libpq accepts
+    the URL. No decomposition, no injected defaults, no env-var TLS."""
+
+    def test_conninfo_strips_only_driver_tag(self, monkeypatch):
+        # sslmode, connect_timeout, and the (percent-encoded) password all pass
+        # through byte-for-byte; only ``+psycopg`` is removed.
+        url = "postgresql+psycopg://mcp:p%40ss@db:5432/mcp?sslmode=require&connect_timeout=7"
+        monkeypatch.setattr(config_module, "get_database_url", lambda: url)
+        assert (
+            config_module.get_procrastinate_conninfo()
+            == "postgresql://mcp:p%40ss@db:5432/mcp?sslmode=require&connect_timeout=7"
+        )
+
+    def test_conninfo_parses_to_expected_libpq_params(self, monkeypatch):
         from psycopg.conninfo import conninfo_to_dict
 
+        url = "postgresql+psycopg://mcp:p%40ss@db:5432/mcp?sslmode=require"
         monkeypatch.setattr(config_module, "get_database_url", lambda: url)
-        # No SSL settings → sslmode omitted (libpq default ``prefer``).
-        monkeypatch.setattr(config_module, "get_database_ssl", lambda: None)
         parsed = conninfo_to_dict(config_module.get_procrastinate_conninfo())
         assert parsed["password"] == "p@ss"
         assert parsed["host"] == "db"
         assert parsed["dbname"] == "mcp"
-        assert parsed.get("sslmode") == expected_sslmode
+        assert parsed["sslmode"] == "require"
 
-    def test_conninfo_connect_timeout_defaults_to_10(self, monkeypatch):
-        from psycopg.conninfo import conninfo_to_dict
+    def test_conninfo_no_injected_connect_timeout(self, monkeypatch):
+        # The server injects nothing — a URL without connect_timeout stays that
+        # way (the CP/gitops-generated DSN owns the default, not the server).
+        monkeypatch.setattr(
+            config_module,
+            "get_database_url",
+            lambda: "postgresql+psycopg://mcp:s@db/mcp",
+        )
+        assert config_module.get_procrastinate_conninfo() == "postgresql://mcp:s@db/mcp"
+
+    def test_conninfo_no_warning_on_query_params(self, monkeypatch, caplog):
+        # The old decomposition dropped unknown query params with a warning;
+        # passthrough must emit no such warning.
+        import logging
 
         monkeypatch.setattr(
             config_module,
             "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:s@db/mcp",
+            lambda: "postgresql+psycopg://mcp:s@db/mcp?sslmode=require&application_name=x",
         )
-        monkeypatch.setattr(config_module, "get_database_ssl", lambda: None)
-        parsed = conninfo_to_dict(config_module.get_procrastinate_conninfo())
-        assert parsed["connect_timeout"] == "10"
-
-    def test_conninfo_honors_url_connect_timeout(self, monkeypatch):
-        from psycopg.conninfo import conninfo_to_dict
-
-        monkeypatch.setattr(
-            config_module,
-            "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:s@db/mcp?connect_timeout=3",
-        )
-        monkeypatch.setattr(config_module, "get_database_ssl", lambda: None)
-        parsed = conninfo_to_dict(config_module.get_procrastinate_conninfo())
-        assert parsed["connect_timeout"] == "3"
-
-    def test_conninfo_ssl_mapping(self, monkeypatch):
-        from psycopg.conninfo import conninfo_to_dict
-
-        monkeypatch.setattr(
-            config_module,
-            "get_database_url",
-            lambda: "postgresql+asyncpg://mcp:s@db/mcp",
-        )
-        # verify off → encrypt without verifying.
-        monkeypatch.setattr(config_module, "get_database_ssl", lambda: False)
-        assert (
-            conninfo_to_dict(config_module.get_procrastinate_conninfo())["sslmode"]
-            == "require"
-        )
-        # verify on → verify-full.
-        monkeypatch.setattr(config_module, "get_database_ssl", lambda: True)
-        assert (
-            conninfo_to_dict(config_module.get_procrastinate_conninfo())["sslmode"]
-            == "verify-full"
-        )
+        with caplog.at_level(logging.WARNING):
+            config_module.get_procrastinate_conninfo()
+        assert "Dropping DATABASE_URL query parameters" not in caplog.text
 
     def test_conninfo_rejects_non_postgres(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/unit/test_ssl_config.py
+++ b/tests/unit/test_ssl_config.py
@@ -1,15 +1,12 @@
 """Tests for SSL/TLS configuration.
 
-Covers two parallel patterns:
+Covers ``NEXTCLOUD_VERIFY_SSL`` / ``NEXTCLOUD_CA_BUNDLE`` for the httpx
+client talking to Nextcloud.
 
-- ``NEXTCLOUD_VERIFY_SSL`` / ``NEXTCLOUD_CA_BUNDLE`` for the httpx
-  client talking to Nextcloud.
-- ``DATABASE_VERIFY_SSL`` / ``DATABASE_CA_BUNDLE`` for the asyncpg
-  driver talking to a centralized Postgres backend (ADR-026).
-
-The DB-side helper has a different default (``None`` instead of
-``True``) because asyncpg's default ``prefer`` is the right back-compat
-posture for cluster-internal Postgres — see ``get_database_ssl()``.
+Postgres backend TLS is no longer configured here: under Model A (ADR-026)
+it lives entirely in ``DATABASE_URL`` (e.g. ``?sslmode=require``) and is read
+by libpq/psycopg — see ``TestProcrastinateConninfo`` in
+``test_decomposition_config.py``.
 """
 
 import logging
@@ -24,7 +21,6 @@ import pytest
 from nextcloud_mcp_server.config import (
     Settings,
     _reload_config,
-    get_database_ssl,
     get_nextcloud_http_keepalive,
     get_nextcloud_ssl_verify,
     get_settings,
@@ -252,80 +248,7 @@ class TestGetNextcloudHTTPKeepalive:
                 _reload_config()
 
 
-class TestDatabaseSSLSettings:
-    """Test DATABASE_VERIFY_SSL / DATABASE_CA_BUNDLE fields on Settings (ADR-026)."""
-
-    def test_defaults(self):
-        """Default is None / None — preserves PR #798's asyncpg ``prefer``."""
-        settings = Settings()
-        assert settings.database_verify_ssl is None
-        assert settings.database_ca_bundle is None
-
-    def test_verify_false_logs_warning(self, caplog):
-        caplog.set_level(logging.WARNING, logger="nextcloud_mcp_server.config")
-        Settings(database_verify_ssl=False)
-        assert "DATABASE_VERIFY_SSL is disabled" in caplog.text
-
-    def test_ca_bundle_nonexistent_path_raises(self):
-        with pytest.raises(ValueError, match="DATABASE_CA_BUNDLE path does not exist"):
-            Settings(database_ca_bundle="/nonexistent/path/ca.pem")
-
-    def test_ca_bundle_existing_path_logs_info(self, caplog, tmp_path):
-        ca_file = tmp_path / "ca.pem"
-        ca_file.write_text(
-            "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"
-        )
-        caplog.set_level(logging.INFO, logger="nextcloud_mcp_server.config")
-        Settings(database_ca_bundle=str(ca_file))
-        assert "custom CA bundle for Postgres backend" in caplog.text
-
-
-class TestGetDatabaseSSL:
-    """Test the get_database_ssl() helper (ADR-026)."""
-
-    def test_both_unset_returns_none(self):
-        """The asyncpg-default opt-out path — no `ssl` kwarg passed."""
-        with patch(
-            "nextcloud_mcp_server.config.get_settings",
-            return_value=Settings(),
-        ):
-            assert get_database_ssl() is None
-
-    def test_verify_true_returns_true(self):
-        with patch(
-            "nextcloud_mcp_server.config.get_settings",
-            return_value=Settings(database_verify_ssl=True),
-        ):
-            assert get_database_ssl() is True
-
-    def test_verify_false_returns_false(self):
-        with patch(
-            "nextcloud_mcp_server.config.get_settings",
-            return_value=Settings(database_verify_ssl=False),
-        ):
-            assert get_database_ssl() is False
-
-    def test_ca_bundle_returns_ssl_context(self):
-        ca_bundle = certifi.where()
-        with patch(
-            "nextcloud_mcp_server.config.get_settings",
-            return_value=Settings(database_ca_bundle=ca_bundle),
-        ):
-            result = get_database_ssl()
-            assert isinstance(result, ssl.SSLContext)
-            assert result.cert_store_stats()["x509_ca"] > 0
-
-    def test_verify_false_wins_over_ca_bundle(self, tmp_path):
-        """False is the explicit-opt-out and must override a stale bundle path."""
-        ca_file = tmp_path / "ca.pem"
-        ca_file.write_text(
-            "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"
-        )
-        with patch(
-            "nextcloud_mcp_server.config.get_settings",
-            return_value=Settings(
-                database_verify_ssl=False,
-                database_ca_bundle=str(ca_file),
-            ),
-        ):
-            assert get_database_ssl() is False
+# Postgres backend TLS is configured entirely in DATABASE_URL (?sslmode=...)
+# and read by libpq/psycopg — there is no DATABASE_VERIFY_SSL / DATABASE_CA_BUNDLE
+# setting to test any more (ADR-026, Model A). See TestProcrastinateConninfo in
+# test_decomposition_config.py for the DATABASE_URL passthrough behaviour.

--- a/tests/unit/test_storage_engine.py
+++ b/tests/unit/test_storage_engine.py
@@ -4,8 +4,7 @@ PR #799 switched the Postgres engine from ``AsyncAdaptedQueuePool``
 to ``NullPool`` to eliminate cross-event-loop crashes under anyio
 TaskGroups. The method is factored out explicitly so a future
 engine-arg unit test has a single seam to mock — these tests pin
-the pool class and the connect-args plumbing so a refactor can't
-silently regress to a sharing pool.
+the pool class so a refactor can't silently regress to a sharing pool.
 """
 
 from __future__ import annotations
@@ -27,19 +26,19 @@ def _storage(url: str) -> RefreshTokenStorage:
 
 
 # The unit-test environment may not have the optional ``[postgres]``
-# extra installed (asyncpg is the C-extension dep). Skip the
-# engine-construction tests when asyncpg isn't importable rather
-# than hitting the "DATABASE_URL points at Postgres via asyncpg but
-# the 'asyncpg' driver is not installed" guard — that branch is
-# exercised explicitly by ``test_postgres_engine_missing_asyncpg_driver_message``
+# extra installed (psycopg is the C-extension dep). Skip the
+# engine-construction tests when psycopg isn't importable rather
+# than hitting the "DATABASE_URL points at Postgres via psycopg but
+# the 'psycopg' driver is not installed" guard — that branch is
+# exercised explicitly by ``test_postgres_engine_missing_psycopg_driver_message``
 # below.
-asyncpg_required = pytest.importorskip("asyncpg")
+psycopg_required = pytest.importorskip("psycopg")
 
 
 def test_postgres_engine_uses_nullpool():
     """The Postgres engine must use ``NullPool`` to avoid cross-loop
     crashes under anyio TaskGroups (see PR #799)."""
-    storage = _storage("postgresql+asyncpg://mcp:placeholder@db.example.com:5432/mcp")
+    storage = _storage("postgresql+psycopg://mcp:placeholder@db.example.com:5432/mcp")
     engine = storage._build_postgres_engine()
 
     assert isinstance(engine, AsyncEngine)
@@ -64,25 +63,25 @@ def test_postgres_engine_ignores_pool_sizing_settings(monkeypatch: pytest.Monkey
     monkeypatch.setattr(cfg.get_settings(), "database_pool_size", 99, raising=False)
     monkeypatch.setattr(cfg.get_settings(), "database_max_overflow", 99, raising=False)
 
-    storage = _storage("postgresql+asyncpg://mcp:placeholder@db.example.com:5432/mcp")
+    storage = _storage("postgresql+psycopg://mcp:placeholder@db.example.com:5432/mcp")
     engine = storage._build_postgres_engine()
     assert isinstance(engine.pool, NullPool)
 
 
-def test_postgres_engine_missing_asyncpg_driver_message(
+def test_postgres_engine_missing_psycopg_driver_message(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """When the ``+asyncpg`` dialect is requested but the asyncpg
+    """When the ``+psycopg`` dialect is requested but the psycopg
     optional dep isn't installed, the engine builder must surface an
     actionable error before SQLAlchemy emits its generic
     ``ModuleNotFoundError``."""
     import importlib.util
 
     def _fake_find_spec(name: str):
-        return None if name == "asyncpg" else importlib.util.find_spec(name)
+        return None if name == "psycopg" else importlib.util.find_spec(name)
 
     monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
 
-    storage = _storage("postgresql+asyncpg://mcp:placeholder@db.example.com:5432/mcp")
-    with pytest.raises(RuntimeError, match="asyncpg.*not installed"):
+    storage = _storage("postgresql+psycopg://mcp:placeholder@db.example.com:5432/mcp")
+    with pytest.raises(RuntimeError, match="psycopg.*not installed"):
         storage._build_postgres_engine()

--- a/tests/unit/test_storage_logging.py
+++ b/tests/unit/test_storage_logging.py
@@ -28,7 +28,7 @@ SENTINEL_PASSWORD_FRAGMENT = "uniqueSecretSentinel123"  # NOSONAR
 def test_mask_db_password_postgres():
     """Postgres URL passwords are replaced with the SQLAlchemy ``***`` token."""
     url = (
-        f"postgresql+asyncpg://mcp:{SENTINEL_PASSWORD_FRAGMENT}@db.example.com:5432/mcp"
+        f"postgresql+psycopg://mcp:{SENTINEL_PASSWORD_FRAGMENT}@db.example.com:5432/mcp"
     )
     masked = mask_db_password(url)
     assert SENTINEL_PASSWORD_FRAGMENT not in masked

--- a/tests/unit/test_usage_store.py
+++ b/tests/unit/test_usage_store.py
@@ -4,7 +4,7 @@ Parametrized over both supported backends via the shared ``storage_backend``
 fixture: SQLite (default, always runs) and Postgres (opt-in, gated on
 ``TEST_DATABASE_URL`` — bring up ``docker compose --profile postgres up -d
 postgres-test`` and export
-``TEST_DATABASE_URL=postgresql+asyncpg://mcp:mcp@localhost:5433/mcp``).
+``TEST_DATABASE_URL=postgresql+psycopg://mcp:mcp@localhost:5433/mcp``).
 
 Covers the recording contract: flag-gated no-op, insert roundtrip, ON CONFLICT
 dedup, JSON metadata roundtrip, NULL metadata, and the best-effort guarantee
@@ -168,7 +168,7 @@ async def test_metadata_json_roundtrip(storage, monkeypatch):
     )
     row = await _fetch(storage, eid)
     raw = row[4]
-    # Depending on the asyncpg/SQLAlchemy JSONB codec in play, Postgres may
+    # Depending on the psycopg/SQLAlchemy JSONB codec in play, Postgres may
     # return JSONB as a Python dict or as a JSON str; SQLite stores TEXT.
     # Handle both so the test is robust across driver/codec versions.
     loaded = raw if isinstance(raw, dict) else json.loads(raw)

--- a/uv.lock
+++ b/uv.lock
@@ -227,54 +227,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncpg"
-version = "0.31.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
-    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
-    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
-    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
-    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
-    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2226,7 +2178,6 @@ dependencies = [
 
 [package.optional-dependencies]
 postgres = [
-    { name = "asyncpg" },
     { name = "procrastinate" },
     { name = "psycopg", extra = ["binary", "pool"] },
 ]
@@ -2256,7 +2207,6 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "anthropic", specifier = ">=0.42.0" },
-    { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29" },
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "caldav", specifier = ">=3.0.1,<4.0" },


### PR DESCRIPTION
## Why

The blackbox-demo tenant logs `Dropping DATABASE_URL query parameters not forwarded to the procrastinate connector: sslmode`. Root cause: `get_procrastinate_conninfo()` rebuilt a libpq conninfo from `DATABASE_URL`, forwarding only host/port/db/user/password/`connect_timeout`, **dropping everything else** (the warning), then re-deriving TLS from `DATABASE_VERIFY_SSL`/`DATABASE_CA_BUNDLE` env vars that tenant pods never set — silently downgrading procrastinate's TLS to libpq's `prefer` while the app engine honoured the URL's `sslmode=require`. The env-var TLS path in `storage.py` was also asyncpg-shaped (`connect_args["ssl"]`) and inert for the `+psycopg` engine.

## What (Model A — DATABASE_URL passthrough)

- **Accept `DATABASE_URL` as given; don't modify it.** `get_procrastinate_conninfo()` now only strips the SQLAlchemy `+psycopg` driver tag so libpq reads `sslmode`/`connect_timeout`/etc. straight from the URL. No decomposition, no injected defaults, no param dropping.
- **TLS lives entirely in the DSN.** Removed `get_database_ssl()`, `_pg_ssl_params()`, and the `DATABASE_VERIFY_SSL`/`DATABASE_CA_BUNDLE` settings. The app engine passes the URL through with no TLS `connect_args`.
- **Retire asyncpg entirely** — psycopg3 is now the sole Postgres driver (app engine + procrastinate queue). `migrations._to_sync_url` keeps `+psycopg` (sync-capable) and strips only `+aiosqlite`.
- Updated `ADR-026` + `docs/configuration.md` and the affected tests.

Part of a 3-PR suite (this repo, control-plane, gitops) tracked on Deck card #540. This PR is independent and safe to ship first — it only changes how the existing `+psycopg?sslmode=require` tenant DSN is consumed (procrastinate now honours `sslmode`).

## Verification

- `ruff check` / `ruff format --check` / `ty check` green
- **2040 unit tests pass**; no `asyncpg` remains in source or tests
- `get_procrastinate_conninfo("postgresql+psycopg://u:p@h/db?sslmode=require&connect_timeout=10")` → `postgresql://u:p@h/db?sslmode=require&connect_timeout=10` (driver stripped, nothing else changed); non-postgres URL raises; no warning logged

---

_This PR was generated with the help of AI, and reviewed by a Human_