### PR TITLE
feat(vector): monitor dense-vector RAM cost during ingestion

### DIFF
--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -25,7 +25,12 @@ from starlette.responses import JSONResponse
 
 from nextcloud_mcp_server.config import Settings, get_settings
 from nextcloud_mcp_server.config_validators import AuthMode, detect_auth_mode
-from nextcloud_mcp_server.vector.metrics_publisher import count_indexed
+from nextcloud_mcp_server.embedding import get_embedding_service
+from nextcloud_mcp_server.observability.metrics import estimate_vector_bytes
+from nextcloud_mcp_server.vector.metrics_publisher import (
+    count_hybrid_chunks,
+    count_indexed,
+)
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
 logger = logging.getLogger(__name__)
@@ -401,10 +406,23 @@ async def get_vector_sync_status(request: Request) -> JSONResponse:
         # fans out to ~N chunks, so both are reported (the UI shows both).
         indexed_documents = 0
         indexed_chunks = 0
+        hybrid_chunks = 0
+        estimated_vector_bytes = 0
         try:
             qdrant_client = await get_qdrant_client()
             indexed_documents, indexed_chunks = await count_indexed(
                 qdrant_client, settings.get_collection_name()
+            )
+            # Hybrid (dense-bearing) chunks drive the vector-RAM footprint; keyword
+            # chunks are sparse-only and cost no dense RAM (card #624).
+            hybrid_chunks = await count_hybrid_chunks(
+                qdrant_client, settings.get_collection_name()
+            )
+            dim = get_embedding_service().get_dimension()
+            estimated_vector_bytes = int(
+                estimate_vector_bytes(
+                    hybrid_chunks, dim, settings.vector_ram_hnsw_overhead_factor
+                )
             )
         except Exception as e:
             logger.warning("Failed to query Qdrant for indexed counts: %s", e)
@@ -422,6 +440,10 @@ async def get_vector_sync_status(request: Request) -> JSONResponse:
             "indexed_documents": indexed_documents,
             "indexed_chunks": indexed_chunks,
             "indexed_count": indexed_chunks,
+            # Vector-RAM cost signals (card #624): hybrid_chunks is the dense-bearing
+            # subset; estimated_vector_bytes is its RAM footprint estimate.
+            "hybrid_chunks": hybrid_chunks,
+            "estimated_vector_bytes": estimated_vector_bytes,
             "pending_documents": pending.pending,
             "ingest_queue": settings.ingest_queue,
         }

--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -25,11 +25,9 @@ from starlette.responses import JSONResponse
 
 from nextcloud_mcp_server.config import Settings, get_settings
 from nextcloud_mcp_server.config_validators import AuthMode, detect_auth_mode
-from nextcloud_mcp_server.embedding import get_embedding_service
-from nextcloud_mcp_server.observability.metrics import estimate_vector_bytes
 from nextcloud_mcp_server.vector.metrics_publisher import (
-    count_hybrid_chunks,
     count_indexed,
+    estimate_hybrid_vector_bytes,
 )
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
@@ -414,15 +412,12 @@ async def get_vector_sync_status(request: Request) -> JSONResponse:
                 qdrant_client, settings.get_collection_name()
             )
             # Hybrid (dense-bearing) chunks drive the vector-RAM footprint; keyword
