### PR TITLE
feat(vector): per-document keyword vs hybrid index mode (keyword-index tag)

### DIFF
--- a/docs/ADR-030-keyword-only-search-mode.md
+++ b/docs/ADR-030-keyword-only-search-mode.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Accepted — 2026-06-30
+**Superseded by ADR-031 — 2026-07-08.** The global `SEARCH_MODE` /
+`Settings.dense_enabled` switch and the separate `{deployment_id}-bm25-keyword`
+collection described here have been **removed**. Keyword-only vs hybrid is now a
+**per-document** choice driven by a Nextcloud tag (`keyword-index` vs
+`vector-index`), stored in one shared collection. See
+[ADR-031](./ADR-031-per-document-index-mode.md). This document is retained for
+historical context only; do not implement against it.
+
+Accepted — 2026-06-30 (superseded)
 
 ## Context
 

--- a/docs/ADR-031-per-document-index-mode.md
+++ b/docs/ADR-031-per-document-index-mode.md
@@ -1,0 +1,114 @@
+# ADR-031: Per-document keyword vs hybrid index mode
+
+## Status
+
+Accepted — 2026-07-08. Supersedes [ADR-030](./ADR-030-keyword-only-search-mode.md).
+
+## Context
+
+ADR-030 introduced a **global** `SEARCH_MODE` switch (`hybrid` | `keyword`)
+surfaced as `Settings.dense_enabled`. In `keyword` mode the whole deployment
+skipped dense embeddings and routed to a separate,
+non-interchangeable `{deployment_id}-bm25-keyword` collection.
+
+That is too coarse. A tenant frequently wants **both**: pay for dense embeddings
+on high-value PDFs (semantic + keyword search) while cheaply lexically-indexing
+bulk/low-value PDFs (keyword only, no embedding cost) — and search **all of it in
+one unified result set**. A global switch cannot express this; it forces the
+whole index into one mode and splits keyword vs hybrid across two collections
+that cannot be queried together.
+
+Enabling fact: a Qdrant collection can define both a `dense` and a `sparse` named
+vector, and a point may populate a **subset** of them. So the dense-vs-sparse
+decision can move from a deployment-global flag to a **per-document** one within
+a single collection — hybrid documents write `dense` + `sparse`, keyword-only
+documents write `sparse` only.
+
+## Decision
+
+**Remove** `SEARCH_MODE` / `Settings.dense_enabled` and the `-bm25-keyword`
+collection entirely. Make the mode **per-document**, driven by which Nextcloud
+tag selected the document:
+
+- **`vector_sync_pdf_tag`** (default `vector-index`) → **hybrid**
+  (dense + BM25 sparse).
+- **`vector_sync_keyword_tag`** (env `VECTOR_SYNC_KEYWORD_TAG`, default **empty =
+  disabled**) → **keyword** (BM25 sparse only).
+
+The collection is always sized for a real dense slot (from the embedding model);
+keyword documents simply omit the dense vector per-point. A new payload field
+`index_mode` (`payload_keys.INDEX_MODE`, values `hybrid` | `keyword`) records the
+mode on every chunk point.
+
+### Ingestion
+
+- The scanner discovers both tags (`_discover_tagged_files`), stamping each file
+  with `_index_mode`. **Hybrid wins** when a file carries both tags (it is a
+  superset of keyword). The keyword tag is queried only when configured, so
+  single-tag deployments issue exactly one OCS Tags query as before.
+- `DocumentTask.index_mode` carries the mode to the processor (default `hybrid`,
+  so every non-file producer — notes, deck, news, mail — is unchanged).
+- The processor computes `dense_for_doc = index_mode != "keyword"` and only runs
+  `generate_dense_embeddings` for hybrid documents; keyword documents upsert
+  sparse-only points.
+- The SystemTag webhook reconcile (`_reconcile_tag_event`) resolves against both
+  tags and sets `index_mode` from whichever matched (hybrid precedence).
+
+### Embedding failures are hard errors (no silent degrade)
+
+With the global skip gone, a hybrid document **always** attempts dense
+embeddings. A failed/unavailable embedding endpoint raises out of
+`generate_dense_embeddings` into `process_document`'s retry → dead-letter path
+(429s are retried inside the provider). It is **never** silently downgraded to a
+sparse-only point. The only way a document is sparse-only is an explicit
+`keyword-index` tag.
+
+### Query
+
+Unchanged and unified: `BM25HybridSearchAlgorithm` always fuses a dense + sparse
+prefetch (RRF/DBSF). Keyword documents carry no dense vector, so the dense
+prefetch never returns them; they surface via the sparse prefetch and are merged
+in by fusion. A pure-`semantic` query naturally omits them.
+
+### Cross-user dedup (monotonic toward hybrid)
+
+`embedding_identity` remains the embedding **model** name (orthogonal to
+keyword/hybrid) and still guards model switches. The keyword/hybrid distinction
+is applied on top via `index_mode` in `find_indexed_content` /
+`claim_existing_index`:
+
+- a **hybrid** claim against an existing **keyword** point is a **miss** → the
+  document is reprocessed and gains a dense vector (**upgrade**);
+- a **keyword** claim against an existing **hybrid** point is a **hit** — hybrid
+  ⊇ keyword, so the shared points are never downgraded while any user holds the
+  hybrid tag;
+- same-mode is a hit, as before.
+
+The scanner's incremental path additionally reprocesses a real point whose stored
+`index_mode` differs from the desired one (the keyword→hybrid upgrade at an
+unchanged etag, which the mtime gate alone would miss).
+
+### Verify-on-read
+
+`search/verification.py` gates file results on membership of **either** tag
+(union via `_discover_tagged_files`), so untagging from whichever tag indexed a
+file drops it from results (ADR-019 semantics, extended to two tags).
+
+### Billing
+
+Ingestion metering moved out of the dense-only coroutine so **both** modes are
+metered. `bytes_ingested` / `bytes_stored` carry an `index_mode` **metadata**
+dimension (same metric names — no new metrics) so the control plane can slice
+hybrid vs keyword ingestion. `tokens_embedded` is naturally hybrid-only (keyword
+documents pass `token_count = 0`, which skips the row).
+
+## Consequences
+
+- **Breaking migration:** any existing `SEARCH_MODE=keyword` deployment used the
+  `-bm25-keyword` collection and `bm25-keyword`-identity points, which are now
+  orphaned. Such a deployment must **re-index** into the model-named collection.
+- Airgapped, no-embedding deployments are still supported: configure no real
+  embedding provider (the local `SimpleProvider` sizes the dense slot) and tag
+  everything `keyword-index`; nothing ever calls an embedding endpoint.
+- The Astrolabe Nextcloud app owns provisioning/exposing the `keyword-index` tag
+  (tracked cross-repo on Deck board 12).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,43 +346,50 @@ OLLAMA_BASE_URL=http://ollama:11434
 
 > **Note:** In multi-user modes (Login Flow v2, Multi-User BasicAuth), enabling `ENABLE_SEMANTIC_SEARCH` automatically enables background operations and refresh token storage. You don't need to set `ENABLE_BACKGROUND_OPERATIONS` separately!
 
-### Search Mode: Keyword-Only (Airgapped) — `SEARCH_MODE`
+### Per-document keyword vs hybrid indexing — `VECTOR_SYNC_KEYWORD_TAG`
 
-`SEARCH_MODE` selects how indexed content is searched (ADR-030):
+Documents are indexed **hybrid** (dense semantic + BM25 sparse) or
+**keyword-only** (BM25 sparse) **per document**, chosen by which Nextcloud system
+tag the file carries (ADR-031). Both live in **one collection** and are returned
+by a single unified search.
 
-| Value | Behavior | Embedding endpoint |
-|-------|----------|--------------------|
-| `hybrid` (default) | Dense semantic vectors **+** BM25 sparse vectors, fused in Qdrant | **Required** (Ollama/Bedrock/OpenAI/Mistral/gateway) |
-| `keyword` | BM25 sparse (full-text/keyword) only — no dense embeddings | **None** |
+| Tag | Env var | Mode | Embedding endpoint |
+|-----|---------|------|--------------------|
+| `vector-index` | `VECTOR_SYNC_PDF_TAG` (default) | hybrid (dense + BM25 sparse) | **Required** (Ollama/Bedrock/OpenAI/Mistral/gateway) |
+| `keyword-index` | `VECTOR_SYNC_KEYWORD_TAG` (default **empty = off**) | keyword (BM25 sparse only) | **None** for those docs |
 
-Use `SEARCH_MODE=keyword` for fully **airgapped** deployments that cannot (or
-do not want to) run a text-embedding endpoint. You still get the unified
-cross-app Qdrant index (notes, files, OCR'd PDFs, deck cards, news, mail) and
-verify-on-read ACLs — just lexical (keyword) matching instead of conceptual
-similarity. BM25 sparse vectors are computed in-process, so no embedding service
-is contacted at ingestion or query time.
+Tag a PDF `keyword-index` to lexically index it **without** paying embedding
+cost; tag it `vector-index` to also get conceptual/semantic matching. **Hybrid
+wins** if a file carries both tags. Files applies PDF-only, mirroring the
+`vector-index` discovery (tagged folders expand to their PDF descendants).
 
 ```dotenv
-# Airgapped, no embedding endpoint:
-ENABLE_SEMANTIC_SEARCH=true   # keyword mode still uses the Qdrant pipeline
-SEARCH_MODE=keyword
+ENABLE_SEMANTIC_SEARCH=true
 QDRANT_URL=http://qdrant:6333
-# (no OLLAMA_BASE_URL / Bedrock / OpenAI / gateway needed)
+VECTOR_SYNC_KEYWORD_TAG=keyword-index   # enable the keyword-only tag
+# vector-index (hybrid) documents need an embedding endpoint, e.g.:
+OLLAMA_BASE_URL=http://ollama:11434
 ```
 
 Notes:
 
-- `keyword` **still requires `ENABLE_SEMANTIC_SEARCH=true`** — it uses the Qdrant
-  index. With vector sync off the search tools don't register.
-- The `nc_semantic_search` / `nc_semantic_search_answer` tools stay available;
-  results carry `search_method="bm25_keyword"`. The RAG answer tool still works
-  airgapped (retrieval via BM25, answer generated client-side via MCP sampling).
-- **Score caveat:** in keyword mode `score` is a raw BM25 value (unbounded), not
-  a normalized [0,1] fusion score, so a non-zero `score_threshold` filters very
-  differently. The `fusion` parameter is ignored.
-- **Switching modes** uses a different collection (keyword collections are named
-  `…-bm25-keyword`). Keyword and hybrid indexes are not interchangeable — to
-  switch, use a fresh collection and let background sync re-ingest.
+- Requires `ENABLE_SEMANTIC_SEARCH=true` (both tags use the Qdrant index).
+- **Unified search:** `nc_semantic_search` fuses dense + sparse. Keyword-only
+  documents contribute only their BM25 (sparse) match, so they appear in
+  bm25/hybrid results and are naturally absent from a pure-`semantic` query.
+- **Hybrid requires embeddings:** a `vector-index` document whose embedding
+  endpoint is unavailable **errors and retries** (then dead-letters) rather than
+  silently degrading to keyword-only. Only the `keyword-index` tag produces
+  sparse-only points.
+- **Fully airgapped:** leave `VECTOR_SYNC_KEYWORD_TAG=keyword-index`, configure
+  **no** embedding provider, and tag everything `keyword-index` — nothing ever
+  contacts an embedding endpoint (the local `SimpleProvider` only sizes the
+  dense slot the keyword points never populate).
+- **Retagging** a file between the two tags (unchanged content) reprocesses it:
+  keyword→`vector-index` adds a dense vector; the reverse is absorbed by the
+  dedup no-downgrade rule while any user still holds `vector-index`.
+- **Provisioning:** the `keyword-index` tag is created/exposed by the Astrolabe
+  Nextcloud app (or `occ tag:add` / the server's own `get_or_create_tag`).
 
 ### Qdrant Vector Database Modes
 
@@ -1023,7 +1030,8 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ENABLE_SEMANTIC_SEARCH` | ⚠️ Optional | `false` | Enable semantic search with background indexing (replaces `VECTOR_SYNC_ENABLED`) |
-| `SEARCH_MODE` | ⚠️ Optional | `hybrid` | `hybrid` (dense+sparse) or `keyword` (BM25 sparse only, no embedding endpoint — airgapped, ADR-030). `keyword` still requires `ENABLE_SEMANTIC_SEARCH=true` |
+| `VECTOR_SYNC_PDF_TAG` | ⚠️ Optional | `vector-index` | Nextcloud tag marking PDFs for **hybrid** (dense + BM25 sparse) indexing (ADR-031) |
+| `VECTOR_SYNC_KEYWORD_TAG` | ⚠️ Optional | _(empty)_ | Nextcloud tag marking PDFs for **keyword-only** (BM25 sparse) indexing into the same collection; empty disables it. Hybrid wins if a file carries both tags (ADR-031) |
 | `QDRANT_URL` | ⚠️ Optional | - | Qdrant service URL (network mode) - mutually exclusive with `QDRANT_LOCATION` |
 | `QDRANT_LOCATION` | ⚠️ Optional | `:memory:` | Local Qdrant path (`:memory:` or `/path/to/data`) - mutually exclusive with `QDRANT_URL` |
 | `QDRANT_API_KEY` | ⚠️ Optional | - | Qdrant API key (network mode only) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -360,8 +360,8 @@ by a single unified search.
 
 Tag a PDF `keyword-index` to lexically index it **without** paying embedding
 cost; tag it `vector-index` to also get conceptual/semantic matching. **Hybrid
-wins** if a file carries both tags. Files applies PDF-only, mirroring the
-`vector-index` discovery (tagged folders expand to their PDF descendants).
+wins** if a file carries both tags. Discovery is PDF-only, mirroring the
+`vector-index` path (tagged folders expand to their PDF descendants).
 
 ```dotenv
 ENABLE_SEMANTIC_SEARCH=true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,7 +384,11 @@ Notes:
 - **Fully airgapped:** leave `VECTOR_SYNC_KEYWORD_TAG=keyword-index`, configure
   **no** embedding provider, and tag everything `keyword-index` — nothing ever
   contacts an embedding endpoint (the local `SimpleProvider` only sizes the
-  dense slot the keyword points never populate).
+  dense slot the keyword points never populate). Note the collection is always
+  dense-sized from the *configured* provider, so if you set e.g. `OLLAMA_BASE_URL`
+  while intending to use only the keyword tag, collection creation still probes
+  that provider's dimension at startup — leave the provider env unset for a truly
+  offline stack.
 - **Retagging** a file between the two tags (unchanged content) reprocesses it:
   keyword→`vector-index` adds a dense vector; the reverse is absorbed by the
   dedup no-downgrade rule while any user still holds `vector-index`.

--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -47,32 +47,32 @@ SUPPORTED_SEARCH_ALGORITHMS: tuple[str, ...] = ("semantic", "bm25", "hybrid")
 def supported_search_types(settings: Settings) -> list[str]:
     """Search algorithms this server can actually serve, given its config.
 
-    Advertised via /api/v1/status (ADR-030) so the astrolabe UI can gate which
-    query types it offers, without having to know the server's SEARCH_MODE:
+    Advertised via /api/v1/status so the astrolabe UI can gate which query types
+    it offers:
 
     - vector sync disabled → ``[]`` (no Qdrant-backed search at all)
-    - SEARCH_MODE=keyword  → ``["bm25"]`` (dense embeddings are off, so
-      ``semantic`` and the dense half of ``hybrid`` are unavailable)
-    - SEARCH_MODE=hybrid   → all three (``semantic``, ``bm25``, ``hybrid``)
+    - vector sync enabled  → all three (``semantic``, ``bm25``, ``hybrid``). The
+      collection is always dense-capable; keyword-only documents
+      (``keyword-index`` tag) simply contribute to ``bm25``/``hybrid`` via their
+      sparse vector.
 
     Order follows ``SUPPORTED_SEARCH_ALGORITHMS`` for a stable contract.
     """
     if not settings.vector_sync_enabled:
         return []
-    if settings.dense_enabled:
-        return list(SUPPORTED_SEARCH_ALGORITHMS)
-    return ["bm25"]
+    return list(SUPPORTED_SEARCH_ALGORITHMS)
 
 
 class UnsupportedSearchType(Exception):
     """A client *explicitly* asked for a search algorithm this server can't serve.
 
     Raised by :func:`select_search_algorithm` and translated by the search
-    endpoints into **HTTP 422** carrying the advertised ``supported_search_types``
-    (ADR-030), so a client (astrolabe) that requests ``semantic`` against a
-    keyword-only server gets a hard, self-correcting error instead of silent BM25
-    results. Only *explicit* requests are strict — an absent ``algorithm`` still
-    defaults gracefully (see :func:`select_search_algorithm`).
+    endpoints into **HTTP 422** carrying the advertised ``supported_search_types``,
+    so a client (astrolabe) that requests an unavailable algorithm (e.g. any
+    algorithm while vector sync is disabled) gets a hard, self-correcting error
+    instead of silent fallback results. Only *explicit* requests are strict — an
+    absent ``algorithm`` still defaults gracefully (see
+    :func:`select_search_algorithm`).
     """
 
     def __init__(self, requested: str, supported: list[str]) -> None:
@@ -85,23 +85,23 @@ class UnsupportedSearchType(Exception):
 
 
 def select_search_algorithm(requested: str | None, settings: Settings) -> str:
-    """Pick the algorithm to run for a search request (ADR-030).
+    """Pick the algorithm to run for a search request.
 
     Single source of truth for the two search endpoints (`/api/v1/search`,
     `/api/v1/vector-viz/search`), called with the raw ``body.get("algorithm")`` —
     ``None`` when the client sent no ``algorithm`` field:
 
     - ``requested is None`` → graceful default: ``hybrid`` when available, else the
-      first supported type (``bm25`` in keyword mode). Never errors, so callers
-      that don't pin an algorithm keep working across modes. (An explicit JSON
-      ``"algorithm": null`` is indistinguishable from an omitted key — both surface
-      as ``None`` — so it takes this default path rather than being rejected.)
+      first supported type. Never errors, so callers that don't pin an algorithm
+      keep working. (An explicit JSON ``"algorithm": null`` is indistinguishable
+      from an omitted key — both surface as ``None`` — so it takes this default
+      path rather than being rejected.)
     - explicit ``requested`` in ``supported_search_types`` → returned unchanged.
     - explicit ``requested`` NOT in ``supported_search_types`` → raise
       :class:`UnsupportedSearchType` (→ 422). This is the strict half of the
