### PR TITLE
ci(pact): use unified `pact broker` CLI instead of deprecated pact-broker

### DIFF
--- a/.github/workflows/pact-record-deployment.yml
+++ b/.github/workflows/pact-record-deployment.yml
@@ -59,8 +59,13 @@ jobs:
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/f03e620e7552239b6ca59438c9beed9d1038c949/install.sh | bash # v2.6.1
-          echo "$PWD/pact/bin" >> "$GITHUB_PATH"
+          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
+          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
+          # now and is no longer maintained). The cargo-dist installer appends
+          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
+          # for the record-deployment step below.
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          "$HOME/.pact/bin/pact" --version
 
       - name: Record deployment to production
         if: ${{ env.PACT_BROKER != '' }}

--- a/.github/workflows/pact-record-deployment.yml
+++ b/.github/workflows/pact-record-deployment.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Record deployment to production
         if: ${{ env.PACT_BROKER != '' }}
         run: |
-          pact-broker record-deployment \
+          pact broker record-deployment \
             --broker-base-url "$PACT_BROKER" \
             --broker-username "$PACT_USERNAME" \
             --broker-password "$PACT_PASSWORD" \

--- a/.github/workflows/pact-record-deployment.yml
+++ b/.github/workflows/pact-record-deployment.yml
@@ -65,7 +65,8 @@ jobs:
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the record-deployment step below.
           curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
-          "$HOME/.pact/bin/pact" --version
+          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
+          "$HOME/.pact/bin/pact" --help > /dev/null
 
       - name: Record deployment to production
         if: ${{ env.PACT_BROKER != '' }}

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -60,7 +60,8 @@ jobs:
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the broker steps below.
           curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
-          "$HOME/.pact/bin/pact" --version
+          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
+          "$HOME/.pact/bin/pact" --help > /dev/null
 
       # Guard the migration: only `publish` runs on a PR (can-i-deploy is
       # master-only, record-deployment is tag-only), so assert here that the
@@ -175,7 +176,8 @@ jobs:
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the broker steps below.
           curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
-          "$HOME/.pact/bin/pact" --version
+          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
+          "$HOME/.pact/bin/pact" --help > /dev/null
 
       # SHADOW MODE: run can-i-deploy for signal but never fail the workflow.
       # The broker's `production` environment is populated by the

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Publish pacts to broker
         if: ${{ env.PACT_BROKER != '' }}
         run: |
-          pact-broker publish tests/contract/pacts \
+          pact broker publish tests/contract/pacts \
             --broker-base-url "$PACT_BROKER" \
             --broker-username "$PACT_USERNAME" \
             --broker-password "$PACT_PASSWORD" \
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [consumer, provider]
     # Only the `github` context is available in a job-level `if`, so the broker
-    # guard lives on each step below (the pact-broker CLI errors on an empty
+    # guard lives on each step below (the pact CLI errors on an empty
     # --broker-base-url, e.g. after a secret rotation or on a fork).
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
@@ -161,7 +161,7 @@ jobs:
         if: ${{ env.PACT_BROKER != '' }}
         run: |
           set +e
-          pact-broker can-i-deploy \
+          pact broker can-i-deploy \
             --broker-base-url "$PACT_BROKER" \
             --broker-username "$PACT_USERNAME" \
             --broker-password "$PACT_PASSWORD" \

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -54,8 +54,31 @@ jobs:
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/f03e620e7552239b6ca59438c9beed9d1038c949/install.sh | bash # v2.6.1
-          echo "$PWD/pact/bin" >> "$GITHUB_PATH"
+          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
+          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
+          # now and is no longer maintained). The cargo-dist installer appends
+          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
+          # for the broker steps below.
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          "$HOME/.pact/bin/pact" --version
+
+      # Guard the migration: only `publish` runs on a PR (can-i-deploy is
+      # master-only, record-deployment is tag-only), so assert here that the
+      # unified CLI exposes every flag those steps pass. Dumps each --help so a
+      # future flag rename is visible in the log, then fails fast if a flag the
+      # workflows rely on is gone.
+      - name: Verify pact broker CLI flags
+        if: ${{ env.PACT_BROKER != '' }}
+        run: |
+          for sub in publish can-i-deploy record-deployment; do
+            echo "::group::pact broker $sub --help"
+            pact broker "$sub" --help
+            echo "::endgroup::"
+          done
+          pact broker publish --help | grep -q -- '--consumer-app-version'
+          pact broker publish --help | grep -q -- '--branch'
+          pact broker can-i-deploy --help | grep -q -- '--to-environment'
+          pact broker record-deployment --help | grep -q -- '--environment'
 
       - name: Publish pacts to broker
         if: ${{ env.PACT_BROKER != '' }}
