### PR TITLE
fix(ingest): reclaim jobs stranded in `doing` under a live worker

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -298,6 +298,15 @@ _DEFAULTS: dict[str, Any] = {
     # worker heartbeat is this many seconds stale (Deck #183). Default is well
     # above the longest expected document; raise it for slow embedding backends.
     "ingest_stalled_job_seconds": 300,
+    # Backstop reclaim: also re-queue a job stuck in ``doing`` for this many seconds
+    # regardless of worker liveness. The heartbeat threshold above only catches DEAD
+    # workers; a job whose OWN completion crashed (e.g. an unhandled queueing_lock
+    # UniqueViolation on the doing->todo retry) is stranded in ``doing`` under a LIVE,
+    # heart-beating worker and is invisible to the heartbeat sweep. Set well above the
+    # longest single process_document attempt — OCR batch polling releases the worker
+    # between polls (BatchPending -> retry_in), so a job never legitimately holds
+    # ``doing`` this long. (Deck: ingest doing-strand reclaim.)
+    "ingest_doing_max_seconds": 1800,
     # Delete succeeded ingest jobs (keeps the queue table lean + the KEDA
     # queue-depth metric clean). Set false to retain succeeded rows for audit
     # (note: indexing success is also recorded in logs/metrics regardless).
@@ -1081,6 +1090,7 @@ class Settings:
     ingest_queue: str | None = None  # memory | postgres
     mcp_role: str = "all"  # api | worker | all (Deck #183 two-pod model)
     ingest_stalled_job_seconds: int = 300  # crashed-worker reclaim threshold
+    ingest_doing_max_seconds: int = 1800  # backstop: reclaim live-worker doing strands
     ingest_delete_succeeded_jobs: bool = True  # drop succeeded ingest jobs
     ingest_listen_notify: bool = True  # False = poll-only (txn-mode pooler, Deck #424)
     ingest_escalation_enabled: bool = True  # per-tier queue-hop (Deck #323)
@@ -1791,6 +1801,7 @@ def get_settings() -> Settings:
         "ingest_queue": "INGEST_QUEUE",
         "mcp_role": "MCP_ROLE",
         "ingest_stalled_job_seconds": "INGEST_STALLED_JOB_SECONDS",
+        "ingest_doing_max_seconds": "INGEST_DOING_MAX_SECONDS",
         "ingest_delete_succeeded_jobs": "INGEST_DELETE_SUCCEEDED_JOBS",
         "ingest_listen_notify": "INGEST_LISTEN_NOTIFY",
         "ingest_escalation_enabled": "INGEST_ESCALATION_ENABLED",

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -302,10 +302,16 @@ _DEFAULTS: dict[str, Any] = {
     # regardless of worker liveness. The heartbeat threshold above only catches DEAD
     # workers; a job whose OWN completion crashed (e.g. an unhandled queueing_lock
     # UniqueViolation on the doing->todo retry) is stranded in ``doing`` under a LIVE,
-    # heart-beating worker and is invisible to the heartbeat sweep. Set well above the
-    # longest single process_document attempt — OCR batch polling releases the worker
-    # between polls (BatchPending -> retry_in), so a job never legitimately holds
-    # ``doing`` this long. (Deck: ingest doing-strand reclaim.)
+    # heart-beating worker and is invisible to the heartbeat sweep.
+    # This fires purely on time-in-``doing``, NOT on liveness, so it can't tell "stuck"
+    # from "legitimately slow": if a single HEALTHY process_document attempt ever ran
+    # past this, it'd be re-queued mid-flight and two workers could process the doc
+    # concurrently. That's safe ONLY because ingest re-runs are idempotent (uuid5
+    # Qdrant point IDs — see the queue module's "Design notes"), NOT because the
+    # reclaim distinguishes the two — so keep the default comfortably above the longest
+    # real single attempt. OCR batch polling releases the worker between polls
+    # (BatchPending -> retry_in), so a job never legitimately holds ``doing`` this
+    # long; 1800s is deep headroom. (Deck: ingest doing-strand reclaim.)
     "ingest_doing_max_seconds": 1800,
     # Delete succeeded ingest jobs (keeps the queue table lean + the KEDA
     # queue-depth metric clean). Set false to retain succeeded rows for audit

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -21,8 +21,10 @@ Design notes:
   deadlock a document if a worker crashed mid-job. The Qdrant upsert is
   idempotent (deterministic ``uuid5`` point IDs), so a concurrent/re-run is
   harmless; ``queueing_lock`` (partial-unique on ``status='todo'``) is enough to
-  dedupe enqueues, and :func:`reclaim_stalled_ingest_jobs` retries jobs orphaned
-  in ``doing`` by a crash.
+  dedupe enqueues, and :func:`reclaim_stalled_ingest_jobs` re-queues jobs stranded
+  in ``doing`` — both by a dead worker (heartbeat sweep) and by a live-worker strand
+  where the job's own completion crashed (time-in-``doing`` backstop; see its
+  docstring). That idempotent-re-run property is also what makes the backstop safe.
 - procrastinate is Postgres-only and uses asyncio; ``anyio`` runs natively on the
   asyncio backend, so the worker can call the anyio-based pipeline directly.
 - Tasks are defined on a :class:`procrastinate.Blueprint` so the connector is
@@ -267,7 +269,21 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
     by_heartbeat = await manager.get_stalled_jobs(seconds_since_heartbeat=stalled_after)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
+        # TODO(procrastinate): ``nb_seconds`` is deprecated upstream in favour of
+        # heartbeat-only detection and MAY be removed in a future major — at which
+        # point this call becomes a hard TypeError inside the periodic instead of a
+        # DeprecationWarning. ``pyproject`` pins ``procrastinate>=3.8`` with no upper
+        # bound, so a routine bump could trip it; when upstream signals removal, pin an
+        # upper bound or reimplement the started-based query directly. Kept because the
+        # heartbeat sweep structurally cannot see a live-worker strand (see above).
         by_started = await manager.get_stalled_jobs(nb_seconds=doing_max)
+    # Attribution for the summary log: how many stalled jobs the (new) time-in-doing
+    # backstop surfaced that the heartbeat sweep alone missed — the exact signal the
+    # motivating incident lacked (reclaimed=0 while jobs sat in ``doing``).
+    hb_ids = {job.id for job in by_heartbeat if job.id is not None}
+    n_started_only = len(
+        {job.id for job in by_started if job.id is not None and job.id not in hb_ids}
+    )
     seen: set[int] = set()
     stalled: list[Job] = []
     for job in (*by_heartbeat, *by_started):
@@ -324,10 +340,13 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
             errored += 1
     if reclaimed or discarded or errored:
         logger.warning(
-            "ingest.reclaimed_stalled_jobs reclaimed=%d discarded=%d errored=%d",
+            "ingest.reclaimed_stalled_jobs reclaimed=%d discarded=%d errored=%d "
+            "heartbeat=%d started_backstop=%d",
             reclaimed,
             discarded,
             errored,
+            len(hb_ids),
+            n_started_only,
         )
     else:
         # Visible heartbeat under verbose logging when debugging a suspected

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -33,6 +33,7 @@ Design notes:
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from types import TracebackType
@@ -219,11 +220,17 @@ async def process_document_task(
 
 
 async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> None:
-    """Re-queue ingest jobs orphaned in ``doing`` by a crashed worker.
+    """Re-queue ingest jobs stranded in ``doing``.
 
-    procrastinate prunes dead *workers* but does not reset their in-flight jobs;
-    without this they'd sit in ``doing`` forever. ``timestamp`` is procrastinate's
-    periodic-run marker (unused).
+    Two causes, two detections (see the sweep below):
+      * a **dead worker** — procrastinate prunes the worker but doesn't reset its
+        in-flight jobs, so they'd sit in ``doing`` forever (heartbeat sweep); and
+      * a **live-worker strand** — a job whose own completion crashed (e.g. an
+        unhandled ``queueing_lock`` collision on the ``doing``->``todo`` retry) is
+        left in ``doing`` under a still-heart-beating worker, invisible to the
+        heartbeat sweep, so a time-in-``doing`` backstop catches it.
+
+    ``timestamp`` is procrastinate's periodic-run marker (unused).
     """
     manager = context.app.job_manager
     settings = get_settings()
@@ -236,24 +243,53 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
         seconds=settings.ingest_reclaim_retry_delay_seconds
     )
     stalled_after = settings.ingest_stalled_job_seconds
+    doing_max = settings.ingest_doing_max_seconds
     reclaimed = 0
     discarded = 0
     errored = 0
-    # queue=None sweeps every queue, so an orphaned job on any tier queue is
-    # reclaimed regardless of which tier's worker happens to run this periodic.
-    # retry_job_by_id_async keeps the job on its own queue, so a stalled ``ocr``
-    # job re-runs on ``ingest-ocr`` (the ocr fleet), not the reclaiming worker's.
+    # Two complementary detections, de-duplicated by job id, both with queue=None so
+    # an orphan on ANY tier queue is reclaimed regardless of which tier's worker runs
+    # this periodic (retry_job_by_id_async keeps the job on its own queue, so a
+    # stalled ``ocr`` job re-runs on ``ingest-ocr``, not the reclaiming worker's):
     #
+    #  1. by heartbeat — jobs of a DEAD/stale/pruned worker (the common crash case).
+    #  2. by time-in-doing — jobs stuck in ``doing`` past ``doing_max`` even under a
+    #     LIVE worker. The heartbeat sweep structurally cannot see these: if a job's
+    #     OWN completion crashes — e.g. an unhandled ``queueing_lock`` UniqueViolation
+    #     when procrastinate's retry moves it ``doing``->``todo`` against a scanner-
+    #     deferred ``todo`` sibling (the lock's partial-unique index covers only
+    #     ``todo``) — the row is stranded in ``doing`` while the worker stays alive and
+    #     heart-beating, so ``select_stalled_jobs_by_heartbeat`` never returns it and
+    #     the job sits forever. ``nb_seconds`` (``select_stalled_jobs_by_started``) is
+    #     the only mechanism that catches it. procrastinate deprecation-warns that
+    #     path (upstream wants heartbeat-only), but heartbeats cannot cover a
+    #     live-worker strand, so we deliberately keep it and silence just that warning.
+    by_heartbeat = await manager.get_stalled_jobs(seconds_since_heartbeat=stalled_after)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        by_started = await manager.get_stalled_jobs(nb_seconds=doing_max)
+    seen: set[int] = set()
+    stalled: list[Job] = []
+    for job in (*by_heartbeat, *by_started):
+        if job.id is None or job.id in seen:
+            continue
+        seen.add(job.id)
+        stalled.append(job)
+
     # Each job is isolated: the retry UPDATE sets status='todo', which trips the
-    # partial-unique ``queueing_lock`` index if the scanner already re-queued the
-    # doc while it sat orphaned in ``doing`` (a fresh ``todo`` sibling holds the
-    # lock). Without per-job isolation the FIRST such UniqueViolation aborted the
-    # whole sweep, so every later orphan stayed in ``doing`` forever.
-    for job in await manager.get_stalled_jobs(seconds_since_heartbeat=stalled_after):
-        if job.id is None:
+    # partial-unique ``queueing_lock`` index if a ``todo`` sibling already holds the
+    # lock (the scanner re-queued the doc, or — for a live-worker strand — the sibling
+    # whose collision stranded this one is still queued). Without per-job isolation the
+    # FIRST such UniqueViolation aborted the whole sweep, so every later orphan stayed
+    # in ``doing`` forever.
+    for job in stalled:
+        job_id = job.id
+        if (
+            job_id is None
+        ):  # already filtered when building ``stalled``; narrows the type
             continue
         try:
-            await manager.retry_job_by_id_async(job_id=job.id, retry_at=retry_at)
+            await manager.retry_job_by_id_async(job_id=job_id, retry_at=retry_at)
             reclaimed += 1
         except UniqueViolation as exc:
             if exc.constraint_name != QUEUEING_LOCK_CONSTRAINT:
@@ -262,7 +298,7 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
                 # constraint today, but guard the assumption explicitly rather
                 # than deleting an unrelated job if procrastinate ever adds one:
                 # log + count it like any unexpected per-job error, don't delete.
-                logger.error("ingest.reclaim_retry_failed job_id=%s: %s", job.id, exc)
+                logger.error("ingest.reclaim_retry_failed job_id=%s: %s", job_id, exc)
                 errored += 1
                 continue
             # A live ``todo`` sibling with the same queueing_lock already exists
@@ -276,15 +312,15 @@ async def reclaim_stalled_ingest_jobs(context: JobContext, timestamp: int) -> No
             # failed / aborted.)
             try:
                 await manager.finish_job_by_id_async(
-                    job_id=job.id, status=Status.ABORTED, delete_job=True
+                    job_id=job_id, status=Status.ABORTED, delete_job=True
                 )
                 discarded += 1
             except Exception as exc:
-                logger.error("ingest.reclaim_discard_failed job_id=%s: %s", job.id, exc)
+                logger.error("ingest.reclaim_discard_failed job_id=%s: %s", job_id, exc)
                 errored += 1
         except Exception as exc:
             # Never let one bad job abort the sweep; the rest still get reclaimed.
-            logger.error("ingest.reclaim_retry_failed job_id=%s: %s", job.id, exc)
+            logger.error("ingest.reclaim_retry_failed job_id=%s: %s", job_id, exc)
             errored += 1
     if reclaimed or discarded or errored:
         logger.warning(

--- a/tests/integration/test_ingest_queue_postgres.py
+++ b/tests/integration/test_ingest_queue_postgres.py
@@ -156,7 +156,9 @@ async def test_reclaim_discards_real_queueing_lock_collision(fresh_app, monkeypa
         pq,
         "get_settings",
         lambda: types.SimpleNamespace(
-            ingest_stalled_job_seconds=0, ingest_reclaim_retry_delay_seconds=0
+            ingest_stalled_job_seconds=0,
+            ingest_doing_max_seconds=0,
+            ingest_reclaim_retry_delay_seconds=0,
         ),
     )
 
@@ -194,3 +196,72 @@ async def test_reclaim_discards_real_queueing_lock_collision(fresh_app, monkeypa
             )
         }
         assert by_status == {"todo": 1}  # orphan gone; the live sibling survives
+
+
+async def test_reclaim_backstops_live_worker_doing_strand(fresh_app, monkeypatch):
+    """Reclaim a job stranded in ``doing`` under a LIVE worker.
+
+    The heartbeat sweep only catches DEAD/pruned workers. When a job's OWN
+    completion crashes — e.g. procrastinate's ``doing``->``todo`` retry raises an
+    unhandled ``queueing_lock`` UniqueViolation against a scanner-deferred ``todo``
+    sibling — the row is left ``doing`` while its worker stays alive and
+    heart-beating, so ``select_stalled_jobs_by_heartbeat`` never returns it and the
+    job would sit forever (observed: 2 docs pinned ``doing``, reaper reclaimed=0).
+    The time-in-``doing`` backstop (``ingest_doing_max_seconds`` / by-started) must
+    reclaim it. Regression for the ingest doing-strand fix.
+    """
+    # Heartbeat threshold huge so the heartbeat sweep can NEVER be what catches the
+    # orphan; doing_max 0 so only the by-started backstop can.
+    monkeypatch.setattr(
+        pq,
+        "get_settings",
+        lambda: types.SimpleNamespace(
+            ingest_stalled_job_seconds=10**9,
+            ingest_doing_max_seconds=0,
+            ingest_reclaim_retry_delay_seconds=0,
+        ),
+    )
+
+    async with fresh_app.open_async():
+        producer = ProcrastinateTaskProducer(fresh_app)
+
+        # A LIVE worker (fresh heartbeat) — the orphan is owned by it, not a dead one.
+        worker = await fresh_app.connector.execute_query_one_async(
+            "INSERT INTO procrastinate_workers DEFAULT VALUES RETURNING id"
+        )
+        worker_id = worker["id"]
+
+        # Job A → todo, then strand it in ``doing`` OWNED BY THE LIVE WORKER, with a
+        # ``started`` event an hour in the past (its crashing attempt began long ago).
+        await producer.send(_task("1"))
+        job_a = await fresh_app.connector.execute_query_one_async(
+            "UPDATE procrastinate_jobs SET status='doing', worker_id=%(w)s "
+            "WHERE queue_name=%(q)s RETURNING id",
+            w=worker_id,
+            q=INGEST_QUEUE_NAME,
+        )
+        await fresh_app.connector.execute_query_async(
+            "INSERT INTO procrastinate_events (job_id, type, at) "
+            "VALUES (%(jid)s, 'started', NOW() - INTERVAL '1 hour')",
+            jid=job_a["id"],
+        )
+        # Scanner re-queues the doc → live todo sibling B, identical queueing_lock.
+        await producer.send(_task("1"))
+
+        # The heartbeat sweep is blind to it (worker alive, worker_id not null) — this
+        # is the exact gap the backstop closes.
+        hb = await fresh_app.job_manager.get_stalled_jobs(seconds_since_heartbeat=10**9)
+        assert list(hb) == []
+
+        ctx = cast(JobContext, types.SimpleNamespace(app=fresh_app))
+        await reclaim_stalled_ingest_jobs(ctx, timestamp=0)
+
+        by_status = {
+            r["status"]: r["n"]
+            for r in await fresh_app.connector.execute_query_all_async(
+                "SELECT status, count(*) AS n FROM procrastinate_jobs GROUP BY status"
+            )
+        }
+        # Backstop found A (by time-in-doing), retried it → collided with B →
+        # discarded the redundant orphan; the live sibling survives to run.
+        assert by_status == {"todo": 1}

--- a/tests/unit/vector/test_procrastinate_producer.py
+++ b/tests/unit/vector/test_procrastinate_producer.py
@@ -251,7 +251,9 @@ class TestReclaimStalledJobs:
                 self.id = id
 
         class FakeManager:
-            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+            async def get_stalled_jobs(
+                self, queue=None, seconds_since_heartbeat=0, nb_seconds=None
+            ):
                 # Reclaim sweeps EVERY queue (Deck #323), so no queue filter.
                 assert queue is None
                 return [Job(1), Job(2), Job(None)]  # None id is skipped
@@ -289,7 +291,9 @@ class TestReclaimStalledJobs:
                 self.id = id
 
         class FakeManager:
-            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+            async def get_stalled_jobs(
+                self, queue=None, seconds_since_heartbeat=0, nb_seconds=None
+            ):
                 return [Job(1), Job(2), Job(3)]
 
             async def retry_job_by_id_async(self, job_id, retry_at):
@@ -335,7 +339,9 @@ class TestReclaimStalledJobs:
                 self.id = id
 
         class FakeManager:
-            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+            async def get_stalled_jobs(
+                self, queue=None, seconds_since_heartbeat=0, nb_seconds=None
+            ):
                 return [Job(1), Job(2)]
 
             async def retry_job_by_id_async(self, job_id, retry_at):
@@ -369,7 +375,9 @@ class TestReclaimStalledJobs:
                 self.id = id
 
         class FakeManager:
-            async def get_stalled_jobs(self, queue=None, seconds_since_heartbeat=0):
+            async def get_stalled_jobs(
+                self, queue=None, seconds_since_heartbeat=0, nb_seconds=None
+            ):
                 return [Job(1), Job(2), Job(3)]
 
             async def retry_job_by_id_async(self, job_id, retry_at):


### PR DESCRIPTION
## Problem

Ingest `process_document` jobs can get stuck in procrastinate `doing` **forever**. Observed on `tenant-smoke-test-20260531`: 2 jobs pinned in `doing` for >1h (`astrolabe_ingest_queue_depth{queue="ingest-ocr",status="doing"}=2`, `todo=0`) while `reclaim_stalled_ingest_jobs` logged `reclaimed=0`.

## Root cause

The `queueing_lock` unique index is **partial on `status='todo'` only** (`procrastinate_jobs_queueing_lock_idx_v1 … WHERE status='todo'`), so a `doing` job and a scanner-deferred `todo` sibling for the same doc can coexist. When the running job's `TieredEscalationStrategy` retry moves it **`doing → todo`**, it collides with the sibling → `UniqueViolation` raised *inside procrastinate's job-completion path* → the worker's `_process_job` task crashes (`asyncio: Task exception was never retrieved … process job ingest:process_document[…] exception=UniqueViolation('queueing_lock')`) → the job is left in `doing` **under a still-live, heart-beating worker**.

`reclaim_stalled_ingest_jobs` swept only `get_stalled_jobs(seconds_since_heartbeat=…)`, whose SQL (`select_stalled_jobs_by_heartbeat`) returns jobs of **dead/stale/pruned workers only** — it can never see a job wedged under a live worker.

## Fix

Add a **time-in-`doing` backstop**: the reaper now also sweeps `get_stalled_jobs(nb_seconds=INGEST_DOING_MAX_SECONDS)` (`select_stalled_jobs_by_started`), which catches a strand regardless of worker liveness, de-dups by job id, and runs both detections through the existing retry / discard-on-collision path (PR #999). New `INGEST_DOING_MAX_SECONDS` (default 1800s — well above the longest single `process_document` attempt; OCR batch polling releases the worker between polls via `BatchPending → retry_in`, so a job never legitimately holds `doing` that long).

This mirrors how the **embedding gateway** avoids the whole class — a self-owned `claimed_at` lease that ages out regardless of worker liveness, plus CAS-guarded completion. The reaper-side collision was already fixed (PR #999); this closes the *same* collision on the job's own retry path.

## Tests

- **Real-Postgres regression** (`test_reclaim_backstops_live_worker_doing_strand`): strands a job in `doing` owned by a **live** worker (fresh heartbeat) with an old `started` event + a live `todo` sibling; asserts the heartbeat sweep returns `[]` (the exact blind spot) and the backstop reclaims/discards the orphan while the sibling survives.
- Existing `test_reclaim_discards_real_queueing_lock_collision` + unit fakes updated for the two-sweep signature. Full `TestReclaimStalledJobs` + the 3 Postgres tests pass.

## Ops

Un-sticks the class going forward. Already-stranded jobs (the 2 smoke-test docs) clear on the next reclaim tick once deployed, or immediately on a worker bounce.

---

_This PR was generated with the help of AI, and reviewed by a Human_