-      contract that /api/v1/status advertises: an explicit ``semantic`` while
-      ``SEARCH_MODE=keyword`` is rejected rather than silently coerced, so the
-      accepted set stays in lockstep with the advertised one.
+      contract that /api/v1/status advertises, so the accepted set stays in
+      lockstep with the advertised one (e.g. any algorithm is rejected when vector
+      sync is disabled).
     """
     supported = supported_search_types(settings)
     if requested is None:
@@ -329,10 +329,9 @@ async def get_server_status(request: Request) -> JSONResponse:
         # not mounted, so the Astrolabe UI can show webhooks as unavailable and
         # vector sync falls back to the polling scanner.
         "webhooks_enabled": bool(settings.webhook_secret),
-        # Query types the astrolabe UI may offer for this server (ADR-030).
-        # Empty when vector sync is off; ["bm25"] in keyword mode; all three in
-        # hybrid mode. Lets the UI gate its algorithm picker without knowing
-        # SEARCH_MODE.
+        # Query types the astrolabe UI may offer for this server. Empty when
+        # vector sync is off; all three (semantic, bm25, hybrid) when it is on.
+        # Lets the UI gate its algorithm picker.
         "supported_search_types": supported_search_types(settings),
         "uptime_seconds": uptime_seconds,
         "management_api_version": "1.0",

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -60,7 +60,7 @@ _NEXTCLOUD_HOST_NOT_CONFIGURED = "Nextcloud host not configured"
 
 
 def _unsupported_search_type_response(e: UnsupportedSearchType) -> JSONResponse:
-    """Uniform 422 for an explicit unsupported search algorithm (ADR-030).
+    """Uniform 422 for an explicit unsupported search algorithm.
 
     Shared by both search endpoints so the ``unsupported_search_type`` payload
     shape (error / requested / supported_search_types) can't drift between them.
@@ -82,7 +82,7 @@ def _build_search_algorithm(
     score_threshold: float,
     fusion: str,
 ) -> tuple[SearchAlgorithm, str]:
-    """Resolve + instantiate the search algorithm for a request (ADR-030).
+    """Resolve + instantiate the search algorithm for a request.
 
     Shared by both search endpoints (`/api/v1/search`, `/api/v1/vector-viz/search`)
     so their selection logic can't drift. Raises :class:`UnsupportedSearchType`
@@ -94,9 +94,9 @@ def _build_search_algorithm(
     algorithm = select_search_algorithm(requested_algorithm, settings)
     if algorithm == "semantic":
         return SemanticSearchAlgorithm(score_threshold=score_threshold), algorithm
-    # Both "bm25" and "hybrid" run BM25HybridSearchAlgorithm — it combines dense
-    # semantic + sparse BM25 in hybrid mode, and issues a sparse-only query in
-    # keyword mode (it branches on dense_enabled internally).
+    # Both "bm25" and "hybrid" run BM25HybridSearchAlgorithm — it fuses dense
+    # semantic + sparse BM25; keyword-only documents contribute via the sparse
+    # side of the same query.
     fusion = fusion if fusion in ("rrf", "dbsf") else "rrf"
     return (
         BM25HybridSearchAlgorithm(score_threshold=score_threshold, fusion=fusion),
@@ -246,10 +246,9 @@ async def unified_search(request: Request) -> JSONResponse:
                 "offset",
             )
 
-            # No upper bound: hybrid DBSF fusion can exceed 1.0 and, under
-            # SEARCH_MODE=keyword (ADR-030), scores are raw BM25 (unbounded). A
-            # le=1.0 cap would 400 a legitimate keyword threshold like 3.0 —
-            # mirrors the round-1 Field(ge=0.0) fix on the nc_semantic_search tool.
+            # No upper bound: hybrid DBSF fusion can exceed 1.0, so a le=1.0 cap
+            # would 400 a legitimate threshold — mirrors the round-1
+            # Field(ge=0.0) fix on the nc_semantic_search tool.
             score_threshold = _parse_float_param(
                 body.get("score_threshold"),
                 0.0,
@@ -296,11 +295,11 @@ async def unified_search(request: Request) -> JSONResponse:
         if not query:
             return JSONResponse({"results": [], "total_found": 0})
 
-        # Resolve + build the search algorithm (ADR-030): an *explicit*
-        # unsupported request (e.g. "semantic" while SEARCH_MODE=keyword) is
-        # rejected with 422 carrying the advertised supported_search_types, so the
-        # client can correct it rather than silently receive BM25 results. An
-        # absent algorithm still defaults gracefully across modes.
+        # Resolve + build the search algorithm: an *explicit* unsupported request
+        # (e.g. any algorithm while vector sync is disabled) is rejected with 422
+        # carrying the advertised supported_search_types, so the client can
+        # correct it rather than silently receive fallback results. An absent
+        # algorithm still defaults gracefully.
         try:
             search_algo, algorithm = _build_search_algorithm(
                 requested_algorithm,
@@ -426,12 +425,11 @@ async def unified_search(request: Request) -> JSONResponse:
             "algorithm_used": algorithm,
         }
 
-        # Optional PCA coordinates
-        # PCA plots the result chunks around the query's dense embedding, so it
-        # only applies in hybrid mode. In keyword mode (ADR-030) there is no dense
-        # query embedding — skip PCA rather than calling the embedding service,
-        # keeping the airgapped path free of any embed attempt.
-        if include_pca and settings.dense_enabled and len(paginated_results) >= 2:
+        # Optional PCA coordinates. PCA plots the result chunks around the query's
+        # dense embedding. Keyword-only result chunks (``keyword-index`` tag) carry
+        # no dense vector, so compute_pca_coordinates places them at the origin
+        # (they can't be positioned) — the hybrid chunks still plot normally.
+        if include_pca and len(paginated_results) >= 2:
             try:
                 if search_algo.query_embedding is not None:
                     query_embedding = search_algo.query_embedding
@@ -545,11 +543,11 @@ async def vector_search(request: Request) -> JSONResponse:
                 status_code=400,
             )
 
-        # Resolve + build the search algorithm (ADR-030): an *explicit*
-        # unsupported request (e.g. "semantic" while SEARCH_MODE=keyword) is
-        # rejected with 422 carrying the advertised supported_search_types, so the
-        # client can correct it rather than silently receive BM25 results. An
-        # absent algorithm still defaults gracefully across modes.
+        # Resolve + build the search algorithm: an *explicit* unsupported request
+        # (e.g. any algorithm while vector sync is disabled) is rejected with 422
+        # carrying the advertised supported_search_types, so the client can
+        # correct it rather than silently receive fallback results. An absent
+        # algorithm still defaults gracefully.
         try:
             search_algo, algorithm = _build_search_algorithm(
                 requested_algorithm,
@@ -630,11 +628,10 @@ async def vector_search(request: Request) -> JSONResponse:
         }
 
         # Compute PCA coordinates for visualization using shared function. PCA
-        # plots chunks around the query's dense embedding, so it only applies in
-        # hybrid mode; keyword mode (ADR-030) has no dense query embedding, so
-        # fall through to the empty-coordinates branch without calling the
-        # embedding service (airgapped-safe).
-        if include_pca and settings.dense_enabled and len(all_results) >= 2:
+        # plots chunks around the query's dense embedding; keyword-only chunks
+        # (``keyword-index`` tag) have no dense vector and are placed at the origin
+        # by compute_pca_coordinates while hybrid chunks plot normally.
+        if include_pca and len(all_results) >= 2:
             try:
                 # Get query embedding from search algorithm or generate it
                 if search_algo.query_embedding is not None:

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1717,28 +1717,10 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
     # Register semantic search tools (cross-app feature)
     if settings.vector_sync_enabled:
-        if settings.dense_enabled:
-            logger.info(
-                "Configuring search tools (vector sync enabled, SEARCH_MODE=hybrid)"
-            )
-        else:
-            logger.info(
-                "Configuring search tools (vector sync enabled, SEARCH_MODE=keyword):"
-                " dense embeddings disabled; BM25 keyword search only — no embedding"
-                " endpoint required (ADR-030)"
-            )
+        logger.info("Configuring search tools (vector sync enabled, hybrid search)")
         configure_semantic_tools(mcp)
     else:
         logger.info("Skipping semantic search tools (VECTOR_SYNC_ENABLED not set)")
-        if not settings.dense_enabled:
-            # keyword mode is meaningless without the Qdrant pipeline it queries;
-            # the tools just won't register. Warn rather than crash, matching the
-            # codebase's gate-don't-crash posture for search enablement.
-            logger.warning(
-                "SEARCH_MODE=keyword has no effect while VECTOR_SYNC_ENABLED is "
-                "off: keyword search uses the Qdrant index, so enable vector sync "
-                "to use it (ADR-030)"
-            )
 
     # Register OAuth provisioning tools (only when offline access is enabled)
     enable_offline_access_for_tools = settings.enable_offline_access

--- a/nextcloud_mcp_server/auth/viz_routes.py
+++ b/nextcloud_mcp_server/auth/viz_routes.py
@@ -205,22 +205,10 @@ async def vector_visualization_search(request: Request) -> JSONResponse:
 
         async with auth_client_ctx as nc_client:
             # Create search algorithm (no client needed - verification removed).
-            # ADR-030: the pure-dense "semantic" algorithm queries the dense
-            # vector slot, which a keyword-only collection (SEARCH_MODE=keyword)
-            # does not have — reject it here rather than letting the query fail
-            # against the sparse-only index. "bm25_hybrid" stays valid in both
-            # modes (it issues a sparse-only query in keyword mode internally).
-            if algorithm == "semantic" and not settings.dense_enabled:
-                return JSONResponse(
-                    {
-                        "success": False,
-                        "error": (
-                            "semantic search is unavailable in keyword-only mode "
-                            "(SEARCH_MODE=keyword)"
-                        ),
-                    },
-                    status_code=400,
-                )
+            # The collection is always dense-capable, so "semantic" is always
+            # valid; keyword-only documents simply don't appear in a pure-dense
+            # query (no dense vector). "bm25_hybrid" fuses dense + sparse and so
+            # surfaces both hybrid and keyword-only documents.
             if algorithm == "semantic":
                 search_algo = SemanticSearchAlgorithm(score_threshold=score_threshold)
             elif algorithm == "bm25_hybrid":

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -122,10 +122,17 @@ _DEFAULTS: dict[str, Any] = {
     # leave work stuck behind the 5x-scan-interval staleness gate.
     # Escape hatch only — leave on by default.
     "vector_sync_orphan_sweep_enabled": True,
-    # System tag that marks files for vector indexing. The scanner indexes
-    # files carrying this tag; verify-on-read gates results on current
-    # membership of this tag (ADR-019).
+    # System tag that marks files for hybrid (dense + BM25 sparse) indexing.
+    # The scanner indexes files carrying this tag; verify-on-read gates results
+    # on current membership of this tag (ADR-019).
     "vector_sync_pdf_tag": "vector-index",
+    # System tag that marks files for keyword-only (BM25 sparse) indexing.
+    # Empty (default) disables the second tag entirely — files are then only
+    # discovered via ``vector_sync_pdf_tag`` (hybrid). When set, files carrying
+    # this tag are indexed sparse-only (no dense embedding, no embedding cost)
+    # into the SAME collection as hybrid files; ``vector-index`` wins if a file
+    # carries both. See the per-document index-mode design.
+    "vector_sync_keyword_tag": "",
     # Verify-on-read concurrency cap (ADR-019)
     "verification_concurrency": 20,
     # Qdrant
@@ -276,11 +283,6 @@ _DEFAULTS: dict[str, Any] = {
     # the current monolithic behavior; self-hosters who set none are
     # unaffected. See docs/architecture/mcp-decomposition.md (sibling repo).
     "embedding_provider": "autodetect",  # autodetect | gateway
-    # Search mode (ADR-030). ``hybrid`` (default) generates + queries dense
-    # embeddings AND BM25 sparse vectors. ``keyword`` skips dense entirely:
-    # BM25 sparse only, so fully airgapped deployments need no embedding
-    # endpoint. ``keyword`` still requires vector sync enabled (it uses Qdrant).
-    "search_mode": "hybrid",  # hybrid (dense+sparse) | keyword (BM25 sparse only)
     # Ingest queue backend (Deck #183). None → ``memory`` (the in-process anyio
     # queue): procrastinate is strictly opt-in, even on a Postgres DATABASE_URL.
     # Set ``postgres`` explicitly to split ingest into a procrastinate worker;
@@ -460,6 +462,8 @@ _dynaconf = Dynaconf(
         Validator("DOCUMENT_CHUNK_OVERLAP", gte=0),
         # Non-empty strings
         Validator("VECTOR_SYNC_PDF_TAG", len_min=1),
+        # VECTOR_SYNC_KEYWORD_TAG is optional (empty disables keyword-only
+        # discovery), so no len_min — but when set it must be a usable tag name.
         # WEBHOOK_SECRET is optional (None disables webhooks — GHSA-8vh3-g2qg-2h2c),
         # but when set it must be long enough to resist guessing. Surfaces a
         # weak/placeholder secret at startup rather than in a later audit.
@@ -909,10 +913,17 @@ class Settings:
     # (app.py): keeps the Nextcloud/Qdrant snapshot warm off the probe path so
     # /health/ready never does external I/O (Deck #302).
     health_ready_refresh_interval: int = 15  # seconds
-    # System tag marking files for vector indexing. The scanner indexes files
-    # carrying this tag and verify-on-read gates results on current membership
-    # (ADR-019), so an untagged file drops out of search immediately.
+    # System tag marking files for hybrid (dense + BM25 sparse) indexing. The
+    # scanner indexes files carrying this tag and verify-on-read gates results
+    # on current membership (ADR-019), so an untagged file drops out of search
+    # immediately.
     vector_sync_pdf_tag: str = "vector-index"
+
+    # System tag marking files for keyword-only (BM25 sparse) indexing. Empty
+    # (default) disables it. When set, tagged files are indexed sparse-only into
+    # the same collection as hybrid files (no dense embedding). ``vector-index``
+    # takes precedence when a file carries both tags.
+    vector_sync_keyword_tag: str = ""
 
     # Verify-on-read concurrency (ADR-019). Cap on parallel Nextcloud
     # round-trips during search-result verification fan-out. Lower this if the
@@ -1056,7 +1067,6 @@ class Settings:
     # MCP decomposition hook points (design §10, opt-in). All defaults
     # reproduce the current monolith; validated in __post_init__.
     embedding_provider: str = "autodetect"  # autodetect | gateway
-    search_mode: str = "hybrid"  # hybrid | keyword (BM25 sparse only) — ADR-030
     # Ingest queue backend (Deck #183). None → resolved in __post_init__ to
     # ``postgres`` when DATABASE_URL is Postgres, else ``memory``.
     ingest_queue: str | None = None  # memory | postgres
@@ -1185,7 +1195,6 @@ class Settings:
         # the monolith, so deployments that set none of these pass through.
         _enum_fields = {
             "embedding_provider": {"autodetect", "gateway"},
-            "search_mode": {"hybrid", "keyword"},
             "mcp_role": {"api", "worker", "all"},
             "collection_metadata_source": {"qdrant", "api"},
             "document_tier1_engine": {"pypdfium2", "pymupdf"},
@@ -1430,15 +1439,11 @@ class Settings:
         # Sanitize deployment ID
         deployment_id = deployment_id.lower().replace(" ", "-").replace("_", "-")
 
-        # Keyword mode (ADR-030) indexes BM25 sparse vectors only and may run
-        # with no embedding provider configured, so the embedding model name is
-        # a meaningless ``simple-{dim}`` fallback. Use a fixed mode marker
-        # instead: this guarantees keyword and hybrid indexes never share a
-        # collection (their point schemas are not interchangeable — see ADR-030)
-        # and removes keyword mode's dependency on the phantom model name.
-        if self.search_mode == "keyword":
-            return f"{deployment_id}-bm25-keyword"
-
+        # The collection always carries a real dense slot sized from the
+        # embedding model. Keyword-only documents (``keyword-index`` tag) simply
+        # omit the dense vector per-point — they share this collection with
+        # hybrid documents (per-document index mode), so the name is always
+        # keyed on the embedding model.
         model_name = self.get_embedding_model_name().replace("/", "-").replace(":", "-")
 
         return f"{deployment_id}-{model_name}"
@@ -1450,17 +1455,6 @@ class Settings:
     def enable_semantic_search(self) -> bool:
         """Semantic search enabled (ADR-021 alias for vector_sync_enabled)."""
         return self.vector_sync_enabled
-
-    @property
-    def dense_enabled(self) -> bool:
-        """Dense embeddings generated + queried.
-
-        False in ``keyword`` mode (ADR-030), where ingestion and search use BM25
-        sparse vectors only — no external embedding endpoint is contacted. Single
-        source of truth for the processor, the search algorithm, and the Qdrant
-        client so the three subsystems stay consistent.
-        """
-        return self.search_mode != "keyword"
 
     @property
     def enable_background_operations(self) -> bool:
@@ -1714,6 +1708,7 @@ def get_settings() -> Settings:
         "vector_sync_orphan_sweep_enabled": "VECTOR_SYNC_ORPHAN_SWEEP_ENABLED",
         "health_ready_refresh_interval": "HEALTH_READY_REFRESH_INTERVAL",
         "vector_sync_pdf_tag": "VECTOR_SYNC_PDF_TAG",
+        "vector_sync_keyword_tag": "VECTOR_SYNC_KEYWORD_TAG",
         # Verify-on-read (ADR-019)
         "verification_concurrency": "VERIFICATION_CONCURRENCY",
         # Qdrant settings
@@ -1783,7 +1778,6 @@ def get_settings() -> Settings:
         "excluded_tags": "EXCLUDED_TAGS",
         # MCP decomposition hook points (design §10)
         "embedding_provider": "EMBEDDING_PROVIDER",
-        "search_mode": "SEARCH_MODE",
         "ingest_queue": "INGEST_QUEUE",
         "mcp_role": "MCP_ROLE",
         "ingest_stalled_job_seconds": "INGEST_STALLED_JOB_SECONDS",

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -29,10 +29,8 @@ class SemanticSearchResult(BaseModel):
     excerpt: str = Field(description="Excerpt from matching chunk")
     score: float = Field(
         description=(
-            "Relevance score (≥ 0.0, higher is better). Range depends on search "
-            "mode (ADR-030): in hybrid mode it is a normalized fusion score — RRF "
-            "in [0.0, 1.0], DBSF can exceed 1.0; in keyword mode it is a raw BM25 "
-            "score that is unbounded (commonly well above 1.0), not normalized."
+            "Relevance score (≥ 0.0, higher is better). A normalized fusion score "
+            "— RRF in [0.0, 1.0], DBSF can exceed 1.0."
         )
     )
     chunk_index: int = Field(description="Index of matching chunk in document")
@@ -82,9 +80,9 @@ class SemanticSearchResponse(BaseResponse):
     search_method: str = Field(
         default="semantic",
         description=(
-            "Search method used: 'bm25_hybrid_<fusion>' (dense+sparse) in hybrid "
-            "mode, or 'bm25_keyword' (BM25 sparse only) under SEARCH_MODE=keyword "
-            "(ADR-030)"
+            "Search method used, e.g. 'bm25_hybrid_<fusion>' (dense + BM25 sparse "
+            "fused). Keyword-only documents contribute via the sparse side of the "
+            "same fused query."
         ),
     )
     verified_chunk_count: int = Field(

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -37,9 +37,11 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
     The fusion happens efficiently in the database using the prefetch mechanism,
     eliminating the need for application-layer result merging.
 
-    In SEARCH_MODE=keyword (ADR-030) the class skips dense embeddings entirely
-    and issues a direct BM25 sparse query with no fusion (the ``fusion``
-    parameter is ignored), so the deployment needs no embedding endpoint.
+    The collection may hold a mix of hybrid documents (dense + sparse) and
+    keyword-only documents (sparse only, ``keyword-index`` tag). The dense
+    prefetch simply never returns keyword-only points (they carry no dense
+    vector); they surface via the sparse prefetch and are merged by fusion — so a
+    single unified query covers both without any mode branch.
     """
 
     def __init__(self, score_threshold: float = 0.0, fusion: str = "rrf"):
@@ -51,7 +53,6 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
                            Note: Both RRF and DBSF produce normalized scores
             fusion: Fusion algorithm to use: "rrf" (Reciprocal Rank Fusion, default)
                    or "dbsf" (Distribution-Based Score Fusion).
-                   Ignored when SEARCH_MODE=keyword (no fusion happens).
 
         Raises:
             ValueError: If fusion is not "rrf" or "dbsf"
@@ -81,21 +82,14 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         return True
 
     async def _embed_query_dense(self, query: str, settings: Any) -> list | None:
