### PR TITLE
perf(usage): batch per-document metering into one transaction + trace DB writes

### DIFF
--- a/nextcloud_mcp_server/usage/__init__.py
+++ b/nextcloud_mcp_server/usage/__init__.py
@@ -5,6 +5,6 @@ control plane to pull. Gated by ``USAGE_METERING_ENABLED`` (default off). See
 Deck #67 and control-plane ``usage-metering.md``.
 """
 
-from nextcloud_mcp_server.usage.store import UsageEventStore
+from nextcloud_mcp_server.usage.store import UsageEvent, UsageEventStore
 
-__all__ = ["UsageEventStore"]
+__all__ = ["UsageEvent", "UsageEventStore"]

--- a/nextcloud_mcp_server/usage/store.py
+++ b/nextcloud_mcp_server/usage/store.py
@@ -246,5 +246,8 @@ class UsageEventStore:
                 self._storage.dialect, "insert", time.time() - start, "error"
             )
             logger.warning(
-                "usage metering batch dropped (%d events): %s", len(events), exc
+                "usage metering batch dropped (%d events, metrics=%s): %s",
+                len(events),
+                [e.metric for e in events],
+                exc,
             )

--- a/nextcloud_mcp_server/usage/store.py
+++ b/nextcloud_mcp_server/usage/store.py
@@ -231,7 +231,8 @@ class UsageEventStore:
                 self._storage.dialect, "insert", "usage_events"
             ) as span:
                 if span is not None:
-                    span.set_attribute("db.rows", len(rows))
+                    # OTel semconv-aligned name for the row count on a DB span.
+                    span.set_attribute("db.rows_affected", len(rows))
                 async with self._storage.acquire() as db:
                     for params in rows:
                         await db.execute(_INSERT_SQL, params)

--- a/nextcloud_mcp_server/usage/store.py
+++ b/nextcloud_mcp_server/usage/store.py
@@ -23,6 +23,8 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -31,6 +33,7 @@ import anyio
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage, get_shared_storage
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.observability.metrics import record_db_operation
+from nextcloud_mcp_server.observability.tracing import trace_db_operation
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +52,22 @@ _INSERT_SQL = (
     "VALUES (?, ?, ?, ?, ?) "
     "ON CONFLICT (event_id) DO NOTHING"
 )
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    """One billable usage event for batch recording via ``record_usage_events``.
+
+    Mirrors the keyword arguments of :meth:`UsageEventStore.record_usage_event`
+    so a caller can accumulate a document's events and write them in a single
+    transaction. ``occurred_at`` / ``event_id`` default lazily at write time.
+    """
+
+    metric: str
+    value: int
+    metadata: dict[str, Any] | None = None
+    occurred_at: datetime | None = None
+    event_id: str | None = None
 
 
 class UsageEventStore:
@@ -140,9 +159,10 @@ class UsageEventStore:
                 value,
                 json.dumps(metadata, sort_keys=True) if metadata is not None else None,
             )
-            async with self._storage.acquire() as db:
-                await db.execute(_INSERT_SQL, params)
-                await db.commit()
+            with trace_db_operation(self._storage.dialect, "insert", "usage_events"):
+                async with self._storage.acquire() as db:
+                    await db.execute(_INSERT_SQL, params)
+                    await db.commit()
             record_db_operation(
                 self._storage.dialect, "insert", time.time() - start, "success"
             )
@@ -156,4 +176,74 @@ class UsageEventStore:
                 metric,
                 value,
                 exc,
+            )
+
+    async def record_usage_events(
+        self,
+        events: Sequence[UsageEvent],
+        *,
+        enabled: bool | None = None,
+    ) -> None:
+        """Record several usage events in ONE connection and ONE transaction.
+
+        Same best-effort, flag-gated contract as :meth:`record_usage_event`, but
+        amortizes the per-event ``acquire() -> INSERT -> commit`` across the whole
+        batch. The shared engine uses ``NullPool`` (ADR-026) behind a
+        transaction-mode PgBouncer, so each such round-trip pays a full
+        connection setup (~0.6-0.8s measured on cloudfleet); a document's ~5
+        metering events therefore serialized into seconds of ingest-critical-path
+        latency. One acquire + N inserts + one commit collapses that to a single
+        round-trip (Deck #667).
+
+        Atomic per call: a mid-batch failure rolls back the whole transaction, so
+        a document's events are recorded all-or-nothing rather than partially —
+        within the best-effort billing contract (dropped writes are tolerated)
+        and cleaner than a half-metered document.
+        """
+        if enabled is None:
+            enabled = get_settings().usage_metering_enabled
+        if not enabled or not events:
+            return
+
+        start = time.time()
+        try:
+            when_default = datetime.now(timezone.utc)
+            # json.dumps lives inside the best-effort try (see record_usage_event):
+            # a non-serializable metadata dict is swallowed, not raised.
+            rows = []
+            for e in events:
+                when = e.occurred_at or when_default
+                when_bind = (
+                    when if self._storage.dialect == "postgresql" else when.isoformat()
+                )
+                rows.append(
+                    (
+                        e.event_id or str(uuid.uuid4()),
+                        when_bind,
+                        e.metric,
+                        e.value,
+                        json.dumps(e.metadata, sort_keys=True)
+                        if e.metadata is not None
+                        else None,
+                    )
+                )
+            with trace_db_operation(
+                self._storage.dialect, "insert", "usage_events"
+            ) as span:
+                if span is not None:
+                    span.set_attribute("db.rows", len(rows))
+                async with self._storage.acquire() as db:
+                    for params in rows:
+                        await db.execute(_INSERT_SQL, params)
+                    await db.commit()
+            record_db_operation(
+                self._storage.dialect, "insert", time.time() - start, "success"
+            )
+        except Exception as exc:
+            # Best-effort: never surface a metering failure to the user op.
+            record_db_operation(
+                self._storage.dialect, "insert", time.time() - start, "error"
+            )
+            logger.warning(
+                "usage metering batch dropped (%d events): %s", len(events), exc
             )

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -44,7 +44,7 @@ from nextcloud_mcp_server.observability.metrics import (
 )
 from nextcloud_mcp_server.observability.tracing import trace_operation
 from nextcloud_mcp_server.search.pdf_highlighter import PDFHighlighter
-from nextcloud_mcp_server.usage import UsageEventStore
+from nextcloud_mcp_server.usage import UsageEvent, UsageEventStore
 from nextcloud_mcp_server.utils.validation import is_valid_nextcloud_doc_id
 from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector._errors import format_exception_group
@@ -482,69 +482,61 @@ async def record_indexing_usage(
         # doc types, which are never parsed.
         "pipeline_tier": pipeline_tier,
     }
+    # Build the document's events in the historical order (tokens -> pages ->
+    # pages_ocr -> bytes_*), then write them in ONE transaction. Each event used
+    # to be its own acquire() -> INSERT -> commit; on the NullPool + pgbouncer
+    # setup every such round-trip pays a full connection setup (~0.6-0.8s on
+    # cloudfleet), so ~5 events serialized into seconds on the ingest critical
+    # path. Batching collapses them to a single round-trip (Deck #667).
+    events: list[UsageEvent] = []
+
+    # tokens_embedded first (intentional ordering): captured before the
+    # conditional parsing/byte costs — don't reverse this in a refactor. Skipped
+    # for keyword docs (token_count == 0), which never embed, so no zero-value
+    # embedding row is written.
+    if token_count > 0:
+        events.append(
+            UsageEvent(metric="tokens_embedded", value=token_count, metadata=metadata)
+        )
+    # pages_embedded: parsed pages only, and only a strictly positive count. Text
+    # content has no page_count; a zero/negative count is skipped rather than
+    # writing a row that would misrepresent a no-parse document as billable
+    # parsing work.
+    if page_count and page_count > 0:
+        events.append(
+            UsageEvent(metric="pages_embedded", value=page_count, metadata=metadata)
+        )
+        # OCR pages are metered as a SEPARATE line (Deck #323) so the OCR tier's
+        # cost is billable independently of CPU-cheap parsing -- pages_embedded
+        # counts all parsed pages, pages_ocr only the OCR tier's. Gated on the
+        # tier so it's emitted exactly when the doc hit OCR.
+        if pipeline_tier == "ocr":
+            events.append(
+                UsageEvent(metric="pages_ocr", value=page_count, metadata=metadata)
+            )
+    # Byte-volume dimensions (card #401), recorded for every embedded document.
+    # Appended after the conditional pages block so the tokens-then-pages
+    # ordering above is preserved. Each is skipped on a non-positive count to
+    # avoid writing a zero-value billing row (the chunk_count guard already
+    # filtered truly-empty documents).
+    if bytes_ingested > 0:
+        events.append(
+            UsageEvent(metric="bytes_ingested", value=bytes_ingested, metadata=metadata)
+        )
+    if bytes_stored > 0:
+        events.append(
+            UsageEvent(metric="bytes_stored", value=bytes_stored, metadata=metadata)
+        )
+
     try:
         store = await UsageEventStore.shared()
         # enabled=True: the guard above already confirmed the flag, so the store
-        # skips a second uncached Settings build per record (ADR-024).
-        # record_usage_event swallows its own write failures, so the records are
-        # independent; one raising never blocks the other — acceptable under the
-        # (day, metric) SUM-aggregation billing model.
-
-        # tokens_embedded first (intentional ordering): captured before the
-        # conditional parsing/byte costs — don't reverse this in a refactor.
-        # Skipped for keyword docs (token_count == 0), which never embed, so no
-        # zero-value embedding row is written.
-        if token_count > 0:
-            await store.record_usage_event(
-                metric="tokens_embedded",
-                value=token_count,
-                metadata=metadata,
-                enabled=True,
-            )
-        # pages_embedded: parsed pages only, and only a strictly positive count.
-        # Text content has no page_count; a zero/negative count is skipped rather
-        # than writing a row that would misrepresent a no-parse document as
-        # billable parsing work.
-        if page_count and page_count > 0:
-            await store.record_usage_event(
-                metric="pages_embedded",
-                value=page_count,
-                metadata=metadata,
-                enabled=True,
-            )
-            # OCR pages are metered as a SEPARATE line (Deck #323) so the OCR
-            # tier's cost is billable independently of CPU-cheap parsing --
-            # pages_embedded counts all parsed pages, pages_ocr only the OCR tier's.
-            # Gated on the tier so it's emitted exactly when the doc hit OCR.
-            if pipeline_tier == "ocr":
-                await store.record_usage_event(
-                    metric="pages_ocr",
-                    value=page_count,
-                    metadata=metadata,
-                    enabled=True,
-                )
-        # Byte-volume dimensions (card #401), recorded for every embedded
-        # document. Appended after the conditional pages block so the
-        # tokens-then-pages ordering above is preserved. Each is skipped on a
-        # non-positive count to avoid writing a zero-value billing row (the
-        # chunk_count guard already filtered truly-empty documents).
-        if bytes_ingested > 0:
-            await store.record_usage_event(
-                metric="bytes_ingested",
-                value=bytes_ingested,
-                metadata=metadata,
-                enabled=True,
-            )
-        if bytes_stored > 0:
-            await store.record_usage_event(
-                metric="bytes_stored",
-                value=bytes_stored,
-                metadata=metadata,
-                enabled=True,
-            )
+        # skips a second uncached Settings build (ADR-024). One connection + one
+        # commit for the whole document instead of ~5 sequential round-trips.
+        await store.record_usage_events(events, enabled=True)
     except Exception:
         # Reached only when shared()/store construction itself raises
-        # (record_usage_event swallows its own write failures). Metering is on,
+        # (record_usage_events swallows its own write failures). Metering is on,
         # so warn rather than hide the "enabled but no billing data" case.
         logger.warning("usage metering hook (indexing embeddings) skipped")
 

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -10,9 +10,12 @@ tokens only — ``pages_embedded`` is a charge for parsing, not content size (ca
 carry an ``index_mode`` metadata dimension (card #609) so the CP rollup can slice
 hybrid vs keyword ingestion. These cover the value mapping, the flag/zero-chunk
 no-ops, the text-only path, and the best-effort failure path without standing up
-the full document pipeline. (The call site's raw-binary-vs-UTF-8 source selection
-for ``bytes_ingested`` lives in the document pipeline and is exercised by the
-integration smoke path, not these helper-level tests.)
+the full document pipeline.
+
+Since Deck #667 the helper writes a document's events with a single
+``record_usage_events(events, enabled=True)`` batch call (one connection + one
+commit) rather than N ``record_usage_event`` calls, so these tests assert on the
+batched ``UsageEvent`` list.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -26,11 +29,17 @@ from nextcloud_mcp_server.vector import processor
 def store_spy(monkeypatch):
     """Patch UsageEventStore.shared() to return a spy store."""
     store = MagicMock()
-    store.record_usage_event = AsyncMock()
+    store.record_usage_events = AsyncMock()
     monkeypatch.setattr(
         processor.UsageEventStore, "shared", AsyncMock(return_value=store)
     )
     return store
+
+
+def _events(store_spy):
+    """The ``UsageEvent`` list from the single batched record_usage_events() call."""
+    store_spy.record_usage_events.assert_awaited_once()
+    return list(store_spy.record_usage_events.await_args.args[0])
 
 
 @pytest.mark.unit
@@ -95,8 +104,8 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
         bytes_stored=178000,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    events = _events(store_spy)
+    by_metric = {e.metric: e.value for e in events}
     # pages_embedded is the real parsed-page count, NOT the chunk count;
     # bytes_* are the raw-ingest / stored-chunk byte counts (card #401).
     assert by_metric == {
@@ -109,18 +118,18 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
     # conditional parsing cost). Asserted so a refactor can't silently reverse
     # it — a comment alone is easier to delete than a failing test. The byte
     # rows are appended after the pages block, so these two stay valid.
-    assert calls[0].kwargs["metric"] == "tokens_embedded"
-    assert calls[1].kwargs["metric"] == "pages_embedded"
-    for c in calls:
-        # Hot-path fast-gate + tenant-local attribution metadata.
-        assert c.kwargs["enabled"] is True
-        assert c.kwargs["metadata"]["provider"] == "mistral"
-        assert c.kwargs["metadata"]["model"] == "mistral-embed"
-        assert c.kwargs["metadata"]["user_id"] == "alice"
-        assert c.kwargs["metadata"]["doc_type"] == "file"
-        # index_mode is threaded onto every event so the CP rollup can slice
-        # hybrid vs keyword ingestion (card #609).
-        assert c.kwargs["metadata"]["index_mode"] == "hybrid"
+    assert events[0].metric == "tokens_embedded"
+    assert events[1].metric == "pages_embedded"
+    # One batched write, hot-path fast-gated (the store skips a Settings rebuild).
+    assert store_spy.record_usage_events.await_args.kwargs["enabled"] is True
+    for e in events:
+        # Tenant-local attribution metadata, threaded onto every event.
+        assert e.metadata["provider"] == "mistral"
+        assert e.metadata["model"] == "mistral-embed"
+        assert e.metadata["user_id"] == "alice"
+        assert e.metadata["doc_type"] == "file"
+        # index_mode lets the CP rollup slice hybrid vs keyword ingestion (#609).
+        assert e.metadata["index_mode"] == "hybrid"
 
 
 @pytest.mark.unit
@@ -141,8 +150,7 @@ async def test_text_doc_records_tokens_and_bytes_no_pages(store_spy):
         bytes_stored=8200,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    by_metric = {e.metric: e.value for e in _events(store_spy)}
     # Byte rows fire for text docs (they have no page_count, so no pages row).
     assert by_metric == {
         "tokens_embedded": 512,
@@ -170,8 +178,7 @@ async def test_zero_pages_skips_pages(store_spy):
         bytes_stored=1100,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    by_metric = {e.metric: e.value for e in _events(store_spy)}
     assert by_metric == {
         "tokens_embedded": 99,
         "bytes_ingested": 2048,
@@ -197,8 +204,7 @@ async def test_negative_pages_skips_pages(store_spy):
         bytes_stored=1100,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    by_metric = {e.metric: e.value for e in _events(store_spy)}
     assert by_metric == {
         "tokens_embedded": 99,
         "bytes_ingested": 2048,
@@ -224,8 +230,7 @@ async def test_nonpositive_bytes_skip_byte_rows(store_spy):
         bytes_stored=-5,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    by_metric = {e.metric: e.value for e in _events(store_spy)}
     # Only tokens_embedded survives — neither byte row is written.
     assert by_metric == {"tokens_embedded": 99}
 
@@ -247,7 +252,7 @@ async def test_disabled_is_noop(store_spy):
         bytes_ingested=4096,
         bytes_stored=512,
     )
-    store_spy.record_usage_event.assert_not_awaited()
+    store_spy.record_usage_events.assert_not_awaited()
 
 
 @pytest.mark.unit
@@ -267,7 +272,7 @@ async def test_zero_chunks_is_noop(store_spy):
         bytes_ingested=4096,
         bytes_stored=512,
     )
-    store_spy.record_usage_event.assert_not_awaited()
+    store_spy.record_usage_events.assert_not_awaited()
 
 
 @pytest.mark.unit
@@ -314,10 +319,8 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         bytes_stored=41000,
         pipeline_tier="ocr",
     )
-    by_metric = {
-        c.kwargs["metric"]: c.kwargs["value"]
-        for c in store_spy.record_usage_event.await_args_list
-    }
+    events = _events(store_spy)
+    by_metric = {e.metric: e.value for e in events}
     # pages_ocr fires IN ADDITION to pages_embedded for OCR-tier pages.
     assert by_metric == {
         "tokens_embedded": 900,
@@ -327,8 +330,8 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         "bytes_stored": 41000,
     }
     # pipeline_tier is threaded into the billing metadata for CP attribution.
-    for c in store_spy.record_usage_event.await_args_list:
-        assert c.kwargs["metadata"]["pipeline_tier"] == "ocr"
+    for e in events:
+        assert e.metadata["pipeline_tier"] == "ocr"
 
 
 @pytest.mark.unit
@@ -349,7 +352,7 @@ async def test_fast_tier_does_not_record_pages_ocr(store_spy):
         bytes_stored=20500,
         pipeline_tier="fast",
     )
-    metrics = {c.kwargs["metric"] for c in store_spy.record_usage_event.await_args_list}
+    metrics = {e.metric for e in _events(store_spy)}
     assert "pages_ocr" not in metrics
     assert metrics == {
         "tokens_embedded",
@@ -379,8 +382,8 @@ async def test_keyword_mode_meters_bytes_not_tokens(store_spy):
         bytes_stored=30500,
     )
 
-    calls = store_spy.record_usage_event.await_args_list
-    by_metric = {c.kwargs["metric"]: c.kwargs["value"] for c in calls}
+    events = _events(store_spy)
+    by_metric = {e.metric: e.value for e in events}
     # No tokens_embedded row; parsing (pages) + byte volume still bill.
     assert by_metric == {
         "pages_embedded": 5,
@@ -389,8 +392,8 @@ async def test_keyword_mode_meters_bytes_not_tokens(store_spy):
     }
     assert "tokens_embedded" not in by_metric
     # Every event carries the keyword mode so the CP can attribute it separately.
-    for c in calls:
-        assert c.kwargs["metadata"]["index_mode"] == "keyword"
+    for e in events:
+        assert e.metadata["index_mode"] == "keyword"
 
 
 @pytest.mark.unit
@@ -412,6 +415,6 @@ async def test_hybrid_zero_tokens_still_skips_tokens_row(store_spy):
         bytes_ingested=200,
         bytes_stored=250,
     )
-    metrics = {c.kwargs["metric"] for c in store_spy.record_usage_event.await_args_list}
+    metrics = {e.metric for e in _events(store_spy)}
     assert "tokens_embedded" not in metrics
     assert metrics == {"bytes_ingested", "bytes_stored"}

--- a/tests/unit/test_usage_store.py
+++ b/tests/unit/test_usage_store.py
@@ -23,7 +23,7 @@ from cryptography.fernet import Fernet
 
 import nextcloud_mcp_server.usage.store as store_module
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
-from nextcloud_mcp_server.usage.store import UsageEventStore
+from nextcloud_mcp_server.usage.store import UsageEvent, UsageEventStore
 
 pytestmark = pytest.mark.unit
 
@@ -271,5 +271,93 @@ async def test_best_effort_swallows_unserializable_metadata(
     # contract as the DB-error path.
     assert any(
         r.levelno == logging.WARNING and "usage metering write dropped" in r.message
+        for r in caplog.records
+    )
+
+
+# --- Batch write: record_usage_events (Deck #667) --------------------------
+
+
+async def test_batch_records_all_events(storage, monkeypatch):
+    """A batch writes every event, with values and metadata intact."""
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+    eids = [str(uuid.uuid4()) for _ in range(3)]
+    await store.record_usage_events(
+        [
+            UsageEvent("tokens_embedded", 100, {"m": "a"}, event_id=eids[0]),
+            UsageEvent("pages_embedded", 5, {"m": "a"}, event_id=eids[1]),
+            UsageEvent("bytes_stored", 2048, {"m": "a"}, event_id=eids[2]),
+        ]
+    )
+    assert await _count(storage) == 3
+    by_metric = {}
+    for eid in eids:
+        row = await _fetch(storage, eid)
+        assert row is not None
+        by_metric[row[2]] = row[3]
+    assert by_metric == {
+        "tokens_embedded": 100,
+        "pages_embedded": 5,
+        "bytes_stored": 2048,
+    }
+
+
+async def test_batch_uses_single_connection(storage, monkeypatch, mocker):
+    """The whole batch runs on ONE acquire()/transaction, not one per event."""
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+    spy = mocker.spy(storage, "acquire")
+    await store.record_usage_events(
+        [
+            UsageEvent("tokens_embedded", 1),
+            UsageEvent("pages_embedded", 2),
+            UsageEvent("bytes_stored", 3),
+        ]
+    )
+    # One connection checkout for all three inserts — the point of Deck #667.
+    assert spy.call_count == 1
+
+
+async def test_batch_is_traced(storage, monkeypatch, mocker):
+    """DB activity is traced: the batch opens a db.<dialect>.insert span."""
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+    spy = mocker.spy(store_module, "trace_db_operation")
+    await store.record_usage_events([UsageEvent("pages_embedded", 1)])
+    spy.assert_called_once_with(storage.dialect, "insert", "usage_events")
+
+
+async def test_batch_flag_off_is_noop(storage, monkeypatch, mocker):
+    """Metering disabled → no rows and no DB access, even with events queued."""
+    _set_metering(monkeypatch, False)
+    store = UsageEventStore(storage)
+    spy = mocker.spy(storage, "acquire")
+    await store.record_usage_events([UsageEvent("pages_embedded", 1)])
+    assert spy.call_count == 0
+    assert await _count(storage) == 0
+
+
+async def test_batch_empty_is_noop(storage, monkeypatch, mocker):
+    """An empty event list touches the DB not at all."""
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+    spy = mocker.spy(storage, "acquire")
+    await store.record_usage_events([])
+    assert spy.call_count == 0
+    assert await _count(storage) == 0
+
+
+async def test_batch_best_effort_swallows_encode_error(storage, monkeypatch, caplog):
+    """A non-serializable event is swallowed (best-effort); the batch writes nothing."""
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+    with caplog.at_level(logging.WARNING, logger="nextcloud_mcp_server.usage.store"):
+        await store.record_usage_events(
+            [UsageEvent("pages_embedded", 1, metadata={"obj": object()})]
+        )
+    assert await _count(storage) == 0
+    assert any(
+        r.levelno == logging.WARNING and "usage metering batch dropped" in r.message
         for r in caplog.records
     )

--- a/tests/unit/test_usage_store.py
+++ b/tests/unit/test_usage_store.py
@@ -361,3 +361,40 @@ async def test_batch_best_effort_swallows_encode_error(storage, monkeypatch, cap
         r.levelno == logging.WARNING and "usage metering batch dropped" in r.message
         for r in caplog.records
     )
+
+
+async def test_batch_rolls_back_on_midbatch_failure(storage, monkeypatch):
+    """A DB failure mid-batch rolls back the WHOLE document's events (atomic).
+
+    Forces the 2nd of three inserts to raise: the first insert must not survive,
+    proving the one-transaction batch is all-or-nothing (docstring claim), not a
+    partial write.
+    """
+    from nextcloud_mcp_server.auth.storage import _DBConn
+
+    _set_metering(monkeypatch, True)
+    store = UsageEventStore(storage)
+
+    real_execute = _DBConn.execute
+    calls = {"n": 0}
+
+    def flaky_execute(self, sql, params=()):
+        calls["n"] += 1
+        if calls["n"] == 2:  # blow up on the 2nd insert of the 3-event batch
+            raise RuntimeError("boom mid-batch")
+        return real_execute(self, sql, params)
+
+    monkeypatch.setattr(_DBConn, "execute", flaky_execute)
+    # Best-effort: the swallowed failure must not raise into the caller.
+    await store.record_usage_events(
+        [
+            UsageEvent("tokens_embedded", 1),
+            UsageEvent("pages_embedded", 2),
+            UsageEvent("bytes_stored", 3),
+        ]
+    )
+    monkeypatch.undo()  # restore the real execute before counting
+
+    # The 1st insert never commits — the transaction rolls back on the failing
+    # batch, so NONE of the document's events are persisted.
+    assert await _count(storage) == 0


### PR DESCRIPTION
## Why

Profiling an ingest worker showed most of the per-document wall time was an **untraced gap** between embedding and the Qdrant upsert — and it turned out to be **usage metering**. `record_indexing_usage` writes up to ~5 usage events per document, each via its own `UsageEventStore.record_usage_event()` → `acquire() → INSERT → commit`. The storage engine uses `NullPool` (ADR-026) behind a transaction-mode PgBouncer, so **every** op pays a full connection setup.

Measured against the real per-tenant Postgres (via the pooler), 20 INSERTs:

| Pattern | per-op |
|---|---|
| Sequential (current) | **630 ms mean / 806 ms median** |
| **Batched** (1 conn, N inserts, 1 commit) | **121 ms/op amortized → ~5.2×** |

So a document's ~5 metering writes were serializing into **~3–4 s** on the ingest critical path. (Pooling only ~2.1× and, under transaction-mode PgBouncer, requires `prepare_threshold=None` — verified to otherwise fail at op#6 with `prepared statement … does not exist`. Batching is the higher-leverage, lower-risk fix.)

## What

**1. Batch the per-document metering** — `usage/store.py`, `vector/processor.py`
- New `UsageEventStore.record_usage_events(events, *, enabled)`: **one** `acquire()`, N INSERTs, **one** commit. Same best-effort, flag-gated, `ON CONFLICT (event_id) DO NOTHING` contract as the single-event path.
- New `UsageEvent` dataclass mirroring the single-event kwargs.
- `record_indexing_usage` now builds the event list (same metrics/values/metadata, same tokens→pages→pages_ocr→bytes ordering) and writes it in one call. `record_usage_event` (single) is kept for the search/query path.
- Behavior note: batching is **atomic per document** (a mid-batch failure rolls back the whole doc's events instead of a partial write) — within the best-effort billing contract and cleaner than a half-metered document.

**2. Trace DB activity** — `usage/store.py`
- Wire the existing `trace_db_operation(...)` helper (`db.<dialect>.insert` span, table `usage_events`) into **both** the batch and single metering writes, wrapping the `acquire()`→insert→commit so the span captures the connection acquisition (the costly part). The metering DB work — previously the invisible gap in traces — is now attributed in Tempo, with a `db.rows` attribute on the batch.

## Observability note (metric semantics)

`record_db_operation` (Prometheus `mcp_db_operations_total` / `mcp_db_operation_duration_seconds`, `operation="insert"`) now fires **once per batch** instead of once per usage event. So the insert **count** reflects DB operations (batches), not `usage_events` rows (~5× fewer), and the **duration** reflects whole-batch latency under the shared `insert` label. Row-level counting moves to the trace layer via the new `db.rows_affected` span attribute on the `db.<dialect>.insert` span — any dashboard that read the Prometheus insert count as a row proxy should switch to the span attribute or the `usage_events` table.

## Testing

- `tests/unit/test_usage_store.py`: batch roundtrip (all events written), **single-connection** assertion (`acquire()` called once for N events), **DB-activity-traced** assertion (`trace_db_operation` invoked with the right args), flag-off / empty no-ops, and best-effort swallow on encode error.
- `tests/unit/test_processor_metering.py`: rewritten to assert on the batched `UsageEvent` list (metrics, values, ordering, metadata, no-op paths, OCR/keyword/zero-token gates) instead of N per-event calls.
- Full unit suite green; `ruff` + `ty` clean.
- No API / MCP tool / Pact surface change → no contract/e2e tier applies. The `usage_events` rows are the same metrics/values/metadata as before, with one intentional nuance: a document's events now share a single `occurred_at` instant (previously each event's `datetime.now()` differed by microseconds) — a cleaner consequence of the one-transaction write.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
