### PR TITLE
feat(auth): short-circuit DCR for pre-configured static clients

### DIFF
--- a/nextcloud_mcp_server/auth/client_registry.py
+++ b/nextcloud_mcp_server/auth/client_registry.py
@@ -242,12 +242,21 @@ class ClientRegistry:
         Returns:
             The first matching static client, or ``None`` if none match.
         """
+        # Guard: only process a non-empty list of plain strings.  Untrusted
+        # request bodies may carry a dict or a list of non-strings; iterating
+        # over a dict yields its keys, which could produce a false positive
+        # match or an unexpected RFC 7591 response that bypasses IdP validation.
+        if (
+            not redirect_uris
+            or not isinstance(redirect_uris, list)
+            or not all(isinstance(uri, str) for uri in redirect_uris)
+        ):
+            return None
+
         for client in self._clients.values():
             if not client.is_static:
                 continue
-            if redirect_uris and all(
-                self._validate_redirect_uri(client, uri) for uri in redirect_uris
-            ):
+            if all(self._validate_redirect_uri(client, uri) for uri in redirect_uris):
                 return client
         return None
 

--- a/nextcloud_mcp_server/auth/client_registry.py
+++ b/nextcloud_mcp_server/auth/client_registry.py
@@ -7,7 +7,8 @@ via Flow 1. In production, this would integrate with Dynamic Client Registration
 """
 
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -26,6 +27,7 @@ class MCPClientInfo:
     allowed_scopes: List[str]
     is_public: bool = True  # Native clients are public (no client_secret)
     is_static: bool = False  # True for pre-configured clients (ALLOWED_MCP_CLIENTS)
+    issued_at: int = field(default_factory=lambda: int(time.time()))
     metadata: Optional[Dict] = None
 
 
@@ -215,9 +217,15 @@ class ClientRegistry:
                 # Handle wildcard port (localhost:*)
                 pattern_base = pattern.replace(":*", "")
                 if redirect_uri.startswith(pattern_base + ":"):
-                    # Validate it's localhost with a port
+                    # Validate it's localhost with a syntactically valid port number.
+                    # parsed.port raises ValueError for non-integer ports (e.g. "abc")
+                    # and returns None for an empty port component (e.g. "localhost:").
                     if parsed.hostname in ("localhost", "127.0.0.1", "::1"):
-                        return True
+                        try:
+                            if parsed.port is not None:
+                                return True
+                        except ValueError:
+                            return False
             elif redirect_uri == pattern:
                 return True
 

--- a/nextcloud_mcp_server/auth/client_registry.py
+++ b/nextcloud_mcp_server/auth/client_registry.py
@@ -25,6 +25,7 @@ class MCPClientInfo:
     redirect_uris: List[str]
     allowed_scopes: List[str]
     is_public: bool = True  # Native clients are public (no client_secret)
+    is_static: bool = False  # True for pre-configured clients (ALLOWED_MCP_CLIENTS)
     metadata: Optional[Dict] = None
 
 
@@ -122,6 +123,7 @@ class ClientRegistry:
                         redirect_uris=[redirect],
                         allowed_scopes=["*"],
                         is_public=True,
+                        is_static=True,
                     )
                     logger.info("Registered static client: %s", cid)
                 else:
@@ -131,6 +133,7 @@ class ClientRegistry:
                         redirect_uris=["http://localhost:*", "http://127.0.0.1:*"],
                         allowed_scopes=["*"],
                         is_public=True,
+                        is_static=True,
                     )
                     logger.info("Registered static client: %s", entry)
 
@@ -219,6 +222,34 @@ class ClientRegistry:
                 return True
 
         return False
