### PR TITLE
fix: harden PDF preview path validation

### DIFF
--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -44,6 +44,7 @@ from nextcloud_mcp_server.search.context import (
 )
 from nextcloud_mcp_server.search.verification import verify_search_results
 from nextcloud_mcp_server.utils.validation import (
+    is_safe_webdav_file_path,
     is_valid_nextcloud_doc_id,
     parse_modified_timestamp,
 )
@@ -919,7 +920,7 @@ async def get_pdf_preview(request: Request) -> JSONResponse:
             )
 
         # Validate no path traversal sequences
-        if ".." in file_path:
+        if not is_safe_webdav_file_path(file_path):
             return JSONResponse(
                 {"success": False, "error": "Invalid file path"},
                 status_code=400,

--- a/nextcloud_mcp_server/utils/validation.py
+++ b/nextcloud_mcp_server/utils/validation.py
@@ -2,6 +2,8 @@
 
 import re
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
+from urllib.parse import unquote
 
 # Nextcloud object IDs are unsigned ints from MySQL AUTO_INCREMENT, which
 # starts at 1. Restrict to ASCII positive integers to exclude Unicode digit
@@ -18,6 +20,22 @@ _UNIX_SECONDS_RE = re.compile(r"^[0-9]+$")
 def is_valid_nextcloud_doc_id(value: str) -> bool:
     """True iff `value` is the str form of a positive ASCII integer (>= 1)."""
     return bool(_NEXTCLOUD_DOC_ID_RE.fullmatch(value))
+
+
+def is_safe_webdav_file_path(file_path: str) -> bool:
+    """Reject traversal in a WebDAV path after repeated URL decoding."""
+    decoded_path = file_path
+    for _ in range(3):
+        next_path = unquote(decoded_path)
+        if next_path == decoded_path:
+            break
+        decoded_path = next_path
+
+    if "\x00" in decoded_path:
+        return False
+
+    path_parts = PurePosixPath(decoded_path.replace("\\", "/").lstrip("/")).parts
+    return ".." not in path_parts
 
 
 def parse_modified_timestamp(

--- a/tests/unit/test_management_pdf_preview_endpoint.py
+++ b/tests/unit/test_management_pdf_preview_endpoint.py
@@ -528,6 +528,8 @@ class TestPdfPreviewSecurityValidation:
                 "/Documents/../../../etc/passwd",
                 "/../secret.pdf",
                 "/folder/..%2F..%2Fetc/passwd",  # URL-encoded
+                "/folder/%252e%252e%252Fsecret.pdf",  # Double URL-encoded
+                "/folder/%2e%2e%5Csecret.pdf",  # Encoded Windows separator
                 "/test/../secret.pdf",
             ]
 

--- a/tests/unit/utils/test_validation.py
+++ b/tests/unit/utils/test_validation.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from nextcloud_mcp_server.utils.validation import (
+    is_safe_webdav_file_path,
     is_valid_nextcloud_doc_id,
     parse_modified_timestamp,
 )
@@ -57,6 +58,38 @@ def test_accepts_positive_ascii_integers(value):
 def test_rejects_invalid_doc_ids(value, reason):
     """Reject empty/zero/leading-zero/non-ASCII/non-digit inputs."""
     assert is_valid_nextcloud_doc_id(value) is False, f"should reject: {reason}"
+
+
+# is_safe_webdav_file_path --------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/Documents/report.pdf",
+        "/Documents/My%20File.pdf",
+        "/Documents/archive..2026.pdf",
+    ],
+)
+def test_safe_webdav_file_path_accepts_normal_paths(value):
+    assert is_safe_webdav_file_path(value) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/Documents/../../../etc/passwd",
+        "/../secret.pdf",
+        "/folder/..%2F..%2Fetc/passwd",
+        "/folder/%252e%252e%252Fsecret.pdf",
+        "/folder/%2e%2e%5Csecret.pdf",
+        "/folder/%00secret.pdf",
+    ],
+)
+def test_safe_webdav_file_path_rejects_traversal(value):
+    assert is_safe_webdav_file_path(value) is False
 
 
 # parse_modified_timestamp (ADR-027) ---------------------------------------


### PR DESCRIPTION
Fixes #503.

## Summary
- validate PDF preview paths after repeated URL decoding
- reject traversal path segments across POSIX and encoded backslash separators
- keep filenames with non-segment `..` intact

## Tests
- `UV_PYTHON=/usr/local/bin/python3.12 uv run pytest tests/unit/utils/test_validation.py -q`
- `UV_PYTHON=/usr/local/bin/python3.12 uv run ruff check nextcloud_mcp_server/api/visualization.py nextcloud_mcp_server/utils/validation.py tests/unit/utils/test_validation.py tests/unit/test_management_pdf_preview_endpoint.py`
- `UV_PYTHON=/usr/local/bin/python3.12 uv run ruff format --check nextcloud_mcp_server/api/visualization.py nextcloud_mcp_server/utils/validation.py tests/unit/utils/test_validation.py tests/unit/test_management_pdf_preview_endpoint.py`