### PR TITLE
refactor(config)!: rename VECTOR_SYNC_PDF_TAG → VECTOR_SYNC_TAG

### DIFF
--- a/docs/ADR-019-verify-on-read-for-semantic-search.md
+++ b/docs/ADR-019-verify-on-read-for-semantic-search.md
@@ -8,7 +8,7 @@
 > described below as a per-id WebDAV check (`PROPFIND`, later
 > `file_accessible_by_id`) now gates on current **`vector-index` tag
 > membership** instead. It issues a single
-> `find_files_by_tag(<VECTOR_SYNC_PDF_TAG>, mime_type_filter="application/pdf")`
+> `find_files_by_tag(<VECTOR_SYNC_TAG>, mime_type_filter="application/pdf")`
 > REPORT per search (plus a one-shot `EXCLUDED_TAGS` lookup) and keeps only
 > files in that set — i.e. exactly what the scanner indexes. This is the
 > "fetch once and intersect" shape (like `news_item`), not per-id fan-out, and

--- a/docs/ADR-031-per-document-index-mode.md
+++ b/docs/ADR-031-per-document-index-mode.md
@@ -30,7 +30,7 @@ documents write `sparse` only.
 collection entirely. Make the mode **per-document**, driven by which Nextcloud
 tag selected the document:
 
-- **`vector_sync_pdf_tag`** (default `vector-index`) → **hybrid**
+- **`vector_sync_tag`** (default `vector-index`) → **hybrid**
   (dense + BM25 sparse).
 - **`vector_sync_keyword_tag`** (env `VECTOR_SYNC_KEYWORD_TAG`, default
   `keyword-index`, symmetric with the hybrid tag; set empty to disable) →

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,7 +355,7 @@ by a single unified search.
 
 | Tag | Env var (override the tag name) | Mode | Embedding endpoint |
 |-----|---------|------|--------------------|
-| `vector-index` | `VECTOR_SYNC_PDF_TAG` (default `vector-index`) | hybrid (dense + BM25 sparse) | **Required** (Ollama/Bedrock/OpenAI/Mistral/gateway) |
+| `vector-index` | `VECTOR_SYNC_TAG` (default `vector-index`) | hybrid (dense + BM25 sparse) | **Required** (Ollama/Bedrock/OpenAI/Mistral/gateway) |
 | `keyword-index` | `VECTOR_SYNC_KEYWORD_TAG` (default `keyword-index`) | keyword (BM25 sparse only) | **None** for those docs |
 
 Both tags are **on by default** — create the `vector-index` and/or `keyword-index`
@@ -996,7 +996,7 @@ aware of:
   an excluded folder) drops out of results immediately rather than waiting for
   the scanner sweep. The REPORT expands tagged folders via a `Depth: infinity`
   SEARCH, so deployments that tag whole directory trees pay that walk once per
-  search; configure `VECTOR_SYNC_PDF_TAG` to change the tag name. The `file`
+  search; configure `VECTOR_SYNC_TAG` to change the tag name. The `file`
   verifier's latency therefore scales with **both** the `Depth: infinity` folder
   expansion **and** the `EXCLUDED_TAGS` lookup: that lookup fans out ~2 WebDAV
   calls (1 PROPFIND + 1 REPORT) *per excluded tag*, concurrently, while holding