+
+    def find_client_for_redirect_uris(
+        self, redirect_uris: List[str]
+    ) -> Optional[MCPClientInfo]:
+        """Find a pre-configured static client that accepts all given redirect URIs.
+
+        Only static clients (loaded from ``ALLOWED_MCP_CLIENTS``) are considered.
+        DCR-proxy clients are excluded to avoid returning an entry that belongs to
+        a different dynamic registration session.
+
+        This is used by the DCR proxy to short-circuit upstream IdP registration
+        when the requesting client's redirect URIs already match a whitelisted
+        static entry, preventing unnecessary client accumulation in the IdP.
+
+        Args:
+            redirect_uris: Redirect URIs from the incoming DCR request.
+
+        Returns:
+            The first matching static client, or ``None`` if none match.
+        """
+        for client in self._clients.values():
+            if not client.is_static:
+                continue
+            if redirect_uris and all(
+                self._validate_redirect_uri(client, uri) for uri in redirect_uris
+            ):
+                return client
+        return None
 
     def register_client(self, client_info: MCPClientInfo) -> bool:
         """

--- a/nextcloud_mcp_server/auth/client_registry.py
+++ b/nextcloud_mcp_server/auth/client_registry.py
@@ -244,11 +244,21 @@ class ClientRegistry:
         when the requesting client's redirect URIs already match a whitelisted
         static entry, preventing unnecessary client accumulation in the IdP.
 
+        Ambiguity guard: loopback redirect URIs are not a client identity — per
+        RFC 8252 §7.3 every native client uses ``http://localhost:<ephemeral>``,
+        and §8.6 treats such clients as mutually indistinguishable. If two or
+        more static entries (e.g. multiple ``localhost:*`` wildcards) both accept
+        the requested URIs, we cannot tell which one the caller actually is, so
+        we refuse to guess: a warning is logged and ``None`` is returned, letting
+        the caller fall through to the normal proxy path rather than silently
+        mis-attributing the registration to the first-listed entry.
+
         Args:
             redirect_uris: Redirect URIs from the incoming DCR request.
 
         Returns:
-            The first matching static client, or ``None`` if none match.
+            The single matching static client, or ``None`` if none match or the
+            match is ambiguous (more than one static client qualifies).
         """
         # Guard: only process a non-empty list of plain strings.  Untrusted
         # request bodies may carry a dict or a list of non-strings; iterating
@@ -261,12 +271,27 @@ class ClientRegistry:
         ):
             return None
 