@@ -146,8 +169,13 @@ jobs:
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/f03e620e7552239b6ca59438c9beed9d1038c949/install.sh | bash # v2.6.1
-          echo "$PWD/pact/bin" >> "$GITHUB_PATH"
+          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
+          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
+          # now and is no longer maintained). The cargo-dist installer appends
+          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
+          # for the broker steps below.
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          "$HOME/.pact/bin/pact" --version
 
       # SHADOW MODE: run can-i-deploy for signal but never fail the workflow.
       # The broker's `production` environment is populated by the

--- a/docs/ADR-029-pact-contract-testing.md
+++ b/docs/ADR-029-pact-contract-testing.md
@@ -72,7 +72,7 @@ client before touching the broker:
    and commit SHA.
 2. **provider** — stand up the MCP server (single-user compose profile), verify
    astrolabe's pacts against it, publish verification results (master only).
-3. **can-i-deploy** — gate `master` on `pact-broker can-i-deploy … --pacticipant
+3. **can-i-deploy** — gate `master` on `pact broker can-i-deploy … --pacticipant
    nextcloud-mcp-server --to-environment production`.
 
 Broker-dependent steps are skipped when `PACT_BROKER` is unset (forks).

--- a/tests/contract/test_mcp_status_search_types_consumer.py
+++ b/tests/contract/test_mcp_status_search_types_consumer.py
@@ -16,7 +16,7 @@ provider-state strings. The matching server-side states are registered in
 them once astrolabe publishes its real consumer pact.
 
 The generated pact is written to ``provider_contracts/`` (NOT ``pacts/``) so the
-``pact-broker publish tests/contract/pacts`` step never publishes it under *our*
+``pact broker publish tests/contract/pacts`` step never publishes it under *our*
 consumer identity — astrolabe owns and publishes the real consumer pact. The
 real provider response is verified by ``tests/unit/test_management_status_endpoint.py``
 (``TestStatusEndpointSearchTypes``) and, in integration CI, by provider


### PR DESCRIPTION
## Problem

The Pact contract-testing workflows use the standalone **`pact-broker`** CLI, which is deprecated: on master it still runs but prints `WARN: This CLI is deprecated and no longer receiving updates` and points at the new unified `pact` CLI. This PR migrates off it.

## What the first attempt got wrong (and CI caught)

Renaming `pact-broker <cmd>` → `pact broker <cmd>` while keeping the `pact-ruby-standalone` install **broke** with `pact: command not found` — that bundle ships only the deprecated Ruby CLIs (`pact-broker`, `pact-mock-service`, …) and **no unified `pact` binary**. The premise that v2.6.1 already shipped `pact` was wrong.

## Fix

1. **Install the unified pact CLI** (Rust, `pact-foundation/pact-cli`), pinned to **v0.10.5** via its cargo-dist installer, in all three broker steps (`pact.yml` consumer + can-i-deploy, `pact-record-deployment.yml`). The installer appends `$HOME/.pact/bin` to `$GITHUB_PATH`, so `pact` is on PATH for the subsequent steps.
2. **Use `pact broker <cmd>`** (`publish` / `can-i-deploy` / `record-deployment`) — all present on the unified CLI with the same flags.
3. **Flag guard**: only `publish` runs on a PR (`can-i-deploy` is master-only, `record-deployment` is tag-only), so a `Verify pact broker CLI flags` step in the consumer job dumps each subcommand's `--help` and asserts the flags the workflows pass (`--consumer-app-version`, `--branch`, `--to-environment`, `--environment`) still exist — validating the whole migration on the PR rather than only post-merge.

Plus prose consistency in the `pact.yml` comment, `docs/ADR-029-pact-contract-testing.md`, and a contract-test docstring.

The Python `pact-python` provider test never calls the CLI, so it is unaffected.

## Test coverage

CI/workflow config + docs only — no application API surface, so the ADR-029/CLAUDE.md e2e+contract gate does not apply. Real validation is the `Pact contract tests` workflow on this PR (the consumer job installs the CLI, verifies the flags, and publishes).

Tracking: Deck card #616 (board 11 — Contract Testing).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)