@@ -1038,8 +1038,8 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ENABLE_SEMANTIC_SEARCH` | ⚠️ Optional | `false` | Enable semantic search with background indexing (replaces `VECTOR_SYNC_ENABLED`) |
-| `VECTOR_SYNC_PDF_TAG` | ⚠️ Optional | `vector-index` | Nextcloud tag marking PDFs for **hybrid** (dense + BM25 sparse) indexing (ADR-031) |
-| `VECTOR_SYNC_KEYWORD_TAG` | ⚠️ Optional | `keyword-index` | Nextcloud tag marking PDFs for **keyword-only** (BM25 sparse) indexing into the same collection; on by default, set empty to disable. Hybrid wins if a file carries both tags (ADR-031) |
+| `VECTOR_SYNC_TAG` | ⚠️ Optional | `vector-index` | Nextcloud tag marking files for **hybrid** (dense + BM25 sparse) indexing (ADR-031) |
+| `VECTOR_SYNC_KEYWORD_TAG` | ⚠️ Optional | `keyword-index` | Nextcloud tag marking files for **keyword-only** (BM25 sparse) indexing into the same collection; on by default, set empty to disable. Hybrid wins if a file carries both tags (ADR-031) |
 | `QDRANT_URL` | ⚠️ Optional | - | Qdrant service URL (network mode) - mutually exclusive with `QDRANT_LOCATION` |
 | `QDRANT_LOCATION` | ⚠️ Optional | `:memory:` | Local Qdrant path (`:memory:` or `/path/to/data`) - mutually exclusive with `QDRANT_URL` |
 | `QDRANT_API_KEY` | ⚠️ Optional | - | Qdrant API key (network mode only) |

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -125,9 +125,9 @@ _DEFAULTS: dict[str, Any] = {
     # System tag that marks files for hybrid (dense + BM25 sparse) indexing.
     # The scanner indexes files carrying this tag; verify-on-read gates results
     # on current membership of this tag (ADR-019).
-    "vector_sync_pdf_tag": "vector-index",
+    "vector_sync_tag": "vector-index",
     # System tag that marks files for keyword-only (BM25 sparse) indexing.
-    # Defaults to ``keyword-index`` (symmetric with ``vector_sync_pdf_tag``), so
+    # Defaults to ``keyword-index`` (symmetric with ``vector_sync_tag``), so
     # a user who creates + applies that tag gets keyword-only indexing out of the
     # box. Files carrying it are indexed sparse-only (no dense embedding, no
     # embedding cost) into the SAME collection as hybrid files; ``vector-index``
@@ -461,7 +461,7 @@ _dynaconf = Dynaconf(
         # Non-negative
         Validator("DOCUMENT_CHUNK_OVERLAP", gte=0),
         # Non-empty strings
-        Validator("VECTOR_SYNC_PDF_TAG", len_min=1),
+        Validator("VECTOR_SYNC_TAG", len_min=1),
         # VECTOR_SYNC_KEYWORD_TAG is optional (empty disables keyword-only
         # discovery), so no len_min — but when set it must be a usable tag name.
         # WEBHOOK_SECRET is optional (None disables webhooks — GHSA-8vh3-g2qg-2h2c),
@@ -917,10 +917,10 @@ class Settings:
     # scanner indexes files carrying this tag and verify-on-read gates results
     # on current membership (ADR-019), so an untagged file drops out of search
     # immediately.
-    vector_sync_pdf_tag: str = "vector-index"
+    vector_sync_tag: str = "vector-index"
 
     # System tag marking files for keyword-only (BM25 sparse) indexing. Defaults
-    # to ``keyword-index`` (symmetric with ``vector_sync_pdf_tag``): tagged files
+    # to ``keyword-index`` (symmetric with ``vector_sync_tag``): tagged files
     # are indexed sparse-only into the same collection as hybrid files (no dense
     # embedding). ``vector-index`` takes precedence when a file carries both tags.
     # Set empty to disable the second tag entirely.
@@ -1708,7 +1708,7 @@ def get_settings() -> Settings:
         "vector_sync_user_poll_interval": "VECTOR_SYNC_USER_POLL_INTERVAL",
         "vector_sync_orphan_sweep_enabled": "VECTOR_SYNC_ORPHAN_SWEEP_ENABLED",
         "health_ready_refresh_interval": "HEALTH_READY_REFRESH_INTERVAL",
-        "vector_sync_pdf_tag": "VECTOR_SYNC_PDF_TAG",
+        "vector_sync_tag": "VECTOR_SYNC_TAG",
         "vector_sync_keyword_tag": "VECTOR_SYNC_KEYWORD_TAG",
         # Verify-on-read (ADR-019)
         "verification_concurrency": "VERIFICATION_CONCURRENCY",

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -151,7 +151,7 @@ async def _discover_tagged_files(
 ) -> list[dict]:
     """Discover tagged PDFs for both index modes, stamping ``_index_mode``.
 
-    ``vector_sync_pdf_tag`` → hybrid (dense + BM25 sparse); ``vector_sync_keyword_tag``
+    ``vector_sync_tag`` → hybrid (dense + BM25 sparse); ``vector_sync_keyword_tag``
     → keyword (BM25 sparse only). Hybrid wins precedence: a file carrying both tags
     is hybrid (a superset of keyword), so it is discovered once with
     ``_index_mode="hybrid"`` and its keyword listing is dropped. The keyword tag is
@@ -162,7 +162,7 @@ async def _discover_tagged_files(
     ``_index_mode`` key consumed by the enqueue loop.
     """
     hybrid_files = await nc_client.find_files_by_tag(
-        settings.vector_sync_pdf_tag, mime_type_filter="application/pdf"
+        settings.vector_sync_tag, mime_type_filter="application/pdf"
     )
     for f in hybrid_files:
         f["_index_mode"] = payload_keys.INDEX_MODE_HYBRID
@@ -170,7 +170,7 @@ async def _discover_tagged_files(
             "Scanned file %s (ID: %s) carries the hybrid tag %r -> index_mode=%s",
             f.get("path"),
             f.get("id"),
-            settings.vector_sync_pdf_tag,
+            settings.vector_sync_tag,
             payload_keys.INDEX_MODE_HYBRID,
         )
 
@@ -179,7 +179,7 @@ async def _discover_tagged_files(
         logger.info(
             "Tagged-file discovery: %d hybrid (tag %r); keyword tag disabled",
             len(hybrid_files),
-            settings.vector_sync_pdf_tag,
+            settings.vector_sync_tag,
         )
         return hybrid_files
 
@@ -197,7 +197,7 @@ async def _discover_tagged_files(
                 "keyword-only tag %r; hybrid precedence -> index_mode=%s",
                 f.get("path"),
                 f.get("id"),
-                settings.vector_sync_pdf_tag,
+                settings.vector_sync_tag,
                 keyword_tag,
                 payload_keys.INDEX_MODE_HYBRID,
             )
@@ -214,7 +214,7 @@ async def _discover_tagged_files(
     logger.info(
         "Tagged-file discovery: %d hybrid (tag %r), %d keyword-only (tag %r)",
         len(hybrid_files),
-        settings.vector_sync_pdf_tag,
+        settings.vector_sync_tag,
         len(extra_keyword_files),
         keyword_tag,
     )
@@ -702,7 +702,7 @@ async def scan_user_documents(
             # Find tagged PDFs via the OCS Tags API. find_files_by_tag also
             # expands tagged directories into their PDF descendants (Depth:
             # infinity SEARCH), so a tag on a folder applies to every PDF beneath
-            # it. Two tags feed one pipeline: ``vector_sync_pdf_tag`` →
+            # it. Two tags feed one pipeline: ``vector_sync_tag`` →
             # hybrid (dense + sparse), ``vector_sync_keyword_tag`` → keyword
             # (sparse only). Each file dict is stamped with ``_index_mode`` so the
             # per-document processor knows which to apply; hybrid wins when a file

--- a/tests/integration/test_acl_shared_search.py
+++ b/tests/integration/test_acl_shared_search.py
@@ -103,7 +103,7 @@ async def shared_file(acl_users):
     await alice.webdav.write_file(path, PDF_BYTES, "application/pdf")
     file_id = (await alice.webdav.get_file_info(path))["id"]
     tag = await alice.webdav.get_or_create_tag(
-        name=get_settings().vector_sync_pdf_tag,
+        name=get_settings().vector_sync_tag,
         user_visible=True,
         user_assignable=True,
     )

--- a/tests/integration/test_index_mode_discovery.py
+++ b/tests/integration/test_index_mode_discovery.py
@@ -1,7 +1,7 @@
 """End-to-end integration test for two-tag index-mode discovery (ADR-031).
 
 The scanner discovers files under two Nextcloud system tags —
-``VECTOR_SYNC_PDF_TAG`` (hybrid) and ``VECTOR_SYNC_KEYWORD_TAG`` (keyword-only)
+``VECTOR_SYNC_TAG`` (hybrid) and ``VECTOR_SYNC_KEYWORD_TAG`` (keyword-only)
 — via ``_discover_tagged_files``, which stamps each file with ``_index_mode``
 and applies **hybrid precedence** (a file carrying both tags is hybrid). This
 exercises the real OCS Tags API for both tags against a running Nextcloud, which
@@ -71,7 +71,7 @@ async def dual_tag_environment(nc_client: NextcloudClient):
         "keyword_tag": keyword_tag,
         "ids": {str(k): str(v) for k, v in ids.items()},
         "settings": SimpleNamespace(
-            vector_sync_pdf_tag=hybrid_tag,
+            vector_sync_tag=hybrid_tag,
             vector_sync_keyword_tag=keyword_tag,
         ),
     }

--- a/tests/integration/test_tag_inclusion.py
+++ b/tests/integration/test_tag_inclusion.py
@@ -2,7 +2,7 @@
 ``NextcloudClient.find_files_by_tag``.
 
 The vector scanner relies on this helper to enumerate files under the
-``vector-index`` system tag (env: ``VECTOR_SYNC_PDF_TAG``). A user can
+``vector-index`` system tag (env: ``VECTOR_SYNC_TAG``). A user can
 tag either an individual file *or* a folder; in the folder case the
 tag should propagate to every matching descendant via a
 ``Depth: infinity`` WebDAV SEARCH.

--- a/tests/integration/test_verify_on_read.py
+++ b/tests/integration/test_verify_on_read.py
@@ -247,7 +247,7 @@ async def test_verify_keeps_nested_file_shared_with_recipient(
     await alice.webdav.write_file(shared_path, PDF_BYTES, "application/pdf")
     file_id = (await alice.webdav.get_file_info(shared_path))["id"]
     tag = await alice.webdav.get_or_create_tag(
-        name=get_settings().vector_sync_pdf_tag,
+        name=get_settings().vector_sync_tag,
         user_visible=True,
         user_assignable=True,
     )

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -50,14 +50,14 @@ class TestDecompositionDefaults:
 
 class TestKeywordTag:
     """VECTOR_SYNC_KEYWORD_TAG selects files to index keyword-only (BM25 sparse,
-    no dense vector), mirroring VECTOR_SYNC_PDF_TAG. Defaults to ``keyword-index``
+    no dense vector), mirroring VECTOR_SYNC_TAG. Defaults to ``keyword-index``
     (symmetric with the ``vector-index`` default); set empty to disable."""
 
     def test_default_is_keyword_index(self):
         assert Settings().vector_sync_keyword_tag == "keyword-index"
 
     def test_explicit_value_round_trips(self):
-        # Mirrors VECTOR_SYNC_PDF_TAG: a configured tag is passed through verbatim
+        # Mirrors VECTOR_SYNC_TAG: a configured tag is passed through verbatim
         # (an explicit value overrides the default tag name).
         assert (
             Settings(vector_sync_keyword_tag="kw-only").vector_sync_keyword_tag

--- a/tests/unit/vector/test_index_mode_discovery.py
+++ b/tests/unit/vector/test_index_mode_discovery.py
@@ -1,6 +1,6 @@
 """Unit tests for per-document index-mode discovery (card #609).
 
-Two Nextcloud tags feed one ingestion pipeline: ``vector_sync_pdf_tag`` →
+Two Nextcloud tags feed one ingestion pipeline: ``vector_sync_tag`` →
 hybrid (dense + BM25 sparse) and ``vector_sync_keyword_tag`` → keyword (BM25
 sparse only). ``_discover_tagged_files`` unions both, stamping ``_index_mode``
 on each file with **hybrid precedence** (a file carrying both tags is hybrid, a
@@ -16,9 +16,9 @@ from nextcloud_mcp_server.vector.processor import _reconcile_tag_event
 from nextcloud_mcp_server.vector.scanner import DocumentTask, _discover_tagged_files
 
 
-def _settings(pdf_tag: str = "vector-index", keyword_tag: str = "") -> MagicMock:
+def _settings(tag: str = "vector-index", keyword_tag: str = "") -> MagicMock:
     s = MagicMock()
-    s.vector_sync_pdf_tag = pdf_tag
+    s.vector_sync_tag = tag
     s.vector_sync_keyword_tag = keyword_tag
     return s
 


### PR DESCRIPTION
## What

Renames the hybrid include-tag setting/env var from `VECTOR_SYNC_PDF_TAG` → **`VECTOR_SYNC_TAG`** (Python attr `vector_sync_pdf_tag` → `vector_sync_tag`).

## Why

The tag marks files for **hybrid** (dense + BM25 sparse) indexing — the content indexed is not restricted to PDFs, so "PDF" in the name is misleading. The new name is file-generic and keeps the `VECTOR_SYNC_*` prefix shared by every sibling setting (`VECTOR_SYNC_KEYWORD_TAG`, `VECTOR_SYNC_SCAN_INTERVAL`, …), reading as the hybrid counterpart to the keyword tag.

## Scope

Pure identifier rename — **no behavior change**. The scanner's `mime_type_filter="application/pdf"` on the file-tag discovery path is untouched; only the misleading name changes. Docs (ADR-019, ADR-031, `configuration.md`) and tests updated in lockstep.

## ⚠️ Breaking change

`VECTOR_SYNC_PDF_TAG` is **removed** (no backward-compat alias, per decision). Deployments setting it must switch to `VECTOR_SYNC_TAG`. Confirmed **no tenant currently overrides** this value, so the default `vector-index` tag is unaffected. The companion Helm-chart change (values key `pdfTag` → `vectorTag`, renders `VECTOR_SYNC_TAG`) ships alongside.

## Testing

- `uv run ruff check` / `ruff format` / `ty check` — green.
- Targeted unit tests (config, index-mode discovery, procrastinate producer) — 50 passed.
- Verified zero remaining `VECTOR_SYNC_PDF_TAG` / `vector_sync_pdf_tag` / `pdf_tag` tokens repo-wide.

Deck: #622

---

_This PR was generated with the help of AI, and reviewed by a Human_