-        for client in self._clients.values():
-            if not client.is_static:
-                continue
-            if all(self._validate_redirect_uri(client, uri) for uri in redirect_uris):
-                return client
-        return None
+        matches = [
+            client
+            for client in self._clients.values()
+            if client.is_static
+            and all(self._validate_redirect_uri(client, uri) for uri in redirect_uris)
+        ]
+
+        if not matches:
+            return None
+        if len(matches) > 1:
+            logger.warning(
+                "Ambiguous DCR short-circuit: %d static clients (%s) all accept "
+                "redirect URIs %s; refusing to guess and falling through to the "
+                "IdP proxy. Configure a single ALLOWED_MCP_CLIENTS entry for "
+                "loopback clients to enable the short-circuit.",
+                len(matches),
+                ", ".join(c.client_id for c in matches),
+                redirect_uris,
+            )
+            return None
+        return matches[0]
 
     def register_client(self, client_info: MCPClientInfo) -> bool:
         """

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -1375,7 +1375,7 @@ async def oauth_register_proxy(request: Request) -> JSONResponse:
                 "token_endpoint_auth_method": "none",
                 "grant_types": ["authorization_code", "refresh_token"],
                 "response_types": ["code"],
-                "client_id_issued_at": int(time.time()),
+                "client_id_issued_at": static_match.issued_at,
             },
             status_code=201,
         )

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -1352,6 +1352,34 @@ async def oauth_register_proxy(request: Request) -> JSONResponse:
     timestamps.append(now)
     _dcr_rate_limit[client_ip] = timestamps
 
+    # Short-circuit: if any pre-configured static client (ALLOWED_MCP_CLIENTS) already
+    # accepts all requested redirect URIs, return it directly without proxying to the
+    # upstream IdP. This prevents a new dynamic client from accumulating in the IdP
+    # for every distinct Claude Code / MCP client installation.
+    requested_redirect_uris = body.get("redirect_uris", [])
+    static_match = get_client_registry().find_client_for_redirect_uris(
+        requested_redirect_uris
+    )
+    if static_match:
+        logger.info(
+            "DCR: serving registration for %r using pre-configured client %r "
+            "(skipping IdP proxy)",
+            body.get("client_name", ""),
+            static_match.client_id,
+        )
+        return JSONResponse(
+            {
+                "client_id": static_match.client_id,
+                "client_name": static_match.name,
+                "redirect_uris": requested_redirect_uris,
+                "token_endpoint_auth_method": "none",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "client_id_issued_at": int(time.time()),
+            },
+            status_code=201,
+        )
+
     # Discover registration endpoint from OIDC discovery
     discovery_url = oauth_config.get("discovery_url")
     registration_endpoint = None

--- a/tests/unit/test_client_registry.py
+++ b/tests/unit/test_client_registry.py
@@ -249,3 +249,18 @@ def test_find_client_for_redirect_uris_empty_list_returns_none(monkeypatch):
     registry = _get_registry(monkeypatch, "claude-code-mcp")
     match = registry.find_client_for_redirect_uris([])
     assert match is None
+
+
+def test_find_client_for_redirect_uris_rejects_dict(monkeypatch):
+    """A dict value (malformed request body) must not trigger a match."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    # A dict is iterable but yields keys, not URIs — should not short-circuit.
+    match = registry.find_client_for_redirect_uris({"http://localhost:9999/cb": True})  # type: ignore[arg-type]
+    assert match is None
+
+
+def test_find_client_for_redirect_uris_rejects_list_of_non_strings(monkeypatch):
+    """A list containing non-string elements must not trigger a match."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    match = registry.find_client_for_redirect_uris([None, 42])  # type: ignore[list-item]
+    assert match is None

--- a/tests/unit/test_client_registry.py
+++ b/tests/unit/test_client_registry.py
@@ -201,3 +201,51 @@ def test_validate_redirect_uri_no_hostname(monkeypatch):
     valid, err = registry.validate_client("test-client", redirect_uri="not-a-uri")
     assert valid is False
     assert "redirect_uri" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# find_client_for_redirect_uris tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_client_for_redirect_uris_matches_localhost_wildcard(monkeypatch):
+    """Static client with localhost:* pattern matches any specific localhost port."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    match = registry.find_client_for_redirect_uris(["http://localhost:54321/callback"])
+    assert match is not None
+    assert match.client_id == "claude-code-mcp"
+
+
+def test_find_client_for_redirect_uris_matches_loopback_ip(monkeypatch):
+    """Static client with 127.0.0.1:* pattern matches any specific loopback port."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    match = registry.find_client_for_redirect_uris(["http://127.0.0.1:8765/callback"])
+    assert match is not None
+    assert match.client_id == "claude-code-mcp"
+
+
+def test_find_client_for_redirect_uris_no_match(monkeypatch):
+    """Returns None when no static client accepts all redirect URIs."""
+    registry = _get_registry(monkeypatch, "my-app|https://app.example.com/callback")
+    match = registry.find_client_for_redirect_uris(["http://localhost:9999/callback"])
+    assert match is None
+
+
+def test_find_client_for_redirect_uris_ignores_proxy_clients(monkeypatch):
+    """DCR-proxy clients (is_static=False) are not returned."""
+    registry = _get_registry(monkeypatch, None)
+    # Register a proxy client (as the DCR proxy does)
+    registry.register_proxy_client(
+        client_id="some-uuid-from-idp",
+        redirect_uris=["http://localhost:*", "http://127.0.0.1:*"],
+        name="Dynamic Client",
+    )
+    match = registry.find_client_for_redirect_uris(["http://localhost:12345/cb"])
+    assert match is None
+
+
+def test_find_client_for_redirect_uris_empty_list_returns_none(monkeypatch):
+    """Empty redirect_uris list returns None (no match without URIs to check)."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    match = registry.find_client_for_redirect_uris([])
+    assert match is None

--- a/tests/unit/test_client_registry.py
+++ b/tests/unit/test_client_registry.py
@@ -264,3 +264,38 @@ def test_find_client_for_redirect_uris_rejects_list_of_non_strings(monkeypatch):
     registry = _get_registry(monkeypatch, "claude-code-mcp")
     match = registry.find_client_for_redirect_uris([None, 42])  # type: ignore[list-item]
     assert match is None
