### PR TITLE
fix(vector): add payload index for index_mode (RAM-gauge 400)

### DIFF
--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -101,6 +101,18 @@ _PAYLOAD_INDEX_FIELDS: dict[str, PayloadSchemaType] = {
     # search/access_filter.build_ownership_filter); KEYWORD indexes match array
     # membership element-wise. Idempotent startup migration.
     "acl_principals": PayloadSchemaType.KEYWORD,
+    # index_mode ("hybrid" | "keyword") is the per-document indexing mode written
+    # to every non-placeholder point (payload_keys.INDEX_MODE). The vector-RAM
+    # observability path (card #624) counts hybrid, dense-bearing chunks via
+    # count_hybrid_chunks -> FieldCondition(key="index_mode", match="hybrid") in
+    # the periodic metrics publisher AND the /vector-sync/status surfaces. Qdrant
+    # strict/server mode requires a payload index for every filtered field, so
+    # without this index that count 400s ("Index required but not found for
+    # index_mode") — the metrics guard swallows it, but the RAM gauges and the
+    # status hybrid_chunks/estimated_vector_bytes never populate. KEYWORD for the
+    # exact string match; idempotent startup migration like the fields above, so
+    # existing collections gain it with no content re-index and no operator action.
+    "index_mode": PayloadSchemaType.KEYWORD,
 }
 
 # Sentinel point that records "this collection has been backfilled to str

--- a/tests/unit/vector/test_qdrant_client.py
+++ b/tests/unit/vector/test_qdrant_client.py
@@ -111,6 +111,19 @@ def test_dead_letter_indexed_as_bool():
     assert _PAYLOAD_INDEX_FIELDS.get("dead_letter") == PayloadSchemaType.BOOL
 
 
+@pytest.mark.unit
+def test_index_mode_indexed_as_keyword():
+    """Card #624: the vector-RAM path filters on index_mode="hybrid".
+
+    count_hybrid_chunks (periodic metrics publisher + /vector-sync/status)
+    adds FieldCondition(key="index_mode", ...). Qdrant strict/server mode
+    requires a payload index for every filtered field, so without this the
+    count 400s ("Index required but not found for index_mode") and the RAM
+    gauges / hybrid_chunks stay empty. KEYWORD for the exact string match.
+    """
+    assert _PAYLOAD_INDEX_FIELDS.get("index_mode") == PayloadSchemaType.KEYWORD
+
+
 # ---------------------------------------------------------------------------
 # _ensure_payload_indexes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Re-indexing runs on the smoke-test and blackbox-demo tenants are logging:

```
Failed to publish vector-RAM gauges: Unexpected Response: 400 (Bad Request)
Bad request: Index required but not found for "index_mode" of one of the following
types: [keyword]. Help: Create an index for this key or use a different filter.
```

The vector-RAM observability path shipped in #1060 (card #624) counts hybrid,
dense-bearing chunks via `count_hybrid_chunks` →
`FieldCondition(key="index_mode", match="hybrid")`, used by the periodic metrics
publisher **and** the `/api/v1/vector-sync/status` + MCP status surfaces. Qdrant
strict/server mode requires a payload index for **every** filtered field, and
`index_mode` was never added to the index set — so the count `400`s.

The metrics guard swallows it (a warning, not a crash), but the consequence is
that `mcp_vector_sync_estimated_vector_bytes` / `_qdrant_vector_bytes` /
`_qdrant_vectors` gauges and the status `hybrid_chunks` / `estimated_vector_bytes`
fields stay empty.

## Fix

Add `index_mode` (`KEYWORD`) to `_PAYLOAD_INDEX_FIELDS` in `qdrant_client.py`.
`_ensure_payload_indexes` is idempotent and runs once at startup, so:

- **existing** collections (smoke, blackbox-demo, …) gain the index with **no
  content re-index and no operator action** — same migration path already used
  for `dead_letter`, `modified_at`, `file_path`, `etag`, `acl_principals`;
- **new** collections create it during setup.

Once deployed, the 400 warnings stop and the RAM gauges/status fields populate.

## Testing

- New `test_index_mode_indexed_as_keyword` contract test (mirrors the
  `modified_at` / `file_path` / `dead_letter` assertions).
- The existing exhaustive `test_ensure_payload_indexes_creates_each_field` (which
  iterates `_PAYLOAD_INDEX_FIELDS`) now covers the new field automatically.
- `tests/unit/vector/test_qdrant_client.py` — 37 passed; ruff / ruff format / ty clean; secrets scan clean.

Follow-up to #1060 (card #624).

---

_This PR was generated with the help of AI, and reviewed by a Human_