### PR TITLE
test(ldap): add login-flow × LDAP integration lane (cross-mode #980 guard)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           # Mode-specific properties
           - mode: single-user
             profile: single-user
-            markers: "(smoke and not keycloak and not login_flow and not multi_user_basic and not ldap) or (integration and not keycloak and not login_flow and not multi_user_basic and not ldap)"
+            markers: "(smoke and not keycloak and not login_flow and not multi_user_basic and not ldap and not login_flow_ldap) or (integration and not keycloak and not login_flow and not multi_user_basic and not ldap and not login_flow_ldap)"
             wait-port: 8000
             mcp-internal-url: "http://mcp:8000"
             needs-playwright: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           - "login-flow"
           - "keycloak"
           - "ldap"
+          - "login-flow-ldap"
         include:
           # Version-specific image pins — Renovate updates these via customManagers in renovate.json
           # Each entry is pinned to its major version (e.g., NC 32 only gets 32.x updates)
@@ -128,6 +129,21 @@ jobs:
             wait-port: 8003
             mcp-internal-url: "http://mcp-multi-user-basic:8000"
             needs-playwright: false
+            extra-args: ""
+
+          # Login-flow mode against the LDAP backend: proves the #980 principal
+          # resolution holds in login-flow mode too (identity via OIDC, API
+          # access via a per-user app password). login-flow MCP (8004) +
+          # openldap; user_ldap is auto-configured by the post-installation
+          # hook. Dedicated `login_flow_ldap` marker keeps it out of the plain
+          # `login_flow` and `ldap` lanes. Needs a browser for Login Flow v2.
+          - mode: login-flow-ldap
+            profile: login-flow
+            extra-compose-profiles: "--profile ldap"
+            markers: "login_flow_ldap"
+            wait-port: 8004
+            mcp-internal-url: "http://mcp-login-flow:8004"
+            needs-playwright: true
             extra-args: ""
 
     name: integration (${{ matrix.mode }} / nc${{ matrix.nextcloud_version }})
@@ -248,7 +264,7 @@ jobs:
       # openldap service). This step just surfaces the resulting config for
       # debugging, mirroring the keycloak verify step below.
       - name: Verify LDAP backend
-        if: matrix.mode == 'ldap'
+        if: matrix.mode == 'ldap' || matrix.mode == 'login-flow-ldap'
         run: |
           echo "=== user_ldap enabled? ==="
           docker compose exec -T app php occ app:list 2>/dev/null | grep -i ldap || echo "user_ldap NOT enabled"
@@ -277,7 +293,7 @@ jobs:
           echo "Keycloak is ready."
 
       - name: Verify OIDC configuration
-        if: matrix.mode == 'login-flow' || matrix.mode == 'keycloak'
+        if: matrix.mode == 'login-flow' || matrix.mode == 'keycloak' || matrix.mode == 'login-flow-ldap'
         run: |
           echo "=== OIDC Discovery ==="
           curl -s http://localhost:8080/.well-known/openid-configuration | jq .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,16 +636,32 @@ derived from the LDAP `entryUUID` — so `loginName != UID` **and**
 only backend that reproduces #980 live: login-by-email resolves to the real home
 (email is a path alias) and `user_oidc` hardcodes `loginName == UID`.
 
-The reproduction test drives the **multi-user BasicAuth** MCP service (port 8003)
-as `alice`, so no browser is needed.
+The bug is exercised in **two deployment modes**, each its own CI lane and
+marker (the markers are mutually exclusive so the lanes don't overlap):
+
+- **`ldap`** (`-m ldap`) — drives the **multi-user BasicAuth** MCP service
+  (port 8003) as `alice`; no browser needed.
+- **`login_flow_ldap`** (`-m login_flow_ldap`) — drives the **login-flow** MCP
+  service (port 8004): identity via OIDC, API access via a per-user app password
+  obtained by completing Login Flow v2 as `alice` (Playwright). Proves the same
+  principal resolution holds when the username comes from the OIDC/app-password
+  path rather than a BasicAuth header.
+
+Both assert the same WebDAV round-trip lands in alice's real home via
+`BaseNextcloudClient._ensure_principal_id` (`current-user-principal` discovery).
 
 **Setup**:
 ```bash
-# openldap (ldap profile) + the multi-user-basic MCP service (port 8003).
+# ldap lane: openldap + the multi-user-basic MCP service (port 8003).
 # user_ldap is auto-configured by app-hooks/post-installation/15-setup-ldap-backend.sh
 # (gated on the openldap service; a no-op for every other profile).
 docker compose --profile ldap --profile multi-user-basic up --build -d
-uv run pytest -m ldap -v             # xfails until #980's client fix lands
+uv run pytest -m ldap -v
+
+# login_flow_ldap lane: openldap + the login-flow MCP service (port 8004).
+docker compose --profile ldap --profile login-flow up --build -d
+uv run playwright install chromium --with-deps
+uv run pytest -m login_flow_ldap -v
 ```
 
 > The post-installation hook only runs on a **fresh** Nextcloud install. If you
@@ -655,11 +671,11 @@ uv run pytest -m ldap -v             # xfails until #980's client fix lands
 **Credentials**: LDAP admin `uid=admin,dc=example,dc=org` / `ldap_admin_pw`;
 user `alice` / `AlicePass123!` (see `ldap/bootstrap.ldif`).
 
-**xfail note**: `tests/server/ldap/test_ldap_dav_principal.py` is
-`xfail(strict=True)` — it fails (RED) on `master` because the bug is present, and
-xpasses (GREEN) once #980's `BaseNextcloudClient._ensure_principal_id` discovery
-lands. `strict=True` turns the unexpected pass into a failure, signalling that
-the marker should be dropped when #980 merges.
+**Status**: #980's fix (`BaseNextcloudClient._ensure_principal_id`) has landed, so
+both `tests/server/ldap/test_ldap_dav_principal.py` and
+`tests/server/login_flow/test_ldap_dav_principal.py` are **passing regression
+guards** (not xfail) — a failure means the principal-discovery fix regressed in
+that deployment mode.
 
 ## Integration Testing with Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ markers = [
     "login_flow: Login Flow v2 integration tests (ADR-022)",
     "multi_user_basic: Multi-user BasicAuth pass-through tests (ADR-020)",
     "ldap: LDAP-backend tests reproducing divergent loginName/UID DAV paths (GH #980)",
+    "login_flow_ldap: Login Flow v2 deployment mode against the LDAP backend (GH #980, cross-mode)",
     "postgres: Tests requiring the docker-compose postgres-test service (ADR-026)",
     "contract: Pact consumer/provider contract tests (ADR-029)",
     "docling: Tests requiring the docker-compose docling-serve backend (ADR-031)",

--- a/tests/server/login_flow/conftest.py
+++ b/tests/server/login_flow/conftest.py
@@ -54,6 +54,8 @@ async def login_flow_oauth_client_credentials(anyio_backend, oauth_callback_serv
     nextcloud_host = os.getenv("NEXTCLOUD_HOST")
     if not nextcloud_host:
         pytest.skip("Login Flow tests require NEXTCLOUD_HOST")
+    # ty doesn't treat pytest.skip as NoReturn, so narrow explicitly.
+    assert nextcloud_host is not None
 
     auth_states, callback_url = oauth_callback_server
 
@@ -124,6 +126,8 @@ async def login_flow_oauth_token(
         pytest.skip(
             "Login Flow OAuth requires NEXTCLOUD_HOST, NEXTCLOUD_USERNAME, NEXTCLOUD_PASSWORD"
         )
+    # ty doesn't treat pytest.skip as NoReturn, so narrow explicitly.
+    assert nextcloud_host is not None and username is not None and password is not None
 
     auth_states, _ = oauth_callback_server
     client_id, client_secret, callback_url, token_endpoint, authorization_endpoint = (
@@ -951,6 +955,58 @@ async def diana_login_flow_mcp_client(
         yield session
 
 
+# ---------------------------------------------------------------------------
+# Login Flow v2 against the LDAP backend (GH #980 cross-mode guard)
+# ---------------------------------------------------------------------------
+
+# The divergent LDAP user seeded by ``ldap/bootstrap.ldif`` — logs in as `alice`
+# but user_ldap maps her to a canonical UID (loginName != UID). Unlike the
+# `test_users_setup` users above, she is NOT Nextcloud-native: she is provisioned
+# on first login by the user_ldap backend (the `ldap` compose profile + the
+# post-installation hook). Only available on the login-flow + ldap CI lane.
+LDAP_LOGIN_FLOW_USERNAME = "alice"
+LDAP_LOGIN_FLOW_PASSWORD = (
+    "AlicePass123!"  # NOSONAR(S2068) - dev-only LDAP fixture credential
+)
+
+
+@pytest.fixture(scope="session")
+async def nc_mcp_login_flow_ldap_alice_client(
+    anyio_backend,
+    browser,
+    login_flow_oauth_client_credentials,
+    oauth_callback_server,
+) -> AsyncGenerator[ClientSession, Any]:
+    """MCP client provisioned as the divergent LDAP user `alice` via login-flow.
+
+    Drives the same Login Flow v2 grant as the per-user fixtures above, but the
+    identity is the LDAP-backed `alice` (`AlicePass123!`) rather than a
+    Nextcloud-native `test_users_setup` user — so it does NOT depend on
+    ``test_users_setup``. The OIDC login and Login Flow v2 grant both authenticate
+    her against user_ldap; the MCP server then holds an app password for her and
+    builds DAV paths from her loginName, which principal discovery
+    (``BaseNextcloudClient._ensure_principal_id``) rewrites to her canonical UID.
+    Requires the login-flow MCP service (8004) plus the `ldap` compose profile.
+    """
+    auth_states, _ = oauth_callback_server
+
+    token = await _get_login_flow_token_for_user(
+        browser,
+        login_flow_oauth_client_credentials,
+        auth_states,
+        LDAP_LOGIN_FLOW_USERNAME,
+        LDAP_LOGIN_FLOW_PASSWORD,
+    )
+
+    async for session in _provision_login_flow_mcp_client(
+        token=token,
+        browser=browser,
+        username=LDAP_LOGIN_FLOW_USERNAME,
+        password=LDAP_LOGIN_FLOW_PASSWORD,
+    ):
+        yield session
+
+
 # Static OIDC client used by the management API integration tests.
 # Matches the `mcp-login-flow` allowlist
 # (`ALLOWED_MGMT_CLIENT=astrolabeMcpClientOAuth00000000000`) — i.e. the same
@@ -1097,6 +1153,8 @@ async def login_flow_static_client_token(
         pytest.skip(
             "Static client OAuth requires NEXTCLOUD_HOST, NEXTCLOUD_USERNAME, NEXTCLOUD_PASSWORD"
         )
+    # ty doesn't treat pytest.skip as NoReturn, so narrow explicitly.
+    assert nextcloud_host is not None and username is not None and password is not None
 
     auth_states, _ = oauth_callback_server
     client_id, client_secret, callback_url, token_endpoint, authorization_endpoint = (

--- a/tests/server/login_flow/test_ldap_dav_principal.py
+++ b/tests/server/login_flow/test_ldap_dav_principal.py
@@ -1,0 +1,72 @@
+"""Login-flow reproduction of GH #980 (divergent loginName/UID DAV paths).
+
+This is the **login-flow** counterpart to
+``tests/server/ldap/test_ldap_dav_principal.py`` (which drives the multi-user
+BasicAuth service). The LDAP user `alice` logs in as `alice` but Nextcloud's
+`user_ldap` backend maps her to a canonical internal UID (the LDAP UUID). In
+login-flow mode identity comes via OIDC and API access via a per-user app
+password, but DAV paths are still built from her loginName — so a naive WebDAV
+operation targets ``/remote.php/dav/files/alice/``, which does NOT resolve to her
+real home at ``/remote.php/dav/files/<uid>/`` (an LDAP login is not a files-path
+alias, so it 404s rather than silently resolving).
+
+``BaseNextcloudClient._ensure_principal_id`` issues a
+``PROPFIND /remote.php/dav/`` for ``current-user-principal``, discovers the real
+UID, and rewrites the base path. This test proves that fix holds in login-flow
+mode too — the WebDAV round-trip below lands in alice's real home and **passes**.
+"""
+
+import json
+
+import pytest
+from mcp import ClientSession
+
+pytestmark = [pytest.mark.integration, pytest.mark.login_flow_ldap]
+
+
+async def test_webdav_round_trip_resolves_ldap_principal_login_flow(
+    nc_mcp_login_flow_ldap_alice_client: ClientSession,
+):
+    """A full WebDAV cycle as the divergent LDAP user in login-flow mode.
+
+    create → write → read → list → delete, all as `alice` provisioned via
+    Login Flow v2. Principal discovery resolves the loginName `alice` to her
+    canonical UID so every operation lands in her real home; before GH #980's fix
+    the first operation failed against the non-existent ``/files/alice/`` home.
+    """
+    client = nc_mcp_login_flow_ldap_alice_client
+    dir_path = "/LdapPrincipalTestLoginFlow"
+    file_path = f"{dir_path}/ldap_principal.txt"
+    content = "webdav round-trip via the divergent LDAP principal (login-flow)"
+
+    mkdir_result = await client.call_tool(
+        "nc_webdav_create_directory", {"path": dir_path}
+    )
+    assert mkdir_result.isError is False, (
+        "create_directory failed — DAV path built from the LDAP loginName "
+        "'alice' instead of the discovered canonical UID (GH #980 not fixed in "
+        f"login-flow mode?): {mkdir_result.content}"
+    )
+
+    try:
+        write_result = await client.call_tool(
+            "nc_webdav_write_file",
+            {"path": file_path, "content": content},
+        )
+        assert write_result.isError is False
+
+        read_result = await client.call_tool("nc_webdav_read_file", {"path": file_path})
+        assert read_result.isError is False
+        read_data = json.loads(read_result.content[0].text)
+        assert content in read_data.get("content", "")
+
+        list_result = await client.call_tool(
+            "nc_webdav_list_directory", {"path": dir_path}
+        )
+        assert list_result.isError is False
+        list_data = json.loads(list_result.content[0].text)
+        names = [f.get("name", "") for f in list_data.get("files", [])]
+        assert "ldap_principal.txt" in names
+    finally:
+        await client.call_tool("nc_webdav_delete_resource", {"path": file_path})
+        await client.call_tool("nc_webdav_delete_resource", {"path": dir_path})


### PR DESCRIPTION
## What

The `ldap` CI lane only exercised **multi-user-BasicAuth** mode (port 8003) as the divergent LDAP user `alice` (loginName ≠ UID, GH #980 regression guard). This adds a second lane that exercises the same principal-resolution behaviour in **login-flow** mode (port 8004), where identity comes via OIDC and Nextcloud API access via a per-user **app password** — a different path to the username used for DAV path construction.

It proves `BaseNextcloudClient._ensure_principal_id` resolves the divergent LDAP loginName→UID **regardless of deployment mode**.

## Changes

- New `login_flow_ldap` pytest marker — **dedicated** so the existing `login_flow` and `ldap` lanes stay zero-touch (verified via `--collect-only`: `-m login_flow` and `-m ldap` both exclude the new test).
- New `tests/server/login_flow/test_ldap_dav_principal.py` mirroring the multi-user-basic WebDAV create→write→read→list→delete round-trip, driven via Login Flow v2 as the LDAP `alice`.
- New fixture `nc_mcp_login_flow_ldap_alice_client` reusing the existing `_get_login_flow_token_for_user` / `_provision_login_flow_mcp_client` helpers — no `test_users_setup` coupling (alice is user_ldap-provisioned on first login).
- New CI matrix lane `login-flow-ldap` (profile `login-flow` + `--profile ldap`, playwright, port 8004); `Verify LDAP backend` and `Verify OIDC configuration` steps extended to the new mode.
- `CLAUDE.md`: document both LDAP lanes and correct the stale `xfail` note (#980's fix has landed → both are passing guards).
- Incidental: `assert ... is not None` narrowing after the existing `pytest.skip` guards in `login_flow/conftest.py` so the `ty-check` pre-commit hook passes on the touched file (ty doesn't treat `pytest.skip` as `NoReturn`; these were pre-existing errors surfaced by editing the file — CI's `ty check -- nextcloud_mcp_server` never covered them).

## Verified locally (end-to-end, not just static)

Ran the full stack (`--profile ldap --profile login-flow`) and the new lane against it:

```
tests/server/login_flow/test_ldap_dav_principal.py::...[chromium] PASSED
1 passed, 2647 deselected in 36.42s
```

Confirmed the test is **meaningful**: LDAP `alice` logs in as `alice` but her canonical UID is `57da83ba-0fda-1041-...` (entryUUID-derived, her real home dir on disk). The round-trip succeeds only because principal discovery rewrites `/files/alice/` → `/files/57da83ba-.../`. **Investigation result: login-flow mode works correctly with the LDAP backend.**

## Test coverage

This PR is test-tier + CI config + docs — no product API surface changes, so the e2e+contract review gate is not triggered. It *adds* integration coverage (a new full-stack lane).

Tracking: Deck card #617 (board 12 — nextcloud-mcp-server Product).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)