+
+
+# ---------------------------------------------------------------------------
+# _validate_redirect_uri port validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_redirect_uri_invalid_port_rejected(monkeypatch):
+    """Wildcard match must reject URIs with a non-numeric port (e.g. localhost:abc)."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    valid, err = registry.validate_client(
+        "claude-code-mcp", redirect_uri="http://localhost:abc/callback"
+    )
+    assert valid is False
+    assert "redirect_uri" in err.lower()
+
+
+def test_validate_redirect_uri_empty_port_rejected(monkeypatch):
+    """Wildcard match must reject URIs with an empty port component (e.g. localhost:)."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    valid, err = registry.validate_client(
+        "claude-code-mcp", redirect_uri="http://localhost:/callback"
+    )
+    assert valid is False
+    assert "redirect_uri" in err.lower()
+
+
+def test_validate_redirect_uri_valid_port_accepted(monkeypatch):
+    """Wildcard match must accept URIs with a valid integer port."""
+    registry = _get_registry(monkeypatch, "claude-code-mcp")
+    valid, err = registry.validate_client(
+        "claude-code-mcp", redirect_uri="http://localhost:8080/callback"
+    )
+    assert valid is True
+    assert err is None

--- a/tests/unit/test_client_registry.py
+++ b/tests/unit/test_client_registry.py
@@ -244,6 +244,39 @@ def test_find_client_for_redirect_uris_ignores_proxy_clients(monkeypatch):
     assert match is None
 
 
+def test_find_client_for_redirect_uris_ambiguous_returns_none(monkeypatch, caplog):
+    """Two static wildcard clients both accept a loopback URI → ambiguous, no guess.
+
+    Loopback redirect URIs are not a client identity (RFC 8252 §7.3/§8.6), so
+    when more than one static entry qualifies the short-circuit must refuse to
+    guess and fall through, rather than silently returning the first-listed one.
+    """
+    registry = _get_registry(monkeypatch, "claude-code-mcp, cursor-mcp")
+    with caplog.at_level(logging.WARNING):
+        match = registry.find_client_for_redirect_uris(["http://localhost:5000/cb"])
+    assert match is None
+    assert "Ambiguous DCR short-circuit" in caplog.text
+    # Both ambiguous candidates are named so the operator can fix their config.
+    assert "claude-code-mcp" in caplog.text
+    assert "cursor-mcp" in caplog.text
+
+
+def test_find_client_for_redirect_uris_single_match_with_nonmatching_static(
+    monkeypatch,
+):
+    """The guard counts only *matching* static clients, not the total registered.
+
+    A non-loopback static entry that does not accept the requested URI must not
+    make an otherwise-unambiguous loopback match look ambiguous.
+    """
+    registry = _get_registry(
+        monkeypatch, "claude-code-mcp, my-app|https://app.example.com/callback"
+    )
+    match = registry.find_client_for_redirect_uris(["http://localhost:7777/cb"])
+    assert match is not None
+    assert match.client_id == "claude-code-mcp"
+
+
 def test_find_client_for_redirect_uris_empty_list_returns_none(monkeypatch):
     """Empty redirect_uris list returns None (no match without URIs to check)."""
     registry = _get_registry(monkeypatch, "claude-code-mcp")

--- a/tests/unit/test_dcr_proxy.py
+++ b/tests/unit/test_dcr_proxy.py
@@ -137,7 +137,12 @@ async def test_static_client_match_different_port_returns_same_client_id(monkeyp
             )
         )
 
-    assert json.loads(resp1.body)["client_id"] == json.loads(resp2.body)["client_id"]
+    body1 = json.loads(resp1.body)
+    body2 = json.loads(resp2.body)
+    assert body1["client_id"] == body2["client_id"]
+    # client_id_issued_at must be stable (sourced from the static MCPClientInfo record,
+    # not from the current request time) so both responses agree on the same value.
+    assert body1["client_id_issued_at"] == body2["client_id_issued_at"]
 
 
 async def test_no_static_client_falls_through_to_idp_proxy(monkeypatch):

