### PR TITLE
feat(metrics): emit astrolabe_qdrant_source_bytes_total for corpus-weighted density

### DIFF
--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -561,6 +561,23 @@ chunk_density_snapshot_truncated = Gauge(
     "1 if the last chunk-density snapshot hit the document scan cap (partial)",
 )
 
+# Sum of ``source_bytes`` across documents currently resident in Qdrant, per
+# ``doc_type``. Covers exactly the same forward-only set as the density snapshot
+# histogram (documents without a usable source_bytes are excluded and surfaced via
+# ``chunk_density_uncovered_documents``). Enables a corpus-weighted (byte-weighted)
+# chunk density in Grafana — ``sum(indexed_chunks) / (sum(source_bytes) / 1e6)`` —
+# which is the pricing driver, vs the doc-weighted mean of the histogram. This is a
+# Gauge, not a Counter, because it falls when documents are deleted from the
+# collection; the ``_total`` name is fixed (the deployed dashboard query depends on
+# it) and denotes the aggregate over the corpus, not a monotonic counter.
+qdrant_source_bytes_total = Gauge(
+    "astrolabe_qdrant_source_bytes_total",
+    "Total source_bytes across documents currently resident in Qdrant "
+    "(byte-weighted density denominator; forward-only — docs without source_bytes "
+    "are excluded, see astrolabe_qdrant_chunk_density_uncovered_documents)",
+    ["doc_type"],
+)
+
 documents_indexed_total = Counter(
     "astrolabe_documents_indexed_total",
     "Total documents indexed, by source type",
@@ -1138,6 +1155,7 @@ def update_qdrant_chunk_density_snapshot(
     *,
     uncovered: dict[str, int] | None = None,
     truncated: bool = False,
+    source_bytes: dict[str, float] | None = None,
 ) -> None:
     """Publish one current-corpus chunk-density snapshot (GaugeHistogram + coverage).
 
@@ -1154,6 +1172,10 @@ def update_qdrant_chunk_density_snapshot(
     ``truncated`` (scan hit the document cap) update the companion coverage
     gauges. The uncovered gauge is fully reset each snapshot so a doc_type that
     falls back to zero uncovered does not leave a stale series.
+
+    ``source_bytes`` (doc_type -> sum of source_bytes over the covered documents)
+    updates ``astrolabe_qdrant_source_bytes_total``, the byte-weighted density
+    denominator. It is reset-then-repopulated the same way as the uncovered gauge.
     """
     edges = [str(b) for b in CHUNK_DENSITY_BUCKETS] + ["+Inf"]
     snapshot: dict[str, tuple[list[tuple[str, float]], float]] = {}
@@ -1170,6 +1192,11 @@ def update_qdrant_chunk_density_snapshot(
     chunk_density_uncovered_documents.clear()
     for doc_type, count in (uncovered or {}).items():
         chunk_density_uncovered_documents.labels(doc_type=doc_type).set(count)
+
+    # Same reset-then-repopulate: a doc_type that leaves the corpus clears its series.
+    qdrant_source_bytes_total.clear()
+    for doc_type, total in (source_bytes or {}).items():
+        qdrant_source_bytes_total.labels(doc_type=doc_type).set(total)
 
     chunk_density_snapshot_truncated.set(1 if truncated else 0)
 

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -240,7 +240,9 @@ async def compute_chunk_density_snapshot(
     *,
     max_documents: int,
     page_size: int = 1000,
-) -> tuple[dict[str, tuple[list[float], float]], dict[str, int], bool]:
+) -> tuple[
+    dict[str, tuple[list[float], float]], dict[str, int], bool, dict[str, float]
+]:
     """Tally the current-corpus chunk-density distribution by scrolling Qdrant.
 
     Iterates the ``chunk_index == 0`` point of every non-placeholder document
@@ -253,15 +255,19 @@ async def compute_chunk_density_snapshot(
     key, or a non-positive value) are tallied in ``uncovered`` instead of silently
     shrinking the histogram.
 
-    Returns ``(per_doc_type, uncovered, truncated)`` shaped for
+    Returns ``(per_doc_type, uncovered, truncated, source_bytes_totals)`` shaped for
     ``update_qdrant_chunk_density_snapshot``: ``per_doc_type`` maps
     ``doc_type -> (bucket_counts, gsum)``, ``uncovered`` maps ``doc_type -> count``,
-    and ``truncated`` is True when the scan stopped at ``max_documents`` (partial
-    snapshot). Errors propagate to the best-effort caller.
+    ``truncated`` is True when the scan stopped at ``max_documents`` (partial
+    snapshot), and ``source_bytes_totals`` maps ``doc_type -> sum(source_bytes)`` over
+    exactly the covered documents (same forward-only set as the histogram — docs
+    counted in ``uncovered`` are excluded), enabling a corpus-weighted (byte-weighted)
+    density in Grafana. Errors propagate to the best-effort caller.
     """
     n_slots = len(CHUNK_DENSITY_BUCKETS) + 1
     bucket_counts: dict[str, list[float]] = {}
     gsums: dict[str, float] = {}
+    source_bytes_totals: dict[str, float] = {}
     uncovered: dict[str, int] = {}
     scanned = 0
     truncated = False
@@ -303,6 +309,9 @@ async def compute_chunk_density_snapshot(
                 counts = bucket_counts.setdefault(doc_type, [0.0] * n_slots)
                 counts[density_bucket_index(density)] += 1
                 gsums[doc_type] = gsums.get(doc_type, 0.0) + density
+                source_bytes_totals[doc_type] = (
+                    source_bytes_totals.get(doc_type, 0.0) + source_bytes
+                )
             else:
                 uncovered[doc_type] = uncovered.get(doc_type, 0) + 1
         scanned += len(points)
@@ -322,7 +331,7 @@ async def compute_chunk_density_snapshot(
             break
 
     per_doc_type = {dt: (bucket_counts[dt], gsums[dt]) for dt in bucket_counts}
-    return per_doc_type, uncovered, truncated
+    return per_doc_type, uncovered, truncated, source_bytes_totals
 
 
 async def publish_chunk_density_snapshot() -> None:
@@ -334,13 +343,21 @@ async def publish_chunk_density_snapshot() -> None:
     settings = get_settings()
     try:
         qdrant_client = await get_qdrant_client()
-        per_doc_type, uncovered, truncated = await compute_chunk_density_snapshot(
+        (
+            per_doc_type,
+            uncovered,
+            truncated,
+            source_bytes_totals,
+        ) = await compute_chunk_density_snapshot(
             qdrant_client,
             settings.get_collection_name(),
             max_documents=settings.vector_density_snapshot_max_documents,
         )
         update_qdrant_chunk_density_snapshot(
-            per_doc_type, uncovered=uncovered, truncated=truncated
+            per_doc_type,
+            uncovered=uncovered,
+            truncated=truncated,
+            source_bytes=source_bytes_totals,
         )
         if truncated:
             logger.warning(

--- a/tests/integration/test_chunk_density_snapshot.py
+++ b/tests/integration/test_chunk_density_snapshot.py
@@ -84,9 +84,12 @@ async def seeded_collection():
 async def test_snapshot_covers_uncovered_and_excludes_placeholder(seeded_collection):
     client, collection = seeded_collection
 
-    per_doc_type, uncovered, truncated = await compute_chunk_density_snapshot(
-        client, collection, max_documents=1000
-    )
+    (
+        per_doc_type,
+        uncovered,
+        truncated,
+        source_bytes,
+    ) = await compute_chunk_density_snapshot(client, collection, max_documents=1000)
 
     assert truncated is False
     # Placeholder excluded; legacy file counted as uncovered.
@@ -102,13 +105,18 @@ async def test_snapshot_covers_uncovered_and_excludes_placeholder(seeded_collect
     # File produced no covered docs, so it has no density series.
     assert "file" not in per_doc_type
 
+    # Byte-weighted denominator sums the SAME covered docs: two notes @1 MB each
+    # -> 2 MB. The uncovered file and the excluded placeholder contribute nothing.
+    assert source_bytes["note"] == pytest.approx(2_000_000.0)
+    assert "file" not in source_bytes
+
 
 async def test_truncation_signalled_against_real_engine(seeded_collection):
     client, collection = seeded_collection
 
     # Cap below the covered-document count with a tiny page size so the scroll
     # has a next page when the cap is reached.
-    _, _, truncated = await compute_chunk_density_snapshot(
+    _, _, truncated, _ = await compute_chunk_density_snapshot(
         client, collection, max_documents=1, page_size=1
     )
 

--- a/tests/unit/test_chunk_density_snapshot_metric.py
+++ b/tests/unit/test_chunk_density_snapshot_metric.py
@@ -119,3 +119,28 @@ class TestUpdateSnapshot:
         assert metric_sample(
             "astrolabe_qdrant_chunk_density_snapshot_truncated", {}
         ) == pytest.approx(0)
+
+    def test_source_bytes_total_published_per_doc_type(self, metric_sample):
+        update_qdrant_chunk_density_snapshot(
+            {"note": _tally(3.0)},
+            source_bytes={"note": 12345.0, "file": 6_000_000.0},
+        )
+        assert metric_sample(
+            "astrolabe_qdrant_source_bytes_total", {"doc_type": "note"}
+        ) == pytest.approx(12345.0)
+        assert metric_sample(
+            "astrolabe_qdrant_source_bytes_total", {"doc_type": "file"}
+        ) == pytest.approx(6_000_000.0)
+
+    def test_source_bytes_total_reset_between_snapshots(self, metric_sample):
+        update_qdrant_chunk_density_snapshot(
+            {"note": _tally(3.0)}, source_bytes={"file": 6_000_000.0}
+        )
+        assert metric_sample(
+            "astrolabe_qdrant_source_bytes_total", {"doc_type": "file"}
+        ) == pytest.approx(6_000_000.0)
+        # A doc_type that leaves the corpus must clear, not linger stale.
+        update_qdrant_chunk_density_snapshot({"note": _tally(3.0)}, source_bytes={})
+        assert metric_sample(
+            "astrolabe_qdrant_source_bytes_total", {"doc_type": "file"}
+        ) == pytest.approx(0)

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -372,9 +372,12 @@ class TestComputeChunkDensitySnapshot:
             ],
         )
 
-        per_doc_type, uncovered, truncated = await mp.compute_chunk_density_snapshot(
-            qc, _COLLECTION, max_documents=1000
-        )
+        (
+            per_doc_type,
+            uncovered,
+            truncated,
+            source_bytes,
+        ) = await mp.compute_chunk_density_snapshot(qc, _COLLECTION, max_documents=1000)
 
         assert truncated is False
         assert uncovered == {"file": 2}
@@ -390,6 +393,14 @@ class TestComputeChunkDensitySnapshot:
         deck_counts, deck_gsum = per_doc_type["deck_card"]
         assert deck_counts[0] == 1
         assert deck_gsum == pytest.approx(0.5)
+
+        # source_bytes_totals sums the SAME covered docs (byte-weighted denominator):
+        # two notes @1e6 -> 2e6, one deck_card @2e6 -> 2e6. The two `file` docs are
+        # uncovered (missing / non-positive source_bytes) so they contribute nothing
+        # and `file` has no series at all — matching the uncovered semantics.
+        assert source_bytes["note"] == pytest.approx(2_000_000.0)
+        assert source_bytes["deck_card"] == pytest.approx(2_000_000.0)
+        assert "file" not in source_bytes
 
     async def test_scrolls_chunk_index_zero_non_placeholder(self) -> None:
         qc = AsyncMock()
@@ -410,13 +421,18 @@ class TestComputeChunkDensitySnapshot:
             [_point(doc_type="note", total_chunks=3, source_bytes=1_000_000)],
         )
 
-        per_doc_type, _, truncated = await mp.compute_chunk_density_snapshot(
-            qc, _COLLECTION, max_documents=1000
-        )
+        (
+            per_doc_type,
+            _,
+            truncated,
+            source_bytes,
+        ) = await mp.compute_chunk_density_snapshot(qc, _COLLECTION, max_documents=1000)
 
         assert qc.scroll.await_count == 2
         assert truncated is False
         assert per_doc_type["note"][0][1] == 2  # both notes counted in le=5 slot
+        # source_bytes accumulates across pages: 1e6 + 1e6.
+        assert source_bytes["note"] == pytest.approx(2_000_000.0)
 
     async def test_truncates_when_corpus_strictly_exceeds_cap(self) -> None:
         qc = AsyncMock()
@@ -432,7 +448,7 @@ class TestComputeChunkDensitySnapshot:
             [note()],  # never fetched
         )
 
-        _, _, truncated = await mp.compute_chunk_density_snapshot(
+        _, _, truncated, _ = await mp.compute_chunk_density_snapshot(
             qc, _COLLECTION, max_documents=2, page_size=2
         )
 
@@ -453,7 +469,7 @@ class TestComputeChunkDensitySnapshot:
             [],  # empty trailing page, offset=None -> authoritative end
         )
 
-        _, _, truncated = await mp.compute_chunk_density_snapshot(
+        _, _, truncated, _ = await mp.compute_chunk_density_snapshot(
             qc, _COLLECTION, max_documents=2, page_size=2
         )
 
@@ -484,6 +500,8 @@ class TestPublishChunkDensitySnapshot:
         _, kwargs = published.call_args
         assert kwargs["truncated"] is False
         assert kwargs["uncovered"] == {}
+        # The byte-weighted denominator is threaded through to the publish entry.
+        assert kwargs["source_bytes"] == {"note": pytest.approx(1_000_000.0)}
 
     async def test_qdrant_failure_is_swallowed(self, monkeypatch) -> None:
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Emit **`astrolabe_qdrant_source_bytes_total`** (per `doc_type`) so Grafana can compute the **corpus-weighted (byte-weighted)** chunk density, which is the real pricing driver.

The cost-to-serve / pricing model was overstating dense-vector RAM and embedding cost by ~2× because it keyed off the **doc-weighted** chunk-density mean (`astrolabe_qdrant_chunk_density_chunks_per_mb_current` `_gsum/_gcount` ≈ 90 for blackbox-demo) instead of the corpus-weighted density (~45.3 chunks/raw-MB — exactly half). RAM/embedding cost scale with **total chunks ÷ total corpus bytes**, so corpus-weighted is the driver — but `Σsource_bytes` was never emitted, so it wasn't computable in Grafana.

A live panel *"Corpus-weighted chunk density (byte-weighted)"* (dashboard `astrolabe-cloud-tenants`, Vector store cost row) already exists and shows **No Data** until this metric ships. Its query:

```
sum by(namespace)(mcp_vector_sync_indexed_chunks)
  / (sum by(namespace)(astrolabe_qdrant_source_bytes_total) / 1e6)
```

## Changes

- **`vector/metrics_publisher.py`** — `compute_chunk_density_snapshot` now also returns `source_bytes_totals` (`doc_type -> Σsource_bytes`) over **exactly the covered documents** — the same forward-only set as the density histogram; documents counted in `uncovered` (no usable `source_bytes`) are excluded. Threaded through `publish_chunk_density_snapshot`. No new scan — the scroll already reads `payload_keys.SOURCE_BYTES` per doc.
- **`observability/metrics.py`** — new `astrolabe_qdrant_source_bytes_total` Gauge (label `doc_type`), published inside `update_qdrant_chunk_density_snapshot` via the same reset-then-repopulate pattern as `chunk_density_uncovered_documents` (a `doc_type` leaving the corpus clears its series). The `_total`-named **Gauge** (not Counter) is deliberate and commented — the name is fixed because the deployed panel query depends on it.

## Testing

Metric-only change (no HTTP/MCP API surface) → **no Pact contract needed**; unit + in-memory integration coverage added per the repo test gate:

- `tests/unit/vector/test_metrics_publisher.py` — per-`doc_type` sum correctness + exclusion of missing/non-positive `source_bytes` (mirrors the uncovered assertions); publisher wire-through.
- `tests/unit/test_chunk_density_snapshot_metric.py` — exposition gauge value + reset-between-snapshots.
- `tests/integration/test_chunk_density_snapshot.py` — real in-memory Qdrant scroll: byte sum over covered docs, placeholder/uncovered excluded.

`ruff` / `ruff format` / `ty` clean; new tests green. (Two unrelated unit failures — `test_decomposition_config[...search_mode...]` and `test_payload_backfill` — pre-exist on `master`, unaffected by this diff.)

## Follow-ups (tracked on Deck #663, not in this PR)

- Codify the Grafana panel in `astrolabe-cloud-gitops` so ArgoCD doesn't revert the live edit.
- Update pricing note 390487 / model to key density off the corpus-weighted metric once live.

Deck #663.

---

_This PR was generated with the help of AI, and reviewed by a Human_
