### PR TITLE
Reduce PDF preview request log noise

### DIFF
--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -890,14 +890,14 @@ async def get_pdf_preview(request: Request) -> JSONResponse:
     # Log incoming request
     file_path_param = request.query_params.get("file_path", "<not provided>")
     page_param = request.query_params.get("page", "1")
-    logger.info(
+    logger.debug(
         "PDF preview request: file_path=%s, page=%s", file_path_param, page_param
     )
 
     try:
         # Validate OAuth token and extract user
         user_id, validated = await validate_token_and_get_user(request)
-        logger.info("PDF preview authenticated for user: %s", user_id)
+        logger.debug("PDF preview authenticated for user: %s", user_id)
     except Exception as e:
         logger.warning("Unauthorized access to /api/v1/pdf-preview: %s", e)
         return JSONResponse(

--- a/tests/unit/test_management_pdf_preview_endpoint.py
+++ b/tests/unit/test_management_pdf_preview_endpoint.py
@@ -9,6 +9,7 @@ Tests the /api/v1/pdf-preview endpoint focusing on:
 """
 
 import base64
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -250,6 +251,63 @@ class TestPdfPreviewRendering:
                 assert decoded[:8] == b"\x89PNG\r\n\x1a\n"
             except Exception as e:
                 pytest.fail(f"Image is not valid base64-encoded PNG: {e}")
+
+    def test_request_and_auth_logs_are_debug_level(self, caplog):
+        """Request/auth logs should not add production INFO noise."""
+        pdf_bytes = create_mock_pdf_bytes()
+
+        mock_webdav = AsyncMock()
+        mock_webdav.read_file = AsyncMock(return_value=(pdf_bytes, "application/pdf"))
+
+        mock_nc_client = MagicMock()
+        mock_nc_client.webdav = mock_webdav
+        mock_nc_client.__aenter__ = AsyncMock(return_value=mock_nc_client)
+        mock_nc_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+                new_callable=AsyncMock,
+                return_value=("testuser", True),
+            ),
+            patch(
+                "nextcloud_mcp_server.api.visualization.get_user_client_basic_auth",
+                new_callable=AsyncMock,
+                return_value=mock_nc_client,
+            ),
+            caplog.at_level(
+                logging.DEBUG, logger="nextcloud_mcp_server.api.visualization"
+            ),
+        ):
+            app = create_test_app()
+            client = TestClient(app)
+            response = client.get(
+                "/api/v1/pdf-preview?file_path=/test.pdf&page=1&scale=1.0",
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 200
+
+        preview_records = [
+            record
+            for record in caplog.records
+            if record.name == "nextcloud_mcp_server.api.visualization"
+        ]
+        assert any(
+            record.levelno == logging.DEBUG
+            and record.message.startswith("PDF preview request:")
+            for record in preview_records
+        )
+        assert any(
+            record.levelno == logging.DEBUG
+            and record.message == "PDF preview authenticated for user: testuser"
+            for record in preview_records
+        )
+        assert any(
+            record.levelno == logging.INFO
+            and record.message.startswith("Rendered PDF preview:")
+            for record in preview_records
+        )
 
     def test_page_out_of_range_returns_400(self):
         """Test that requesting page beyond total pages returns 400."""


### PR DESCRIPTION
Fixes #506

Summary:
- Move PDF preview request/auth logs from info to debug.
- Keep the render completion log at info.

Tests:
- .venv/bin/pytest tests/unit/test_management_pdf_preview_endpoint.py -q
- .venv/bin/ruff check
- .venv/bin/ruff format --check
- .venv/bin/ty check -- nextcloud_mcp_server
- .venv/bin/pytest tests/unit/ -x -q
