### PR TITLE
fix(auth): guarantee oauth_context storage in login_flow mode (#1068)

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1916,7 +1916,13 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             scopes = settings.oidc_scopes
 
             oauth_context_dict = {
-                "storage": refresh_token_storage,
+                # login_flow needs storage for browser sessions + app passwords
+                # regardless of offline access. refresh_token_storage is only
+                # created when offline access is enabled (default off), so fall
+                # back to the always-initialized process-wide singleton — the
+                # same instance the MCP tools use — so browser/provisioning
+                # routes never dereference None (GH #1068).
+                "storage": refresh_token_storage or await get_shared_storage(),
                 "oauth_client": oauth_client,
                 "token_verifier": token_verifier,  # For querying IdP userinfo endpoint
                 "config": {

--- a/nextcloud_mcp_server/auth/browser_oauth_routes.py
+++ b/nextcloud_mcp_server/auth/browser_oauth_routes.py
@@ -17,6 +17,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from nextcloud_mcp_server.auth.storage import get_shared_storage
 from nextcloud_mcp_server.auth.token_utils import (
     IdTokenVerificationError,
     get_oidc_discovery,
@@ -145,7 +146,10 @@ async def oauth_login(request: Request) -> RedirectResponse | JSONResponse:
         # BasicAuth mode - no login needed, redirect to app
         return RedirectResponse("/app", status_code=302)
 
-    storage = oauth_ctx["storage"]
+    # Fall back to the always-initialized shared storage singleton when the
+    # OAuth context carries no storage — login_flow with offline access off
+    # (the default) leaves oauth_context["storage"] None (GH #1068).
+    storage = oauth_ctx.get("storage") or await get_shared_storage()
     oauth_client = oauth_ctx["oauth_client"]
     oauth_config = oauth_ctx["config"]
 
@@ -359,7 +363,9 @@ async def oauth_login_callback(request: Request) -> RedirectResponse | HTMLRespo
 
     # Get OAuth context
     oauth_ctx = request.app.state.oauth_context
-    storage = oauth_ctx["storage"]
+    # Same GH #1068 fallback as oauth_login: the callback also writes to storage
+    # and must not dereference a None captured under offline-access-off config.
+    storage = oauth_ctx.get("storage") or await get_shared_storage()
     oauth_client = oauth_ctx["oauth_client"]
     oauth_config = oauth_ctx["config"]
 

--- a/tests/server/login_flow/test_login_flow_integration.py
+++ b/tests/server/login_flow/test_login_flow_integration.py
@@ -659,3 +659,37 @@ class TestLoginFlowConnectivity:
         """Verify resource templates are available."""
         templates = await nc_mcp_login_flow_client.list_resource_templates()
         logger.info("Resource templates: %s", len(templates.resourceTemplates))
+
+
+# ---------------------------------------------------------------------------
+# Browser login route (GH #1068)
+# ---------------------------------------------------------------------------
+#
+# Regression guard for GH #1068: in login_flow mode with offline access
+# disabled (the default — the mcp-login-flow container sets TOKEN_ENCRYPTION_KEY
+# but not ENABLE_BACKGROUND_OPERATIONS), app.py built oauth_context with
+# storage=None, so GET /oauth/login dereferenced None and returned HTTP 500.
+# The existing suite drives provisioning through the MCP tool / app-password
+# paths (which use the always-initialized shared storage) and never exercised
+# this browser route, so the bug shipped. This asserts the route redirects to
+# the IdP instead of 500-ing.
+
+
+class TestBrowserOAuthLoginRoute:
+    """The browser /oauth/login route must not 500 on default login_flow config."""
+
+    LOGIN_FLOW_MCP_BASE_URL = "http://localhost:8004"
+
+    async def test_oauth_login_redirects_not_500(self):
+        import httpx
+
+        async with httpx.AsyncClient(follow_redirects=False) as client:
+            resp = await client.get(f"{self.LOGIN_FLOW_MCP_BASE_URL}/oauth/login")
+
+        # 302 redirect to the IdP authorization endpoint — the pre-#1068
+        # behaviour was a 500 from `None.store_oauth_session`.
+        assert resp.status_code == 302, (
+            f"/oauth/login returned {resp.status_code}, expected 302 "
+            f"(GH #1068 regression: oauth_context storage was None)"
+        )
+        assert "location" in resp.headers

--- a/tests/unit/test_browser_oauth_routes.py
+++ b/tests/unit/test_browser_oauth_routes.py
@@ -10,13 +10,17 @@ import json
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 from cryptography.fernet import Fernet
 
 from nextcloud_mcp_server.auth import browser_oauth_routes, token_utils
-from nextcloud_mcp_server.auth.browser_oauth_routes import oauth_login_callback
+from nextcloud_mcp_server.auth.browser_oauth_routes import (
+    oauth_login,
+    oauth_login_callback,
+)
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
 
 pytestmark = pytest.mark.unit
@@ -218,3 +222,72 @@ async def test_callback_rejects_token_response_without_refresh_token(
     # session cookie.
     set_cookie = response.headers.get("set-cookie", "")
     assert "mcp_session" not in set_cookie
+
+
+# ---------------------------------------------------------------------------
+# oauth_login: None storage in oauth_context must NOT 500 (GH #1068)
+# ---------------------------------------------------------------------------
+#
+# In login_flow mode with offline access disabled (the default), app.py builds
+# oauth_context with ``storage=None`` (refresh_token_storage is only created
+# when offline access is enabled). Before the fix, ``oauth_login`` hard-indexed
+# ``oauth_ctx["storage"]`` and called ``store_oauth_session`` on ``None``,
+# raising ``AttributeError: 'NoneType' object has no attribute
+# 'store_oauth_session'`` and returning HTTP 500. The route now falls back to
+# the always-initialized shared storage singleton.
+
+
+async def test_oauth_login_falls_back_to_shared_storage_when_ctx_storage_none(
+    _clear_oidc_caches, _no_refresh_storage
+):
+    """Reproduces GH #1068: oauth_login must tolerate oauth_context storage=None.
+
+    Fails before the fix with AttributeError on ``None.store_oauth_session``.
+    """
+    shared_storage = _no_refresh_storage
+
+    request = MagicMock()
+    request.query_params = {}
+    # Exactly the context login_flow builds when offline access is off.
+    request.app.state.oauth_context = {
+        "storage": None,
+        "oauth_client": None,  # integrated Nextcloud OIDC mode
+        "config": {
+            "mcp_server_url": "http://localhost:8004",
+            "discovery_url": "http://idp.example/.well-known/openid-configuration",
+            "client_id": "static-client",
+            "client_secret": "secret",
+            "nextcloud_host": "http://idp.example",
+            "nextcloud_resource_uri": "http://idp.example",
+        },
+    }
+
+    discovery = {
+        "issuer": "http://idp.example",
+        "authorization_endpoint": "http://idp.example/authorize",
+        "scopes_supported": ["openid", "profile", "email"],
+    }
+
+    with (
+        patch(
+            "nextcloud_mcp_server.auth.browser_oauth_routes.get_shared_storage",
+            new=AsyncMock(return_value=shared_storage),
+        ),
+        patch(
+            "nextcloud_mcp_server.auth.browser_oauth_routes.get_oidc_discovery",
+            new=AsyncMock(return_value=discovery),
+        ),
+    ):
+        response = await oauth_login(request)
+
+    # Redirect to the IdP authorization endpoint — not a 500.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("http://idp.example/authorize?")
+
+    # The PKCE/session row was persisted to the fallback (shared) storage,
+    # keyed by the generated ``state`` carried in the redirect URL.
+    location = response.headers["location"]
+    state = parse_qs(urlparse(location).query)["state"][0]
+    session = await shared_storage.get_oauth_session(state)
+    assert session is not None
+    assert session["flow_type"] == "browser"


### PR DESCRIPTION
## Summary

Fixes #1068. In `login_flow` mode with offline access disabled (the default), `GET /oauth/login` returned **HTTP 500** and per-user app-password provisioning was blocked:

```
browser_oauth_routes.py, in oauth_login
    await storage.store_oauth_session(...)
AttributeError: 'NoneType' object has no attribute 'store_oauth_session'
```

## Root cause

`oauth_login` reads `storage = oauth_ctx["storage"]`, which is `refresh_token_storage` captured in `app.py` when the OAuth context is built. `refresh_token_storage` is **only** created when offline access is enabled (`enable_offline_access` / `enable_background_operations` default to **False**, and the `mcp-login-flow` container sets `TOKEN_ENCRYPTION_KEY` but not `ENABLE_BACKGROUND_OPERATIONS`). So in a stock `login_flow` deployment `oauth_context["storage"]` is permanently `None`, and every route that dereferences it 500s.

Login Flow v2 needs storage for browser sessions and per-user app passwords **regardless of offline access**. Flow 1 (MCP client OAuth) and the `nc_auth_provision_access` tool kept working because they use the always-initialized `get_shared_storage()` singleton, not the captured value.

## Fix

- **Central (root cause)** — `app.py`: `"storage": refresh_token_storage or await get_shared_storage()`. The fallback is the process-wide, lock-guarded, already-initialized singleton — the same instance the MCP tools use, so browser routes and tools converge on one storage. This also protects the other `oauth_context["storage"]` consumers (MCP OAuth flow, webhooks, userinfo).
- **Defense-in-depth** — `browser_oauth_routes.py`: `oauth_login` and `oauth_login_callback` resolve storage via `oauth_ctx.get("storage") or await get_shared_storage()`.

## Why existing tests missed it

The `login_flow` suite drives provisioning through the MCP tool / Playwright app-password paths (which use `get_shared_storage`) and **never curled the browser `/oauth/login` route** — the only consumer that hard-indexed the `None` storage.

## Tests

- **Unit** (`tests/unit/test_browser_oauth_routes.py`): injects the exact `storage=None` context `login_flow` produces and asserts `oauth_login` returns 302. Verified it reproduces the exact `AttributeError` **without** the fix and passes with it.
- **Integration** (`tests/server/login_flow/test_login_flow_integration.py`, `-m login_flow`): `GET http://localhost:8004/oauth/login` must return 302, not 500 — closes the precise gap the suite lacked. Runs against the real `mcp-login-flow` container in CI.

## Verification

```bash
uv run pytest tests/unit/test_browser_oauth_routes.py -v   # local
# integration tier (-m login_flow) runs in GitHub CI against the docker stack
```

---

_This PR was generated with the help of AI, and reviewed by a Human_