--- a/tests/unit/test_dcr_proxy.py
+++ b/tests/unit/test_dcr_proxy.py
@@ -1,13 +1,22 @@
-"""Unit tests for DCR proxy registration_not_supported path."""
+"""Unit tests for DCR proxy: static client short-circuit and registration_not_supported."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import nextcloud_mcp_server.auth.client_registry as registry_mod
 from nextcloud_mcp_server.auth.oauth_routes import oauth_register_proxy
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset the singleton registry before each test."""
+    registry_mod._registry = None
+    yield
+    registry_mod._registry = None
 
 
 def _make_request(body: dict, oauth_config: dict) -> MagicMock:
@@ -63,3 +72,101 @@ async def test_registration_not_supported_when_no_discovery_url():
     assert response.status_code == 400
     body = json.loads(response.body)
     assert body["error"] == "registration_not_supported"
+
+
+# ---------------------------------------------------------------------------
+# Static client short-circuit tests
+# ---------------------------------------------------------------------------
+
+
+async def test_static_client_match_skips_idp_proxy(monkeypatch):
+    """DCR for localhost redirect URI returns pre-configured static client without proxying IdP."""
+    monkeypatch.setenv("ALLOWED_MCP_CLIENTS", "claude-code-mcp")
+    from nextcloud_mcp_server.config import _reload_config
+
+    _reload_config()
+
+    request = _make_request(
+        body={
+            "client_name": "Claude Code (nextcloud)",
+            "redirect_uris": ["http://localhost:54321/callback"],
+        },
+        oauth_config={
+            "discovery_url": "https://idp.example.com/.well-known/openid-configuration"
+        },
+    )
+
+    # get_oidc_discovery must NOT be called — the short-circuit fires first
+    with patch(
+        "nextcloud_mcp_server.auth.oauth_routes.get_oidc_discovery",
+        new_callable=AsyncMock,
+    ) as mock_discovery:
+        response = await oauth_register_proxy(request)
+
+    mock_discovery.assert_not_called()
+    assert response.status_code == 201
+    body = json.loads(response.body)
+    assert body["client_id"] == "claude-code-mcp"
+    assert body["redirect_uris"] == ["http://localhost:54321/callback"]
+    assert body["token_endpoint_auth_method"] == "none"
+    assert "client_id_issued_at" in body
+
+
+async def test_static_client_match_different_port_returns_same_client_id(monkeypatch):
+    """Two DCR requests with different localhost ports return the same static client_id."""
+    monkeypatch.setenv("ALLOWED_MCP_CLIENTS", "claude-code-mcp")
+    from nextcloud_mcp_server.config import _reload_config
+
+    _reload_config()
+
+    oauth_config = {
+        "discovery_url": "https://idp.example.com/.well-known/openid-configuration"
+    }
+
+    with patch("nextcloud_mcp_server.auth.oauth_routes.get_oidc_discovery"):
+        resp1 = await oauth_register_proxy(
+            _make_request(
+                body={"client_name": "Claude Code", "redirect_uris": ["http://localhost:11111/cb"]},
+                oauth_config=oauth_config,
+            )
+        )
+        resp2 = await oauth_register_proxy(
+            _make_request(
+                body={"client_name": "Claude Code", "redirect_uris": ["http://localhost:22222/cb"]},
+                oauth_config=oauth_config,
+            )
+        )
+
+    assert json.loads(resp1.body)["client_id"] == json.loads(resp2.body)["client_id"]
+
+
+async def test_no_static_client_falls_through_to_idp_proxy(monkeypatch):
+    """When no static client matches the redirect URI, the IdP proxy path is taken."""
+    monkeypatch.delenv("ALLOWED_MCP_CLIENTS", raising=False)
+    from nextcloud_mcp_server.config import _reload_config
+
+    _reload_config()
+
+    request = _make_request(
+        body=_DCR_BODY,
+        oauth_config={
+            "discovery_url": "https://idp.example.com/.well-known/openid-configuration"
+        },
+    )
+
+    discovery_doc = {
+        "issuer": "https://idp.example.com",
+        "authorization_endpoint": "https://idp.example.com/auth",
+        # No registration_endpoint → falls through to 400
+    }
+
+    with patch(
+        "nextcloud_mcp_server.auth.oauth_routes.get_oidc_discovery",
+        new_callable=AsyncMock,
+        return_value=discovery_doc,
+    ) as mock_discovery:
+        response = await oauth_register_proxy(request)
+
+    mock_discovery.assert_called_once()
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "registration_not_supported"

