### PR TITLE
feat(chunker): greedy page-packing + chunking_config_version + density sweep harness

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -630,6 +630,8 @@ VECTOR_SYNC_QUEUE_MAX_SIZE=10000      # Max queued documents (default: 10000)
 # Document chunking settings (for vector embeddings)
 DOCUMENT_CHUNK_SIZE=2048              # Characters per chunk (default: 2048)
 DOCUMENT_CHUNK_OVERLAP=200            # Overlapping characters between chunks (default: 200)
+DOCUMENT_CHUNK_PAGE_PACK=false        # Merge consecutive sub-budget PDF pages into one chunk (default: false)
+CHUNKING_CONFIG_VERSION=1             # Chunker config generation; bump on any chunker behaviour change (default: 1)
 ```
 
 > **Note:** The `VECTOR_SYNC_*` tuning parameters keep their names as they're implementation details. Only the user-facing feature flag was renamed to `ENABLE_SEMANTIC_SEARCH`.
@@ -1070,6 +1072,8 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | `DOCUMENT_CHUNK_SIZE` | ⚠️ Optional | `2048` | Characters per chunk for document embedding |
 | `DOCUMENT_CHUNK_OVERLAP` | ⚠️ Optional | `200` | Overlapping characters between chunks (must be < chunk size) |
 | `DOCUMENT_CHUNK_PAGE_AWARE` | ⚠️ Optional | `true` | Split PDFs on page boundaries first (one chunk per page; oversized pages split within the page). Exact page numbers, clean snippets, and a predictable ~1 chunk/page when chunk size ≥ the largest page. Set `false` for the legacy char-based path. |
+| `DOCUMENT_CHUNK_PAGE_PACK` | ⚠️ Optional | `false` | Greedy page-packing (requires page-aware): merge consecutive sub-budget PDF pages into one chunk (page-range citation via `page_number`/`page_end`) instead of one-per-page. Cuts dense-vector density on lean-page/born-digital PDFs. Enabling it re-scales density fleet-wide — re-calibrate the storage rate first (Deck #636/#626). |
+| `CHUNKING_CONFIG_VERSION` | ⚠️ Optional | `1` | Chunker config generation stamped on the collection sentinel. Bump on any chunker behaviour change (size, overlap, page-aware, page-pack) so the pricing density reference can't silently go stale. |
 
 **Deprecated variables (still functional):**
 - `VECTOR_SYNC_ENABLED` - Use `ENABLE_SEMANTIC_SEARCH` instead (will be removed in v1.0.0)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -1177,6 +1177,17 @@ class Settings:
                 )
             logger.info("Using custom CA bundle: %s", self.nextcloud_ca_bundle)
 
+        # Page-packing is a sub-mode of page-aware chunking (the packing logic
+        # only runs inside the page-aware branch). Enabling it without page-aware
+        # is a silent no-op, so surface the misconfiguration at startup.
+        if self.document_chunk_page_pack and not self.document_chunk_page_aware:
+            logger.warning(
+                "DOCUMENT_CHUNK_PAGE_PACK is enabled but DOCUMENT_CHUNK_PAGE_AWARE "
+                "is disabled; page-packing only runs inside page-aware chunking, so "
+                "this setting has no effect. Enable DOCUMENT_CHUNK_PAGE_AWARE to "
+                "activate packing."
+            )
+
         # Surface the keep-alive opt-out at startup so an operator who set it to
         # work around #965 gets confirmation it took effect.
         if not self.nextcloud_http_keepalive:

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -170,6 +170,14 @@ _DEFAULTS: dict[str, Any] = {
     # first so no chunk spans a page (exact page_number, clean snippets, and
     # predictable ~1 chunk/page when chunk_size >= the largest page).
     "document_chunk_page_aware": True,
+    # Greedy page-packing (density fix, Deck #636): merge consecutive sub-budget
+    # pages into one chunk instead of one-per-page. Off by default until the
+    # post-change density re-measure + pricing re-calibration land.
+    "document_chunk_page_pack": False,
+    # Chunking config generation. Bump whenever chunker behaviour changes (size,
+    # overlap, page-aware, page-pack, split strategy) so the pricing model's
+    # density reference can't silently go stale. Pinned in stripe-catalog.tf.
+    "chunking_config_version": 1,
     # PDF parse isolation (OOM guard)
     "document_pdf_graphics_limit": 1000,
     "document_parse_timeout_seconds": 120.0,
@@ -456,6 +464,7 @@ _dynaconf = Dynaconf(
         Validator("PORT", gte=1, lte=65535),
         Validator("VERIFICATION_CONCURRENCY", gte=1),
         Validator("DOCUMENT_CHUNK_SIZE", gte=1),
+        Validator("CHUNKING_CONFIG_VERSION", gte=1),
         Validator("DOCUMENT_PARSE_TIMEOUT_SECONDS", gte=1),
         Validator("DOCUMENT_OCR_TIMEOUT_SECONDS", gte=1),
         # DOCUMENT_OCR_MODE is normalised + membership-checked in
@@ -998,6 +1007,17 @@ class Settings:
     # ~1 chunk/page when document_chunk_size >= the largest page. When False,
     # the legacy char-based path runs with post-hoc assign_page_numbers.
     document_chunk_page_aware: bool = True
+    # Greedy page-packing (Deck #636). When True, the page-aware chunker merges
+    # consecutive sub-budget pages into one chunk (page-range citation via
+    # page_number/page_end) instead of one-chunk-per-page — the density fix for
+    # lean-page/born-digital PDFs. Off by default: enabling it re-scales density
+    # fleet-wide and requires the storage-rate re-calibration first (#626).
+    document_chunk_page_pack: bool = False
+    # Chunking config generation. Bump on ANY chunker behaviour change (size,
+    # overlap, page-aware, page-pack, split strategy) so a change can't silently
+    # invalidate the €/GiB density reference. Stamped on the collection sentinel
+    # and pinned next to the density reference in stripe-catalog.tf + note 389935.
+    chunking_config_version: int = 1
 
     # PDF parse isolation (OOM guard). The parse runs in a subprocess so one
     # pathological file fails that doc, not the pod.
@@ -1768,6 +1788,8 @@ def get_settings() -> Settings:
         "document_chunk_size": "DOCUMENT_CHUNK_SIZE",
         "document_chunk_overlap": "DOCUMENT_CHUNK_OVERLAP",
         "document_chunk_page_aware": "DOCUMENT_CHUNK_PAGE_AWARE",
+        "document_chunk_page_pack": "DOCUMENT_CHUNK_PAGE_PACK",
+        "chunking_config_version": "CHUNKING_CONFIG_VERSION",
         "document_pdf_graphics_limit": "DOCUMENT_PDF_GRAPHICS_LIMIT",
         "document_parse_timeout_seconds": "DOCUMENT_PARSE_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -42,7 +42,12 @@ class SemanticSearchResult(BaseModel):
         default=None, description="Character position where chunk ends in document"
     )
     page_number: int | None = Field(
-        default=None, description="Page number for PDF documents"
+        default=None, description="First (or only) page for PDF documents"
+    )
+    page_end: int | None = Field(
+        default=None,
+        description="Last page for packed multi-page chunks; equals page_number "
+        "for single-page chunks",
     )
     page_count: int | None = Field(
         default=None, description="Total number of pages in PDF document"

--- a/nextcloud_mcp_server/search/algorithms.py
+++ b/nextcloud_mcp_server/search/algorithms.py
@@ -175,7 +175,9 @@ class SearchResult:
         metadata: Additional algorithm-specific metadata
         chunk_start_offset: Character position where chunk starts (None if not available)
         chunk_end_offset: Character position where chunk ends (None if not available)
-        page_number: Page number for PDF documents (None for other doc types)
+        page_number: First (or only) page for PDF documents (None for other doc types)
+        page_end: Last page for packed multi-page chunks; equals page_number for
+            single-page chunks (None for other doc types)
         page_count: Total number of pages in PDF document (None for other doc types)
         chunk_index: Zero-based index of this chunk in the document
         total_chunks: Total number of chunks in the document
@@ -191,6 +193,7 @@ class SearchResult:
     chunk_start_offset: int | None = None
     chunk_end_offset: int | None = None
     page_number: int | None = None
+    page_end: int | None = None
     page_count: int | None = None
     chunk_index: int = 0
     total_chunks: int = 1
@@ -273,6 +276,7 @@ def build_search_result_from_point(
         chunk_start_offset=point.payload.get("chunk_start_offset"),
         chunk_end_offset=point.payload.get("chunk_end_offset"),
         page_number=point.payload.get("page_number"),
+        page_end=point.payload.get("page_end"),
         page_count=point.payload.get("page_count"),
         chunk_index=point.payload.get("chunk_index", 0),
         total_chunks=point.payload.get("total_chunks", 1),

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -524,6 +524,7 @@ def configure_semantic_tools(mcp: FastMCP):
                         chunk_start_offset=r.chunk_start_offset,
                         chunk_end_offset=r.chunk_end_offset,
                         page_number=r.page_number,
+                        page_end=r.page_end,
                     )
                 )
 
@@ -597,6 +598,7 @@ def configure_semantic_tools(mcp: FastMCP):
                                     chunk_start_offset=result.chunk_start_offset,
                                     chunk_end_offset=result.chunk_end_offset,
                                     page_number=result.page_number,
+                                    page_end=result.page_end,
                                     # Context expansion fields
                                     has_context_expansion=True,
                                     marked_text=chunk_context.marked_text,

--- a/nextcloud_mcp_server/vector/collection_metadata.py
+++ b/nextcloud_mcp_server/vector/collection_metadata.py
@@ -68,6 +68,12 @@ def env_default_metadata(settings: Settings | None = None) -> dict[str, Any]:
         "chunking_config": {
             "chunk_size": s.document_chunk_size,
             "chunk_overlap": s.document_chunk_overlap,
+            # Full chunker config so a collection records exactly what produced
+            # its vectors — the density reference the €/GiB rate is pinned to
+            # (Deck #636). Bump ``version`` on any chunker behaviour change.
+            "page_aware": s.document_chunk_page_aware,
+            "page_pack": s.document_chunk_page_pack,
+            "version": s.chunking_config_version,
         },
     }
 

--- a/nextcloud_mcp_server/vector/document_chunker.py
+++ b/nextcloud_mcp_server/vector/document_chunker.py
@@ -226,6 +226,28 @@ class PageAwareChunker:
         )
         return chunks
 
+    def _split_oversized_page(
+        self, page_text: str, start: int, page: int
+    ) -> list[ChunkWithPosition]:
+        """Character-split a page that exceeds the budget within its own boundary.
+
+        Offsets stay absolute (into ``content``) and the page number is fixed —
+        an oversized page never spans a page range, so ``page_end == page``.
+        """
+        chunks: list[ChunkWithPosition] = []
+        for doc in self.splitter.create_documents([page_text]):
+            sub_start = start + doc.metadata.get("start_index", 0)
+            chunks.append(
+                ChunkWithPosition(
+                    text=doc.page_content,
+                    start_offset=sub_start,
+                    end_offset=sub_start + len(doc.page_content),
+                    page_number=page,
+                    page_end=page,
+                )
+            )
+        return chunks
+
     def _chunk_by_page(
         self, content: str, page_boundaries: list[dict[str, Any]]
     ) -> list[ChunkWithPosition]:
@@ -259,19 +281,8 @@ class PageAwareChunker:
                 )
                 continue
 
-            # Oversized page: split within the page only, keeping offsets
-            # absolute and the page number fixed.
-            for doc in self.splitter.create_documents([page_text]):
-                sub_start = start + doc.metadata.get("start_index", 0)
-                chunks.append(
-                    ChunkWithPosition(
-                        text=doc.page_content,
-                        start_offset=sub_start,
-                        end_offset=sub_start + len(doc.page_content),
-                        page_number=page,
-                        page_end=page,
-                    )
-                )
+            # Oversized page: split within the page only.
+            chunks.extend(self._split_oversized_page(page_text, start, page))
         return chunks
 
     def _chunk_by_page_packed(
@@ -332,17 +343,7 @@ class PageAwareChunker:
                 # An oversized page cannot join a pack: flush the pending pack,
                 # then character-split the page within its own boundary.
                 flush()
-                for doc in self.splitter.create_documents([page_text]):
-                    sub_start = start + doc.metadata.get("start_index", 0)
-                    chunks.append(
-                        ChunkWithPosition(
-                            text=doc.page_content,
-                            start_offset=sub_start,
-                            end_offset=sub_start + len(doc.page_content),
-                            page_number=page,
-                            page_end=page,
-                        )
-                    )
+                chunks.extend(self._split_oversized_page(page_text, start, page))
                 continue
 
             if pack_start is None:

--- a/nextcloud_mcp_server/vector/document_chunker.py
+++ b/nextcloud_mcp_server/vector/document_chunker.py
@@ -17,7 +17,9 @@ class ChunkWithPosition:
     text: str
     start_offset: int  # Character position where chunk starts
     end_offset: int  # Character position where chunk ends (exclusive)
-    page_number: int | None = None  # Page number for PDF chunks (optional)
+    page_number: int | None = None  # First (or only) page for PDF chunks (optional)
+    page_end: int | None = None  # Last page for packed multi-page chunks; equals
+    # ``page_number`` for single-page chunks. None for non-paginated content.
     metadata: dict | None = None  # Additional processor-specific metadata (optional)
 
 
@@ -120,22 +122,39 @@ class PageAwareChunker:
 
     Page numbers are assigned inline, so callers must NOT additionally run
     ``assign_page_numbers`` on the result.
+
+    When ``pack_pages`` is enabled, consecutive sub-budget pages are greedily
+    merged into a single chunk (up to ``chunk_size``) instead of one chunk per
+    page — the density fix for lean-page PDFs (forms, slides, lean prose) where
+    the per-page floor mints a full dense vector per near-empty page (Deck #636).
+    Packed chunks span a page RANGE: ``page_number`` is the first page and
+    ``page_end`` the last, so page-level citation survives packing. The
+    single-page invariant above holds only when ``pack_pages`` is False.
     """
 
-    def __init__(self, chunk_size: int = 2048, overlap: int = 200):
+    def __init__(
+        self, chunk_size: int = 2048, overlap: int = 200, pack_pages: bool = False
+    ):
         """
         Initialize page-aware chunker.
 
         Args:
             chunk_size: Number of characters per chunk (default: 2048). Pages at
-                or below this size become a single chunk; larger pages are
-                character-split (with overlap) within the page only.
+                or below this size become a single chunk (or, with
+                ``pack_pages``, are merged with neighbours up to this budget);
+                larger pages are character-split (with overlap) within the page
+                only.
             overlap: Overlapping characters between sub-chunks of an oversized
                 page (default: 200). Pages that fit in one chunk carry no
                 overlap.
+            pack_pages: When True, greedily merge consecutive sub-budget pages
+                into one chunk (page-range citation preserved via
+                ``page_number``/``page_end``). Default False keeps the legacy
+                one-chunk-per-page behaviour.
         """
         self.chunk_size = chunk_size
         self.overlap = overlap
+        self.pack_pages = pack_pages
 
         # Only used for pages that exceed chunk_size. Same hierarchical splitter
         # as DocumentChunker so oversized pages keep semantic-boundary splitting.
@@ -187,19 +206,23 @@ class PageAwareChunker:
                 for doc in docs
             ]
 
+        splitter = (
+            self._chunk_by_page_packed if self.pack_pages else self._chunk_by_page
+        )
         chunks = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
-            self._chunk_by_page,
+            splitter,
             content,
             page_boundaries,
         )
 
         logger.debug(
             "Page-aware chunked document into %s chunks across %s pages "
-            "(chunk_size=%s, overlap=%s)",
+            "(chunk_size=%s, overlap=%s, pack_pages=%s)",
             len(chunks),
             len(page_boundaries),
             self.chunk_size,
             self.overlap,
+            self.pack_pages,
         )
         return chunks
 
@@ -231,6 +254,7 @@ class PageAwareChunker:
                         start_offset=chunk_start,
                         end_offset=chunk_start + len(stripped),
                         page_number=page,
+                        page_end=page,
                     )
                 )
                 continue
@@ -245,6 +269,95 @@ class PageAwareChunker:
                         start_offset=sub_start,
                         end_offset=sub_start + len(doc.page_content),
                         page_number=page,
+                        page_end=page,
                     )
                 )
+        return chunks
+
+    def _chunk_by_page_packed(
+        self, content: str, page_boundaries: list[dict[str, Any]]
+    ) -> list[ChunkWithPosition]:
+        """Greedy page-packing variant of :meth:`_chunk_by_page`.
+
+        Merges consecutive sub-budget pages into a single chunk (spanning a page
+        range) instead of emitting one chunk per page. Oversized pages still
+        split within-page (they can't join a pack); blank pages are still
+        skipped. Because the extractor joins pages with no separator, a pack is
+        exactly the contiguous slice ``content[pack_start:pack_end]`` and the
+        pre-strip span is bounded by ``chunk_size`` (no chunk exceeds budget).
+        Runs in a worker thread (CPU-bound).
+        """
+        chunks: list[ChunkWithPosition] = []
+        # Open pack: character span into ``content`` + covered page range.
+        pack_start: int | None = None
+        pack_end = 0
+        first_page = 0
+        last_page = 0
+
+        def flush() -> None:
+            nonlocal pack_start
+            if pack_start is None:
+                return
+            raw = content[pack_start:pack_end]
+            stripped = raw.strip()
+            # A pack only opens on a non-blank page, so ``stripped`` is normally
+            # non-empty; the guard keeps an all-whitespace pack from minting a
+            # vector (parity with the blank-page skip).
+            if stripped:
+                lead = len(raw) - len(raw.lstrip())
+                chunk_start = pack_start + lead
+                chunks.append(
+                    ChunkWithPosition(
+                        text=stripped,
+                        start_offset=chunk_start,
+                        end_offset=chunk_start + len(stripped),
+                        page_number=first_page,
+                        page_end=last_page,
+                    )
+                )
+            pack_start = None
+
+        for boundary in page_boundaries:
+            page = boundary["page"]
+            start = boundary["start_offset"]
+            end = boundary["end_offset"]
+            page_text = content[start:end]
+
+            # Skip blank pages (no wasted vector). A blank page interior to a
+            # pack contributes only whitespace to the contiguous slice.
+            if not page_text.strip():
+                continue
+
+            if len(page_text) > self.chunk_size:
+                # An oversized page cannot join a pack: flush the pending pack,
+                # then character-split the page within its own boundary.
+                flush()
+                for doc in self.splitter.create_documents([page_text]):
+                    sub_start = start + doc.metadata.get("start_index", 0)
+                    chunks.append(
+                        ChunkWithPosition(
+                            text=doc.page_content,
+                            start_offset=sub_start,
+                            end_offset=sub_start + len(doc.page_content),
+                            page_number=page,
+                            page_end=page,
+                        )
+                    )
+                continue
+
+            if pack_start is None:
+                # Open a new pack on this page.
+                pack_start, pack_end = start, end
+                first_page = last_page = page
+            elif end - pack_start <= self.chunk_size:
+                # Extend the pack to include this contiguous page.
+                pack_end = end
+                last_page = page
+            else:
+                # Adding this page would overflow the budget: flush and reopen.
+                flush()
+                pack_start, pack_end = start, end
+                first_page = last_page = page
+
+        flush()
         return chunks

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -297,6 +297,18 @@ def assign_page_numbers(chunks, page_boundaries):
             chunk.page_number = assigned_page
 
 
+def resolve_page_end(chunk: ChunkWithPosition) -> int | None:
+    """Citation end-page for a chunk's Qdrant payload (Deck #636).
+
+    Packed multi-page chunks carry a real ``page_end`` (last page of the range);
+    every other chunk leaves it ``None`` — notably the char-based path, where
+    :func:`assign_page_numbers` back-fills ``page_number`` post-hoc but never
+    ``page_end``. Fall back to ``page_number`` so the payload always ships a
+    citation range (single-page chunks report ``page_end == page_number``).
+    """
+    return chunk.page_end if chunk.page_end is not None else chunk.page_number
+
+
 def should_use_page_aware(
     *, page_aware_enabled: bool, doc_type: str, page_boundaries: Any
 ) -> bool:
@@ -1881,7 +1893,7 @@ async def _index_document(
         # Last page of a packed multi-page chunk (Deck #636); falls back to
         # page_number for single-page and char-path chunks so the citation
         # range is always set.
-        page_end = chunk.page_end if chunk.page_end is not None else chunk.page_number
+        page_end = resolve_page_end(chunk)
 
         points.append(
             PointStruct(

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1481,6 +1481,7 @@ async def _index_document(
             chunks = await PageAwareChunker(
                 chunk_size=settings.document_chunk_size,
                 overlap=settings.document_chunk_overlap,
+                pack_pages=settings.document_chunk_page_pack,
             ).chunk_text(content, page_boundaries_list)
         else:
             chunks = await DocumentChunker(
@@ -1934,6 +1935,12 @@ async def _index_document(
                             "mime_type": content_type,  # From WebDAV response
                             "file_size": file_metadata.get("file_size"),
                             "page_number": chunk.page_number,
+                            # Last page of a packed multi-page chunk (Deck #636);
+                            # falls back to page_number for single-page and
+                            # char-path chunks so citation range is always set.
+                            "page_end": chunk.page_end
+                            if chunk.page_end is not None
+                            else chunk.page_number,
                             "page_count": file_metadata.get("page_count"),
                             "author": file_metadata.get("author"),
                             "creation_date": file_metadata.get("creation_date"),

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1878,6 +1878,11 @@ async def _index_document(
             sparse_emb, dense_embeddings, i, dense_enabled=dense_for_doc
         )
 
+        # Last page of a packed multi-page chunk (Deck #636); falls back to
+        # page_number for single-page and char-path chunks so the citation
+        # range is always set.
+        page_end = chunk.page_end if chunk.page_end is not None else chunk.page_number
+
         points.append(
             PointStruct(
                 id=point_id,
@@ -1935,12 +1940,7 @@ async def _index_document(
                             "mime_type": content_type,  # From WebDAV response
                             "file_size": file_metadata.get("file_size"),
                             "page_number": chunk.page_number,
-                            # Last page of a packed multi-page chunk (Deck #636);
-                            # falls back to page_number for single-page and
-                            # char-path chunks so citation range is always set.
-                            "page_end": chunk.page_end
-                            if chunk.page_end is not None
-                            else chunk.page_number,
+                            "page_end": page_end,
                             "page_count": file_metadata.get("page_count"),
                             "author": file_metadata.get("author"),
                             "creation_date": file_metadata.get("creation_date"),

--- a/scripts/chunk_density_sweep.py
+++ b/scripts/chunk_density_sweep.py
@@ -61,6 +61,23 @@ DEFAULT_CORPUS = Path("~/Downloads/OHR-Bench").expanduser()
 DEFAULT_CHUNK_SIZES = (2048, 4096)
 
 
+def _safe_output_path(raw: str) -> Path:
+    """Resolve a user-supplied ``--output`` path, confined to the working tree.
+
+    The report is dev output, but the path comes from a CLI argument, so refuse
+    anything that resolves outside the current working directory (defends against
+    ``../`` traversal / absolute-path escape when the script is driven by an
+    agent or wrapper).
+    """
+    base = Path.cwd().resolve()
+    resolved = (base / raw).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ValueError(
+            f"--output must stay within {base}, refusing to write {resolved}"
+        )
+    return resolved
+
+
 @dataclass(frozen=True)
 class ChunkerConfig:
     """A named chunker configuration under test."""
@@ -260,8 +277,9 @@ def main() -> None:
     report = anyio.run(run, args)
     print_table(report)
     if args.output:
-        Path(args.output).write_text(json.dumps(report, indent=2))
-        print(f"Wrote {args.output}")
+        out_path = _safe_output_path(args.output)
+        out_path.write_text(json.dumps(report, indent=2))
+        print(f"Wrote {out_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/chunk_density_sweep.py
+++ b/scripts/chunk_density_sweep.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Offline chunk-density sweep for chunker-config A/B (Deck #636 / #626).
+
+Measures **chunks/MB** — the dense-vector density that drives the hybrid storage
+cost-to-serve — for candidate chunker configs, WITHOUT re-indexing any tenant or
+touching billing. Use it to pick a config before the fleet-wide re-index +
+storage-rate re-calibration (the live re-measure in note 389935 is the
+authoritative fleet number; this is the fast pre-flight).
+
+Density is computed with the SAME formula as the production metric
+``record_chunk_density`` (``nextcloud_mcp_server/observability/metrics.py``):
+
+    chunks_per_mb = chunk_count / (source_bytes / 1_000_000)   # decimal MB
+
+``source_bytes`` is the raw PDF byte size, matching ``ingested_byte_size(...)``
+for files (the raw WebDAV binary size the histogram observes).
+
+Corpus: OHR-Bench (``~/Downloads/OHR-Bench``, 1,261 PDFs across academic /
+administration / finance / law / manual / news / textbook — the same docs live
+in the smoke-test tenant). QA pairs for a retrieval-rank quality check live in
+``~/Software/OHR-Bench/data/qas.json``; the existing A/B retrieval harness under
+``~/Software/OHR-Bench/astrolabe/`` (+ ``ocr_bench/ab_run.py``) drives retrieval
+against a running stack. This script deliberately covers only the density half —
+the pricing-relevant number — and leaves retrieval quality to that harness.
+
+Reuses repo primitives only (no network): ``PyMuPDFProcessor`` for extraction →
+``page_boundaries``, then ``DocumentChunker`` / ``PageAwareChunker`` (incl. the
+``pack_pages`` variant).
+
+Examples
+--------
+    # Quick look: 15 PDFs/category, default configs, table output
+    uv run python -m scripts.chunk_density_sweep --limit 15
+
+    # Full sweep to JSON for the pricing re-calibration hand-off
+    uv run python -m scripts.chunk_density_sweep --output sweep.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import anyio
+
+# Tier-1 fast extractor (pypdfium2). Used directly — not via the registry — so
+# the sweep skips the subprocess OOM-guard isolation that needs a running-service
+# context. Matches the production born-digital path AND OHR-Bench's
+# ``retrieval_base/pypdfium2_fast``.
+from nextcloud_mcp_server.document_processors.pypdfium2_fast import _extract
+from nextcloud_mcp_server.vector.document_chunker import (
+    DocumentChunker,
+    PageAwareChunker,
+)
+
+DEFAULT_CORPUS = Path("~/Downloads/OHR-Bench").expanduser()
+DEFAULT_CHUNK_SIZES = (2048, 4096)
+
+
+@dataclass(frozen=True)
+class ChunkerConfig:
+    """A named chunker configuration under test."""
+
+    name: str
+    chunk_size: int
+    page_aware: bool
+    pack_pages: bool
+
+    async def chunk_count(self, content: str, page_boundaries: list[dict]) -> int:
+        """Number of chunks this config produces for one document."""
+        if self.page_aware and page_boundaries:
+            chunks = await PageAwareChunker(
+                chunk_size=self.chunk_size, pack_pages=self.pack_pages
+            ).chunk_text(content, page_boundaries)
+        else:
+            chunks = await DocumentChunker(chunk_size=self.chunk_size).chunk_text(
+                content
+            )
+        return len(chunks)
+
+
+def build_configs(chunk_sizes: tuple[int, ...]) -> list[ChunkerConfig]:
+    """The sweep matrix: {page-aware, page-aware+pack} × chunk_size.
+
+    ``page-aware`` (pack off) is today's production baseline; ``+pack`` is the
+    Deck #636 density fix. A larger chunk_size multiplies the pack win.
+    """
+    configs: list[ChunkerConfig] = []
+    for cs in chunk_sizes:
+        configs.append(
+            ChunkerConfig(f"page-aware@{cs}", cs, page_aware=True, pack_pages=False)
+        )
+        configs.append(
+            ChunkerConfig(f"page-pack@{cs}", cs, page_aware=True, pack_pages=True)
+        )
+    return configs
+
+
+@dataclass
+class ConfigStats:
+    """Accumulated per-config chunks/MB samples (one per document)."""
+
+    densities: list[float] = field(default_factory=list)
+    total_chunks: int = 0
+    total_bytes: int = 0
+
+    def add(self, chunks: int, source_bytes: int) -> None:
+        if source_bytes > 0 and chunks > 0:
+            self.densities.append(chunks / (source_bytes / 1_000_000))
+            self.total_chunks += chunks
+            self.total_bytes += source_bytes
+
+    def summary(self) -> dict[str, float]:
+        if not self.densities:
+            return {"n": 0}
+        ds = sorted(self.densities)
+        return {
+            "n": len(ds),
+            "mean": round(statistics.fmean(ds), 1),
+            "p50": round(_pct(ds, 0.50), 1),
+            "p90": round(_pct(ds, 0.90), 1),
+            "p99": round(_pct(ds, 0.99), 1),
+            # Byte-weighted density (matches the live indexed_chunks/bytes_processed
+            # cross-check in note 389935 — diverges from doc-mean on mixed corpora).
+            "byte_weighted": round(
+                self.total_chunks / (self.total_bytes / 1_000_000), 1
+            ),
+            # Implied dense-RAM carry €/GiB-mo (6,144 B/point × €1.75/GB-mo).
+            "eur_per_gib_mo": round(statistics.fmean(ds) * 0.01101, 2),
+        }
+
+
+def _pct(sorted_vals: list[float], q: float) -> float:
+    """Nearest-rank percentile (matches the histogram's coarse buckets well enough)."""
+    if not sorted_vals:
+        return 0.0
+    idx = min(len(sorted_vals) - 1, int(round(q * (len(sorted_vals) - 1))))
+    return sorted_vals[idx]
+
+
+def iter_pdfs(
+    corpus: Path, categories: list[str] | None, limit: int | None
+) -> Iterator[tuple[str, Path]]:
+    """Yield (category, pdf_path) for PDFs under the corpus, capped per category."""
+    cats = categories or sorted(p.name for p in corpus.iterdir() if p.is_dir())
+    for cat in cats:
+        cat_dir = corpus / cat
+        if not cat_dir.is_dir():
+            continue
+        pdfs = sorted(cat_dir.rglob("*.pdf"))
+        if limit is not None:
+            pdfs = pdfs[:limit]
+        for pdf in pdfs:
+            yield cat, pdf
+
+
+async def run(args: argparse.Namespace) -> dict:
+    corpus = Path(args.corpus).expanduser()
+    if not corpus.is_dir():
+        raise SystemExit(f"corpus not found: {corpus}")
+
+    configs = build_configs(tuple(args.chunk_sizes))
+    # category -> config-name -> ConfigStats
+    stats: dict[str, dict[str, ConfigStats]] = {}
+    overall: dict[str, ConfigStats] = {c.name: ConfigStats() for c in configs}
+    processed = 0
+    skipped = 0
+
+    for category, pdf in iter_pdfs(corpus, args.categories, args.limit):
+        try:
+            pdf_bytes = pdf.read_bytes()
+            text, metadata = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
+                _extract, pdf_bytes
+            )
+        except Exception as exc:  # noqa: BLE001 — a bad PDF must not abort the sweep
+            skipped += 1
+            if args.verbose:
+                print(f"  skip {pdf.name}: {exc}")
+            continue
+        if not text:
+            skipped += 1
+            continue
+
+        source_bytes = len(pdf_bytes)  # raw binary size — matches the live metric
+        boundaries = metadata.get("page_boundaries") or []
+        cat_stats = stats.setdefault(category, {c.name: ConfigStats() for c in configs})
+        for cfg in configs:
+            n = await cfg.chunk_count(text, boundaries)
+            cat_stats[cfg.name].add(n, source_bytes)
+            overall[cfg.name].add(n, source_bytes)
+        processed += 1
+        if args.verbose and processed % 25 == 0:
+            print(f"  ...{processed} PDFs processed")
+
+    report = {
+        "corpus": str(corpus),
+        "processed": processed,
+        "skipped": skipped,
+        "configs": [c.name for c in configs],
+        "per_category": {
+            cat: {name: s.summary() for name, s in by_cfg.items()}
+            for cat, by_cfg in stats.items()
+        },
+        "overall": {name: s.summary() for name, s in overall.items()},
+    }
+    return report
+
+
+def print_table(report: dict) -> None:
+    print(
+        f"\nChunk-density sweep — {report['processed']} PDFs "
+        f"({report['skipped']} skipped) from {report['corpus']}\n"
+    )
+    header = f"{'config':<18}{'n':>6}{'mean':>8}{'p50':>7}{'p90':>7}{'p99':>7}{'byteW':>8}{'€/GiB':>8}"
+    for scope, block in (
+        ("OVERALL", report["overall"]),
+        *report["per_category"].items(),
+    ):
+        print(f"— {scope} —")
+        print(header)
+        for name, s in block.items():
+            if s.get("n"):
+                print(
+                    f"{name:<18}{s['n']:>6}{s['mean']:>8}{s['p50']:>7}{s['p90']:>7}"
+                    f"{s['p99']:>7}{s['byte_weighted']:>8}{s['eur_per_gib_mo']:>8}"
+                )
+        print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", default=str(DEFAULT_CORPUS))
+    parser.add_argument(
+        "--categories",
+        nargs="*",
+        default=None,
+        help="Subset of category dirs (default: all under corpus)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max PDFs per category (default: all)",
+    )
+    parser.add_argument(
+        "--chunk-sizes",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_CHUNK_SIZES),
+        dest="chunk_sizes",
+    )
+    parser.add_argument("--output", default=None, help="Write full report JSON here")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    report = anyio.run(run, args)
+    print_table(report)
+    if args.output:
+        Path(args.output).write_text(json.dumps(report, indent=2))
+        print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_pdf_page_packing.py
+++ b/tests/integration/test_pdf_page_packing.py
@@ -1,0 +1,133 @@
+"""Integration test for greedy page-packing (Deck #636).
+
+Drives the real extraction path (pypdfium2 -> page_boundaries), the real
+PageAwareChunker (packed vs unpacked), then indexes packed chunks into an
+in-memory Qdrant and asserts the page-range citation payload survives.
+"""
+
+import pymupdf
+import pytest
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import Distance, PointStruct, VectorParams
+
+from nextcloud_mcp_server.document_processors.pypdfium2_fast import _extract
+from nextcloud_mcp_server.embedding import SimpleEmbeddingProvider
+from nextcloud_mcp_server.vector.document_chunker import PageAwareChunker
+
+pytestmark = pytest.mark.integration
+
+
+def create_lean_multipage_pdf(n_pages: int = 12) -> bytes:
+    """Create a born-digital PDF with many short (lean) pages.
+
+    Mimics the blackbox-demo density regime: one near-empty page each, so the
+    per-page chunker floor would mint one dense vector per page (Deck #636).
+    """
+    doc = pymupdf.open()
+    for i in range(1, n_pages + 1):
+        page = doc.new_page(width=595, height=842)
+        page.insert_text((50, 50), f"Form field page {i}: value {i * 7} recorded.")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+@pytest.fixture
+async def simple_embedding_provider() -> SimpleEmbeddingProvider:
+    """Simple in-process embedding provider for testing."""
+    return SimpleEmbeddingProvider(dimension=384)
+
+
+@pytest.fixture
+async def qdrant_test_client():
+    """In-memory Qdrant client for testing."""
+    client = AsyncQdrantClient(":memory:")
+    yield client
+    await client.close()
+
+
+@pytest.fixture
+async def test_collection(qdrant_test_client: AsyncQdrantClient):
+    """Create + tear down a test collection in Qdrant."""
+    collection_name = "test_pdf_page_packing"
+    await qdrant_test_client.create_collection(
+        collection_name=collection_name,
+        vectors_config=VectorParams(size=384, distance=Distance.COSINE),
+    )
+    yield collection_name
+    try:
+        await qdrant_test_client.delete_collection(collection_name)
+    except Exception:
+        pass
+
+
+async def test_page_packing_reduces_chunk_count_and_preserves_citation_e2e(
+    qdrant_test_client: AsyncQdrantClient,
+    test_collection: str,
+    simple_embedding_provider: SimpleEmbeddingProvider,
+):
+    """Greedy page-packing cuts density and keeps page-range citation end-to-end."""
+    pdf_bytes = create_lean_multipage_pdf(n_pages=12)
+    text, metadata = _extract(pdf_bytes)
+    assert metadata["page_count"] == 12
+    boundaries = metadata.get("page_boundaries") or []
+
+    unpacked = await PageAwareChunker(chunk_size=2048, pack_pages=False).chunk_text(
+        text, boundaries
+    )
+    packed = await PageAwareChunker(chunk_size=2048, pack_pages=True).chunk_text(
+        text, boundaries
+    )
+
+    # Density win: lean pages collapse from ~one-vector-per-page to far fewer.
+    assert len(unpacked) == 12
+    assert len(packed) < len(unpacked)
+
+    spans_a_range = False
+    for chunk in packed:
+        page_start = chunk.page_number
+        page_last = chunk.page_end
+        assert page_start is not None and page_last is not None
+        # No chunk exceeds the budget; page-range citation is well-formed.
+        assert len(chunk.text) <= 2048
+        assert page_start <= page_last
+        # Offsets still extract exactly from the original document text.
+        assert text[chunk.start_offset : chunk.end_offset] == chunk.text
+        if page_last > page_start:
+            spans_a_range = True
+    # A packed chunk really does span a page range (first != last).
+    assert spans_a_range
+
+    # Index the packed chunks and confirm the page_end payload round-trips.
+    points = []
+    for idx, chunk in enumerate(packed):
+        embedding = await simple_embedding_provider.embed(chunk.text)
+        points.append(
+            PointStruct(
+                id=idx,
+                vector=embedding,
+                payload={
+                    "doc_type": "file",
+                    "file_path": "/Documents/lean-forms.pdf",
+                    "page_number": chunk.page_number,
+                    "page_end": chunk.page_end,
+                    "page_count": metadata["page_count"],
+                    "excerpt": chunk.text[:200],
+                },
+            )
+        )
+    await qdrant_test_client.upsert(
+        collection_name=test_collection, points=points, wait=True
+    )
+
+    query_embedding = await simple_embedding_provider.embed("form field value recorded")
+    response = await qdrant_test_client.query_points(
+        collection_name=test_collection,
+        query=query_embedding,
+        limit=3,
+        score_threshold=0.0,
+    )
+    assert len(response.points) > 0
+    payload = response.points[0].payload
+    assert payload is not None
+    assert payload["page_end"] >= payload["page_number"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -67,6 +67,26 @@ class TestQdrantConfigValidation:
         )
         assert "API key is only relevant for network mode" not in caplog.text
 
+    def test_page_pack_without_page_aware_warns(self, caplog):
+        """page-pack without page-aware is a silent no-op; warn at startup."""
+
+        caplog.set_level(logging.WARNING, logger="nextcloud_mcp_server.config")
+        Settings(
+            document_chunk_page_pack=True,
+            document_chunk_page_aware=False,
+        )
+        assert "DOCUMENT_CHUNK_PAGE_PACK is enabled" in caplog.text
+
+    def test_page_pack_with_page_aware_no_warning(self, caplog):
+        """page-pack alongside page-aware is a valid combination; no warning."""
+
+        caplog.set_level(logging.WARNING, logger="nextcloud_mcp_server.config")
+        Settings(
+            document_chunk_page_pack=True,
+            document_chunk_page_aware=True,
+        )
+        assert "DOCUMENT_CHUNK_PAGE_PACK is enabled" not in caplog.text
+
 
 class TestGetSettings:
     """Test get_settings() function with environment variables."""

--- a/tests/unit/test_document_chunker.py
+++ b/tests/unit/test_document_chunker.py
@@ -477,7 +477,7 @@ class TestPageAwareChunker:
         for chunk in chunks:
             assert chunk.page_end == chunk.page_number
 
-    async def test_pack_pages_off_by_default(self):
+    def test_pack_pages_off_by_default(self):
         """Packing is opt-in; the default keeps one-chunk-per-page."""
         assert PageAwareChunker().pack_pages is False
 

--- a/tests/unit/test_document_chunker.py
+++ b/tests/unit/test_document_chunker.py
@@ -464,3 +464,119 @@ class TestPageAwareChunker:
         assert chunks[0].text == ""
         assert chunks[0].start_offset == 0
         assert chunks[0].end_offset == 0
+
+    async def test_page_end_equals_page_number_without_packing(self):
+        """Single-page chunks carry page_end == page_number (citation range)."""
+        content, boundaries = _make_doc(["One.", "Two.", "Three."])
+
+        chunks = await PageAwareChunker(chunk_size=2048, overlap=200).chunk_text(
+            content, boundaries
+        )
+
+        assert len(chunks) == 3
+        for chunk in chunks:
+            assert chunk.page_end == chunk.page_number
+
+    async def test_pack_pages_off_by_default(self):
+        """Packing is opt-in; the default keeps one-chunk-per-page."""
+        assert PageAwareChunker().pack_pages is False
+
+
+class TestPageAwarePacking:
+    """Test suite for greedy page-packing (Deck #636)."""
+
+    async def test_merges_sub_budget_pages_into_one_chunk(self):
+        """Consecutive sub-budget pages merge into a single page-range chunk."""
+        content, boundaries = _make_doc(["AAAA", "BBBB", "CCCC"])
+
+        chunks = await PageAwareChunker(
+            chunk_size=2048, overlap=200, pack_pages=True
+        ).chunk_text(content, boundaries)
+
+        assert len(chunks) == 1
+        chunk = chunks[0]
+        assert chunk.text == "AAAABBBB" + "CCCC"
+        assert chunk.page_number == 1  # first page
+        assert chunk.page_end == 3  # last page — citation range preserved
+        assert content[chunk.start_offset : chunk.end_offset] == chunk.text
+
+    async def test_packing_respects_the_budget(self):
+        """A page that would overflow the budget starts a fresh chunk."""
+        content, boundaries = _make_doc(["AAAAAAAA", "BBBBBBBB", "CCCCCCCC"])  # 8 each
+
+        chunks = await PageAwareChunker(
+            chunk_size=20, overlap=5, pack_pages=True
+        ).chunk_text(content, boundaries)
+
+        # pages 1+2 (16) fit; adding page 3 (24) overflows -> new chunk.
+        assert len(chunks) == 2
+        assert (chunks[0].page_number, chunks[0].page_end) == (1, 2)
+        assert (chunks[1].page_number, chunks[1].page_end) == (3, 3)
+        for chunk in chunks:
+            assert len(chunk.text) <= 20
+            assert content[chunk.start_offset : chunk.end_offset] == chunk.text
+
+    async def test_oversized_page_flushes_pack_and_splits_within_page(self):
+        """An oversized page can't join a pack: flush, then split within-page."""
+        content, boundaries = _make_doc(["AAAA", "word " * 200, "BBBB"])
+
+        chunks = await PageAwareChunker(
+            chunk_size=200, overlap=20, pack_pages=True
+        ).chunk_text(content, boundaries)
+
+        per_page: dict[int, int] = {}
+        for chunk in chunks:
+            page = chunk.page_number
+            assert page is not None
+            per_page[page] = per_page.get(page, 0) + 1
+            assert chunk.page_end == chunk.page_number  # single-page sub-chunks
+        assert per_page[1] == 1  # small page, its own chunk
+        assert per_page[2] > 1  # oversized page split within the page
+        assert per_page[3] == 1
+        for chunk in chunks:
+            assert content[chunk.start_offset : chunk.end_offset] == chunk.text
+
+    async def test_no_chunk_exceeds_budget(self):
+        """Across a realistic mix, no packed chunk exceeds chunk_size."""
+        pages = [f"Page {i} " + "x" * (i * 30) for i in range(1, 12)]
+        content, boundaries = _make_doc(pages)
+
+        chunks = await PageAwareChunker(
+            chunk_size=200, overlap=20, pack_pages=True
+        ).chunk_text(content, boundaries)
+
+        for chunk in chunks:
+            page_start = chunk.page_number
+            page_last = chunk.page_end
+            assert page_start is not None and page_last is not None
+            assert len(chunk.text) <= 200
+            assert content[chunk.start_offset : chunk.end_offset] == chunk.text
+            assert page_start <= page_last
+
+    async def test_blank_interior_page_kept_in_contiguous_pack(self):
+        """A blank page interior to a pack contributes no vector of its own."""
+        content, boundaries = _make_doc(["Real one.", "   ", "Real two."])
+
+        chunks = await PageAwareChunker(
+            chunk_size=2048, overlap=200, pack_pages=True
+        ).chunk_text(content, boundaries)
+
+        assert len(chunks) == 1
+        assert "Real one." in chunks[0].text
+        assert "Real two." in chunks[0].text
+        assert chunks[0].page_number == 1
+
+    async def test_packing_reduces_chunk_count_vs_unpacked(self):
+        """The density win: packing yields strictly fewer chunks on lean pages."""
+        pages = ["Lean page." for _ in range(10)]  # 10 near-empty pages
+        content, boundaries = _make_doc(pages)
+
+        unpacked = await PageAwareChunker(chunk_size=2048, pack_pages=False).chunk_text(
+            content, boundaries
+        )
+        packed = await PageAwareChunker(chunk_size=2048, pack_pages=True).chunk_text(
+            content, boundaries
+        )
+
+        assert len(unpacked) == 10  # one vector per lean page (the inflator)
+        assert len(packed) < len(unpacked)  # merged into far fewer vectors

--- a/tests/unit/test_processor_page_end.py
+++ b/tests/unit/test_processor_page_end.py
@@ -1,0 +1,79 @@
+"""Unit tests for the ``page_end`` citation-range payload fallback (Deck #636).
+
+``_index_document`` stamps ``page_end`` on every file chunk's Qdrant payload via
+:func:`processor.resolve_page_end`. Packed multi-page chunks carry a real range
+(first page = ``page_number``, last = ``page_end``); every other chunk leaves
+``page_end`` unset and must fall back to ``page_number`` so the citation range is
+always present. The char-based path is the case that matters:
+:func:`processor.assign_page_numbers` back-fills ``page_number`` post-hoc but
+never touches ``page_end``, so without the fallback those chunks would ship
+``page_end=None`` while ``page_number`` is set.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.vector.document_chunker import ChunkWithPosition
+from nextcloud_mcp_server.vector.processor import (
+    assign_page_numbers,
+    resolve_page_end,
+)
+
+
+@pytest.mark.unit
+def test_resolve_page_end_preserves_packed_range():
+    """A packed chunk's explicit page range is passed through unchanged."""
+    chunk = ChunkWithPosition(
+        text="one two three",
+        start_offset=0,
+        end_offset=13,
+        page_number=1,
+        page_end=3,
+    )
+    assert resolve_page_end(chunk) == 3
+
+
+@pytest.mark.unit
+def test_resolve_page_end_single_page_chunk():
+    """A single-page chunk reports ``page_end == page_number``."""
+    chunk = ChunkWithPosition(
+        text="solo",
+        start_offset=0,
+        end_offset=4,
+        page_number=2,
+        page_end=2,
+    )
+    assert resolve_page_end(chunk) == 2
+
+
+@pytest.mark.unit
+def test_resolve_page_end_falls_back_for_char_path_chunk():
+    """The char-based path sets page_number but not page_end; fall back to it.
+
+    Drives the real ``assign_page_numbers`` seam: a chunk built by the char
+    splitter has ``page_end=None``; after page assignment ``page_number`` is set
+    but ``page_end`` is still ``None``, so ``resolve_page_end`` must recover the
+    page as the citation end (never leaking ``None`` into the payload).
+    """
+    # Char-path chunk: no page info yet, page_end left unset by the splitter.
+    chunk = ChunkWithPosition(
+        text="body text on the second page",
+        start_offset=120,
+        end_offset=148,
+    )
+    boundaries = [
+        {"page": 1, "start_offset": 0, "end_offset": 100},
+        {"page": 2, "start_offset": 100, "end_offset": 200},
+    ]
+
+    assign_page_numbers([chunk], boundaries)
+
+    assert chunk.page_number == 2  # back-filled by majority overlap
+    assert chunk.page_end is None  # assign_page_numbers never sets page_end
+    assert resolve_page_end(chunk) == 2  # fallback recovers the citation page
+
+
+@pytest.mark.unit
+def test_resolve_page_end_none_when_unpaginated():
+    """Non-paginated content (no page info at all) stays ``None``."""
+    chunk = ChunkWithPosition(text="note body", start_offset=0, end_offset=9)
+    assert resolve_page_end(chunk) is None


### PR DESCRIPTION
## Why

Density prerequisite for the hybrid storage guardrail (Deck **#636** / **#626**). Cost-to-serve is per **dense vector** (6,144 B RAM), but current PDF chunking mints ~**one vector per page** (`chunks ≈ pages → density ≈ pages/MB`), so born-digital tenants (blackbox-demo **~90 chunks/MB**) run the `bytes_stored` storage meter **underwater** (€0.99/GiB carry vs €0.50 overage). A full dense vector per near-empty page is *our* inefficiency — fix the chunker baseline before any density surcharge lands. Notes 390397 (options + measurement), 390385 (guardrail), 389935 (cost-to-serve re-measure).

## What

- **Greedy page-packing** in `PageAwareChunker`, opt-in via `DOCUMENT_CHUNK_PAGE_PACK` (**default off** until the re-measure + storage-rate re-calibration land). Merges consecutive sub-budget pages into one chunk up to the char budget.
- **Page-range citation preserved**: new `ChunkWithPosition.page_end` (first page = `page_number`, last = `page_end`), threaded through the Qdrant payload and the `SearchResult` / `SemanticSearchResult` models (falls back to `page_number` for single-page + char-path chunks). No chunk exceeds the budget; oversized/blank-page handling unchanged.
- **`CHUNKING_CONFIG_VERSION`** (default 1) + the full chunker config (`chunk_size`, `overlap`, `page_aware`, `page_pack`, `version`) stamped on the collection sentinel so a chunker change can't silently invalidate the €/GiB density reference. To be pinned in `stripe-catalog.tf` (follow-up).
- **`scripts/chunk_density_sweep.py`**: offline chunks/MB A/B over a PDF corpus (OHR-Bench), using the exact production `record_chunk_density` formula, to pick a config before the fleet-wide re-index.

## Measurement (first offline sweep, 30 OHR-Bench PDFs, chunks/MB)

| config | finance byteW | overall byteW | overall €/GiB |
|---|---|---|---|
| page-aware@2048 (prod) | **89.7** | 22.8 | 0.54 |
| page-pack@2048 | 88.7 | 22.6 | 0.54 |
| page-aware@4096 | 55.2 | 13.9 | 0.32 |
| **page-pack@4096** | **50.5** | 12.8 | **0.30** |

Reproduces blackbox's ~90 offline. Finding: `chunk_size` 2048→4096 is the bigger lever; packing adds on top and helps most on lean/sub-budget pages.

## Test coverage (per repo CLAUDE.md)

- **Unit**: 6 packing tests (merge / budget / oversized-flush / blank-interior / citation-range / reduction) + `page_end` parity. Full unit suite green (2087).
- **e2e**: `tests/integration/test_pdf_page_packing.py` drives real extraction → pack → index → query, asserting the density drop + page-range payload round-trip.
- **Contract**: no cross-service boundary changed. `page_end` is additive internal payload + search-model surface; the authenticated `/search` provider verification remains a tracked gap (board 11), not introduced here.

## Follow-ups (not in this PR)

- Retrieval-rank A/B on the chosen config (OHR-Bench `astrolabe/` harness + `qas.json`) before any `chunk_size` bump.
- **Live re-measure** (D4) reproducing note 389935 on blackbox-demo + smoke-test → the authoritative #626 number → re-calibrate €/GiB + ceiling + pin `chunking_config_version` in `stripe-catalog.tf`.
- **PDF highlighter multi-page span** (found in round-3 review) — `PDFHighlighter.highlight_chunk` / `find_chunk_page` (`search/pdf_highlighter.py`) assume a chunk lies on a single page and clip the highlight/rendered image to the max-overlap page. For a packed multi-page chunk (`page_number != page_end`) this silently drops the highlight to one page — no crash, but a UX regression in PDF-viz once page-pack is enabled fleet-wide. Must be addressed **before** the flag flips on broadly (tracked alongside the D4 re-measure above / board 12).

---

_This PR was generated with the help of AI, and reviewed by a Human_
