### PR TITLE
fix(ingest): accept and thread index_mode through worker task

### DIFF
--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -52,6 +52,7 @@ from procrastinate.jobs import Job, Status
 from procrastinate.manager import QUEUEING_LOCK_CONSTRAINT
 
 from ...config import get_procrastinate_conninfo, get_settings
+from .. import payload_keys
 from ..scanner import DocumentTask
 
 if TYPE_CHECKING:
@@ -164,6 +165,7 @@ async def process_document_task(
     metadata: dict[str, int | str] | None = None,
     etag: str | None = None,
     owner_id: str | None = None,
+    index_mode: str = payload_keys.INDEX_MODE_HYBRID,
 ) -> None:
     """Worker entry: rebuild the DocumentTask, resolve creds, run the pipeline.
 
@@ -195,6 +197,7 @@ async def process_document_task(
         metadata=metadata,
         etag=etag,
         owner_id=owner_id,
+        index_mode=index_mode,
     )
     try:
         nc_client = await _resolve_client(user_id)

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -166,9 +166,21 @@ async def _discover_tagged_files(
     )
     for f in hybrid_files:
         f["_index_mode"] = payload_keys.INDEX_MODE_HYBRID
+        logger.debug(
+            "Scanned file %s (ID: %s) carries the hybrid tag %r -> index_mode=%s",
+            f.get("path"),
+            f.get("id"),
+            settings.vector_sync_pdf_tag,
+            payload_keys.INDEX_MODE_HYBRID,
+        )
 
     keyword_tag = settings.vector_sync_keyword_tag
     if not keyword_tag:
+        logger.info(
+            "Tagged-file discovery: %d hybrid (tag %r); keyword tag disabled",
+            len(hybrid_files),
+            settings.vector_sync_pdf_tag,
+        )
         return hybrid_files
 
     hybrid_ids = {str(f["id"]) for f in hybrid_files}
@@ -179,9 +191,33 @@ async def _discover_tagged_files(
     extra_keyword_files = []
     for f in keyword_files:
         if str(f["id"]) in hybrid_ids:
+            # File carries both tags: hybrid wins (superset of keyword).
+            logger.debug(
+                "Scanned file %s (ID: %s) carries both the hybrid tag %r and the "
+                "keyword-only tag %r; hybrid precedence -> index_mode=%s",
+                f.get("path"),
+                f.get("id"),
+                settings.vector_sync_pdf_tag,
+                keyword_tag,
+                payload_keys.INDEX_MODE_HYBRID,
+            )
             continue
         f["_index_mode"] = payload_keys.INDEX_MODE_KEYWORD
+        logger.debug(
+            "Scanned file %s (ID: %s) carries the keyword-only tag %r -> index_mode=%s",
+            f.get("path"),
+            f.get("id"),
+            keyword_tag,
+            payload_keys.INDEX_MODE_KEYWORD,
+        )
         extra_keyword_files.append(f)
+    logger.info(
+        "Tagged-file discovery: %d hybrid (tag %r), %d keyword-only (tag %r)",
+        len(hybrid_files),
+        settings.vector_sync_pdf_tag,
+        len(extra_keyword_files),
+        keyword_tag,
+    )
     return hybrid_files + extra_keyword_files
 
 

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -3,6 +3,8 @@
 Uses procrastinate's in-memory connector so no live Postgres is required.
 """
 
+import inspect
+from dataclasses import fields
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -11,9 +13,25 @@ import pytest
 from procrastinate import App, JobContext, testing
 
 import nextcloud_mcp_server.vector.queue.procrastinate as pq
+from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.scanner import DocumentTask
 
 pytestmark = pytest.mark.unit
+
+
+def test_document_task_fields_are_all_accepted_by_worker_task():
+    """Every ``DocumentTask`` field must be an accepted kwarg of the worker task.
+
+    Regression for the ``index_mode`` TypeError: the producer defers via
+    ``defer_async(**asdict(task))``, so any ``DocumentTask`` field the worker
+    entrypoint does not declare raises ``TypeError: process_document_task() got an
+    unexpected keyword argument`` on 100% of deferred jobs. This locks the
+    producer→worker kwarg contract so a new field can't silently break every job.
+    """
+    task_params = set(inspect.signature(pq.process_document_task).parameters)
+    task_params.discard("context")  # supplied by procrastinate, not from asdict()
+    missing = {f.name for f in fields(DocumentTask)} - task_params
+    assert not missing, f"process_document_task() is missing kwargs: {missing}"
 
 
 def _ctx(queue: str = pq.INGEST_QUEUE_FAST) -> JobContext:
@@ -128,11 +146,42 @@ class TestProcessDocumentTask:
         assert isinstance(captured["task"], DocumentTask)
         assert captured["task"].doc_id == "42"
         assert captured["task"].etag == "e1"
+        # index_mode omitted from the call defaults to hybrid, so jobs enqueued by
+        # an older producer (before the field existed) still run.
+        assert captured["task"].index_mode == payload_keys.INDEX_MODE_HYBRID
         # Worker disables the in-process retry loop; durable retry is the queue's.
         assert captured["max_retries"] == 1
         # Tier is derived from the job's queue (escalation enabled by default).
         assert captured["tier"] == "ocr"
         fake_client.close.assert_awaited_once()
+
+    async def test_index_mode_threaded_into_rebuilt_task(self, monkeypatch):
+        """A keyword-mode job must rebuild a DocumentTask carrying that mode, so the
+        pipeline embeds sparse-only (not the hybrid default)."""
+        captured = {}
+        fake_client = AsyncMock()
+
+        async def fake_resolve(user_id):
+            return fake_client
+
+        async def fake_process(task, nc_client, *, max_retries, tier):
+            captured["task"] = task
+
+        monkeypatch.setattr(pq, "_resolve_client", fake_resolve)
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.vector.processor.process_document", fake_process
+        )
+
+        await pq.process_document_task(
+            _ctx(),
+            user_id="alice",
+            doc_id="42",
+            doc_type="file",
+            operation="index",
+            modified_at=100,
+            index_mode=payload_keys.INDEX_MODE_KEYWORD,
+        )
+        assert captured["task"].index_mode == payload_keys.INDEX_MODE_KEYWORD
 
     async def test_pipeline_error_propagates_and_closes_client(self, monkeypatch):
         # A non-credential failure must propagate (so procrastinate's


### PR DESCRIPTION
## Problem

Every `ingest:process_document` job fails immediately (~2 ms) on the smoke-test tenant (`tenant-smoke-test-20260531`, cloudfleet/dev), so **no file re-indexes**. Loki:

```
TypeError: process_document_task() got an unexpected keyword argument 'index_mode'
```

## Root cause

Regression from card #609 / commit `e8772bbb` (*feat: per-document keyword vs hybrid index mode*). That commit added an `index_mode` field to the `DocumentTask` dataclass but did **not** update the procrastinate worker entrypoint. The producer defers via `defer_async(**asdict(task))`, so every deferred job now carries an `index_mode` kwarg that `process_document_task()` never declared → `TypeError` on 100% of file index jobs. The keyword/hybrid mode was also never threaded through the worker boundary, so even absent the crash the per-document mode would silently fall back to hybrid.

## Fix

- `process_document_task()` accepts `index_mode: str = INDEX_MODE_HYBRID` (the default keeps jobs enqueued by an older producer runnable across a rolling deploy) and threads it into the rebuilt `DocumentTask`.
- **Regression guard**: a contract test asserts every `DocumentTask` field is an accepted kwarg of `process_document_task` (the producer→worker contract) — it fails without this fix and will catch any *future* field added to the dataclass without threading it through. Plus an `index_mode` thread-through test and a hybrid-default assertion.
- `_discover_tagged_files` now logs which tag (hybrid vs keyword-only) each scanned file carries, plus a per-mode discovery summary.

## Testing

- `uv run pytest tests/unit/` — 2055 passed.
- Verified the new contract test fails with the signature reverted (`AssertionError: process_document_task() is missing kwargs: {'index_mode'}`) and passes with the fix.
- Root cause confirmed live in Loki (cloudfleet/dev) from the actual worker tracebacks.

Deck: #622 (regression of #609)

---

_This PR was generated with the help of AI, and reviewed by a Human_