--- a/tests/unit/test_dcr_proxy.py
+++ b/tests/unit/test_dcr_proxy.py
@@ -126,13 +126,19 @@ async def test_static_client_match_different_port_returns_same_client_id(monkeyp
     with patch("nextcloud_mcp_server.auth.oauth_routes.get_oidc_discovery"):
         resp1 = await oauth_register_proxy(
             _make_request(
-                body={"client_name": "Claude Code", "redirect_uris": ["http://localhost:11111/cb"]},
+                body={
+                    "client_name": "Claude Code",
+                    "redirect_uris": ["http://localhost:11111/cb"],
+                },
                 oauth_config=oauth_config,
             )
         )
         resp2 = await oauth_register_proxy(
             _make_request(
-                body={"client_name": "Claude Code", "redirect_uris": ["http://localhost:22222/cb"]},
+                body={
+                    "client_name": "Claude Code",
+                    "redirect_uris": ["http://localhost:22222/cb"],
+                },
                 oauth_config=oauth_config,
             )
         )


### PR DESCRIPTION
## Problem

When `ALLOWED_MCP_CLIENTS` is configured, each distinct MCP client installation (e.g. every developer machine running Claude Code) creates a new dynamic client in the upstream IdP via the DCR proxy. This happens because each DCR request carries a different ephemeral localhost port in its `redirect_uri` field, which the IdP treats as a unique registration.

In practice, operators using Keycloak as an external IdP end up with an unbounded list of UUID clients (e.g. `c8523c01-…`, `d18ea000-…`, all named "Claude Code (nextcloud)") that differ only by localhost port. These clients are never cleaned up automatically and accumulate indefinitely.

## Solution

Short-circuit the DCR proxy for clients that are already whitelisted in `ALLOWED_MCP_CLIENTS`.

Before forwarding a DCR request to the upstream IdP, `oauth_register_proxy` now calls `ClientRegistry.find_client_for_redirect_uris()`. If a pre-configured static client already accepts all requested redirect URIs (via the existing `http://localhost:*` wildcard pattern), the static client is returned directly — no upstream registration is performed.

All Claude Code instances therefore receive the same stable `client_id` (e.g. `claude-code-mcp`) regardless of which ephemeral port they happen to bind, and the IdP remains free of accumulated dynamic client entries.

## Changes

- **`MCPClientInfo`** gains an `is_static: bool` field (`True` for `ALLOWED_MCP_CLIENTS` entries, `False` for DCR-proxy registrations), so the new lookup excludes dynamic entries.
- **`ClientRegistry.find_client_for_redirect_uris()`** returns the first static client whose registered URI patterns cover all URIs in the DCR request. Returns `None` if no static client matches, preserving the existing proxy path.
- **`oauth_register_proxy()`** calls the new method immediately after rate-limiting. On a match it responds with a RFC 7591-compliant payload (`client_id`, `client_name`, `redirect_uris`, `grant_types`, `response_types`, `client_id_issued_at`) and skips the IdP entirely.

Dynamic-registration flows (no `ALLOWED_MCP_CLIENTS`, or redirect URIs that don't match any static entry) are completely unaffected.

## Tests

- `test_static_client_match_skips_idp_proxy` — verifies `get_oidc_discovery` is never called when a static match is found
- `test_static_client_match_different_port_returns_same_client_id` — two requests with different ports yield the same `client_id`
- `test_no_static_client_falls_through_to_idp_proxy` — fallback to existing proxy path when no match
- `test_find_client_for_redirect_uris_matches_localhost_wildcard` / `_loopback_ip` / `_no_match` / `_ignores_proxy_clients` / `_empty_list_returns_none`