-            # chunks are sparse-only and cost no dense RAM (card #624).
-            hybrid_chunks = await count_hybrid_chunks(
-                qdrant_client, settings.get_collection_name()
-            )
-            dim = get_embedding_service().get_dimension()
-            estimated_vector_bytes = int(
-                estimate_vector_bytes(
-                    hybrid_chunks, dim, settings.vector_ram_hnsw_overhead_factor
-                )
+            # chunks are sparse-only and cost no dense RAM (card #624). Shared helper
+            # so this and the MCP tool surface can't drift.
+            hybrid_chunks, estimated_vector_bytes = await estimate_hybrid_vector_bytes(
+                qdrant_client,
+                settings.get_collection_name(),
+                settings.vector_ram_hnsw_overhead_factor,
             )
         except Exception as e:
             logger.warning("Failed to query Qdrant for indexed counts: %s", e)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -114,6 +114,7 @@ _DEFAULTS: dict[str, Any] = {
     "vector_sync_processor_workers": 3,
     "vector_sync_queue_max_size": 10000,
     "vector_sync_metrics_refresh_interval": 20,
+    "vector_ram_hnsw_overhead_factor": 1.5,
     "vector_sync_user_poll_interval": 60,
     "health_ready_refresh_interval": 15,
     # Orphan-sweep at Pod startup (card #101). When True, delete any
@@ -434,6 +435,7 @@ _dynaconf = Dynaconf(
         Validator("VECTOR_SYNC_PROCESSOR_WORKERS", gte=1),
         Validator("VECTOR_SYNC_QUEUE_MAX_SIZE", gte=1),
         Validator("VECTOR_SYNC_METRICS_REFRESH_INTERVAL", gte=1),
+        Validator("VECTOR_RAM_HNSW_OVERHEAD_FACTOR", gte=1),
         Validator("VECTOR_SYNC_USER_POLL_INTERVAL", gte=1),
         Validator("HEALTH_READY_REFRESH_INTERVAL", gte=1),
         Validator("PORT", gte=1, lte=65535),
@@ -907,6 +909,12 @@ class Settings:
     # outstanding-work + indexed documents/chunks. Decoupled from the consumer
     # so the gauges are correct on every deployment mode and queue backend.
     vector_sync_metrics_refresh_interval: int = 20  # seconds
+    # HNSW-graph/segment overhead multiplier applied when estimating dense-vector
+    # RAM (``chunks * dim * 4 bytes * factor``). ~1.5 matches the cost-to-serve
+    # note's ~6 KB / 1024-dim observation; a deployment knob because the real
+    # overhead varies with HNSW ``m``/segment layout. Observability only — no
+    # billing impact.
+    vector_ram_hnsw_overhead_factor: float = 1.5
     vector_sync_user_poll_interval: int = 60  # seconds - OAuth mode user discovery
     vector_sync_orphan_sweep_enabled: bool = True  # card #101
     # Cadence for the background readiness dependency-health refresh loop
@@ -1705,6 +1713,7 @@ def get_settings() -> Settings:
         "vector_sync_processor_workers": "VECTOR_SYNC_PROCESSOR_WORKERS",
         "vector_sync_queue_max_size": "VECTOR_SYNC_QUEUE_MAX_SIZE",
         "vector_sync_metrics_refresh_interval": "VECTOR_SYNC_METRICS_REFRESH_INTERVAL",
+        "vector_ram_hnsw_overhead_factor": "VECTOR_RAM_HNSW_OVERHEAD_FACTOR",
         "vector_sync_user_poll_interval": "VECTOR_SYNC_USER_POLL_INTERVAL",
         "vector_sync_orphan_sweep_enabled": "VECTOR_SYNC_ORPHAN_SWEEP_ENABLED",
         "health_ready_refresh_interval": "HEALTH_READY_REFRESH_INTERVAL",

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -205,6 +205,22 @@ class VectorSyncStatusResponse(BaseResponse):
             "None on the in-memory backend"
         ),
     )
+    hybrid_chunks: int = Field(
+        default=0,
+        description=(
+            "Chunks indexed in hybrid mode (dense + sparse). These carry a dense "
+            "vector and so drive the vector-RAM footprint; keyword-index chunks "
+            "(indexed_chunks - hybrid_chunks) are sparse-only and cost no dense RAM."
+        ),
+    )
+    estimated_vector_bytes: int = Field(
+        default=0,
+        description=(
+            "Estimated dense-vector RAM footprint in bytes "
+            "(hybrid_chunks * embedding_dim * 4 * hnsw_overhead) — the real "
+            "hybrid-search cost driver, which source-byte billing does not capture."
+        ),
+    )
 
 
 __all__ = [

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -190,6 +190,29 @@ vector_sync_indexed_chunks = Gauge(
     "Total indexed chunks (non-placeholder points) in the vector store",
 )
 
+# Dense-vector RAM footprint of the collection — the real cost driver for hybrid
+# search (billing is on source bytes, not vector RAM). Two views published by the
+# periodic vector_sync metrics task so operators can watch the "density risk"
+# (dense/low-fill docs pull chunk-per-byte high) and validate the estimate:
+#   * ``estimated_vector_bytes`` — deterministic, from OUR hybrid chunk count:
+#     ``hybrid_chunks * dim * 4 (float32) * hnsw_overhead``. Keyword-index chunks
+#     are sparse-only and carry no dense vector, so they contribute nothing.
+#   * ``qdrant_vectors`` / ``qdrant_vector_bytes`` — ground truth from Qdrant's own
+#     reported ``vectors_count`` (via ``get_collection``), converted with the same
+#     dim/overhead. The estimate-vs-actual gap catches duplication/segment drift.
+vector_sync_estimated_vector_bytes = Gauge(
+    "mcp_vector_sync_estimated_vector_bytes",
+    "Estimated dense-vector RAM footprint (hybrid_chunks * dim * 4 * hnsw_overhead)",
+)
+vector_sync_qdrant_vectors = Gauge(
+    "mcp_vector_sync_qdrant_vectors",
+    "Dense vectors reported by Qdrant get_collection().vectors_count",
+)
+vector_sync_qdrant_vector_bytes = Gauge(
+    "mcp_vector_sync_qdrant_vector_bytes",
+    "Estimated dense-vector RAM from Qdrant vectors_count (vectors * dim * 4 * hnsw_overhead)",
+)
+
 # Per-tier-queue ingest depth (Deck #323). One series per (queue, status) so an
 # operator can see where work sits -- a ``fast`` backlog, docs waiting on
 # ``ingest-structured``/``ingest-ocr``, or failures piling up per tier. KEDA
@@ -419,6 +442,29 @@ document_chunks_total = Counter(
     "astrolabe_document_chunks_total",
     "Total chunks produced by the chunker",
     ["doc_type"],
+)
+
+# Dense-vector RAM added per unit time, from OUR deterministic estimate at ingest
+# (hybrid docs only; keyword docs embed no dense vector). The cumulative counter
+# pairs with the corpus gauge above: rate() shows RAM-growth pressure, the gauge
+# shows the live footprint. See ``record_estimated_vector_bytes``.
+estimated_vector_bytes_total = Counter(
+    "astrolabe_estimated_vector_bytes_total",
+    "Estimated dense-vector RAM added at ingest (chunks * dim * 4 * hnsw_overhead)",
+    ["doc_type"],
+)
+
+# Chunk density = chunks per MB of source content, observed once per embedded
+# document. This is the "density risk" distribution from the cost-to-serve note:
+# born-digital text sits around ~91 chunks/MB, while dense/low-fill docs push the
+# tail higher and disproportionately inflate vector RAM relative to the billed
+# source bytes. Buckets straddle that band so the risky tail is visible. Recorded
+# for both index modes (density is a property of content, not of dense-vs-keyword).
+document_chunk_density_chunks_per_mb = Histogram(
+    "astrolabe_document_chunk_density_chunks_per_mb",
+    "Chunks produced per MB of source content, per embedded document",
+    ["doc_type"],
+    buckets=(1, 5, 10, 20, 40, 60, 91, 120, 160, 200, 300, 500),
 )
 
 documents_indexed_total = Counter(
@@ -690,6 +736,21 @@ def update_vector_sync_indexed_chunks(count: int) -> None:
     vector_sync_indexed_chunks.set(count)
 
 
+def update_vector_sync_estimated_vector_bytes(byte_estimate: float) -> None:
+    """Set the deterministic dense-vector RAM-footprint gauge (from hybrid chunks)."""
+    vector_sync_estimated_vector_bytes.set(byte_estimate)
+
+
+def update_vector_sync_qdrant_vectors(count: int) -> None:
+    """Set the Qdrant-reported dense-vector count gauge."""
+    vector_sync_qdrant_vectors.set(count)
+
+
+def update_vector_sync_qdrant_vector_bytes(byte_estimate: float) -> None:
+    """Set the dense-vector RAM-footprint gauge derived from Qdrant vectors_count."""
+    vector_sync_qdrant_vector_bytes.set(byte_estimate)
+
+
 def update_ingest_queue_depth(by_queue: dict[str, dict[str, int]] | None) -> None:
     """Set the per-tier-queue depth gauge from procrastinate job counts (#323).
 
@@ -918,6 +979,49 @@ def record_document_chunks(doc_type: str, count: int) -> None:
         count: Number of chunks produced
     """
     document_chunks_total.labels(doc_type=doc_type).inc(count)
+
+
+# float32 elements — the dense-vector storage width. A module constant (not config)
+# because it is a property of the vector encoding, not a deployment knob.
+DENSE_VECTOR_BYTES_PER_DIMENSION = 4
+
+
+def estimate_vector_bytes(chunk_count: int, dimension: int, overhead: float) -> float:
+    """Estimate the dense-vector RAM footprint of ``chunk_count`` vectors.
+
+    ``chunk_count * dimension * 4 (float32) * overhead``, where ``overhead`` is the
+    HNSW-graph/segment multiplier (``VECTOR_RAM_HNSW_OVERHEAD_FACTOR``). Returns 0
+    for a non-positive chunk count or dimension — a keyword-only document embeds no
+    dense vector, so it must contribute nothing to the estimate.
+    """
+    if chunk_count <= 0 or dimension <= 0:
+        return 0.0
+    return chunk_count * dimension * DENSE_VECTOR_BYTES_PER_DIMENSION * overhead
+
+
+def record_estimated_vector_bytes(doc_type: str, byte_estimate: float) -> None:
+    """Record the estimated dense-vector RAM a document added at ingest.
+
+    No-op when ``byte_estimate <= 0`` (keyword-only docs, empty docs) so the
+    counter never advances on a document that stored no dense vector.
+    """
+    if byte_estimate > 0:
+        estimated_vector_bytes_total.labels(doc_type=doc_type).inc(byte_estimate)
+
+
+def record_chunk_density(doc_type: str, chunk_count: int, source_bytes: int) -> None:
+    """Observe chunk density (chunks per MB of source) for one embedded document.
+
+    Surfaces the "density risk" distribution: dense/low-fill docs produce many
+    chunks per source byte and so inflate vector RAM relative to the billed source
+    bytes. No-op when ``source_bytes <= 0`` (avoids a divide-by-zero) or when the
+    document produced no chunks.
+    """
+    if source_bytes > 0 and chunk_count > 0:
+        chunks_per_mb = chunk_count / (source_bytes / 1_000_000)
+        document_chunk_density_chunks_per_mb.labels(doc_type=doc_type).observe(
+            chunks_per_mb
+        )
 
 
 # =============================================================================

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -23,7 +23,6 @@ from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import allowed_doc_types
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
-from nextcloud_mcp_server.embedding import get_embedding_service
 from nextcloud_mcp_server.models.semantic import (
     SamplingSearchResponse,
     SemanticSearchResponse,
@@ -31,7 +30,6 @@ from nextcloud_mcp_server.models.semantic import (
     VectorSyncStatusResponse,
 )
 from nextcloud_mcp_server.observability.metrics import (
-    estimate_vector_bytes,
     instrument_tool,
 )
 from nextcloud_mcp_server.search.access_filter import (
@@ -45,8 +43,8 @@ from nextcloud_mcp_server.search.verification import verify_search_results
 from nextcloud_mcp_server.usage import UsageEventStore
 from nextcloud_mcp_server.utils.validation import parse_modified_timestamp
 from nextcloud_mcp_server.vector.metrics_publisher import (
-    count_hybrid_chunks,
     count_indexed,
+    estimate_hybrid_vector_bytes,
 )
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
@@ -1164,14 +1162,14 @@ def configure_semantic_tools(mcp: FastMCP):
                 )
                 # Hybrid chunks (dense-bearing) drive the vector-RAM footprint;
                 # keyword-index chunks are sparse-only and cost no dense RAM (#624).
-                hybrid_chunks = await count_hybrid_chunks(
-                    qdrant_client, settings.get_collection_name()
-                )
-                dim = get_embedding_service().get_dimension()
-                estimated_vector_bytes = int(
-                    estimate_vector_bytes(
-                        hybrid_chunks, dim, settings.vector_ram_hnsw_overhead_factor
-                    )
+                # Shared helper so this and the HTTP status route can't drift.
+                (
+                    hybrid_chunks,
+                    estimated_vector_bytes,
+                ) = await estimate_hybrid_vector_bytes(
+                    qdrant_client,
+                    settings.get_collection_name(),
+                    settings.vector_ram_hnsw_overhead_factor,
                 )
             except Exception as e:
                 logger.warning("Failed to query Qdrant for indexed counts: %s", e)

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -23,6 +23,7 @@ from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import allowed_doc_types
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
+from nextcloud_mcp_server.embedding import get_embedding_service
 from nextcloud_mcp_server.models.semantic import (
     SamplingSearchResponse,
     SemanticSearchResponse,
@@ -30,6 +31,7 @@ from nextcloud_mcp_server.models.semantic import (
     VectorSyncStatusResponse,
 )
 from nextcloud_mcp_server.observability.metrics import (
+    estimate_vector_bytes,
     instrument_tool,
 )
 from nextcloud_mcp_server.search.access_filter import (
@@ -42,7 +44,10 @@ from nextcloud_mcp_server.search.context import get_chunk_with_context
 from nextcloud_mcp_server.search.verification import verify_search_results
 from nextcloud_mcp_server.usage import UsageEventStore
 from nextcloud_mcp_server.utils.validation import parse_modified_timestamp
-from nextcloud_mcp_server.vector.metrics_publisher import count_indexed
+from nextcloud_mcp_server.vector.metrics_publisher import (
+    count_hybrid_chunks,
+    count_indexed,
+)
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
 logger = logging.getLogger(__name__)
@@ -1150,10 +1155,23 @@ def configure_semantic_tools(mcp: FastMCP):
             # document fans out to ~N chunks.
             indexed_documents = 0
             indexed_chunks = 0
+            hybrid_chunks = 0
+            estimated_vector_bytes = 0
             try:
                 qdrant_client = await get_qdrant_client()
                 indexed_documents, indexed_chunks = await count_indexed(
                     qdrant_client, settings.get_collection_name()
+                )
+                # Hybrid chunks (dense-bearing) drive the vector-RAM footprint;
+                # keyword-index chunks are sparse-only and cost no dense RAM (#624).
+                hybrid_chunks = await count_hybrid_chunks(
+                    qdrant_client, settings.get_collection_name()
+                )
+                dim = get_embedding_service().get_dimension()
+                estimated_vector_bytes = int(
+                    estimate_vector_bytes(
+                        hybrid_chunks, dim, settings.vector_ram_hnsw_overhead_factor
+                    )
                 )
             except Exception as e:
                 logger.warning("Failed to query Qdrant for indexed counts: %s", e)
@@ -1172,6 +1190,8 @@ def configure_semantic_tools(mcp: FastMCP):
                 ingest_queue=settings.ingest_queue,
                 job_counts=pending.job_counts,
                 job_counts_by_queue=pending.job_counts_by_queue,
+                hybrid_chunks=hybrid_chunks,
+                estimated_vector_bytes=estimated_vector_bytes,
             )
 
         except Exception as e:

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -105,6 +105,27 @@ async def count_hybrid_chunks(
     return result.count
 
 
+async def estimate_hybrid_vector_bytes(
+    qdrant_client: AsyncQdrantClient,
+    collection: str,
+    overhead: float,
+    *,
+    exact: bool = True,
+) -> tuple[int, int]:
+    """Return ``(hybrid_chunks, estimated_vector_bytes)`` for the collection.
+
+    Single source of truth for the dense-vector RAM figure surfaced by the MCP
+    tool and the ``/api/v1/vector-sync/status`` HTTP route, so the two can't
+    drift. ``overhead`` is ``settings.vector_ram_hnsw_overhead_factor``;
+    ``estimated_vector_bytes`` is ``hybrid_chunks * dim * 4 * overhead`` (card
+    #624), rounded to an int for the response payloads.
+    """
+    hybrid_chunks = await count_hybrid_chunks(qdrant_client, collection, exact=exact)
+    dim = get_embedding_service().get_dimension()
+    estimated = int(estimate_vector_bytes(hybrid_chunks, dim, overhead))
+    return hybrid_chunks, estimated
+
+
 async def publish_vector_sync_metrics(
     task_producer: Any, document_receive_stream: Any
 ) -> None:

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -28,13 +28,19 @@ from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import FieldCondition, Filter, MatchValue
 
 from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.embedding import get_embedding_service
 from nextcloud_mcp_server.observability.metrics import (
+    estimate_vector_bytes,
     update_ingest_queue_depth,
+    update_vector_sync_estimated_vector_bytes,
     update_vector_sync_indexed_chunks,
     update_vector_sync_indexed_documents,
     update_vector_sync_pending_documents,
+    update_vector_sync_qdrant_vector_bytes,
+    update_vector_sync_qdrant_vectors,
     update_vector_sync_queue_size,
 )
+from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.ingest_status import get_ingest_pending
 from nextcloud_mcp_server.vector.placeholder import get_placeholder_filter
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
@@ -72,6 +78,31 @@ async def count_indexed(
         exact=exact,
     )
     return docs_result.count, chunks_result.count
+
+
+async def count_hybrid_chunks(
+    qdrant_client: AsyncQdrantClient, collection: str, *, exact: bool = True
+) -> int:
+    """Return the number of hybrid (dense-bearing) chunks in the collection.
+
+    Only ``index_mode == hybrid`` points carry a dense vector; keyword-index
+    points are sparse-only and cost no dense-vector RAM. This is the count that
+    drives the RAM estimate. Excludes in-flight placeholder points.
+    """
+    result = await qdrant_client.count(
+        collection_name=collection,
+        count_filter=Filter(
+            must=[
+                get_placeholder_filter(),
+                FieldCondition(
+                    key=payload_keys.INDEX_MODE,
+                    match=MatchValue(value=payload_keys.INDEX_MODE_HYBRID),
+                ),
+            ]
+        ),
+        exact=exact,
+    )
+    return result.count
 
 
 async def publish_vector_sync_metrics(
@@ -115,6 +146,42 @@ async def publish_vector_sync_metrics(
         update_vector_sync_indexed_chunks(chunks)
     except Exception as exc:  # noqa: BLE001 — metrics must not break ingest
         logger.warning("Failed to publish indexed-corpus gauges: %s", exc)
+
+    # Dense-vector RAM footprint (card #624) — the real hybrid-search cost driver
+    # that source-byte billing does not capture. Two independent views so the
+    # deterministic estimate can be validated against Qdrant's own reported count:
+    #   * estimate  = OUR hybrid chunk count (payload filter) * dim * 4 * overhead
+    #   * actuals   = Qdrant vectors_count (get_collection) * dim * 4 * overhead
+    # Separate try/except so a Qdrant hiccup here never blocks the gauges above.
+    try:
+        qdrant_client = await get_qdrant_client()
+        collection = settings.get_collection_name()
+        dim = get_embedding_service().get_dimension()
+        overhead = settings.vector_ram_hnsw_overhead_factor
+
+        hybrid_chunks = await count_hybrid_chunks(
+            qdrant_client, collection, exact=False
+        )
+        update_vector_sync_estimated_vector_bytes(
+            estimate_vector_bytes(hybrid_chunks, dim, overhead)
+        )
+
+        # Qdrant's own reported count as an independent reality check.
+        # ``vectors_count`` is optional/deprecated in the client model (often None);
+        # ``getattr`` keeps this robust across client versions and falls back to
+        # ``points_count``. It aggregates all named vectors / includes non-dense
+        # points, so it is a coarse upper bound, not a clean dense-only figure —
+        # the gap vs the estimate is the drift signal, not a bug.
+        info = await qdrant_client.get_collection(collection)
+        qdrant_count = getattr(info, "vectors_count", None)
+        if qdrant_count is None:
+            qdrant_count = info.points_count or 0
+        update_vector_sync_qdrant_vectors(qdrant_count)
+        update_vector_sync_qdrant_vector_bytes(
+            estimate_vector_bytes(qdrant_count, dim, overhead)
+        )
+    except Exception as exc:  # noqa: BLE001 — metrics must not break ingest
+        logger.warning("Failed to publish vector-RAM gauges: %s", exc)
 
 
 async def vector_sync_metrics_task(

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -352,6 +352,37 @@ def build_point_vector(
     return point_vector
 
 
+def _record_ingest_vector_cost(
+    *,
+    doc_type: str,
+    chunk_count: int,
+    source_bytes: int,
+    dense_for_doc: bool,
+    overhead: float,
+) -> None:
+    """Emit the observability-only dense-vector cost signals for one document.
+
+    Records the deterministic per-document RAM estimate (hybrid docs only —
+    keyword docs embed no dense vector, so the estimate would be 0 anyway, but
+    gating on the mode avoids a needless ``get_dimension`` call) and the
+    chunk-density histogram (every embedded doc). Card #624.
+
+    Best-effort by contract: this never raises. A metrics failure here must not
+    disturb the indexing path, so every failure mode is caught and logged with
+    its cause (matching the ``metrics_publisher`` gauge guards) rather than
+    propagating.
+    """
+    try:
+        if dense_for_doc:
+            dim = get_embedding_service().get_dimension()
+            record_estimated_vector_bytes(
+                doc_type, estimate_vector_bytes(chunk_count, dim, overhead)
+            )
+        record_chunk_density(doc_type, chunk_count, source_bytes)
+    except Exception as exc:  # noqa: BLE001 — cost metrics must not break indexing
+        logger.warning("vector-cost observability hook skipped: %s", exc)
+
+
 async def record_indexing_usage(
     *,
     enabled: bool,
@@ -1764,32 +1795,15 @@ async def _index_document(
     )
 
     # Observability-only cost signals (card #624), independent of USAGE_METERING.
-    # These never touch billing; they measure the true hybrid-search cost driver
-    # (dense-vector RAM) that source-byte billing does not capture. Best-effort:
-    # a metrics failure must never disturb indexing.
-    try:
-        # Deterministic per-document dense-vector RAM estimate, hybrid docs only —
-        # keyword docs embed no dense vector (estimate_vector_bytes returns 0, but
-        # gate on the mode too so we don't call get_dimension needlessly).
-        if dense_for_doc:
-            _dim = get_embedding_service().get_dimension()
-            record_estimated_vector_bytes(
-                doc_task.doc_type,
-                estimate_vector_bytes(
-                    len(chunk_texts),
-                    _dim,
-                    settings.vector_ram_hnsw_overhead_factor,
-                ),
-            )
-        # Chunk density (chunks per MB of source) for every embedded doc — the
-        # "density risk" distribution. Reuses the same source size as bytes_ingested.
-        record_chunk_density(
-            doc_task.doc_type,
-            len(chunk_texts),
-            ingested_byte_size(content_bytes, content),
-        )
-    except Exception:  # noqa: BLE001 — cost metrics must not break indexing
-        logger.warning("vector-cost observability hook skipped")
+    # Best-effort and self-contained in the helper so a metrics failure can never
+    # disturb indexing.
+    _record_ingest_vector_cost(
+        doc_type=doc_task.doc_type,
+        chunk_count=len(chunk_texts),
+        source_bytes=ingested_byte_size(content_bytes, content),
+        dense_for_doc=dense_for_doc,
+        overhead=settings.vector_ram_hnsw_overhead_factor,
+    )
 
     # Prepare Qdrant points
     indexed_at = int(time.time())

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -27,6 +27,8 @@ from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.embedding import get_bm25_service, get_embedding_service
 from nextcloud_mcp_server.models.deck import DeckCard
 from nextcloud_mcp_server.observability.metrics import (
+    estimate_vector_bytes,
+    record_chunk_density,
     record_document_chunks,
     record_document_dead_lettered,
     record_document_escalation,
@@ -34,6 +36,7 @@ from nextcloud_mcp_server.observability.metrics import (
     record_document_parse_failed,
     record_embedding,
     record_embedding_tokens,
+    record_estimated_vector_bytes,
     record_ingest_dropped,
     record_qdrant_operation,
     record_vector_sync_processing,
@@ -1759,6 +1762,34 @@ async def _index_document(
             _meter_pipeline_tier if isinstance(_meter_pipeline_tier, str) else None
         ),
     )
+
+    # Observability-only cost signals (card #624), independent of USAGE_METERING.
+    # These never touch billing; they measure the true hybrid-search cost driver
+    # (dense-vector RAM) that source-byte billing does not capture. Best-effort:
+    # a metrics failure must never disturb indexing.
+    try:
+        # Deterministic per-document dense-vector RAM estimate, hybrid docs only —
+        # keyword docs embed no dense vector (estimate_vector_bytes returns 0, but
+        # gate on the mode too so we don't call get_dimension needlessly).
+        if dense_for_doc:
+            _dim = get_embedding_service().get_dimension()
+            record_estimated_vector_bytes(
+                doc_task.doc_type,
+                estimate_vector_bytes(
+                    len(chunk_texts),
+                    _dim,
+                    settings.vector_ram_hnsw_overhead_factor,
+                ),
+            )
+        # Chunk density (chunks per MB of source) for every embedded doc — the
+        # "density risk" distribution. Reuses the same source size as bytes_ingested.
+        record_chunk_density(
+            doc_task.doc_type,
+            len(chunk_texts),
+            ingested_byte_size(content_bytes, content),
+        )
+    except Exception:  # noqa: BLE001 — cost metrics must not break indexing
+        logger.warning("vector-cost observability hook skipped")
 
     # Prepare Qdrant points
     indexed_at = int(time.time())

--- a/tests/unit/test_vector_ram_metrics.py
+++ b/tests/unit/test_vector_ram_metrics.py
@@ -1,0 +1,109 @@
+"""Unit tests for the dense-vector RAM cost observability helpers (card #624).
+
+Covers the pure estimate helper and the two ingest-time recorders in
+``observability/metrics.py``:
+
+- ``estimate_vector_bytes`` — the deterministic RAM model
+  (``chunks * dim * 4 * overhead``), with keyword/empty docs contributing 0.
+- ``record_estimated_vector_bytes`` — the per-document RAM counter.
+- ``record_chunk_density`` — the chunks-per-MB "density risk" histogram.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nextcloud_mcp_server.observability.metrics import (
+    DENSE_VECTOR_BYTES_PER_DIMENSION,
+    estimate_vector_bytes,
+    record_chunk_density,
+    record_estimated_vector_bytes,
+)
+
+pytestmark = pytest.mark.unit
+
+# ``metric_sample`` is provided as a shared fixture in tests/unit/conftest.py.
+
+
+class TestEstimateVectorBytes:
+    def test_basic_float32_times_overhead(self):
+        # 10 chunks * 1536 dims * 4 bytes (float32) * 1.5 overhead.
+        assert estimate_vector_bytes(10, 1536, 1.5) == pytest.approx(
+            10 * 1536 * DENSE_VECTOR_BYTES_PER_DIMENSION * 1.5
+        )
+
+    def test_overhead_of_one_is_raw_footprint(self):
+        assert estimate_vector_bytes(4, 384, 1.0) == pytest.approx(
+            4 * 384 * DENSE_VECTOR_BYTES_PER_DIMENSION
+        )
+
+    def test_zero_chunks_is_zero(self):
+        # A keyword-only document embeds no dense vector → no RAM.
+        assert estimate_vector_bytes(0, 1536, 1.5) == pytest.approx(0.0)
+
+    def test_negative_chunks_is_zero(self):
+        assert estimate_vector_bytes(-5, 1536, 1.5) == pytest.approx(0.0)
+
+    def test_zero_dimension_is_zero(self):
+        assert estimate_vector_bytes(10, 0, 1.5) == pytest.approx(0.0)
+
+
+class TestRecordEstimatedVectorBytes:
+    def test_positive_increments_counter(self, metric_sample):
+        labels = {"doc_type": "ut-ram-file"}
+        before = metric_sample("astrolabe_estimated_vector_bytes_total", labels)
+        record_estimated_vector_bytes("ut-ram-file", 92160.0)
+        assert metric_sample(
+            "astrolabe_estimated_vector_bytes_total", labels
+        ) == pytest.approx(before + 92160.0)
+
+    def test_zero_is_noop(self, metric_sample):
+        # Keyword docs pass a 0 estimate and must not advance the counter.
+        labels = {"doc_type": "ut-ram-keyword"}
+        record_estimated_vector_bytes("ut-ram-keyword", 0.0)
+        assert metric_sample(
+            "astrolabe_estimated_vector_bytes_total", labels
+        ) == pytest.approx(0.0)
+
+
+class TestRecordChunkDensity:
+    def test_observes_chunks_per_mb(self, metric_sample):
+        labels = {"doc_type": "ut-density-file"}
+        # 91 chunks from exactly 1 MB of source → 91 chunks/MB, the note's
+        # born-digital baseline.
+        record_chunk_density("ut-density-file", 91, 1_000_000)
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_count", labels
+        ) == pytest.approx(1.0)
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_sum", labels
+        ) == pytest.approx(91.0)
+
+    def test_dense_low_fill_doc_lands_in_upper_bucket(self, metric_sample):
+        # 200 chunks from 0.5 MB → 400 chunks/MB, well into the risky tail.
+        labels = {"doc_type": "ut-density-dense"}
+        record_chunk_density("ut-density-dense", 200, 500_000)
+        # The 91-chunks/MB bucket must NOT capture a 400/MB observation...
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_bucket",
+            {**labels, "le": "91.0"},
+        ) == pytest.approx(0.0)
+        # ...but the 500/MB bucket must.
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_bucket",
+            {**labels, "le": "500.0"},
+        ) == pytest.approx(1.0)
+
+    def test_zero_source_bytes_is_noop(self, metric_sample):
+        labels = {"doc_type": "ut-density-zerobytes"}
+        record_chunk_density("ut-density-zerobytes", 5, 0)
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_count", labels
+        ) == pytest.approx(0.0)
+
+    def test_zero_chunks_is_noop(self, metric_sample):
+        labels = {"doc_type": "ut-density-zerochunks"}
+        record_chunk_density("ut-density-zerochunks", 0, 1_000_000)
+        assert metric_sample(
+            "astrolabe_document_chunk_density_chunks_per_mb_count", labels
+        ) == pytest.approx(0.0)

--- a/tests/unit/test_vector_ram_metrics.py
+++ b/tests/unit/test_vector_ram_metrics.py
@@ -11,6 +11,9 @@ Covers the pure estimate helper and the two ingest-time recorders in
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 from nextcloud_mcp_server.observability.metrics import (
@@ -19,6 +22,7 @@ from nextcloud_mcp_server.observability.metrics import (
     record_chunk_density,
     record_estimated_vector_bytes,
 )
+from nextcloud_mcp_server.vector import processor as proc
 
 pytestmark = pytest.mark.unit
 
@@ -107,3 +111,70 @@ class TestRecordChunkDensity:
         assert metric_sample(
             "astrolabe_document_chunk_density_chunks_per_mb_count", labels
         ) == pytest.approx(0.0)
+
+
+class TestRecordIngestVectorCost:
+    """The best-effort ingest hook wiring (processor._record_ingest_vector_cost)."""
+
+    @pytest.fixture
+    def spies(self, monkeypatch) -> dict[str, MagicMock]:
+        s = {
+            "record_estimated_vector_bytes": MagicMock(),
+            "record_chunk_density": MagicMock(),
+        }
+        for name, mock in s.items():
+            monkeypatch.setattr(proc, name, mock)
+        monkeypatch.setattr(
+            proc,
+            "get_embedding_service",
+            lambda: SimpleNamespace(get_dimension=lambda: 1024),
+        )
+        return s
+
+    def test_hybrid_records_estimate_and_density(self, spies) -> None:
+        proc._record_ingest_vector_cost(
+            doc_type="file",
+            chunk_count=10,
+            source_bytes=1_000_000,
+            dense_for_doc=True,
+            overhead=1.5,
+        )
+        # Estimate = 10 * 1024 * 4 * 1.5.
+        spies["record_estimated_vector_bytes"].assert_called_once_with(
+            "file", 10 * 1024 * 4 * 1.5
+        )
+        spies["record_chunk_density"].assert_called_once_with("file", 10, 1_000_000)
+
+    def test_keyword_skips_estimate_but_records_density(self, spies) -> None:
+        proc._record_ingest_vector_cost(
+            doc_type="note",
+            chunk_count=4,
+            source_bytes=500_000,
+            dense_for_doc=False,
+            overhead=1.5,
+        )
+        # Keyword docs embed no dense vector — no RAM estimate row...
+        spies["record_estimated_vector_bytes"].assert_not_called()
+        # ...but density is still observed (it's a property of the content).
+        spies["record_chunk_density"].assert_called_once_with("note", 4, 500_000)
+
+    def test_exception_never_propagates(self, monkeypatch) -> None:
+        # A failure in the hook must not break indexing — it is swallowed+logged.
+        monkeypatch.setattr(
+            proc,
+            "get_embedding_service",
+            MagicMock(side_effect=RuntimeError("provider down")),
+        )
+        density = MagicMock()
+        monkeypatch.setattr(proc, "record_chunk_density", density)
+
+        # Must not raise.
+        proc._record_ingest_vector_cost(
+            doc_type="file",
+            chunk_count=10,
+            source_bytes=1_000_000,
+            dense_for_doc=True,
+            overhead=1.5,
+        )
+        # The exception short-circuited before the density call.
+        density.assert_not_called()

--- a/tests/unit/test_vector_sync_status_model.py
+++ b/tests/unit/test_vector_sync_status_model.py
@@ -34,3 +34,21 @@ def test_vector_sync_status_defaults_zeroed() -> None:
     assert data["indexed_documents"] == 0
     assert data["indexed_chunks"] == 0
     assert data["indexed_count"] == 0
+    # Vector-RAM cost fields (card #624) also default to 0.
+    assert data["hybrid_chunks"] == 0
+    assert data["estimated_vector_bytes"] == 0
+
+
+def test_vector_sync_status_ram_cost_fields() -> None:
+    """hybrid_chunks / estimated_vector_bytes carry the dense-vector RAM signal."""
+    response = VectorSyncStatusResponse(
+        indexed_documents=486,
+        indexed_chunks=16039,
+        hybrid_chunks=12000,
+        estimated_vector_bytes=73_728_000,
+        status="idle",
+        enabled=True,
+    )
+    data = response.model_dump()
+    assert data["hybrid_chunks"] == 12000
+    assert data["estimated_vector_bytes"] == 73_728_000

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -88,6 +88,130 @@ class TestCountIndexed:
         assert all(call.kwargs["exact"] is True for call in qc.count.await_args_list)
 
 
+class TestCountHybridChunks:
+    async def test_counts_hybrid_only(self) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(1234)
+
+        hybrid = await mp.count_hybrid_chunks(qc, _COLLECTION)
+
+        assert hybrid == 1234
+        assert qc.count.await_count == 1
+
+    async def test_filters_on_placeholder_and_hybrid_index_mode(self) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(3)
+
+        await mp.count_hybrid_chunks(qc, _COLLECTION)
+
+        flt = qc.count.await_args.kwargs["count_filter"]
+        # Excludes placeholders AND restricts to the hybrid (dense-bearing) mode.
+        assert _must_keys(flt) == ["is_placeholder", "index_mode"]
+        assert flt.must[0].match.value is False
+        assert flt.must[1].match.value == "hybrid"
+
+    async def test_exact_kwarg_forwarded(self) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(3)
+
+        await mp.count_hybrid_chunks(qc, _COLLECTION, exact=False)
+
+        assert qc.count.await_args.kwargs["exact"] is False
+
+
+class TestPublishVectorRamGauges:
+    """The dense-vector RAM gauges block of publish_vector_sync_metrics (#624)."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_settings(self, monkeypatch) -> None:
+        settings = SimpleNamespace(
+            ingest_queue="memory",
+            get_collection_name=lambda: _COLLECTION,
+            vector_ram_hnsw_overhead_factor=1.5,
+        )
+        monkeypatch.setattr(mp, "get_settings", lambda: settings)
+        monkeypatch.setattr(
+            mp, "get_ingest_pending", AsyncMock(return_value=IngestPending(pending=0))
+        )
+        # Dimension is a fixed 1024 for the estimate math.
+        monkeypatch.setattr(
+            mp,
+            "get_embedding_service",
+            lambda: SimpleNamespace(get_dimension=lambda: 1024),
+        )
+
+    @pytest.fixture
+    def ram_gauges(self, monkeypatch) -> dict[str, MagicMock]:
+        g = {
+            name: MagicMock()
+            for name in (
+                "update_vector_sync_estimated_vector_bytes",
+                "update_vector_sync_qdrant_vectors",
+                "update_vector_sync_qdrant_vector_bytes",
+            )
+        }
+        for name, mock in g.items():
+            monkeypatch.setattr(mp, name, mock)
+        return g
+
+    async def test_publishes_estimate_and_qdrant_actuals(
+        self, monkeypatch, ram_gauges
+    ) -> None:
+        qc = AsyncMock()
+        # count_indexed (2 calls) then count_hybrid_chunks (1 call).
+        qc.count.side_effect = [_count_obj(1000), _count_obj(200), _count_obj(600)]
+        qc.get_collection.return_value = SimpleNamespace(
+            vectors_count=700, points_count=1000
+        )
+        monkeypatch.setattr(mp, "get_qdrant_client", AsyncMock(return_value=qc))
+
+        await mp.publish_vector_sync_metrics(
+            task_producer=None, document_receive_stream=object()
+        )
+
+        # Estimate uses OUR hybrid count (600): 600 * 1024 * 4 * 1.5.
+        ram_gauges["update_vector_sync_estimated_vector_bytes"].assert_called_once_with(
+            600 * 1024 * 4 * 1.5
+        )
+        # Qdrant actuals use the reported vectors_count (700).
+        ram_gauges["update_vector_sync_qdrant_vectors"].assert_called_once_with(700)
+        ram_gauges["update_vector_sync_qdrant_vector_bytes"].assert_called_once_with(
+            700 * 1024 * 4 * 1.5
+        )
+
+    async def test_falls_back_to_points_count_when_vectors_count_none(
+        self, monkeypatch, ram_gauges
+    ) -> None:
+        qc = AsyncMock()
+        qc.count.side_effect = [_count_obj(1000), _count_obj(200), _count_obj(600)]
+        qc.get_collection.return_value = SimpleNamespace(
+            vectors_count=None, points_count=999
+        )
+        monkeypatch.setattr(mp, "get_qdrant_client", AsyncMock(return_value=qc))
+
+        await mp.publish_vector_sync_metrics(
+            task_producer=None, document_receive_stream=object()
+        )
+
+        ram_gauges["update_vector_sync_qdrant_vectors"].assert_called_once_with(999)
+
+    async def test_qdrant_failure_does_not_raise(self, monkeypatch, ram_gauges) -> None:
+        # get_collection raising must be swallowed — metrics can't disturb ingest.
+        qc = AsyncMock()
+        qc.count.side_effect = [_count_obj(1000), _count_obj(200), _count_obj(600)]
+        qc.get_collection.side_effect = RuntimeError("qdrant down")
+        monkeypatch.setattr(mp, "get_qdrant_client", AsyncMock(return_value=qc))
+
+        await mp.publish_vector_sync_metrics(
+            task_producer=None, document_receive_stream=object()
+        )
+
+        # The estimate gauge (computed before get_collection) still published;
+        # the Qdrant-actuals gauges did not (the exception short-circuited them).
+        ram_gauges["update_vector_sync_estimated_vector_bytes"].assert_called_once()
+        ram_gauges["update_vector_sync_qdrant_vectors"].assert_not_called()
+
+
 class TestPublishVectorSyncMetrics:
     @pytest.fixture(autouse=True)
     def _stub_settings(self, monkeypatch) -> None:

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -119,6 +119,25 @@ class TestCountHybridChunks:
         assert qc.count.await_args.kwargs["exact"] is False
 
 
+class TestEstimateHybridVectorBytes:
+    """Shared helper used by the MCP tool + HTTP status route (no drift)."""
+
+    async def test_returns_hybrid_count_and_estimate(self, monkeypatch) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(600)
+        monkeypatch.setattr(
+            mp,
+            "get_embedding_service",
+            lambda: SimpleNamespace(get_dimension=lambda: 1024),
+        )
+
+        hybrid, estimated = await mp.estimate_hybrid_vector_bytes(qc, _COLLECTION, 1.5)
+
+        assert hybrid == 600
+        # 600 * 1024 * 4 * 1.5, rounded to int for the response payload.
+        assert estimated == int(600 * 1024 * 4 * 1.5)
+
+
 class TestPublishVectorRamGauges:
     """The dense-vector RAM gauges block of publish_vector_sync_metrics (#624)."""
 


### PR DESCRIPTION
## Context

Astrolabe Cloud bills on **indexed source content** (`bytes_ingested`), but the real cost driver for hybrid search is the **dense-vector RAM footprint** in Qdrant — `hybrid_chunks × embedding_dim × 4 bytes (float32) × HNSW_overhead`. The 2026-07-06 cost-to-serve note flagged this "density risk" (born-digital ≈ 91 chunks/MB) and noted it was only *proxied* by `bytes_stored`/`pages_embedded`, never measured. Keyword-index docs are sparse-only → no dense RAM.

Before this PR: chunk *count* was loose observability (`astrolabe_document_chunks_total`, `mcp_vector_sync_indexed_chunks`), not split hybrid-vs-keyword, and nothing estimated or measured vector RAM. `record_indexing_usage()` even received `chunk_count` but used it only as an empty-batch guard.

**Scope: observability-only, single repo. No billing / control-plane / Stripe change.**

## Changes

- **Deterministic estimate at ingest** — `astrolabe_estimated_vector_bytes_total{doc_type}` (hybrid docs only; keyword→0), emitted alongside the existing metering hook in `processor.py`.
- **Chunk-density histogram** — `astrolabe_document_chunk_density_chunks_per_mb{doc_type}`, buckets `[1,5,10,20,40,60,91,120,160,200,300,500]` straddling the note's band so the risky dense/low-fill tail is visible; recorded for every embedded doc.
- **Periodic corpus gauges** — `mcp_vector_sync_estimated_vector_bytes` (our hybrid chunk count × dim × 4 × overhead) plus Qdrant `get_collection()` actuals `mcp_vector_sync_qdrant_vectors` / `_qdrant_vector_bytes`, so the estimate is validated against the store's own reported count.
- **`count_hybrid_chunks()`** splits hybrid (dense-bearing) vs keyword chunks via the `index_mode` payload filter.
- **Optional status fields** — `hybrid_chunks` + `estimated_vector_bytes` on `VectorSyncStatusResponse`, the `nc_get_vector_sync_status` tool, and `/api/v1/vector-sync/status`.
- **Config** — new `VECTOR_RAM_HNSW_OVERHEAD_FACTOR` (default 1.5), wired through all four dynaconf sites.

## Testing

- New `tests/unit/test_vector_ram_metrics.py`: estimate math, keyword→0 no-ops, density-histogram bucketing.
- Extended `tests/unit/vector/test_metrics_publisher.py`: `count_hybrid_chunks` filter shape, RAM-gauge publishing, `points_count` fallback, Qdrant-failure swallow.
- Extended `tests/unit/test_vector_sync_status_model.py` for the new fields.
- ruff / ruff format / ty clean; 2074 unit tests pass; local secrets scan clean.

### Follow-ups (tracked on Deck #624)

- Grafana panel + PrometheusRule live in `helm-charts` / `astrolabe-cloud-gitops` (out of this repo).
- Full-stack integration assertion against `:9090/metrics` needs the Docker stack (no dedicated `e2e` marker yet).
- The new public status fields are additive/backward-compatible, so Pact provider verification is unaffected; the authenticated-surface verification gap stays tracked on board 11.

Deck card: **#624** (board 9 — Platform Observability).

---

_This PR was generated with the help of AI, and reviewed by a Human_