-        """Embed the query for dense search, or return None in keyword mode.
+        """Embed the query for the dense prefetch.
 
         Cached per query on this (per-request) instance: nc_semantic_search calls
         search() once per doc_type with the same query, so re-embedding each time
         would make N redundant API calls and bill the query's tokens N times
         (Deck #67). Reuse the first call's embedding + token count so the query is
         embedded — and metered — exactly once.
-
-        Keyword mode (ADR-030) returns None without contacting any embedding
-        endpoint; query_embedding / query_token_count stay None so the metering
-        hook records 0 tokens.
         """
-        if not settings.dense_enabled:
-            return None
-
         with trace_operation("search.get_embedding_service"):
             embedding_service = get_embedding_service()
         with trace_operation("search.dense_embedding"):
@@ -128,32 +122,14 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         limit: int,
         score_threshold: float,
     ) -> Any:
-        """Execute the Qdrant query for the active search mode (ADR-030).
+        """Execute the Qdrant query: dense + sparse prefetches merged by native
+        fusion (RRF or DBSF).
 
-        Hybrid mode runs dense + sparse prefetches merged by native fusion (RRF or
-        DBSF). Keyword mode issues a direct sparse query with no fusion: RRF over a
-        single source is a rank-identity transform that only rescales the score,
-        whereas the direct query returns the raw BM25 similarity that
-        ``score_threshold`` is interpreted against. The ``fusion`` param is unused
-        in keyword mode.
+        Keyword-only documents (``keyword-index`` tag) carry no dense vector, so
+        the dense prefetch never returns them; they surface via the sparse
+        prefetch and are merged in by fusion. No mode branch is needed.
         """
         collection_name = settings.get_collection_name()
-        if not settings.dense_enabled:
-            with trace_operation(
-                "search.qdrant_query",
-                attributes={"query.limit": limit * 2, "query.mode": "keyword"},
-            ):
-                return await qdrant_client.query_points(
-                    collection_name=collection_name,
-                    query=sparse_query,
-                    using="sparse",
-                    query_filter=query_filter,
-                    limit=limit * 2,  # Get extra for deduplication
-                    score_threshold=score_threshold,
-                    with_payload=True,
-                    with_vectors=False,  # Don't return vectors to save bandwidth
-                )
-
         with trace_operation(
             "search.qdrant_query",
             attributes={"query.limit": limit * 2, "query.fusion": self.fusion_name},
@@ -238,14 +214,9 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         score_threshold = kwargs.get("score_threshold", self.score_threshold)
 
         # Self-describing label reused across every log line below and the result
-        # metadata: "bm25_keyword" in keyword mode (no fusion happens),
-        # "bm25_hybrid_<fusion>" otherwise. Computed up front so even the entry
-        # log is mode-accurate (keyword deployments must not see "hybrid"/fusion).
-        method_label = (
-            f"bm25_hybrid_{self.fusion_name}"
-            if settings.dense_enabled
-            else "bm25_keyword"
-        )
+        # metadata: always "bm25_hybrid_<fusion>" — the query fuses dense + sparse
+        # prefetches; keyword-only documents simply contribute via the sparse side.
+        method_label = f"bm25_hybrid_{self.fusion_name}"
 
         logger.info(
             "%s: query='%s', user=%s, limit=%s, score_threshold=%s, doc_type=%s",
@@ -257,7 +228,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
             doc_type,
         )
 
-        # Dense query embedding (hybrid only; None in keyword mode — ADR-030).
+        # Dense query embedding (fused with the sparse prefetch below).
         dense_embedding = await self._embed_query_dense(query, settings)
 
         # Generate sparse embedding for BM25 keyword search
@@ -315,9 +286,8 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         )
 
         if search_response.points:
-            # Log top 3 scores to help with threshold tuning. In hybrid mode
-            # these are normalized fusion scores; in keyword mode they are raw
-            # BM25 scores (unbounded — see ADR-030).
+            # Log top 3 scores to help with threshold tuning — normalized fusion
+            # scores (RRF in [0,1]; DBSF can exceed 1).
             top_scores = [p.score for p in search_response.points[:3]]
             logger.debug("Top 3 %s scores: %s", method_label, top_scores)
 

--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -152,11 +152,11 @@ async def _verify_files(
     fetch therefore subsumes the old per-file ``file_accessible_by_id`` check
     and replaces N round-trips with one.
 
-    This is the verify-on-read fix for stale tags (ADR-019): a file removed
-    from the ``vector-index`` tag — or outright deleted — drops out of the
-    tagged set, so it is dropped from results and scheduled for eviction by the
-    caller immediately, rather than lingering until the scanner's grace-period
-    sweep reconciles it.
+    This is the verify-on-read fix for stale tags (ADR-019): a file removed from
+    both index tags (``vector-index``/``keyword-index``) — or outright deleted —
+    drops out of the tagged set, so it is dropped from results and scheduled for
+    eviction by the caller immediately, rather than lingering until the scanner's
+    grace-period sweep reconciles it.
 
     Failure policy mirrors ``_verify_news_items``: if the tag fetch itself
     fails we keep every file result (fail-open, the next query re-verifies),
@@ -173,7 +173,13 @@ async def _verify_files(
         is_path_excluded,
     )
 
-    tag_name = get_settings().vector_sync_pdf_tag
+    # Lazy import (same import-cycle reason as tag_exclusion above): scanner pulls
+    # this module in indirectly via the server package.
+    from nextcloud_mcp_server.vector.scanner import (  # noqa: PLC0415
+        _discover_tagged_files,
+    )
+
+    settings = get_settings()
 
     # One semaphore slot is held for both Nextcloud round-trips: the tagged-file
     # REPORT (plus optional Depth:infinity folder expansion) and — only when the
@@ -199,23 +205,23 @@ async def _verify_files(
     # an untag is reflected on the very next search rather than after a TTL.
     async with semaphore:
         try:
-            tagged = await client.find_files_by_tag(
-                tag_name, mime_type_filter="application/pdf"
-            )
+            # Union of BOTH index tags (vector-index → hybrid, keyword-index →
+            # keyword): a result stays verified if its file still carries either
+            # tag, so untagging from whichever tag indexed it drops it from
+            # results. Membership is all that matters here, not the mode.
+            tagged = await _discover_tagged_files(client, settings)
         except HTTPStatusError as e:
             logger.warning(
-                "Transient error fetching %r-tagged files for verification: "
+                "Transient error fetching index-tagged files for verification: "
                 "%s %s; keeping all file results",
-                tag_name,
                 e.response.status_code,
                 e,
             )
             return {r.id for r in results}
         except Exception as e:
             logger.warning(
-                "Unexpected error fetching %r-tagged files for verification: "
+                "Unexpected error fetching index-tagged files for verification: "
                 "%s; keeping all file results",
-                tag_name,
                 e,
             )
             return {r.id for r in results}

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -205,30 +205,24 @@ def configure_semantic_tools(mcp: FastMCP):
         """
         Search Nextcloud content across apps, indexed in Qdrant.
 
-        Behavior depends on the server's SEARCH_MODE (ADR-030):
-        - hybrid (default): Qdrant native hybrid search combining dense semantic
-          vectors (conceptual similarity, natural language) and BM25 sparse
-          vectors (precise keyword/acronym matching), fused in the database for
-          optimal relevance.
-        - keyword: BM25 sparse (full-text/keyword) search only. No dense
-          embeddings are generated or queried, so the deployment needs no text-
-          embedding endpoint (airgapped). The ``fusion`` arg is ignored and
-          ``score`` is a raw BM25 score (unbounded), not a 0-1 fusion score.
+        Qdrant native hybrid search combining dense semantic vectors (conceptual
+        similarity, natural language) and BM25 sparse vectors (precise
+        keyword/acronym matching), fused in the database for optimal relevance.
+        Documents indexed keyword-only (``keyword-index`` tag) carry no dense
+        vector and so contribute via the BM25 sparse side only; they appear in the
+        same unified result set.
 
-        Requires VECTOR_SYNC_ENABLED=true in both modes. Supports indexing of
-        notes, files, news items, deck cards, and mail messages.
+        Requires VECTOR_SYNC_ENABLED=true. Supports indexing of notes, files,
+        news items, deck cards, and mail messages.
 
         Args:
             query: Natural language or keyword search query
             limit: Maximum number of results to return (default: 10)
             doc_types: Document types to search (e.g., ["note", "file", "deck_card", "news_item", "mail_message"]). None = search all indexed types (default)
-            score_threshold: Minimum score (default: 0.0). In hybrid mode this is
-                a normalized fusion score (0-1); in keyword mode it is a raw BM25
-                score (unbounded), so a >0 threshold filters very differently.
+            score_threshold: Minimum normalized fusion score (0-1).
             fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion)
                    RRF: Good general-purpose fusion using reciprocal ranks
                    DBSF: Uses distribution-based normalization, may better balance different score ranges
-                   Ignored when SEARCH_MODE=keyword (no fusion happens).
             include_context: Whether to expand results with surrounding context (default: False)
             context_chars: Number of characters to include before/after matched chunk (default: 300)
             modified_after: Only return documents whose last-modified time is at or after this
@@ -261,13 +255,10 @@ def configure_semantic_tools(mcp: FastMCP):
         client = await get_client(ctx)
         username = client.username
 
-        # Self-describing method label, mirroring BM25HybridSearchAlgorithm:
-        # keyword mode (ADR-030) runs a sparse-only query, hybrid mode fuses.
-        # Used in the log line below and on every response so logs/results say
-        # "bm25_keyword" in keyword mode rather than the misleading "hybrid".
-        search_method = (
-            f"bm25_hybrid_{fusion}" if settings.dense_enabled else "bm25_keyword"
-        )
+        # Self-describing method label, mirroring BM25HybridSearchAlgorithm: the
+        # query always fuses dense + sparse prefetches (keyword-only documents
+        # contribute via the sparse side), so the label is always the fusion one.
+        search_method = f"bm25_hybrid_{fusion}"
 
         logger.info(
             "%s: query=%r, user=%s, limit=%d, score_threshold=%s, fusion=%s",
@@ -279,8 +270,7 @@ def configure_semantic_tools(mcp: FastMCP):
             fusion,
         )
 
-        # Check that vector sync is enabled. Both hybrid and keyword (ADR-030)
-        # modes use the Qdrant index, so this gate applies regardless of mode.
+        # Check that vector sync is enabled — search queries the Qdrant index.
         if not settings.vector_sync_enabled:
             raise McpError(
                 ErrorData(
@@ -748,13 +738,11 @@ def configure_semantic_tools(mcp: FastMCP):
             query: Natural language question to answer (e.g., "What are my Q1 objectives?" or "When is my next dentist appointment?")
             ctx: MCP context for session access
             limit: Maximum number of documents to retrieve (default: 5)
-            score_threshold: Minimum relevance score. None (default) selects a
-                mode-appropriate default: 0.7 in hybrid mode (tuned for normalized
-                fusion scores) and 0.0 in keyword mode (raw BM25 scores are
-                unbounded, so a 0.7 cutoff would drop most matches). Pass an
-                explicit value (including 0.7) to override in either mode.
+            score_threshold: Minimum relevance score. None (default) uses 0.7,
+                tuned for the normalized fusion scores the query produces. Pass an
+                explicit value to override.
             max_answer_tokens: Maximum tokens for generated answer (default: 500)
-            fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion). Ignored when SEARCH_MODE=keyword.
+            fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion).
             include_context: Whether to expand results with surrounding context (default: False)
             context_chars: Number of characters to include before/after matched chunk (default: 300)
 
@@ -777,13 +765,11 @@ def configure_semantic_tools(mcp: FastMCP):
         cost roughly linearly. File / news / deck results do not pay this
         cost — they reuse the verified excerpt.
         """
-        # Resolve the mode-appropriate default when the caller didn't specify
-        # one. The 0.7 default is calibrated for normalized hybrid-fusion scores;
-        # keyword mode (ADR-030) scores raw, unbounded BM25, where 0.7 would drop
-        # most/all matches — so default to 0.0 there. A None sentinel (rather than
-        # a magic 0.7 compare) lets a caller pass 0.7 explicitly in either mode.
+        # Default to 0.7, calibrated for the normalized hybrid-fusion scores the
+        # query always produces. A None sentinel (rather than a magic 0.7 compare)
+        # lets a caller pass any explicit threshold, including 0.7.
         if score_threshold is None:
-            score_threshold = 0.0 if not get_settings().dense_enabled else 0.7
+            score_threshold = 0.7
 
         # 1. Retrieve relevant documents via existing semantic search
         search_response = await nc_semantic_search(

--- a/nextcloud_mcp_server/vector/collection_metadata.py
+++ b/nextcloud_mcp_server/vector/collection_metadata.py
@@ -41,33 +41,21 @@ CHUNKING_CONFIG = "chunking_config"
 IS_SENTINEL = "is_sentinel"
 
 
-# ADR-030 keyword-mode embedding identity. Keyword collections carry only BM25
-# sparse vectors, so the dense model name is a meaningless ``simple-{dim}``
-# fallback; a fixed marker is stamped instead. This MUST be produced identically
-# everywhere the identity is written OR compared — chunk points, the collection
-# sentinel, the admin backfill, and the cross-user dedup lookup. A keyword-mode
-# mismatch here (the chunk-point writer stamped this marker while the dedup lookup
-# compared the model name) made the dedup ALWAYS miss, so unchanged shared docs
-# were re-processed + re-OCR'd on every scan and the run never converged, pinning
-# the burst GPU (Deck #509).
-KEYWORD_EMBEDDING_IDENTITY = "bm25-keyword"
-
-
 def build_embedding_identity(settings: Settings | None = None) -> str:
     """The embedding identity for locally-produced vectors — the single source of
     truth for the identity stamped on chunk points, the collection sentinel, the
     admin backfill, and the cross-user dedup comparison, so all four agree.
 
-    - Hybrid mode: the active dense embedding model name. The gateway and query
-      path route on it, matching the collection-name derivation.
-    - Keyword mode (ADR-030, ``dense_enabled`` False): the fixed
-      ``KEYWORD_EMBEDDING_IDENTITY`` marker — the collection has no dense vectors
-      and ``get_embedding_model_name()`` would return the bogus ``simple-{dim}``
-      fallback. Using the marker keeps the dedup comparison correct (Deck #509).
+    It is the active dense embedding MODEL name: the gateway and query path route
+    on it, matching the collection-name derivation, and a model switch changes it
+    so the dedup lookup misses and forces a re-embed. It is orthogonal to
+    keyword-vs-hybrid — keyword documents share this collection and carry the same
+    model identity (they simply omit the dense vector), so both modes dedup in one
+    identity space. The keyword/hybrid distinction is tracked separately by
+    ``payload_keys.INDEX_MODE``. This MUST be produced identically everywhere the
+    identity is written OR compared (Deck #509).
     """
     s = settings or get_settings()
-    if not s.dense_enabled:
-        return KEYWORD_EMBEDDING_IDENTITY
     return s.get_embedding_model_name()
 
 

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -106,13 +106,9 @@ async def mark_dead_letter(
     try:
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
-        # Match the collection's dense slot; in keyword mode (dense_enabled=False)
-        # it's sized to SIMPLE_EMBEDDING_DIMENSION and there may be no embedding
-        # endpoint — so don't call the embedding service (mirrors placeholder.py).
-        if settings.dense_enabled:
-            dimension = get_embedding_service().get_dimension()
-        else:
-            dimension = settings.simple_embedding_dimension
+        # Match the collection's dense slot, which is always sized from the
+        # embedding service (mirrors placeholder.py / collection creation).
+        dimension = get_embedding_service().get_dimension()
 
         payload: dict[str, Any] = {
             "doc_id": doc_id,

--- a/nextcloud_mcp_server/vector/payload_keys.py
+++ b/nextcloud_mcp_server/vector/payload_keys.py
@@ -24,6 +24,14 @@ PROCESSOR_VERSION = "processor_version"
 PARSED_AT = "parsed_at"
 PIPELINE_TIER = "pipeline_tier"
 
+# Per-document index mode: "hybrid" (dense + BM25 sparse) or "keyword" (BM25
+# sparse only). Drives whether a point carries a dense vector, gates verify-on-
+# read to the right tag, and slices ingestion billing. See INDEX_MODE_HYBRID /
+# INDEX_MODE_KEYWORD.
+INDEX_MODE = "index_mode"
+INDEX_MODE_HYBRID = "hybrid"
+INDEX_MODE_KEYWORD = "keyword"
+
 # Fixed platform namespace for deterministic chunk point IDs (design §2.2).
 # Derived once from ``uuid5(NAMESPACE_DNS, "astrolabe.cloud/mcp/point-id/v1")``
 # and pinned here as a literal so neither repo recomputes it. DO NOT CHANGE —

--- a/nextcloud_mcp_server/vector/placeholder.py
+++ b/nextcloud_mcp_server/vector/placeholder.py
@@ -81,19 +81,10 @@ async def write_placeholder_point(
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
 
-        # Size the dense zero-vector to match the collection's dense slot. In
-        # keyword mode (SEARCH_MODE=keyword, dense_enabled=False) the collection's
-        # dense slot is created sized to SIMPLE_EMBEDDING_DIMENSION — NOT the
-        # embedding provider's dimension (see qdrant_client collection creation) —
-        # and the deployment may have no text-embedding endpoint at all. So gate on
-        # dense_enabled and never touch the embedding service in keyword mode;
-        # otherwise a Mistral-sized (e.g. 1024) placeholder vector is rejected by
-        # the 384-dim slot and the pre-enqueue placeholder write aborts the whole
-        # scan (no document ever gets indexed).
-        if settings.dense_enabled:
-            dimension = get_embedding_service().get_dimension()
-        else:
-            dimension = settings.simple_embedding_dimension
+        # Size the dense zero-vector to match the collection's dense slot, which
+        # is always sized from the embedding service (the collection carries a
+        # real dense slot even for keyword-only docs, which just omit the vector).
+        dimension = get_embedding_service().get_dimension()
 
         # Create zero vectors
         zero_dense = [0.0] * dimension

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1729,6 +1729,7 @@ async def _index_document(
     # int subclass, so exclude it explicitly.
     _meter_total_chars = sum(len(t) for t in chunk_texts)
     _meter_raw_page_count = file_metadata.get("page_count")
+    _meter_pipeline_tier = file_metadata.get("pipeline_tier")
     await record_indexing_usage(
         enabled=settings.usage_metering_enabled,
         provider=settings.get_embedding_provider_family(),
@@ -1755,7 +1756,7 @@ async def _index_document(
         # Tier that produced the parsed pages (registry stamps it on the result
         # metadata); text doc types stay "fast". Narrow defensively to str|None.
         pipeline_tier=(
-            pt if isinstance(pt := file_metadata.get("pipeline_tier"), str) else None
+            _meter_pipeline_tier if isinstance(_meter_pipeline_tier, str) else None
         ),
     )
 

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -65,7 +65,7 @@ from nextcloud_mcp_server.vector.placeholder import (
     update_placeholder_status,
 )
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
-from nextcloud_mcp_server.vector.scanner import DocumentTask
+from nextcloud_mcp_server.vector.scanner import DocumentTask, _discover_tagged_files
 from nextcloud_mcp_server.vector.sharing_state import (
     claim_existing_index,
     existing_principals,
@@ -334,14 +334,14 @@ def build_point_vector(
     *,
     dense_enabled: bool,
 ) -> dict[str, Any]:
-    """Build the Qdrant named-vector dict for one chunk's point (ADR-030).
+    """Build the Qdrant named-vector dict for one chunk's point.
 
-    Hybrid mode carries both ``dense`` and ``sparse``. Keyword mode carries only
+    Hybrid docs carry both ``dense`` and ``sparse``. Keyword docs carry only
     ``sparse``: dense embeddings are never generated (``dense_embeddings`` is
     empty), so the point is upserted with a subset of the collection's named
-    vectors — valid against the unchanged dense+sparse schema. Indexing into an
-    empty ``dense_embeddings`` here would be the silent zero-points bug, so the
-    dense slot is only read when dense is enabled.
+    vectors — valid against the dense+sparse schema. Indexing into an empty
+    ``dense_embeddings`` here would be the silent zero-points bug, so the dense
+    slot is only read when dense is enabled for this document.
     """
     point_vector: dict[str, Any] = {"sparse": sparse_emb}
     if dense_enabled:
@@ -356,6 +356,7 @@ async def record_indexing_usage(
     model: str,
     doc_type: str,
     user_id: str,
+    index_mode: str,
     chunk_count: int,
     token_count: int,
     total_chars: int,
@@ -364,14 +365,21 @@ async def record_indexing_usage(
     bytes_stored: int,
     pipeline_tier: str | None = None,
 ) -> None:
-    """Record the billable usage events for one embedded document.
+    """Record the billable usage events for one indexed document.
+
+    ``index_mode`` (``"hybrid"`` | ``"keyword"``) is stamped on every event's
+    metadata so the CP rollup can slice ingestion cost by mode without new metric
+    names — a keyword doc (sparse-only, no embedding) and a hybrid doc bill the
+    same ``bytes_ingested`` / ``bytes_stored`` metrics, distinguished only by this
+    dimension. ``tokens_embedded`` is naturally hybrid-only: keyword docs pass
+    ``token_count=0`` and the row is skipped.
 
     Metered dimensions (Deck #67 / #401), recorded independently:
 
     - ``tokens_embedded`` — the embedding request's token count, recorded for
-      *every* embedded document. The same metric search records, so the meter
-      bills embedding tokens whether they were incurred indexing a document or
-      embedding a query.
+      every *hybrid* document (skipped when ``token_count`` is 0, i.e. keyword
+      docs). The same metric search records, so the meter bills embedding tokens
+      whether they were incurred indexing a document or embedding a query.
     - ``pages_embedded`` — a charge for **parsing** (PDF page extraction / OCR),
       not a normalized content size. ``page_count`` is the real number of pages
       the document processor parsed. Text content (notes, deck cards, news
@@ -417,6 +425,10 @@ async def record_indexing_usage(
         "model": model,
         "doc_type": doc_type,
         "user_id": user_id,
+        # Per-document index mode (card #609): lets the CP rollup slice ingestion
+        # cost into hybrid (dense+sparse) vs keyword (sparse-only) without new
+        # metric names.
+        "index_mode": index_mode,
         "total_chars": total_chars,
         # Which extraction tier produced the parsed pages (Deck #323). Carried so
         # the CP rollup / a future per-tier price can attribute parsing cost to
@@ -432,15 +444,17 @@ async def record_indexing_usage(
         # independent; one raising never blocks the other — acceptable under the
         # (day, metric) SUM-aggregation billing model.
 
-        # tokens_embedded first (intentional ordering): it is recorded for every
-        # embedded document, so the embedding cost is always captured before the
-        # conditional parsing cost — don't reverse this in a refactor.
-        await store.record_usage_event(
-            metric="tokens_embedded",
-            value=token_count,
-            metadata=metadata,
-            enabled=True,
-        )
+        # tokens_embedded first (intentional ordering): captured before the
+        # conditional parsing/byte costs — don't reverse this in a refactor.
+        # Skipped for keyword docs (token_count == 0), which never embed, so no
+        # zero-value embedding row is written.
+        if token_count > 0:
+            await store.record_usage_event(
+                metric="tokens_embedded",
+                value=token_count,
+                metadata=metadata,
+                enabled=True,
+            )
         # pages_embedded: parsed pages only, and only a strictly positive count.
         # Text content has no page_count; a zero/negative count is skipped rather
         # than writing a row that would misrepresent a no-parse document as
@@ -582,23 +596,21 @@ async def _reconcile_tag_event(
     """Resolve a tag-webhook file task into a concrete index or delete.
 
     A SystemTag ``MapperEvent`` only tells us a fileid's tags changed — not the
-    path, nor whether our ``vector-index`` tag is (still) on it. Look up the
-    user's current ``vector-index`` PDFs (the same call the scanner uses, which
-    also expands tagged folders into their PDF descendants) and reconcile the
-    task in place:
+    path, nor which of our index tags is (still) on it. Look up the user's current
+    tagged PDFs across BOTH tags (the same discovery the scanner uses, which
+    applies hybrid precedence and expands tagged folders into their PDF
+    descendants) and reconcile the task in place:
 
-    - fileid present -> index it; fill path/etag/mtime from the tag listing.
-    - fileid absent  -> it isn't a tagged PDF (anymore); flip ``operation`` to
+    - fileid present -> index it; fill path/etag/mtime and set ``index_mode`` from
+      whichever tag matched (``vector-index`` → hybrid wins over ``keyword-index``).
+    - fileid absent  -> it carries neither tag (anymore); flip ``operation`` to
       ``delete`` so any existing points are released for this user.
 
     A tagged *folder*'s own fileid won't appear in the file-level listing, so it
     resolves to a harmless no-op delete here; the hourly scanner still expands
     tagged folders into their descendants.
     """
-    tag_name = get_settings().vector_sync_pdf_tag
-    tagged = await nc_client.find_files_by_tag(
-        tag_name, mime_type_filter="application/pdf"
-    )
+    tagged = await _discover_tagged_files(nc_client, get_settings())
     match = next(
         (f for f in tagged if str(f.get("id")) == str(doc_task.doc_id)),
         None,
@@ -607,13 +619,13 @@ async def _reconcile_tag_event(
     if match is None:
         doc_task.operation = "delete"
         logger.info(
-            "Tag reconcile: file %s is not a %r PDF; releasing for %s",
+            "Tag reconcile: file %s carries no index tag; releasing for %s",
             doc_task.doc_id,
-            tag_name,
             doc_task.user_id,
         )
         return
 
+    doc_task.index_mode = match.get("_index_mode", payload_keys.INDEX_MODE_HYBRID)
     doc_task.file_path = match["path"]
     if not doc_task.etag:
         doc_task.etag = match.get("etag")
@@ -621,9 +633,10 @@ async def _reconcile_tag_event(
     if last_modified:
         doc_task.modified_at = int(last_modified)
     logger.info(
-        "Tag reconcile: indexing %s (file %s) for %s",
+        "Tag reconcile: indexing %s (file %s, mode=%s) for %s",
         doc_task.file_path,
         doc_task.doc_id,
+        doc_task.index_mode,
         doc_task.user_id,
     )
 
@@ -1111,6 +1124,7 @@ async def _index_document(
                 "file",
                 doc_task.etag,
                 doc_task.user_id,
+                index_mode=doc_task.index_mode,
                 current_path=doc_task.file_path,
             ):
                 await delete_placeholder_point(
@@ -1482,9 +1496,19 @@ async def _index_document(
     # Extract chunk texts for embedding
     chunk_texts = [chunk.text for chunk in chunks]
 
+    # Per-document index mode (per-document keyword vs hybrid). Keyword docs
+    # (``keyword-index`` tag) skip dense embeddings entirely and upsert
+    # sparse-only points into the shared collection; hybrid docs (default) carry
+    # both dense and sparse. This replaces the removed global ``dense_enabled``.
+    dense_for_doc = doc_task.index_mode != payload_keys.INDEX_MODE_KEYWORD
+
     # Initialize results containers
     dense_embeddings: list = []
     sparse_embeddings: list = []
+    # Embedding-token count from the dense pass (0 for keyword docs, which never
+    # embed). Captured as a nonlocal so the post-task-group metering can record
+    # ``tokens_embedded`` for hybrid docs while byte/page metering covers both.
+    dense_embed_tokens: int = 0
     # chunk_index -> list[(x0, y0, x1, y1)] of normalized rectangles
     # in [0, 1] relative to page width/height. The page is taken from
     # `chunk.page_number` (offset-based) and stored as `page_number`
@@ -1500,7 +1524,7 @@ async def _index_document(
     # Define async tasks for parallel execution
     async def generate_dense_embeddings():
         """Generate dense embeddings (I/O bound - external API call)."""
-        nonlocal dense_embeddings
+        nonlocal dense_embeddings, dense_embed_tokens
         provider = settings.get_embedding_provider_family()
         total_chars = sum(len(t) for t in chunk_texts)
         with trace_operation(
@@ -1535,51 +1559,10 @@ async def _index_document(
             # Export token consumption to Prometheus (always-on, independent of
             # the billing flag) so Grafana sees indexing token cost.
             record_embedding_tokens(provider, "index", embed_tokens)
-            # Usage metering (Deck #67): record the embedding-token count (all
-            # docs) and, for parsed files, the real parsed-page count. Best-
-            # effort and flag-gated; placed after the embedding succeeds so it
-            # can never affect the indexing path. ``page_count`` is set by the
-            # document processors for PDFs and absent for text types, so text
-            # content meters tokens only. See record_indexing_usage for the
-            # metric/privacy details.
-            #
-            # Narrow defensively: file_metadata values are loosely typed, so a
-            # malformed page_count meters as "no pages" rather than erroring on
-            # the indexing path.
-            # bool is an int subclass, so exclude it explicitly — a stray
-            # page_count=True in metadata must not slip through as pages=1.
-            raw_page_count = file_metadata.get("page_count")
-            await record_indexing_usage(
-                enabled=settings.usage_metering_enabled,
-                provider=provider,
-                model=settings.get_embedding_model_name(),
-                doc_type=doc_task.doc_type,
-                user_id=doc_task.user_id,
-                chunk_count=len(chunk_texts),
-                token_count=embed_tokens,
-                total_chars=total_chars,
-                page_count=(
-                    raw_page_count
-                    if isinstance(raw_page_count, int)
-                    and not isinstance(raw_page_count, bool)
-                    else None
-                ),
-                # bytes_ingested: raw source size at ingestion (raw WebDAV binary
-                # for files, UTF-8 text size for text doc types — note,
-                # deck_card, news_item, mail_message). See helper.
-                bytes_ingested=ingested_byte_size(content_bytes, content),
-                # bytes_stored: UTF-8 size of the chunk texts persisted as Qdrant
-                # payload excerpts (includes chunk-overlap duplication).
-                bytes_stored=sum(len(t.encode("utf-8")) for t in chunk_texts),
-                # Tier that produced the parsed pages (registry stamps it on the
-                # result metadata); text doc types stay "fast". Narrow defensively
-                # to str|None — file_metadata is loosely typed (Any values).
-                pipeline_tier=(
-                    pt
-                    if isinstance(pt := file_metadata.get("pipeline_tier"), str)
-                    else None
-                ),
-            )
+            # Hand the token count to the post-task-group usage metering (byte +
+            # page dimensions are recorded there for BOTH modes; embedding tokens
+            # are hybrid-only, so keyword docs keep the initialised 0).
+            dense_embed_tokens = embed_tokens
 
     async def generate_sparse_embeddings():
         """Generate sparse embeddings (BM25 for keyword matching)."""
@@ -1723,15 +1706,58 @@ async def _index_document(
         },
     ):
         async with anyio.create_task_group() as tg:
-            # Keyword mode (ADR-030) skips dense embeddings entirely so airgapped
-            # deployments need no embedding endpoint; only BM25 sparse vectors are
-            # generated and indexed. ``dense_embeddings`` stays [] in that case,
-            # and the token-metering block lives inside generate_dense_embeddings,
-            # so it is correctly skipped (no embedding tokens to meter).
-            if settings.dense_enabled:
+            # Keyword-only documents (``keyword-index`` tag → index_mode
+            # "keyword") skip dense embeddings entirely: no embedding endpoint is
+            # contacted and the point is upserted sparse-only. ``dense_embeddings``
+            # stays [] in that case. Hybrid documents (default) always embed — a
+            # failed/unavailable embedding endpoint raises out of
+            # generate_dense_embeddings into process_document's retry/dead-letter
+            # path rather than silently degrading to sparse-only.
+            if dense_for_doc:
                 tg.start_soon(generate_dense_embeddings)
             tg.start_soon(generate_sparse_embeddings)
             tg.start_soon(generate_highlights)
+
+    # Usage metering (Deck #67), recorded once per document AFTER the embedding/
+    # sparse task group so it covers BOTH modes (byte + page dimensions for
+    # keyword and hybrid alike; embedding tokens are hybrid-only via
+    # dense_embed_tokens, which stays 0 for keyword docs). Best-effort and
+    # flag-gated; placed after processing succeeds so it can never affect the
+    # indexing path. ``page_count`` is set by the document processors for PDFs
+    # and absent for text types. Narrow defensively: file_metadata values are
+    # loosely typed, so a malformed page_count meters as "no pages"; bool is an
+    # int subclass, so exclude it explicitly.
+    _meter_total_chars = sum(len(t) for t in chunk_texts)
+    _meter_raw_page_count = file_metadata.get("page_count")
+    await record_indexing_usage(
+        enabled=settings.usage_metering_enabled,
+        provider=settings.get_embedding_provider_family(),
+        model=settings.get_embedding_model_name(),
+        doc_type=doc_task.doc_type,
+        user_id=doc_task.user_id,
+        index_mode=doc_task.index_mode,
+        chunk_count=len(chunk_texts),
+        token_count=dense_embed_tokens,
+        total_chars=_meter_total_chars,
+        page_count=(
+            _meter_raw_page_count
+            if isinstance(_meter_raw_page_count, int)
+            and not isinstance(_meter_raw_page_count, bool)
+            else None
+        ),
+        # bytes_ingested: raw source size at ingestion (raw WebDAV binary for
+        # files, UTF-8 text size for text doc types — note, deck_card,
+        # news_item, mail_message). See helper.
+        bytes_ingested=ingested_byte_size(content_bytes, content),
+        # bytes_stored: UTF-8 size of the chunk texts persisted as Qdrant payload
+        # excerpts (includes chunk-overlap duplication).
+        bytes_stored=sum(len(t.encode("utf-8")) for t in chunk_texts),
+        # Tier that produced the parsed pages (registry stamps it on the result
+        # metadata); text doc types stay "fast". Narrow defensively to str|None.
+        pipeline_tier=(
+            pt if isinstance(pt := file_metadata.get("pipeline_tier"), str) else None
+        ),
+    )
 
     # Prepare Qdrant points
     indexed_at = int(time.time())
@@ -1745,8 +1771,11 @@ async def _index_document(
     # safe because the query-side pre-filter only applies when present + enabled).
     # Embedding identity stamped on every chunk point. Via the shared helper so it
     # is IDENTICAL to what the collection sentinel and the cross-user dedup lookup
-    # produce — keyword mode returns a fixed marker (not the bogus ``simple-{dim}``
-    # model-name fallback), which is what makes dedup match (Deck #509).
+    # produce (Deck #509). It records the dense embedding MODEL (so a model switch
+    # forces a re-embed); it is orthogonal to keyword-vs-hybrid, which is tracked
+    # separately by INDEX_MODE. Keyword points carry the model identity too — they
+    # simply omit the dense vector — so a keyword doc dedups against the same
+    # model-identity space (see claim_existing_index's monotonic rule).
     _embedding_identity = build_embedding_identity(settings)
     _acl_hash = compute_acl_hash([("user", doc_task.user_id)])
 
@@ -1795,11 +1824,11 @@ async def _index_document(
         point_name = f"{doc_task.doc_type}:{doc_task.doc_id}:chunk:{i}"
         point_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, point_name))
 
-        # Keyword mode (ADR-030) upserts sparse-only points; the loop is driven
-        # off ``sparse_embeddings`` so the chunk count stays correct when
+        # Keyword docs upsert sparse-only points; the loop is driven off
+        # ``sparse_embeddings`` so the chunk count stays correct when
         # ``dense_embeddings`` is empty. See build_point_vector for the rationale.
         point_vector = build_point_vector(
-            sparse_emb, dense_embeddings, i, dense_enabled=settings.dense_enabled
+            sparse_emb, dense_embeddings, i, dense_enabled=dense_for_doc
         )
 
         points.append(
@@ -1847,6 +1876,10 @@ async def _index_document(
                         "pipeline_tier", "fast"
                     ),
                     payload_keys.EMBEDDING_IDENTITY: _embedding_identity,
+                    # Per-document index mode: "hybrid" (this point carries a
+                    # dense vector) or "keyword" (sparse-only). Drives verify-on-
+                    # read tag selection, the dedup monotonic rule, and billing.
+                    payload_keys.INDEX_MODE: doc_task.index_mode,
                     payload_keys.ACL_HASH: _acl_hash,
                     # File-specific metadata (PDF, etc.)
                     **(

--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -721,24 +721,19 @@ async def get_qdrant_client() -> AsyncQdrantClient:
             # Get collection name (auto-generated from deployment ID + model)
             collection_name = settings.get_collection_name()
 
-            # Keyword mode (ADR-030) indexes BM25 sparse vectors only and may run
-            # fully airgapped with no embedding endpoint. Skip the embedding
-            # service entirely so collection creation never touches the network —
-            # even if a stray OLLAMA_BASE_URL is set, the Ollama
-            # ``_detect_dimension`` probe must not fire here. The dense named
-            # vector still has to be sized (the schema keeps a dense slot the
-            # keyword points simply never populate), so use the fixed local
-            # SimpleProvider dimension as the placeholder.
-            if settings.dense_enabled:
-                embedding_service = get_embedding_service()
+            # The collection always carries a real dense slot sized from the
+            # embedding model; keyword-only documents share this collection and
+            # simply omit the dense vector per-point. When no real provider is
+            # configured the embedding service resolves to the local
+            # SimpleProvider (deterministic, no network), so this stays correct
+            # for airgapped deployments that only ever use the keyword tag.
+            embedding_service = get_embedding_service()
 
-                # Detect dimension dynamically (for OllamaEmbeddingProvider)
-                if hasattr(embedding_service.provider, "_detect_dimension"):
-                    await embedding_service.provider._detect_dimension()  # type: ignore[call-non-callable]
+            # Detect dimension dynamically (for OllamaEmbeddingProvider)
+            if hasattr(embedding_service.provider, "_detect_dimension"):
+                await embedding_service.provider._detect_dimension()  # type: ignore[call-non-callable]
 
-                expected_dimension = embedding_service.get_dimension()
-            else:
-                expected_dimension = settings.simple_embedding_dimension
+            expected_dimension = embedding_service.get_dimension()
 
             # Existence check folded into the get_collection() call.
             #
@@ -793,36 +788,16 @@ async def get_qdrant_client() -> AsyncQdrantClient:
 
                 # Validate dimension matches
                 if actual_dimension != expected_dimension:
-                    # In keyword mode the expected dense size is
-                    # SIMPLE_EMBEDDING_DIMENSION (no embedding model), so a
-                    # mismatch almost always means an explicit QDRANT_COLLECTION
-                    # is pointed at a hybrid collection — not a model change.
-                    if settings.dense_enabled:
-                        expected_source = (
-                            f"from embedding model "
-                            f"'{settings.get_embedding_model_name()}'"
-                        )
-                        likely_cause = (
-                            "This usually means you changed the embedding model."
-                        )
-                    else:
-                        expected_source = (
-                            "from SIMPLE_EMBEDDING_DIMENSION; SEARCH_MODE=keyword"
-                        )
-                        likely_cause = (
-                            "This usually means QDRANT_COLLECTION points at a "
-                            "hybrid-mode collection; keyword and hybrid indexes "
-                            "are not interchangeable (ADR-030)."
-                        )
                     raise ValueError(
                         f"Dimension mismatch for collection '{collection_name}':\n"
-                        f"  Expected: {expected_dimension} ({expected_source})\n"
+                        f"  Expected: {expected_dimension} (from embedding model "
+                        f"'{settings.get_embedding_model_name()}')\n"
                         f"  Found: {actual_dimension}\n"
-                        f"{likely_cause}\n"
+                        f"This usually means you changed the embedding model.\n"
                         f"Solutions:\n"
                         f"  1. Delete the old collection: Collection will be recreated with new dimensions\n"
                         f"  2. Set QDRANT_COLLECTION to use a different collection name\n"
-                        f"  3. Revert to the original embedding model / SEARCH_MODE"
+                        f"  3. Revert to the original embedding model"
                     )
 
                 logger.info(

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -8,7 +8,7 @@ import random
 import time
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import anyio
 from anyio.abc import TaskStatus
@@ -19,7 +19,7 @@ from qdrant_client.models import FieldCondition, Filter, MatchValue, Record
 from nextcloud_mcp_server.capabilities import allowed_doc_types, is_doc_type_allowed
 from nextcloud_mcp_server.client import NextcloudClient
 from nextcloud_mcp_server.client.news import NewsItemType
-from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.config import Settings, get_settings
 from nextcloud_mcp_server.models.deck import DeckCard
 from nextcloud_mcp_server.observability.metrics import record_vector_sync_scan
 from nextcloud_mcp_server.observability.tracing import trace_operation
@@ -27,6 +27,7 @@ from nextcloud_mcp_server.server.tag_exclusion import (
     get_excluded_file_paths,
     is_path_excluded,
 )
+from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.dead_letter import is_dead_lettered
 from nextcloud_mcp_server.vector.mail_content import MAIL_SCAN_MAX_PER_MAILBOX
 from nextcloud_mcp_server.vector.placeholder import (
@@ -35,6 +36,10 @@ from nextcloud_mcp_server.vector.placeholder import (
 )
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 from nextcloud_mcp_server.vector.queue.ports import TaskProducer
+
+if TYPE_CHECKING:
+    from nextcloud_mcp_server.search.algorithms import NextcloudClientProtocol
+
 from nextcloud_mcp_server.vector.sharing_state import (
     claim_existing_index,
     reconcile_document_path,
@@ -127,6 +132,11 @@ class DocumentTask:
     # shared-with-me crawl can pass through the actual owner without
     # reshaping the payload contract.
     owner_id: str | None = None
+    # Per-document index mode: "hybrid" (dense + BM25 sparse, the default and what
+    # every non-file producer emits) or "keyword" (BM25 sparse only). Set to
+    # "keyword" for files discovered via the ``keyword-index`` tag so the
+    # processor skips dense embedding for them. See payload_keys.INDEX_MODE_*.
+    index_mode: str = payload_keys.INDEX_MODE_HYBRID
 
 
 # Track documents potentially deleted (grace period before actual deletion)
@@ -134,6 +144,45 @@ class DocumentTask:
 # part of the key so the same numeric id under different doc types (a note 42
 # and a mail_message 42 for one user) tracks grace periods independently.
 _potentially_deleted: dict[tuple[str, str, str], float] = {}
+
+
+async def _discover_tagged_files(
+    nc_client: "NextcloudClientProtocol", settings: Settings
+) -> list[dict]:
+    """Discover tagged PDFs for both index modes, stamping ``_index_mode``.
+
+    ``vector_sync_pdf_tag`` → hybrid (dense + BM25 sparse); ``vector_sync_keyword_tag``
+    → keyword (BM25 sparse only). Hybrid wins precedence: a file carrying both tags
+    is hybrid (a superset of keyword), so it is discovered once with
+    ``_index_mode="hybrid"`` and its keyword listing is dropped. The keyword tag is
+    only queried when ``vector_sync_keyword_tag`` is non-empty (empty = disabled),
+    so single-tag deployments issue exactly one OCS Tags query as before.
+
+    Each returned dict is a ``find_files_by_tag`` row (id/path/etag/...) plus an
+    ``_index_mode`` key consumed by the enqueue loop.
+    """
+    hybrid_files = await nc_client.find_files_by_tag(
+        settings.vector_sync_pdf_tag, mime_type_filter="application/pdf"
+    )
+    for f in hybrid_files:
+        f["_index_mode"] = payload_keys.INDEX_MODE_HYBRID
+
+    keyword_tag = settings.vector_sync_keyword_tag
+    if not keyword_tag:
+        return hybrid_files
+
+    hybrid_ids = {str(f["id"]) for f in hybrid_files}
+    keyword_files = await nc_client.find_files_by_tag(
+        keyword_tag, mime_type_filter="application/pdf"
+    )
+    # Hybrid precedence: drop keyword rows for files already tagged hybrid.
+    extra_keyword_files = []
+    for f in keyword_files:
+        if str(f["id"]) in hybrid_ids:
+            continue
+        f["_index_mode"] = payload_keys.INDEX_MODE_KEYWORD
+        extra_keyword_files.append(f)
+    return hybrid_files + extra_keyword_files
 
 
 async def get_last_indexed_timestamp(user_id: str) -> int | None:
@@ -614,16 +663,18 @@ async def scan_user_documents(
         nextcloud_file_ids = set()
 
         try:
-            # Find files with vector-index tag using OCS Tags API.
-            # find_files_by_tag also expands tagged directories into their
-            # PDF descendants (Depth: infinity SEARCH), so a tag on a
-            # folder applies to every PDF beneath it.
+            # Find tagged PDFs via the OCS Tags API. find_files_by_tag also
+            # expands tagged directories into their PDF descendants (Depth:
+            # infinity SEARCH), so a tag on a folder applies to every PDF beneath
+            # it. Two tags feed one pipeline: ``vector_sync_pdf_tag`` →
+            # hybrid (dense + sparse), ``vector_sync_keyword_tag`` → keyword
+            # (sparse only). Each file dict is stamped with ``_index_mode`` so the
+            # per-document processor knows which to apply; hybrid wins when a file
+            # carries both (it is a superset of keyword). ``vector_sync_keyword_tag``
+            # empty (default) disables the second tag entirely.
             settings = get_settings()
-            tag_name = settings.vector_sync_pdf_tag
             if is_doc_type_allowed("file", allowed):
-                tagged_files = await nc_client.find_files_by_tag(
-                    tag_name, mime_type_filter="application/pdf"
-                )
+                tagged_files = await _discover_tagged_files(nc_client, settings)
             else:
                 # Files disabled by admin: discover nothing so no new file is
                 # indexed. The deletion-reconcile below then sees every indexed
@@ -685,6 +736,12 @@ async def scan_user_documents(
                 # and producers across doc_types must agree on a single type.
                 file_id = str(file_info["id"])
                 file_path = file_info["path"]  # Keep path for logging
+                # Which index mode this file's tag selected (hybrid default;
+                # keyword for keyword-index-tagged files). Threaded into the dedup
+                # claim and the DocumentTask so the processor embeds accordingly.
+                index_mode = file_info.get(
+                    "_index_mode", payload_keys.INDEX_MODE_HYBRID
+                )
                 nextcloud_file_ids.add(file_id)
 
                 # Use last_modified timestamp if available, otherwise use current time
@@ -705,7 +762,12 @@ async def scan_user_documents(
                 # because chunk point IDs are user-agnostic (note 386945 #5).
                 etag = str(file_info.get("etag") or "")
                 if etag and await claim_existing_index(
-                    file_id, "file", etag, user_id, current_path=file_path
+                    file_id,
+                    "file",
+                    etag,
+                    user_id,
+                    index_mode=index_mode,
+                    current_path=file_path,
                 ):
                     _potentially_deleted.pop((user_id, file_id, "file"), None)
                     logger.debug(
@@ -754,6 +816,7 @@ async def scan_user_documents(
                             modified_at=modified_at,
                             file_path=file_path,
                             etag=etag,
+                            index_mode=index_mode,
                         )
                     )
                     file_queued += 1
@@ -817,6 +880,29 @@ async def scan_user_documents(
                                 format(placeholder_age, ".1f"),
                                 format(stale_threshold, ".1f"),
                             )
+                    elif (
+                        # Default hybrid: points indexed before INDEX_MODE existed
+                        # carry no key and were dense+sparse, so they read as
+                        # hybrid and don't spuriously reindex under a hybrid scan.
+                        existing_metadata.get(
+                            payload_keys.INDEX_MODE, payload_keys.INDEX_MODE_HYBRID
+                        )
+                        != index_mode
+                    ):
+                        # Real point whose index mode changed at unchanged content
+                        # (a retag). In practice this is the keyword→hybrid upgrade:
+                        # the modified_at gate above is stable, and the dedup claim
+                        # can't reuse sparse-only points for a hybrid request, so
+                        # reprocess to add the dense vector. (The hybrid→keyword
+                        # downgrade is absorbed by the dedup no-downgrade rule and
+                        # never reaches here.)
+                        logger.info(
+                            "File %s (ID: %s) index mode changed to %s; reindexing",
+                            file_path,
+                            file_id,
+                            index_mode,
+                        )
+                        needs_indexing = True
 
                     if needs_indexing:
                         # Write placeholder before queuing
@@ -837,6 +923,7 @@ async def scan_user_documents(
                                 modified_at=modified_at,
                                 file_path=file_path,
                                 etag=etag,
+                                index_mode=index_mode,
                             )
                         )
                         file_queued += 1

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -73,6 +73,7 @@ async def find_indexed_content(
     doc_type: str,
     etag: str,
     embedding_identity: str,
+    index_mode: str = payload_keys.INDEX_MODE_HYBRID,
 ) -> dict | None:
     """Return a real point's payload if this exact content is already indexed.
 
@@ -83,6 +84,13 @@ async def find_indexed_content(
     overwrites the same points, so all live points for a doc share one identity —
     a mismatch means the existing vectors were produced by a different model and
     must be re-embedded, so we report "not indexed".
+
+    ``index_mode`` applies the monotonic keyword→hybrid rule so a mixed collection
+    never re-embeds in a loop: a **hybrid** claim against an existing **keyword**
+    (sparse-only) point reports "not indexed" so the doc is reprocessed and gains
+    a dense vector (upgrade); a **keyword** claim against an existing **hybrid**
+    point is a hit (hybrid ⊇ keyword — never downgrade/strip the dense vector
+    while any user holds the hybrid tag). Same-mode is a hit as before.
 
     Returns the payload dict (including ``acl_principals``) on a hit, else None.
     """
@@ -110,6 +118,18 @@ async def find_indexed_content(
     if payload.get(payload_keys.EMBEDDING_IDENTITY) != embedding_identity:
         # Existing vectors were produced by a different embedding model — a
         # re-embed is required, so this content is not reusable as-is.
+        return None
+    # Monotonic keyword→hybrid upgrade: a hybrid claim cannot reuse sparse-only
+    # keyword points (they lack the dense vector), so force a reprocess. Every
+    # other combination reuses the existing points (same mode, or a keyword claim
+    # against hybrid points — hybrid satisfies keyword). Existing points written
+    # before INDEX_MODE existed have no key; treat them as hybrid (the prior
+    # dense+sparse default) so a hybrid claim still dedups against them.
+    existing_mode = payload.get(payload_keys.INDEX_MODE, payload_keys.INDEX_MODE_HYBRID)
+    if (
+        index_mode == payload_keys.INDEX_MODE_HYBRID
+        and existing_mode == payload_keys.INDEX_MODE_KEYWORD
+    ):
         return None
     return payload
 
@@ -223,6 +243,7 @@ async def claim_existing_index(
     doc_type: str,
     etag: str,
     user_id: str,
+    index_mode: str = payload_keys.INDEX_MODE_HYBRID,
     current_path: str | None = None,
 ) -> bool:
     """Tenant-wide dedup claim: skip reprocessing if content is already indexed.
@@ -245,14 +266,14 @@ async def claim_existing_index(
     after a confirmed hit is non-fatal (logged, not raised): verify-on-read still
     gates access and the user's next scan re-claims it.
     """
-    # Must match what the chunk-point WRITER stamps (processor.py), which is the
-    # shared helper — NOT get_embedding_model_name(), whose ``simple-{dim}`` keyword
-    # fallback never equals the writer's ``bm25-keyword`` marker, so dedup would
-    # always miss and unchanged docs re-process every scan (Deck #509).
+    # Must match what the chunk-point WRITER stamps (processor.py) via the shared
+    # helper so the dedup comparison agrees (Deck #509). The identity is the
+    # embedding model; the keyword-vs-hybrid mode is applied separately by
+    # ``index_mode`` (monotonic keyword→hybrid — see find_indexed_content).
     embedding_identity = build_embedding_identity(get_settings())
     try:
         existing = await find_indexed_content(
-            doc_id, doc_type, etag, embedding_identity
+            doc_id, doc_type, etag, embedding_identity, index_mode
         )
     except Exception as exc:  # noqa: BLE001 — degrade to "process normally"
         logger.warning(

--- a/nextcloud_mcp_server/vector/visualization.py
+++ b/nextcloud_mcp_server/vector/visualization.py
@@ -101,9 +101,13 @@ async def compute_pca_coordinates(
         if chunk_key in chunk_vectors_map:
             chunk_vectors.append(chunk_vectors_map[chunk_key])
         else:
-            # Chunk not found in vectors (shouldn't happen)
-            logger.warning(
-                "Chunk %s not found in fetched vectors, using zero vector", chunk_key
+            # No dense vector for this chunk — expected for keyword-only results
+            # (``keyword-index`` tag), which carry a sparse vector only and so
+            # can't be positioned by PCA. Placed at the origin; hybrid chunks are
+            # unaffected.
+            logger.debug(
+                "Chunk %s has no dense vector (keyword-only?); placing at origin",
+                chunk_key,
             )
             chunk_vectors.append(np.zeros(embedding_dim))
 

--- a/tests/contract/test_mcp_provider_verification.py
+++ b/tests/contract/test_mcp_provider_verification.py
@@ -85,38 +85,38 @@ def _state_admin_can_purge() -> None:
 
 
 def _state_search_mode_hybrid() -> None:
-    """Provider state for astrolabe's status pact when it expects hybrid search
-    support (``supported_search_types == ["semantic", "bm25", "hybrid"]``).
+    """Provider state for astrolabe's status pact when it expects the full search
+    advertisement (``supported_search_types == ["semantic", "bm25", "hybrid"]``).
 
-    The integration stack runs in the default SEARCH_MODE=hybrid, so the running
-    server already advertises all three types — no setup needed. Registered (not
-    relying on the no-op fallback) so the dispatcher recognises the state by name
-    and a future config-injection hook has a home. See ADR-030.
+    The integration stack runs with vector sync enabled, so the running server
+    already advertises all three types — no setup needed. Registered (not relying
+    on the no-op fallback) so the dispatcher recognises the state by name and a
+    future config-injection hook has a home. See ADR-031.
     """
-    # Default integration server is already hybrid; nothing to set up.
+    # Default integration server has vector sync enabled; nothing to set up.
 
 
-def _state_search_mode_keyword() -> None:
-    """Provider state for astrolabe's status pact when it expects keyword-only
-    search support (``supported_search_types == ["bm25"]``).
+def _state_vector_sync_disabled() -> None:
+    """Provider state for astrolabe's status pact when it expects no search
+    support (``supported_search_types == []``).
 
     Verifying this against a live server needs the server started with
-    SEARCH_MODE=keyword (a dedicated provider instance / the ADR-029 phase-4
-    config-injection hook); until then the interaction rides the broker's pending
-    flow. Registered so the state is recognised by name rather than warned about.
-    See ADR-030.
+    ENABLE_SEMANTIC_SEARCH=false (a dedicated provider instance / the ADR-029
+    phase-4 config-injection hook); until then the interaction rides the broker's
+    pending flow. Registered so the state is recognised by name rather than warned
+    about. See ADR-031.
     """
     # No in-process injection into the separate provider yet (phase 4).
 
 
 _PROVIDER_STATES: dict[str, Callable[[], None]] = {
     "an admin can purge indexed documents": _state_admin_can_purge,
-    # Search-mode advertisement states for GET /api/v1/status (ADR-030); the
-    # astrolabe UI consumer pact declares one of these to assert
-    # supported_search_types. Keys must match the consumer ``given(...)`` strings
-    # in test_mcp_status_search_types_consumer.py / astrolabe's published pact.
+    # Search advertisement states for GET /api/v1/status (ADR-031); the astrolabe
+    # UI consumer pact declares one of these to assert supported_search_types.
+    # Keys must match the consumer ``given(...)`` strings in
+    # test_mcp_status_search_types_consumer.py / astrolabe's published pact.
     "the server advertises hybrid search support": _state_search_mode_hybrid,
-    "the server advertises keyword-only search support": _state_search_mode_keyword,
+    "the server has vector sync disabled": _state_vector_sync_disabled,
     # "a webhook is registered for user alice": _state_webhook_registered,
     # "vector sync has indexed documents": _state_vector_sync_ran,
     # "the search index returns a hit for 'budget'": _state_search_has_hit,

--- a/tests/contract/test_mcp_status_search_types_consumer.py
+++ b/tests/contract/test_mcp_status_search_types_consumer.py
@@ -3,11 +3,11 @@
 For the status endpoint the roles are reversed from the other contract tests in
 this package: **astrolabe is the consumer** and **nextcloud-mcp-server is the
 provider**. The astrolabe UI reads ``supported_search_types`` from
-``/api/v1/status`` to gate which query types it offers (ADR-030):
+``/api/v1/status`` to gate which query types it offers (ADR-031):
 
-- ``SEARCH_MODE=hybrid`` → ``["semantic", "bm25", "hybrid"]``
-- ``SEARCH_MODE=keyword`` → ``["bm25"]`` (dense embeddings are off)
-- vector sync disabled  → ``[]``
+- vector sync enabled  → ``["semantic", "bm25", "hybrid"]`` (the collection is
+  always dense-capable; keyword-only documents contribute via the sparse side)
+- vector sync disabled → ``[]``
 
 This is **contract-first**: we author the pact astrolabe's follow-up UI PR will
 implement against, pinning the field name, the value vocabulary, and the
@@ -22,7 +22,7 @@ real provider response is verified by ``tests/unit/test_management_status_endpoi
 (``TestStatusEndpointSearchTypes``) and, in integration CI, by provider
 verification against a running server.
 
-See ADR-029 (contract architecture) and ADR-030 (SEARCH_MODE).
+See ADR-029 (contract architecture) and ADR-031 (per-document index mode).
 """
 
 import shutil
@@ -75,10 +75,15 @@ async def _fetch_supported_search_types(base_url: str) -> list[str]:
         return resp.json()["supported_search_types"]
 
 
-async def test_status_advertises_all_query_types_in_hybrid_mode(status_pact):
-    """Hybrid mode advertises semantic + bm25 + hybrid, so the UI offers all."""
+async def test_status_advertises_all_query_types_when_vector_sync_enabled(status_pact):
+    """Vector sync on advertises semantic + bm25 + hybrid, so the UI offers all.
+
+    The collection is always dense-capable (ADR-031); keyword-only documents
+    contribute via the sparse side of the fused query, so all three types are
+    offered whenever vector sync is enabled.
+    """
     (
-        status_pact.upon_receiving("a status request when the server is in hybrid mode")
+        status_pact.upon_receiving("a status request when vector sync is enabled")
         .given("the server advertises hybrid search support")
         .with_request("GET", "/api/v1/status")
         .will_respond_with(200)
@@ -96,17 +101,15 @@ async def test_status_advertises_all_query_types_in_hybrid_mode(status_pact):
     assert types == ["semantic", "bm25", "hybrid"]
 
 
-async def test_status_advertises_bm25_only_in_keyword_mode(status_pact):
-    """Keyword mode advertises bm25 only, so the UI hides semantic/hybrid."""
+async def test_status_advertises_nothing_when_vector_sync_disabled(status_pact):
+    """Vector sync off advertises no query types, so the UI hides the picker."""
     (
-        status_pact.upon_receiving(
-            "a status request when the server is in keyword mode"
-        )
-        .given("the server advertises keyword-only search support")
+        status_pact.upon_receiving("a status request when vector sync is disabled")
+        .given("the server has vector sync disabled")
         .with_request("GET", "/api/v1/status")
         .will_respond_with(200)
         .with_body(
-            {"supported_search_types": ["bm25"]},
+            {"supported_search_types": []},
             content_type="application/json",
         )
     )
@@ -114,7 +117,7 @@ async def test_status_advertises_bm25_only_in_keyword_mode(status_pact):
     with status_pact.serve() as srv:
         types = await _fetch_supported_search_types(str(srv.url))
 
-    assert types == ["bm25"]
+    assert types == []
 
 
 async def _post_search_algorithm(
@@ -122,7 +125,7 @@ async def _post_search_algorithm(
 ) -> httpx.Response:
     """Stand-in for astrolabe's McpServerClient search calls: POST ``path`` with an
     explicit ``algorithm``. Returns the raw response so the caller can assert on
-    the (strict, ADR-030) 422 the server sends for an unsupported algorithm.
+    the (strict, ADR-031) 422 the server sends for an unsupported algorithm.
 
     Both astrolabe search entry points are exercised — ``searchForUnifiedSearch``
     (POST /api/v1/search) and ``search`` (POST /api/v1/vector-viz/search) — which
@@ -137,23 +140,24 @@ async def _post_search_algorithm(
 
 
 @pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
-async def test_search_rejects_unsupported_algorithm_in_keyword_mode(
+async def test_search_rejects_algorithm_when_vector_sync_disabled(
     status_pact, path: str
 ):
-    """Explicitly requesting ``semantic`` on a keyword-only server → 422 (ADR-030).
+    """Any explicit algorithm against a vector-sync-disabled server → 422 (ADR-031).
 
-    This is the strict half of the contract: rather than silently degrading a
-    ``semantic`` request to BM25, the server rejects it with the advertised
-    ``supported_search_types`` so astrolabe can surface/guard the error. astrolabe
-    also gates the request client-side from ``/api/v1/status``, but this pins the
-    server-side backstop the client relies on — on **both** search endpoints,
-    which share one ``_build_search_algorithm`` gate.
+    With per-document index mode there is no keyword-only server: whenever vector
+    sync is on, all three algorithms are supported. The remaining strict-reject
+    case is a request made while vector sync is **off** (``supported_search_types``
+    is empty) — the server rejects it with the advertised (empty) set rather than
+    silently returning nothing, so astrolabe can surface/guard the error. astrolabe
+    also gates client-side from ``/api/v1/status``, but this pins the server-side
+    backstop on **both** search endpoints, which share one gate.
     """
     (
         status_pact.upon_receiving(
-            f"a semantic search request to {path} when the server is in keyword mode"
+            f"a semantic search request to {path} when vector sync is disabled"
         )
-        .given("the server advertises keyword-only search support")
+        .given("the server has vector sync disabled")
         .with_request("POST", path)
         .with_body(
             {"query": "torch leadership award", "algorithm": "semantic"},
@@ -164,7 +168,7 @@ async def test_search_rejects_unsupported_algorithm_in_keyword_mode(
             {
                 "error": "unsupported_search_type",
                 "requested": "semantic",
-                "supported_search_types": ["bm25"],
+                "supported_search_types": [],
             },
             content_type="application/json",
         )
@@ -177,4 +181,4 @@ async def test_search_rejects_unsupported_algorithm_in_keyword_mode(
     body = resp.json()
     assert body["error"] == "unsupported_search_type"
     assert body["requested"] == "semantic"
-    assert body["supported_search_types"] == ["bm25"]
+    assert body["supported_search_types"] == []

--- a/tests/integration/test_index_mode_discovery.py
+++ b/tests/integration/test_index_mode_discovery.py
@@ -1,0 +1,100 @@
+"""End-to-end integration test for two-tag index-mode discovery (ADR-031).
+
+The scanner discovers files under two Nextcloud system tags —
+``VECTOR_SYNC_PDF_TAG`` (hybrid) and ``VECTOR_SYNC_KEYWORD_TAG`` (keyword-only)
+— via ``_discover_tagged_files``, which stamps each file with ``_index_mode``
+and applies **hybrid precedence** (a file carrying both tags is hybrid). This
+exercises the real OCS Tags API for both tags against a running Nextcloud, which
+the mocked unit tests in ``tests/unit/vector/test_index_mode_discovery.py``
+cannot.
+"""
+
+import logging
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from nextcloud_mcp_server.client import NextcloudClient
+from nextcloud_mcp_server.vector import payload_keys
+from nextcloud_mcp_server.vector.scanner import _discover_tagged_files
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def dual_tag_environment(nc_client: NextcloudClient):
+    """Provision a hybrid tag, a keyword tag, and three PDFs: hybrid-only,
+    keyword-only, and one carrying both tags."""
+    suffix = uuid.uuid4().hex[:8]
+    hybrid_tag = f"mcp-hybrid-{suffix}"
+    keyword_tag = f"mcp-keyword-{suffix}"
+    test_dir = f"mcp_idx_mode_{suffix}"
+    hybrid_pdf = f"{test_dir}/hybrid.pdf"
+    keyword_pdf = f"{test_dir}/keyword.pdf"
+    both_pdf = f"{test_dir}/both.pdf"
+
+    # Minimal valid PDF bytes so Nextcloud reports application/pdf.
+    pdf_bytes = (
+        b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF"
+    )
+
+    await nc_client.webdav.create_directory(test_dir)
+    for path in (hybrid_pdf, keyword_pdf, both_pdf):
+        await nc_client.webdav.write_file(path, pdf_bytes, "application/pdf")
+
+    hybrid = await nc_client.webdav.get_or_create_tag(
+        name=hybrid_tag, user_visible=True, user_assignable=True
+    )
+    keyword = await nc_client.webdav.get_or_create_tag(
+        name=keyword_tag, user_visible=True, user_assignable=True
+    )
+
+    ids = {}
+    for key, path in (
+        ("hybrid", hybrid_pdf),
+        ("keyword", keyword_pdf),
+        ("both", both_pdf),
+    ):
+        info = await nc_client.webdav.get_file_info(path)
+        assert info is not None
+        ids[key] = info["id"]
+
+    await nc_client.webdav.assign_tag_to_file(ids["hybrid"], hybrid["id"])
+    await nc_client.webdav.assign_tag_to_file(ids["keyword"], keyword["id"])
+    await nc_client.webdav.assign_tag_to_file(ids["both"], hybrid["id"])
+    await nc_client.webdav.assign_tag_to_file(ids["both"], keyword["id"])
+
+    yield {
+        "hybrid_tag": hybrid_tag,
+        "keyword_tag": keyword_tag,
+        "ids": {str(k): str(v) for k, v in ids.items()},
+        "settings": SimpleNamespace(
+            vector_sync_pdf_tag=hybrid_tag,
+            vector_sync_keyword_tag=keyword_tag,
+        ),
+    }
+
+    try:
+        await nc_client.webdav.delete_resource(test_dir)
+    except Exception as e:
+        logger.warning("failed to delete %s: %s", test_dir, e)
+
+
+async def test_discover_stamps_modes_with_hybrid_precedence(
+    dual_tag_environment, nc_client: NextcloudClient
+):
+    """Hybrid-only → hybrid, keyword-only → keyword, both-tags → hybrid (once)."""
+    env = dual_tag_environment
+
+    files = await _discover_tagged_files(nc_client, env["settings"])
+
+    by_id = {str(f["id"]): f["_index_mode"] for f in files}
+    ids = env["ids"]
+    assert by_id.get(ids["hybrid"]) == payload_keys.INDEX_MODE_HYBRID
+    assert by_id.get(ids["keyword"]) == payload_keys.INDEX_MODE_KEYWORD
+    # A file carrying both tags is hybrid (superset) and appears exactly once.
+    assert by_id.get(ids["both"]) == payload_keys.INDEX_MODE_HYBRID
+    returned_both = [f for f in files if str(f["id"]) == ids["both"]]
+    assert len(returned_both) == 1

--- a/tests/unit/search/test_bm25_hybrid.py
+++ b/tests/unit/search/test_bm25_hybrid.py
@@ -56,11 +56,10 @@ def test_bm25_hybrid_requires_vector_db():
     assert algo.requires_vector_db is True
 
 
-def _make_search_deps(monkeypatch, *, dense_enabled: bool):
+def _make_search_deps(monkeypatch):
     """Stub the embedding / BM25 / Qdrant / settings deps of ``search()`` and
-    return ``(embed, qdrant)`` mocks. ``dense_enabled`` selects hybrid (True) vs
-    keyword (False) mode; everything else is identical, so both fixtures below
-    share this one builder."""
+    return ``(embed, qdrant)`` mocks. The query always fuses dense + sparse
+    (there is no keyword-only mode), so a single builder serves every test."""
     embed = AsyncMock(return_value=([0.1, 0.2, 0.3], 7))
     svc = MagicMock()
     svc.embed_with_usage = embed
@@ -85,7 +84,6 @@ def _make_search_deps(monkeypatch, *, dense_enabled: bool):
     )
 
     settings = MagicMock()
-    settings.dense_enabled = dense_enabled
     settings.get_collection_name.return_value = "test_collection"
     settings.get_embedding_provider_family.return_value = "mistral"
     monkeypatch.setattr(
@@ -102,7 +100,7 @@ def _make_search_deps(monkeypatch, *, dense_enabled: bool):
 def patched_search(monkeypatch):
     """Hybrid-mode deps; returns the embed mock so tests can assert how often the
     query was embedded."""
-    embed, _ = _make_search_deps(monkeypatch, dense_enabled=True)
+    embed, _ = _make_search_deps(monkeypatch)
     return embed
 
 
@@ -156,47 +154,10 @@ async def test_hybrid_query_uses_dense_prefetch_and_fusion(patched_search, monke
     assert isinstance(kwargs["query"], models.FusionQuery)
 
 
-@pytest.fixture
-def patched_keyword_search(monkeypatch):
-    """Keyword mode (ADR-030): dense disabled. Returns (embed, qdrant) so tests
-    can assert the embedding service is never called and the Qdrant call is a
-    direct sparse query with no fusion."""
-    return _make_search_deps(monkeypatch, dense_enabled=False)
-
-
 @pytest.mark.unit
-async def test_keyword_mode_never_embeds_query(patched_keyword_search):
-    """Keyword mode must not contact the embedding service (airgapped)."""
-    embed, _ = patched_keyword_search
-    algo = BM25HybridSearchAlgorithm()
-
-    await algo.search(query="invoice 2026", user_id="alice")
-
-    assert embed.await_count == 0
-    assert algo.query_embedding is None
-    assert algo.query_token_count is None
-
-
-@pytest.mark.unit
-async def test_keyword_mode_issues_direct_sparse_query(patched_keyword_search):
-    """Keyword mode issues a single sparse query, no dense prefetch / fusion."""
-    _, qdrant = patched_keyword_search
-    algo = BM25HybridSearchAlgorithm()
-
-    await algo.search(query="invoice 2026", user_id="alice")
-
-    kwargs = qdrant.query_points.await_args.kwargs
-    assert kwargs["using"] == "sparse"
-    assert isinstance(kwargs["query"], models.SparseVector)
-    assert "prefetch" not in kwargs
-    assert not isinstance(kwargs["query"], models.FusionQuery)
-
-
-@pytest.mark.unit
-async def test_keyword_mode_search_method_label(patched_keyword_search, monkeypatch):
-    """Keyword results are tagged search_method='bm25_keyword'."""
-    _, qdrant = patched_keyword_search
-
+async def test_search_method_label_is_always_bm25_hybrid(patched_search, monkeypatch):
+    """Results are tagged search_method='bm25_hybrid_<fusion>' — the query always
+    fuses dense + sparse, so there is no keyword-only label anymore."""
     captured: dict = {}
 
     def fake_build(point, metadata_extras):
@@ -209,10 +170,15 @@ async def test_keyword_mode_search_method_label(patched_keyword_search, monkeypa
     )
     response = MagicMock()
     response.points = [MagicMock(score=3.2)]
+    qdrant = MagicMock()
     qdrant.query_points = AsyncMock(return_value=response)
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+        AsyncMock(return_value=qdrant),
+    )
 
     algo = BM25HybridSearchAlgorithm()
     results = await algo.search(query="invoice", user_id="alice", limit=5)
 
     assert results
-    assert captured["search_method"] == "bm25_keyword"
+    assert captured["search_method"] == "bm25_hybrid_rrf"

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -41,38 +41,27 @@ class TestDecompositionDefaults:
             mcp_role=" API ",
             document_tier1_engine=" PyPDFium2 ",
             document_ocr_provider=" Gateway ",
-            search_mode=" KEYWORD ",
         )
         assert s.collection_metadata_source == "qdrant"
         assert s.mcp_role == "api"
         assert s.document_tier1_engine == "pypdfium2"
         assert s.document_ocr_provider == "gateway"
-        assert s.search_mode == "keyword"
 
 
-class TestSearchMode:
-    """SEARCH_MODE = hybrid (default) | keyword (BM25 sparse only), ADR-030."""
+class TestKeywordTag:
+    """VECTOR_SYNC_KEYWORD_TAG selects files to index keyword-only (BM25 sparse,
+    no dense vector), mirroring VECTOR_SYNC_PDF_TAG. Empty by default (disabled)."""
 
-    def test_default_is_hybrid_with_dense_enabled(self):
-        s = Settings()
-        assert s.search_mode == "hybrid"
-        assert s.dense_enabled is True
+    def test_default_is_empty(self):
+        assert Settings().vector_sync_keyword_tag == ""
 
-    def test_keyword_disables_dense(self):
-        s = Settings(search_mode="keyword")
-        assert s.dense_enabled is False
-
-    def test_keyword_collection_name_is_mode_marked(self, monkeypatch):
-        # Keyword collections must not collide with hybrid ones and must not
-        # depend on the (phantom) embedding model name.
-        monkeypatch.setattr("socket.gethostname", lambda: "mcp-host", raising=True)
-        s = Settings(search_mode="keyword")
-        assert s.get_collection_name() == "mcp-host-bm25-keyword"
-
-    def test_explicit_collection_override_wins(self):
-        # An explicit QDRANT_COLLECTION still takes precedence in keyword mode.
-        s = Settings(search_mode="keyword", qdrant_collection="my_collection")
-        assert s.get_collection_name() == "my_collection"
+    def test_explicit_value_round_trips(self):
+        # Mirrors VECTOR_SYNC_PDF_TAG: a configured tag is passed through verbatim
+        # (an explicit value takes precedence over the empty default).
+        assert (
+            Settings(vector_sync_keyword_tag="keyword-index").vector_sync_keyword_tag
+            == "keyword-index"
+        )
 
 
 class TestEnumValidation:
@@ -84,7 +73,6 @@ class TestEnumValidation:
             ("collection_metadata_source", "redis"),
             ("document_tier1_engine", "mupdf"),
             ("document_ocr_provider", "gatway"),
-            ("search_mode", "fulltext"),
         ],
     )
     def test_invalid_enum_rejected(self, field, value):

--- a/tests/unit/test_management_status_endpoint.py
+++ b/tests/unit/test_management_status_endpoint.py
@@ -40,7 +40,6 @@ def create_mock_settings(
     nextcloud_url: str = "http://localhost",
     mcp_client_id: str | None = None,
     mcp_client_secret: str | None = None,
-    dense_enabled: bool = True,
 ):
     """Create mock settings with specified auth configuration."""
     settings = MagicMock()
@@ -49,9 +48,6 @@ def create_mock_settings(
     settings.oidc_discovery_url = oidc_discovery_url
     settings.oidc_issuer = oidc_issuer
     settings.vector_sync_enabled = vector_sync_enabled
-    # dense_enabled is False only in SEARCH_MODE=keyword (ADR-030); drives the
-    # supported_search_types advertised by /api/v1/status.
-    settings.dense_enabled = dense_enabled
     # Explicit so bool(settings.webhook_secret) is deterministic (a bare
     # MagicMock attribute is truthy, which would always report webhooks on).
     settings.webhook_secret = webhook_secret
@@ -398,25 +394,25 @@ class TestStatusEndpointBasicResponse:
 
 
 class TestSupportedSearchTypesHelper:
-    """Pure helper: supported_search_types(settings) (ADR-030)."""
+    """Pure helper: supported_search_types(settings).
+
+    Per-document index mode replaced the old global keyword switch: the
+    collection is always dense-capable, so when vector sync is on the server
+    advertises all three algorithms; keyword-only documents simply contribute to
+    ``bm25``/``hybrid`` via their sparse vector.
+    """
 
     def test_vector_sync_disabled_is_empty(self):
         from nextcloud_mcp_server.api.management import supported_search_types
 
-        s = create_mock_settings(vector_sync_enabled=False, dense_enabled=True)
+        s = create_mock_settings(vector_sync_enabled=False)
         assert supported_search_types(s) == []
 
-    def test_hybrid_mode_advertises_all_three(self):
+    def test_vector_sync_enabled_advertises_all_three(self):
         from nextcloud_mcp_server.api.management import supported_search_types
 
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        s = create_mock_settings(vector_sync_enabled=True)
         assert supported_search_types(s) == ["semantic", "bm25", "hybrid"]
-
-    def test_keyword_mode_advertises_bm25_only(self):
-        from nextcloud_mcp_server.api.management import supported_search_types
-
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
-        assert supported_search_types(s) == ["bm25"]
 
 
 class TestSelectSearchAlgorithm:
@@ -428,16 +424,9 @@ class TestSelectSearchAlgorithm:
     def test_none_defaults_gracefully_in_hybrid(self):
         from nextcloud_mcp_server.api.management import select_search_algorithm
 
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        s = create_mock_settings(vector_sync_enabled=True)
         # No explicit algorithm → historical "hybrid" default.
         assert select_search_algorithm(None, s) == "hybrid"
-
-    def test_none_defaults_to_bm25_in_keyword_mode(self):
-        from nextcloud_mcp_server.api.management import select_search_algorithm
-
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
-        # No explicit algorithm → coerced to the one serviceable type.
-        assert select_search_algorithm(None, s) == "bm25"
 
     def test_none_defaults_to_hybrid_when_vector_sync_off(self):
         from nextcloud_mcp_server.api.management import select_search_algorithm
@@ -449,26 +438,25 @@ class TestSelectSearchAlgorithm:
     def test_explicit_supported_passes_through(self):
         from nextcloud_mcp_server.api.management import select_search_algorithm
 
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        s = create_mock_settings(vector_sync_enabled=True)
         for algo in ("semantic", "bm25", "hybrid"):
             assert select_search_algorithm(algo, s) == algo
 
-    def test_explicit_semantic_in_keyword_mode_raises(self):
+    def test_explicit_algorithm_rejected_when_vector_sync_off(self):
         from nextcloud_mcp_server.api.management import (
             UnsupportedSearchType,
             select_search_algorithm,
         )
 
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
-        # Both dense-requiring algorithms are unsupported in keyword mode.
-        for algo in ("semantic", "hybrid"):
+        # Vector sync off ⇒ supported is empty ⇒ every explicit algorithm is a
+        # hard, self-correcting 422 (no Qdrant-backed search exists to serve).
+        s = create_mock_settings(vector_sync_enabled=False)
+        for algo in ("semantic", "bm25", "hybrid"):
             with pytest.raises(UnsupportedSearchType) as excinfo:
                 select_search_algorithm(algo, s)
             # Error carries the request + advertised set for a self-correcting 422.
             assert excinfo.value.requested == algo
-            assert excinfo.value.supported == ["bm25"]
-        # bm25 is still accepted in keyword mode.
-        assert select_search_algorithm("bm25", s) == "bm25"
+            assert excinfo.value.supported == []
 
     def test_explicit_unknown_algorithm_raises(self):
         from nextcloud_mcp_server.api.management import (
@@ -476,7 +464,7 @@ class TestSelectSearchAlgorithm:
             select_search_algorithm,
         )
 
-        s = create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
+        s = create_mock_settings(vector_sync_enabled=True)
         # Unknown values are a client bug — fail loud rather than coerce.
         with pytest.raises(UnsupportedSearchType):
             select_search_algorithm("nonsense", s)
@@ -502,17 +490,9 @@ class TestStatusEndpointSearchTypes:
         assert response.status_code == 200
         return response.json()
 
-    def test_hybrid_mode(self):
-        data = self._get_status(
-            create_mock_settings(vector_sync_enabled=True, dense_enabled=True)
-        )
+    def test_vector_sync_on_advertises_all_three(self):
+        data = self._get_status(create_mock_settings(vector_sync_enabled=True))
         assert data["supported_search_types"] == ["semantic", "bm25", "hybrid"]
-
-    def test_keyword_mode(self):
-        data = self._get_status(
-            create_mock_settings(vector_sync_enabled=True, dense_enabled=False)
-        )
-        assert data["supported_search_types"] == ["bm25"]
 
     def test_vector_sync_off(self):
         data = self._get_status(create_mock_settings(vector_sync_enabled=False))

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -1,14 +1,16 @@
 """Unit tests for the indexing-path usage-metering helper (Deck #67 / #401).
 
 ``record_indexing_usage`` records the billable events after a document's chunks
-are embedded: ``tokens_embedded`` for every document, and ``pages_embedded``
-only for parsed files (real ``page_count``). Text content (no ``page_count``)
-meters tokens only — ``pages_embedded`` is a charge for parsing, not content
-size (card #282). The byte-volume dimensions ``bytes_ingested`` /
-``bytes_stored`` (card #401) are recorded for every document, skipped only on a
-non-positive count. These cover the value mapping, the flag/zero-chunk no-ops,
-the text-only path, and the best-effort failure path without standing up the
-full document pipeline. (The call site's raw-binary-vs-UTF-8 source selection
+are indexed: ``tokens_embedded`` for hybrid documents (skipped when
+``token_count`` is 0, i.e. keyword-only docs), and ``pages_embedded`` only for
+parsed files (real ``page_count``). Text content (no ``page_count``) meters
+tokens only — ``pages_embedded`` is a charge for parsing, not content size (card
+#282). The byte-volume dimensions ``bytes_ingested`` / ``bytes_stored`` (card
+#401) are recorded for every document, skipped only on a non-positive count, and
+carry an ``index_mode`` metadata dimension (card #609) so the CP rollup can slice
+hybrid vs keyword ingestion. These cover the value mapping, the flag/zero-chunk
+no-ops, the text-only path, and the best-effort failure path without standing up
+the full document pipeline. (The call site's raw-binary-vs-UTF-8 source selection
 for ``bytes_ingested`` lives in the document pipeline and is exercised by the
 integration smoke path, not these helper-level tests.)
 """
@@ -51,7 +53,7 @@ def test_ingested_byte_size_text_uses_utf8_length():
 
 @pytest.mark.unit
 def test_build_point_vector_hybrid_carries_dense_and_sparse():
-    """Hybrid mode (ADR-030) upserts both named vectors for the chunk."""
+    """A hybrid document upserts both named vectors for the chunk."""
     dense = [[0.1, 0.2], [0.3, 0.4]]
     v = processor.build_point_vector("sparse-1", dense, 1, dense_enabled=True)
     assert v == {"sparse": "sparse-1", "dense": [0.3, 0.4]}
@@ -59,8 +61,8 @@ def test_build_point_vector_hybrid_carries_dense_and_sparse():
 
 @pytest.mark.unit
 def test_build_point_vector_keyword_is_sparse_only():
-    """Keyword mode carries only the sparse vector and never indexes into the
-    empty dense list (the silent zero-points bug guard)."""
+    """A keyword document carries only the sparse vector and never indexes into
+    the empty dense list (the silent zero-points bug guard)."""
     v = processor.build_point_vector("sparse-1", [], 0, dense_enabled=False)
     assert v == {"sparse": "sparse-1"}
     assert "dense" not in v
@@ -84,6 +86,7 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=110,
         token_count=4242,
         total_chars=170826,
@@ -115,6 +118,9 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
         assert c.kwargs["metadata"]["model"] == "mistral-embed"
         assert c.kwargs["metadata"]["user_id"] == "alice"
         assert c.kwargs["metadata"]["doc_type"] == "file"
+        # index_mode is threaded onto every event so the CP rollup can slice
+        # hybrid vs keyword ingestion (card #609).
+        assert c.kwargs["metadata"]["index_mode"] == "hybrid"
 
 
 @pytest.mark.unit
@@ -126,6 +132,7 @@ async def test_text_doc_records_tokens_and_bytes_no_pages(store_spy):
         model="mistral-embed",
         doc_type="note",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=4,
         token_count=512,
         total_chars=7000,
@@ -154,6 +161,7 @@ async def test_zero_pages_skips_pages(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=4,
         token_count=99,
         total_chars=1000,
@@ -180,6 +188,7 @@ async def test_negative_pages_skips_pages(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=4,
         token_count=99,
         total_chars=1000,
@@ -206,6 +215,7 @@ async def test_nonpositive_bytes_skip_byte_rows(store_spy):
         model="mistral-embed",
         doc_type="note",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=4,
         token_count=99,
         total_chars=0,
@@ -229,6 +239,7 @@ async def test_disabled_is_noop(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=10,
         token_count=20,
         total_chars=5,
@@ -248,6 +259,7 @@ async def test_zero_chunks_is_noop(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=0,
         token_count=0,
         total_chars=0,
@@ -274,6 +286,7 @@ async def test_store_failure_is_swallowed(monkeypatch):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=3,
         token_count=7,
         total_chars=9,
@@ -292,6 +305,7 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=20,
         token_count=900,
         total_chars=40000,
@@ -326,6 +340,7 @@ async def test_fast_tier_does_not_record_pages_ocr(store_spy):
         model="mistral-embed",
         doc_type="file",
         user_id="alice",
+        index_mode="hybrid",
         chunk_count=10,
         token_count=500,
         total_chars=20000,
@@ -342,3 +357,61 @@ async def test_fast_tier_does_not_record_pages_ocr(store_spy):
         "bytes_ingested",
         "bytes_stored",
     }
+
+
+@pytest.mark.unit
+async def test_keyword_mode_meters_bytes_not_tokens(store_spy):
+    """A keyword-only file (index_mode='keyword', token_count=0) meters the byte
+    dimensions tagged index_mode='keyword' but emits NO tokens_embedded row —
+    keyword docs never embed, so there is no embedding-token cost (card #609)."""
+    await processor.record_indexing_usage(
+        enabled=True,
+        provider="mistral",
+        model="mistral-embed",
+        doc_type="file",
+        user_id="alice",
+        index_mode="keyword",
+        chunk_count=12,
+        token_count=0,  # keyword docs skip dense embedding → zero embed tokens
+        total_chars=30000,
+        page_count=5,
+        bytes_ingested=40960,
+        bytes_stored=30500,
+    )
+
+    calls = store_spy.record_usage_event.await_args_list
+    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    # No tokens_embedded row; parsing (pages) + byte volume still bill.
+    assert by_metric == {
+        "pages_embedded": 5,
+        "bytes_ingested": 40960,
+        "bytes_stored": 30500,
+    }
+    assert "tokens_embedded" not in by_metric
+    # Every event carries the keyword mode so the CP can attribute it separately.
+    for c in calls:
+        assert c.kwargs["metadata"]["index_mode"] == "keyword"
+
+
+@pytest.mark.unit
+async def test_hybrid_zero_tokens_still_skips_tokens_row(store_spy):
+    """Guard the token gate independently of mode: a 0 token_count never writes a
+    tokens_embedded row even for a hybrid doc (defensive — a real hybrid embed
+    always reports > 0, but a zero must not emit a bogus billing row)."""
+    await processor.record_indexing_usage(
+        enabled=True,
+        provider="mistral",
+        model="mistral-embed",
+        doc_type="note",
+        user_id="alice",
+        index_mode="hybrid",
+        chunk_count=3,
+        token_count=0,
+        total_chars=100,
+        page_count=None,
+        bytes_ingested=200,
+        bytes_stored=250,
+    )
+    metrics = {c.kwargs["metric"] for c in store_spy.record_usage_event.await_args_list}
+    assert "tokens_embedded" not in metrics
+    assert metrics == {"bytes_ingested", "bytes_stored"}

--- a/tests/unit/test_search_endpoint_algorithm_gate.py
+++ b/tests/unit/test_search_endpoint_algorithm_gate.py
@@ -21,11 +21,14 @@ from nextcloud_mcp_server.api.visualization import unified_search, vector_search
 pytestmark = pytest.mark.unit
 
 
-def _keyword_mode_settings() -> MagicMock:
-    """Vector sync on, dense off → SEARCH_MODE=keyword advertises only ["bm25"]."""
+def _vector_sync_on_settings() -> MagicMock:
+    """Vector sync on → the collection is always dense-capable, so all three
+    algorithms are supported. The old per-instance keyword switch is gone, so a
+    dense-requiring algorithm is never rejected on dense grounds; the only
+    endpoint-level 422 left is an *unknown* algorithm value.
+    """
     settings = MagicMock()
     settings.vector_sync_enabled = True
-    settings.dense_enabled = False
     return settings
 
 
@@ -39,17 +42,15 @@ def _app() -> Starlette:
 
 
 @pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
-# Both dense-requiring algorithms are unsupported in keyword mode (supported is
-# ["bm25"]), so each must be rejected — not just "semantic".
-@pytest.mark.parametrize("algorithm", ["semantic", "hybrid"])
-def test_explicit_dense_algorithm_in_keyword_mode_returns_422(
-    path: str, algorithm: str
-):
-    """An explicit unsupported algorithm is rejected before any Qdrant call."""
+def test_explicit_unknown_algorithm_returns_422(path: str):
+    """An explicit *unknown* algorithm is rejected at the gate before any Qdrant
+    call, carrying the advertised supported set for a self-correcting 422. (Vector
+    sync off short-circuits to 404 earlier, so this is the only reachable 422 at
+    the endpoint level now that semantic/bm25/hybrid are always supported.)"""
     with (
         patch(
             "nextcloud_mcp_server.api.visualization.get_settings",
-            return_value=_keyword_mode_settings(),
+            return_value=_vector_sync_on_settings(),
         ),
         patch(
             "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
@@ -58,24 +59,26 @@ def test_explicit_dense_algorithm_in_keyword_mode_returns_422(
     ):
         client = TestClient(_app())
         resp = client.post(
-            path, json={"query": "torch leadership award", "algorithm": algorithm}
+            path, json={"query": "torch leadership award", "algorithm": "fulltext"}
         )
 
     assert resp.status_code == 422
     body = resp.json()
     assert body["error"] == "unsupported_search_type"
-    assert body["requested"] == algorithm
-    assert body["supported_search_types"] == ["bm25"]
+    assert body["requested"] == "fulltext"
+    assert body["supported_search_types"] == ["semantic", "bm25", "hybrid"]
 
 
 @pytest.mark.parametrize("path", ["/api/v1/search", "/api/v1/vector-viz/search"])
-def test_supported_bm25_in_keyword_mode_is_not_rejected(path: str):
-    """A supported algorithm passes the gate (it fails later, at the real search,
-    which is patched out here — the point is it is NOT a 422 gate rejection)."""
+@pytest.mark.parametrize("algorithm", ["semantic", "bm25", "hybrid"])
+def test_supported_algorithm_is_not_rejected(path: str, algorithm: str):
+    """When vector sync is on, every advertised algorithm passes the gate (it
+    fails later, at the real search, which is patched out here — the point is it
+    is NOT a 422 gate rejection)."""
     with (
         patch(
             "nextcloud_mcp_server.api.visualization.get_settings",
-            return_value=_keyword_mode_settings(),
+            return_value=_vector_sync_on_settings(),
         ),
         patch(
             "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
@@ -85,10 +88,14 @@ def test_supported_bm25_in_keyword_mode_is_not_rejected(path: str):
             "nextcloud_mcp_server.api.visualization.BM25HybridSearchAlgorithm",
             side_effect=RuntimeError("stop after the gate"),
         ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.SemanticSearchAlgorithm",
+            side_effect=RuntimeError("stop after the gate"),
+        ),
     ):
         client = TestClient(_app())
         resp = client.post(
-            path, json={"query": "leadership award", "algorithm": "bm25"}
+            path, json={"query": "leadership award", "algorithm": algorithm}
         )
 
     # Not a 422 from the algorithm gate — the request got past it to the search.

--- a/tests/unit/test_viz_routes_search_algorithm_gate.py
+++ b/tests/unit/test_viz_routes_search_algorithm_gate.py
@@ -1,12 +1,11 @@
-"""Keyword-mode gate for the OAuth-session PCA-viz search endpoint
+"""Algorithm selection for the OAuth-session PCA-viz search endpoint
 (`nextcloud_mcp_server.auth.viz_routes.vector_visualization_search`).
 
-The pure-dense ``semantic`` algorithm queries the dense vector slot, which a
-keyword-only collection (SEARCH_MODE=keyword) does not have. Unlike the
-management API endpoints, this route selects the algorithm from a raw query
-param, so it must guard ``semantic`` explicitly (ADR-030) rather than letting the
-query fail against the sparse-only index. ``bm25_hybrid`` stays valid in keyword
-mode (it issues a sparse-only query internally), so it must NOT be rejected.
+The old global keyword switch is gone: keyword-vs-hybrid is now per-document and
+the collection is always dense-capable, so ``semantic`` (pure dense) is always
+valid — the route no longer rejects it. This pins that an explicit
+``algorithm=semantic`` now builds the dense ``SemanticSearchAlgorithm`` and
+proceeds, rather than being 400'd by the removed "keyword-only" gate.
 
 Auth harness mirrors ``tests/unit/test_viz_routes_chunk_context.py``.
 """
@@ -53,12 +52,12 @@ def _make_app() -> Starlette:
     )
 
 
-def _keyword_mode_settings() -> MagicMock:
-    """Vector sync on, dense off → SEARCH_MODE=keyword (supported = ["bm25"])."""
+def _vector_sync_on_settings() -> MagicMock:
+    """Vector sync on. The collection is always dense-capable, so ``semantic`` is
+    always a valid algorithm (no keyword-only gate)."""
     settings = MagicMock()
     settings.vector_sync_enabled = True
-    settings.dense_enabled = False
-    settings.get_collection_name.return_value = "test-bm25-keyword"
+    settings.get_collection_name.return_value = "test-collection"
     return settings
 
 
@@ -70,13 +69,16 @@ def _mock_auth_client_ctx() -> MagicMock:
     return client
 
 
-def test_semantic_rejected_in_keyword_mode_without_building_dense_algo():
-    """An explicit ``algorithm=semantic`` on a keyword-only server → 400, and the
-    dense SemanticSearchAlgorithm is never constructed (no dead dense query)."""
+def test_semantic_is_built_and_not_rejected():
+    """An explicit ``algorithm=semantic`` now builds the dense
+    SemanticSearchAlgorithm and proceeds — the removed keyword-only gate no longer
+    400s it. We stop the handler right after construction (the algorithm's
+    ``search`` raises) so the assertion is purely about the gate: the dense algo
+    IS constructed, and the response is never the old "keyword-only" 400."""
     with (
         patch(
             "nextcloud_mcp_server.auth.viz_routes.get_settings",
-            return_value=_keyword_mode_settings(),
+            return_value=_vector_sync_on_settings(),
         ),
         patch(
             "nextcloud_mcp_server.auth.viz_routes._get_authenticated_client_for_userinfo",
@@ -84,7 +86,8 @@ def test_semantic_rejected_in_keyword_mode_without_building_dense_algo():
             return_value=_mock_auth_client_ctx(),
         ),
         patch(
-            "nextcloud_mcp_server.auth.viz_routes.SemanticSearchAlgorithm"
+            "nextcloud_mcp_server.auth.viz_routes.SemanticSearchAlgorithm",
+            side_effect=RuntimeError("stop after the gate"),
         ) as mock_semantic,
     ):
         with TestClient(_make_app()) as client:
@@ -92,8 +95,8 @@ def test_semantic_rejected_in_keyword_mode_without_building_dense_algo():
                 "/app/vector-viz/search?query=leadership&algorithm=semantic"
             )
 
-    assert resp.status_code == 400
-    body = resp.json()
-    assert body["success"] is False
-    assert "keyword-only" in body["error"]
-    mock_semantic.assert_not_called()
+    # The dense algorithm IS constructed now (the keyword-only gate is gone).
+    mock_semantic.assert_called_once()
+    # And the response is never the removed "keyword-only" rejection.
+    if resp.status_code == 400:
+        assert "keyword-only" not in resp.json().get("error", "")

--- a/tests/unit/vector/test_collection_metadata.py
+++ b/tests/unit/vector/test_collection_metadata.py
@@ -42,24 +42,18 @@ async def test_qdrant_error_falls_back_to_env(mocker):
     assert meta == cm.env_default_metadata(settings)
 
 
-def test_build_embedding_identity_hybrid_is_model_name():
-    # Hybrid mode: the identity is the active dense embedding model name.
+def test_build_embedding_identity_is_model_name():
+    # The identity is always the active dense embedding model name — the global
+    # keyword switch (and its ``bm25-keyword`` marker) is gone; keyword-vs-hybrid
+    # is now per-document (payload_keys.INDEX_MODE) and shares one identity space,
+    # so the identity never depends on mode.
     settings = Settings()
-    assert settings.dense_enabled is True
     assert cm.build_embedding_identity(settings) == settings.get_embedding_model_name()
-
-
-def test_build_embedding_identity_keyword_is_bm25_marker():
-    # Regression (Deck #509): keyword mode must return the fixed ``bm25-keyword``
-    # marker, NOT get_embedding_model_name()'s ``simple-{dim}`` fallback — the value
-    # the chunk-point writer stamps and the dedup lookup compares must agree, or an
-    # unchanged shared doc is re-processed + re-OCR'd every scan.
-    settings = Settings(search_mode="keyword")
-    assert settings.dense_enabled is False
-    assert cm.build_embedding_identity(settings) == cm.KEYWORD_EMBEDDING_IDENTITY
-    assert cm.build_embedding_identity(settings) == "bm25-keyword"
-    # The sentinel/env-fallback metadata carries the same marker.
-    assert cm.env_default_metadata(settings)["embedding_identity"] == "bm25-keyword"
+    # The sentinel/env-fallback metadata carries the same model-name identity.
+    assert (
+        cm.env_default_metadata(settings)["embedding_identity"]
+        == settings.get_embedding_model_name()
+    )
 
 
 async def test_api_source(mocker):
@@ -83,7 +77,8 @@ async def test_api_source(mocker):
     mocker.patch.object(
         httpx,
         "AsyncClient",
-        lambda *a, **k: orig(*a, **{**k, "transport": transport}),
+        # ty can't narrow the spread kwargs through the constructor overloads.
+        lambda *a, **k: orig(*a, **{**k, "transport": transport}),  # ty: ignore[invalid-argument-type]
     )
 
     meta = await cm.read_collection_metadata(mocker.AsyncMock(), "col", settings)
@@ -100,6 +95,7 @@ async def test_api_source_uses_shared_http_client():
     shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     async with shared:
         meta = await cm._read_from_api("https://cp", "col", client=shared)
+    assert meta is not None
     assert meta["embedding_identity"] == "mistral-embed"
 
 

--- a/tests/unit/vector/test_dead_letter.py
+++ b/tests/unit/vector/test_dead_letter.py
@@ -26,10 +26,8 @@ _COLLECTION = "test_collection"
 
 
 class _Settings:
-    # Hybrid mode by default (dense slot sized from the embedding provider).
-    dense_enabled = True
-    simple_embedding_dimension = 384
-
+    # The dense slot is always sized from the embedding provider (no keyword
+    # branch anymore); the embedding service stub in the fixture returns dim=4.
     def get_collection_name(self) -> str:
         return _COLLECTION
 
@@ -98,32 +96,9 @@ class TestMarkDeadLetter:
         assert payload["reason"] == "timeout"
         assert payload["doc_id"] == "520189"
         assert payload["file_path"] == "/Plans/big.pdf"
-        # Hybrid mode: dense slot sized from the embedding provider (dim=4 here).
+        # Dense slot is always sized from the embedding provider (dim=4 here) —
+        # the keyword/simple-dimension branch is gone (per-document index mode).
         assert len(point.vector["dense"]) == 4
-
-    async def test_keyword_mode_sizes_dense_from_simple_dimension(
-        self, client, monkeypatch
-    ) -> None:
-        """Regression (Deck #495): in keyword mode (dense_enabled=False) the dead-
-        letter marker's dense slot must be sized to simple_embedding_dimension and
-        the embedding service must NOT be built — mirrors the placeholder fix."""
-        kw = SimpleNamespace(
-            get_collection_name=lambda: _COLLECTION,
-            dense_enabled=False,
-            simple_embedding_dimension=384,
-        )
-        monkeypatch.setattr(dl, "get_settings", lambda: kw)
-
-        def _boom():
-            raise AssertionError("embedding service must not be built in keyword mode")
-
-        monkeypatch.setattr(dl, "get_embedding_service", _boom)
-
-        await dl.mark_dead_letter("520189", "file", "etag-1", "sig", "timeout")
-
-        client.upsert.assert_awaited_once()
-        point = client.upsert.await_args.kwargs["points"][0]
-        assert len(point.vector["dense"]) == 384
 
     async def test_failure_is_swallowed(self, client) -> None:
         client.upsert.side_effect = RuntimeError("qdrant down")

--- a/tests/unit/vector/test_index_mode_discovery.py
+++ b/tests/unit/vector/test_index_mode_discovery.py
@@ -27,9 +27,10 @@ def _client_for(tag_files: dict[str, list[dict]]) -> MagicMock:
     """A client whose find_files_by_tag returns per-tag file lists."""
     nc = MagicMock()
 
-    async def _find(tag_name, mime_type_filter=None):
+    def _find(tag_name, mime_type_filter=None):
         # Return a shallow copy so the helper's ``_index_mode`` stamping does not
-        # mutate the fixture across calls.
+        # mutate the fixture across calls. Plain sync side_effect — AsyncMock
+        # wraps the return value in the awaitable the helper awaits.
         return [dict(f) for f in tag_files.get(tag_name, [])]
 
     nc.find_files_by_tag = AsyncMock(side_effect=_find)

--- a/tests/unit/vector/test_index_mode_discovery.py
+++ b/tests/unit/vector/test_index_mode_discovery.py
@@ -1,0 +1,118 @@
+"""Unit tests for per-document index-mode discovery (card #609).
+
+Two Nextcloud tags feed one ingestion pipeline: ``vector_sync_pdf_tag`` →
+hybrid (dense + BM25 sparse) and ``vector_sync_keyword_tag`` → keyword (BM25
+sparse only). ``_discover_tagged_files`` unions both, stamping ``_index_mode``
+on each file with **hybrid precedence** (a file carrying both tags is hybrid, a
+superset of keyword). The keyword tag is only queried when configured.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nextcloud_mcp_server.vector import payload_keys
+from nextcloud_mcp_server.vector.processor import _reconcile_tag_event
+from nextcloud_mcp_server.vector.scanner import DocumentTask, _discover_tagged_files
+
+
+def _settings(pdf_tag: str = "vector-index", keyword_tag: str = "") -> MagicMock:
+    s = MagicMock()
+    s.vector_sync_pdf_tag = pdf_tag
+    s.vector_sync_keyword_tag = keyword_tag
+    return s
+
+
+def _client_for(tag_files: dict[str, list[dict]]) -> MagicMock:
+    """A client whose find_files_by_tag returns per-tag file lists."""
+    nc = MagicMock()
+
+    async def _find(tag_name, mime_type_filter=None):
+        # Return a shallow copy so the helper's ``_index_mode`` stamping does not
+        # mutate the fixture across calls.
+        return [dict(f) for f in tag_files.get(tag_name, [])]
+
+    nc.find_files_by_tag = AsyncMock(side_effect=_find)
+    return nc
+
+
+@pytest.mark.unit
+def test_document_task_defaults_to_hybrid():
+    """Every producer that doesn't set index_mode gets hybrid (unchanged behavior)."""
+    task = DocumentTask(
+        user_id="alice",
+        doc_id="1",
+        doc_type="note",
+        operation="index",
+        modified_at=0,
+    )
+    assert task.index_mode == payload_keys.INDEX_MODE_HYBRID
+
+
+@pytest.mark.unit
+async def test_keyword_tag_empty_queries_only_hybrid():
+    """With the keyword tag disabled (default ""), only the hybrid tag is queried
+    and every discovered file is hybrid — one OCS query, as before the feature."""
+    nc = _client_for({"vector-index": [{"id": "1", "path": "/a.pdf", "etag": "e1"}]})
+    files = await _discover_tagged_files(nc, _settings(keyword_tag=""))
+
+    assert [f["_index_mode"] for f in files] == [payload_keys.INDEX_MODE_HYBRID]
+    nc.find_files_by_tag.assert_awaited_once_with(
+        "vector-index", mime_type_filter="application/pdf"
+    )
+
+
+@pytest.mark.unit
+async def test_both_tags_stamp_modes_with_hybrid_precedence():
+    """A file tagged both wins hybrid (appears once); keyword-only files are
+    keyword; hybrid-only files are hybrid."""
+    nc = _client_for(
+        {
+            "vector-index": [
+                {"id": "1", "path": "/hybrid.pdf", "etag": "e1"},
+                {"id": "2", "path": "/both.pdf", "etag": "e2"},
+            ],
+            "keyword-index": [
+                {"id": "2", "path": "/both.pdf", "etag": "e2"},  # also hybrid
+                {"id": "3", "path": "/keyword.pdf", "etag": "e3"},
+            ],
+        }
+    )
+    files = await _discover_tagged_files(nc, _settings(keyword_tag="keyword-index"))
+
+    by_id = {f["id"]: f["_index_mode"] for f in files}
+    assert by_id == {
+        "1": payload_keys.INDEX_MODE_HYBRID,
+        "2": payload_keys.INDEX_MODE_HYBRID,  # hybrid wins over keyword
+        "3": payload_keys.INDEX_MODE_KEYWORD,
+    }
+    # File 2 appears exactly once (deduped by hybrid precedence).
+    assert [f["id"] for f in files].count("2") == 1
+
+
+@pytest.mark.unit
+async def test_reconcile_sets_keyword_mode(monkeypatch):
+    """A keyword-index-tagged fileid reconciles to an index task with keyword mode."""
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.vector.processor.get_settings",
+        lambda: _settings(keyword_tag="keyword-index"),
+    )
+    nc = _client_for(
+        {
+            "vector-index": [{"id": "10", "path": "/h.pdf", "etag": "eh"}],
+            "keyword-index": [{"id": "20", "path": "/k.pdf", "etag": "ek"}],
+        }
+    )
+    task = DocumentTask(
+        user_id="alice",
+        doc_id="20",
+        doc_type="file",
+        operation="index",
+        modified_at=0,
+        file_path=None,
+    )
+    await _reconcile_tag_event(task, nc)
+
+    assert task.operation == "index"
+    assert task.index_mode == payload_keys.INDEX_MODE_KEYWORD
+    assert task.file_path == "/k.pdf"

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -190,8 +190,6 @@ async def test_write_placeholder_payload_includes_instance_id(monkeypatch):
     fake_qdrant = AsyncMock()
     fake_settings = SimpleNamespace(
         get_collection_name=lambda: "nextcloud_content",
-        dense_enabled=True,
-        simple_embedding_dimension=384,
     )
     fake_embedding = SimpleNamespace(get_dimension=lambda: 4)
 

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -218,50 +218,6 @@ async def test_write_placeholder_payload_includes_instance_id(monkeypatch):
     # Sanity: the other contract-pinning fields are still emitted.
     assert upserted_point.payload["is_placeholder"] is True
     assert upserted_point.payload["status"] == "pending"
-    # Hybrid mode: dense slot sized from the embedding provider (dim=4 here).
+    # Dense slot is always sized from the embedding provider (dim=4 here) — the
+    # keyword/simple-dimension branch is gone (per-document index mode).
     assert len(upserted_point.vector["dense"]) == 4
-
-
-@pytest.mark.unit
-async def test_keyword_mode_sizes_dense_from_simple_dimension_without_embedding(
-    monkeypatch,
-):
-    """Regression (Deck #495): in keyword mode (SEARCH_MODE=keyword,
-    dense_enabled=False) the collection's dense slot is sized to
-    SIMPLE_EMBEDDING_DIMENSION, not the provider dimension, and there may be no
-    embedding endpoint. ``write_placeholder_point`` MUST size its zero-vector to
-    simple_embedding_dimension and NEVER call the embedding service — otherwise a
-    Mistral-sized (1024) placeholder is rejected by the 384-dim slot and the
-    pre-enqueue placeholder write aborts the whole scan (keyword tenant indexes
-    NOTHING)."""
-    monkeypatch.setattr(placeholder_module, "_INSTANCE_ID", "pod-kw")
-
-    fake_qdrant = AsyncMock()
-    fake_settings = SimpleNamespace(
-        get_collection_name=lambda: "nextcloud_content",
-        dense_enabled=False,
-        simple_embedding_dimension=384,
-    )
-
-    async def fake_get_qdrant_client():
-        return fake_qdrant
-
-    def _boom():
-        raise AssertionError("embedding service must not be built in keyword mode")
-
-    monkeypatch.setattr(placeholder_module, "get_qdrant_client", fake_get_qdrant_client)
-    monkeypatch.setattr(placeholder_module, "get_settings", lambda: fake_settings)
-    monkeypatch.setattr(placeholder_module, "get_embedding_service", _boom)
-
-    await placeholder_module.write_placeholder_point(
-        doc_id="d-99",
-        doc_type="file",
-        user_id="alice",
-        modified_at=1700000000,
-        etag="xyz",
-    )
-
-    fake_qdrant.upsert.assert_awaited_once()
-    upserted_point = fake_qdrant.upsert.await_args.kwargs["points"][0]
-    # Sized to the keyword-mode dense slot (384), never the provider dimension.
-    assert len(upserted_point.vector["dense"]) == 384

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -27,27 +27,13 @@ _MODEL = "model-x"
 
 
 class _Settings:
-    # Hybrid mode: the dedup identity is the dense embedding model name.
-    dense_enabled = True
-
+    # The dedup identity is always the dense embedding model name (keyword-vs-
+    # hybrid is tracked per-document via payload_keys.INDEX_MODE, not the identity).
     def get_collection_name(self) -> str:
         return _COLLECTION
 
     def get_embedding_model_name(self) -> str:
         return _MODEL
-
-
-class _KeywordSettings:
-    # Keyword mode (ADR-030): no dense vectors. The dedup identity must be the
-    # fixed ``bm25-keyword`` marker, NOT the ``simple-{dim}`` model-name fallback,
-    # so it matches what the chunk-point writer stamps (Deck #509).
-    dense_enabled = False
-
-    def get_collection_name(self) -> str:
-        return _COLLECTION
-
-    def get_embedding_model_name(self) -> str:
-        return "simple-384"
 
 
 def _point(payload: dict) -> SimpleNamespace:
@@ -284,29 +270,116 @@ class TestClaimExistingIndex:
         assert await ss.claim_existing_index("42", "file", "abc", "alice") is True
         client.set_payload.assert_not_called()
 
-    async def test_keyword_mode_hit_matches_bm25_marker(
-        self, client, monkeypatch
-    ) -> None:
-        # Regression (Deck #509): in keyword mode the dedup identity is the fixed
-        # ``bm25-keyword`` marker the writer stamps — NOT get_embedding_model_name()'s
-        # ``simple-{dim}`` fallback. With the pre-fix code these disagreed, so the
-        # claim always missed and an unchanged shared doc was re-processed + re-OCR'd
-        # every scan. A point stamped ``bm25-keyword`` must register as a HIT.
-        monkeypatch.setattr(ss, "get_settings", lambda: _KeywordSettings())
+    async def test_hybrid_claim_misses_existing_keyword_point(self, client) -> None:
+        # Monotonic keyword→hybrid upgrade: a hybrid claim cannot reuse a
+        # sparse-only keyword point (it lacks the dense vector), so — even though
+        # the embedding identity matches (same model) — it MUST miss and force a
+        # reprocess that adds the dense vector. No principal is granted on a miss.
         client.scroll.return_value = (
             [
                 _point(
                     {
-                        payload_keys.EMBEDDING_IDENTITY: "bm25-keyword",
+                        payload_keys.EMBEDDING_IDENTITY: _MODEL,
+                        payload_keys.INDEX_MODE: payload_keys.INDEX_MODE_KEYWORD,
                         ss.ACL_PRINCIPALS_KEY: ["user:alice"],
                     }
                 )
             ],
             None,
         )
-        # alice already listed -> HIT (skip reprocess), no write.
-        assert await ss.claim_existing_index("42", "file", "abc", "alice") is True
+        assert (
+            await ss.find_indexed_content(
+                "42",
+                "file",
+                "abc",
+                _MODEL,
+                index_mode=payload_keys.INDEX_MODE_HYBRID,
+            )
+            is None
+        )
+        # claim_existing_index defaults to index_mode="hybrid" → same miss → False.
+        assert await ss.claim_existing_index("42", "file", "abc", "bob") is False
         client.set_payload.assert_not_called()
+
+    async def test_keyword_claim_hits_existing_hybrid_point(self, client) -> None:
+        # hybrid ⊇ keyword: a keyword claim reuses an existing hybrid point rather
+        # than downgrading/stripping the dense vector while a hybrid reader holds
+        # the tag. alice already listed → HIT (skip reprocess), no write.
+        client.scroll.return_value = (
+            [
+                _point(
+                    {
+                        payload_keys.EMBEDDING_IDENTITY: _MODEL,
+                        payload_keys.INDEX_MODE: payload_keys.INDEX_MODE_HYBRID,
+                        ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+                    }
+                )
+            ],
+            None,
+        )
+        assert (
+            await ss.claim_existing_index(
+                "42",
+                "file",
+                "abc",
+                "alice",
+                index_mode=payload_keys.INDEX_MODE_KEYWORD,
+            )
+            is True
+        )
+        client.set_payload.assert_not_called()
+
+    async def test_same_mode_claim_hits(self, client) -> None:
+        # Same-mode (keyword claim vs existing keyword point) is a hit as before —
+        # the monotonic rule only forces a miss for hybrid-over-keyword.
+        client.scroll.return_value = (
+            [
+                _point(
+                    {
+                        payload_keys.EMBEDDING_IDENTITY: _MODEL,
+                        payload_keys.INDEX_MODE: payload_keys.INDEX_MODE_KEYWORD,
+                        ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+                    }
+                )
+            ],
+            None,
+        )
+        assert (
+            await ss.claim_existing_index(
+                "42",
+                "file",
+                "abc",
+                "alice",
+                index_mode=payload_keys.INDEX_MODE_KEYWORD,
+            )
+            is True
+        )
+        client.set_payload.assert_not_called()
+
+    async def test_missing_index_mode_defaults_to_hybrid(self, client) -> None:
+        # A legacy point written before INDEX_MODE existed has no key; it defaults
+        # to "hybrid", so a hybrid claim still dedups against it (HIT).
+        client.scroll.return_value = (
+            [
+                _point(
+                    {
+                        payload_keys.EMBEDDING_IDENTITY: _MODEL,
+                        ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+                    }
+                )
+            ],
+            None,
+        )
+        assert (
+            await ss.find_indexed_content(
+                "42",
+                "file",
+                "abc",
+                _MODEL,
+                index_mode=payload_keys.INDEX_MODE_HYBRID,
+            )
+            is not None
+        )
 
     async def test_lookup_error_degrades_to_process_normally(self, client) -> None:
         # A Qdrant hiccup during dedup must not abort the scan — fall back to


### PR DESCRIPTION
## Summary

Support **both keyword-only and hybrid documents in one shared index**, chosen
**per-document** by a Nextcloud tag, replacing the coarse global `SEARCH_MODE`
switch (ADR-030 → superseded by **ADR-031**).

- `vector-index` (`VECTOR_SYNC_PDF_TAG`) → **hybrid** (dense + BM25 sparse).
- `keyword-index` (`VECTOR_SYNC_KEYWORD_TAG`, default **empty = off**) →
  **keyword-only** (BM25 sparse, no embedding cost).
- Both live in one collection; a single `nc_semantic_search` fuses them.
  Keyword docs carry no dense vector, so they contribute via the sparse side and
  are absent from a pure-`semantic` query. **Hybrid wins** if a file has both tags.

### What changed

- **Removed** the global `search_mode` / `dense_enabled` flag and the separate
  `{deployment}-bm25-keyword` collection. The collection is always dense-sized;
  keyword documents omit the dense vector per-point (`payload_keys.INDEX_MODE`).
- **Discovery / reconcile / verify-on-read** all resolve both tags through one
  helper (`_discover_tagged_files`, hybrid precedence). The scanner reprocesses a
  file whose mode changed at unchanged content (keyword→hybrid upgrade).
- **Hybrid = embeddings required:** a `vector-index` doc whose embedding endpoint
  is unavailable errors → retries (429s inside the provider) → dead-letters,
  never silently degrading to sparse-only. Only `keyword-index` yields sparse-only.
- **Cross-user dedup is monotonic toward hybrid:** a hybrid claim upgrades an
  existing keyword point (adds the dense vector); a keyword claim never downgrades
  a shared hybrid point.
- **Billing split:** `bytes_ingested` / `bytes_stored` now carry an `index_mode`
  metadata dimension (same metric names) and are metered for **both** modes
  (previously keyword ingestion metered nothing — the metering was inside the
  dense-only coroutine and is now unconditional). `tokens_embedded` stays
  hybrid-only. Control-plane rollup / Stripe meter wiring is handled separately.

## ⚠️ Breaking / migration

Existing `SEARCH_MODE=keyword` deployments used the `{deployment}-bm25-keyword`
collection with `bm25-keyword`-identity points. Those are now orphaned — such a
deployment must **re-index** into the model-named collection. Fully-airgapped
deployments still work: configure no embedding provider and tag everything
`keyword-index`.

## Test coverage

- **Unit:** two-tag discovery + hybrid precedence, `DocumentTask.index_mode`
  default, reconcile mode-setting, mode-change reprocess, monotonic dedup
  (hybrid↔keyword), the billing split (bytes metered + `tokens_embedded` skipped
  for keyword). Full unit suite green (2053).
- **Integration:** `tests/integration/test_index_mode_discovery.py` exercises both
  tags against a real Nextcloud (OCS Tags API + precedence).
- **Contract (Pact):** no new cross-service boundary is introduced (ingestion is
  internal), so no new pact.

## Cross-repo

The `keyword-index` tag is created/exposed by the **Astrolabe Nextcloud app**
(tracked on Deck board 12, card #609 — `repo:astrolabe` label attached).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
