### PR TITLE
feat(ingest): safe per-tier worker concurrency (serialize pypdfium2/pymupdf) + overrides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -625,6 +625,10 @@ ENABLE_SEMANTIC_SEARCH=true           # Enable background indexing
 # Tuning parameters (advanced - only modify if needed)
 VECTOR_SYNC_SCAN_INTERVAL=300         # Scan interval in seconds (default: 5 minutes)
 VECTOR_SYNC_PROCESSOR_WORKERS=3       # Concurrent indexing workers (default: 3)
+# Optional per-tier concurrency overrides (unset = inherit PROCESSOR_WORKERS).
+# Precedence: worker --concurrency flag > tier override > PROCESSOR_WORKERS.
+VECTOR_SYNC_FAST_CONCURRENCY=         # Fast-tier worker concurrency (default: unset)
+VECTOR_SYNC_STRUCTURED_CONCURRENCY=   # Structured-tier worker concurrency (default: unset)
 VECTOR_SYNC_QUEUE_MAX_SIZE=10000      # Max queued documents (default: 10000)
 
 # Document chunking settings (for vector embeddings)
@@ -1096,6 +1100,8 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | `VECTOR_SYNC_SCAN_INTERVAL` | ⚠️ Optional | `300` | Document scan interval (seconds) |
 | `VECTOR_SYNC_EMPTY_DISCOVERY_DELETE_THRESHOLD` | ⚠️ Optional | `3` | Fail-safe against a flaky/empty tag-discovery read. A scan deletes indexed points whose files a tag-discovery no longer returns; if a Nextcloud intermittently answers the systemtag `REPORT` with an empty result, that would wrongly purge (then re-index) the whole corpus each cycle. This is the number of **consecutive** scan cycles an index mode's discovery must return zero (while Qdrant still holds points for it) before deletions for that mode are believed — a transient empty deletes nothing; a sustained empty (a genuine mass-untag) still deletes once the streak is reached. Worst-case deletion latency for a real mass-untag ≈ `(threshold-1) × VECTOR_SYNC_SCAN_INTERVAL + 1.5 × VECTOR_SYNC_SCAN_INTERVAL`. Set `≤1` to restore immediate deletion. |
 | `VECTOR_SYNC_PROCESSOR_WORKERS` | ⚠️ Optional | `3` | Concurrent indexing workers |
+| `VECTOR_SYNC_FAST_CONCURRENCY` | ⚠️ Optional | unset | Per-tier override for the **fast** ingest worker's concurrency. Unset inherits `VECTOR_SYNC_PROCESSOR_WORKERS`. Must be `>= 1` when set. Resolution precedence: the worker `--concurrency` flag > this tier override > `VECTOR_SYNC_PROCESSOR_WORKERS`. |
+| `VECTOR_SYNC_STRUCTURED_CONCURRENCY` | ⚠️ Optional | unset | Per-tier override for the **structured** ingest worker's concurrency. Unset inherits `VECTOR_SYNC_PROCESSOR_WORKERS`. Must be `>= 1` when set. Same precedence as `VECTOR_SYNC_FAST_CONCURRENCY`. |
 | `VECTOR_SYNC_QUEUE_MAX_SIZE` | ⚠️ Optional | `10000` | Max queued documents |
 | `OLLAMA_BASE_URL` | ⚠️ Optional | - | Ollama API endpoint for embeddings |
 | `OLLAMA_EMBEDDING_MODEL` | ⚠️ Optional | `nomic-embed-text` | Embedding model to use |

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -14,6 +14,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import anyio
 import pymupdf
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -57,6 +58,19 @@ from nextcloud_mcp_server.vector.visualization import compute_pca_coordinates
 logger = logging.getLogger(__name__)
 
 _NEXTCLOUD_HOST_NOT_CONFIGURED = "Nextcloud host not configured"
+
+
+class _PageOutOfRangeError(Exception):
+    """Requested preview page exceeds the document's page count.
+
+    Raised inside the off-loop render callable so the caller can map it to a
+    400 response after the (locked) PyMuPDF work has completed and the doc is
+    closed.
+    """
+
+    def __init__(self, total_pages: int) -> None:
+        self.total_pages = total_pages
+        super().__init__(f"page out of range (document has {total_pages} pages)")
 
 
 def _unsupported_search_type_response(e: UnsupportedSearchType) -> JSONResponse:
@@ -966,27 +980,40 @@ async def get_pdf_preview(request: Request) -> JSONResponse:
                 status_code=413,
             )
 
-        # Render page with PyMuPDF
-        doc = pymupdf.open(stream=pdf_bytes, filetype="pdf")
+        # Render page with PyMuPDF. MuPDF is not thread-safe, and with
+        # INGEST_QUEUE=memory the ingest workers run in-process and offload
+        # their PyMuPDF work under PYMUPDF_LOCK; serialize this render under the
+        # same lock (and run it off the event loop) so a preview request can't
+        # race a worker thread. Open/use/close happen entirely in one thread.
+        def _render_preview() -> tuple[bytes, int]:
+            from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+                pymupdf_serialized,
+            )
+
+            with (
+                pymupdf_serialized(),
+                pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc,
+            ):
+                total = doc.page_count
+                if page_num > total:
+                    raise _PageOutOfRangeError(total)
+                page = doc[page_num - 1]  # 0-indexed
+                mat = pymupdf.Matrix(scale, scale)
+                pix = page.get_pixmap(matrix=mat, alpha=False)
+                return pix.tobytes("png"), total
+
         try:
-            total_pages = doc.page_count
-
-            # Validate page number
-            if page_num > total_pages:
-                return JSONResponse(
-                    {
-                        "success": False,
-                        "error": f"Page {page_num} does not exist (document has {total_pages} pages)",
-                    },
-                    status_code=400,
-                )
-
-            page = doc[page_num - 1]  # 0-indexed
-            mat = pymupdf.Matrix(scale, scale)
-            pix = page.get_pixmap(matrix=mat, alpha=False)
-            png_bytes = pix.tobytes("png")
-        finally:
-            doc.close()
+            png_bytes, total_pages = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
+                _render_preview
+            )
+        except _PageOutOfRangeError as e:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": f"Page {page_num} does not exist (document has {e.total_pages} pages)",
+                },
+                status_code=400,
+            )
 
         # Encode as base64
         image_b64 = base64.b64encode(png_bytes).decode("ascii")

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -332,6 +332,25 @@ def _init_worker_observability(settings: Settings) -> None:
     )
 
 
+def _resolve_worker_concurrency(
+    cli_concurrency: int | None,
+    tier: str | None,
+    *,
+    fast: int | None,
+    structured: int | None,
+    default: int,
+) -> int:
+    """Resolve the procrastinate worker concurrency for a tier.
+
+    Precedence: an explicit ``--concurrency`` (the chart's per-tier arg) wins,
+    else the per-tier setting override (fast/structured), else the global
+    ``vector_sync_processor_workers``. ``or`` also treats a 0/None override as
+    "unset", so a bogus value can never yield ``concurrency=0``.
+    """
+    tier_override = {"fast": fast, "structured": structured}.get(tier)
+    return cli_concurrency or tier_override or default
+
+
 @click.command()
 @click.option(
     "--concurrency",
@@ -425,7 +444,13 @@ def worker(concurrency: int | None, tier: str | None):
     # directly (run_worker_async), so it does NOT go through IngestTransport —
     # DistributedTransport.run_consumers is a deliberate no-op precisely because
     # this separate process is the consumer (see vector/queue/transport.py).
-    workers = concurrency or settings.vector_sync_processor_workers
+    workers = _resolve_worker_concurrency(
+        concurrency,
+        tier,
+        fast=settings.vector_sync_fast_concurrency,
+        structured=settings.vector_sync_structured_concurrency,
+        default=settings.vector_sync_processor_workers,
+    )
     app = get_procrastinate_app()
 
     # Register the configured document processors (Unstructured / Tesseract /

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -490,6 +490,25 @@ _dynaconf = Dynaconf(
         Validator("QDRANT_INIT_BACKOFF_MAX", gte=0),
         Validator("VECTOR_SYNC_SCAN_INTERVAL", gte=1),
         Validator("VECTOR_SYNC_PROCESSOR_WORKERS", gte=1),
+        # Optional per-tier concurrency overrides (None = fall back to
+        # VECTOR_SYNC_PROCESSOR_WORKERS). Like the sibling above they must be
+        # >=1 when set — a 0/negative value would otherwise reach
+        # app.run_worker_async(concurrency=...) and fail with an opaque runtime
+        # error instead of a clear config error at startup.
+        Validator(
+            "VECTOR_SYNC_FAST_CONCURRENCY",
+            condition=lambda v: v is None or v >= 1,
+            messages={
+                "condition": "VECTOR_SYNC_FAST_CONCURRENCY must be >= 1 when set"
+            },
+        ),
+        Validator(
+            "VECTOR_SYNC_STRUCTURED_CONCURRENCY",
+            condition=lambda v: v is None or v >= 1,
+            messages={
+                "condition": "VECTOR_SYNC_STRUCTURED_CONCURRENCY must be >= 1 when set"
+            },
+        ),
         Validator("VECTOR_SYNC_QUEUE_MAX_SIZE", gte=1),
         Validator("VECTOR_SYNC_METRICS_REFRESH_INTERVAL", gte=1),
         Validator("VECTOR_DENSITY_SNAPSHOT_INTERVAL", gte=1),

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -114,6 +114,10 @@ _DEFAULTS: dict[str, Any] = {
     # Vector sync
     "vector_sync_scan_interval": 300,
     "vector_sync_processor_workers": 3,
+    # Optional per-tier concurrency overrides (None = fall back to
+    # vector_sync_processor_workers). Consumed by the `worker` CLI per --tier.
+    "vector_sync_fast_concurrency": None,
+    "vector_sync_structured_concurrency": None,
     "vector_sync_queue_max_size": 10000,
     "vector_sync_metrics_refresh_interval": 20,
     "vector_density_snapshot_enabled": True,
@@ -970,6 +974,11 @@ class Settings:
     vector_sync_enabled: bool = False
     vector_sync_scan_interval: int = 300  # seconds (5 minutes)
     vector_sync_processor_workers: int = 3
+    # Optional per-tier concurrency overrides for the ingest worker (None = use
+    # vector_sync_processor_workers). Only fast/structured are exposed; the
+    # CPU-heavy PDF paths are serialized (see document_processors/_native_locks).
+    vector_sync_fast_concurrency: int | None = None
+    vector_sync_structured_concurrency: int | None = None
     vector_sync_queue_max_size: int = 10000
     # Cadence for the periodic gauge publisher (vector/metrics_publisher.py):
     # outstanding-work + indexed documents/chunks. Decoupled from the consumer
@@ -1859,6 +1868,8 @@ def _build_settings() -> Settings:
         # Vector sync settings (ADR-007)
         "vector_sync_scan_interval": "VECTOR_SYNC_SCAN_INTERVAL",
         "vector_sync_processor_workers": "VECTOR_SYNC_PROCESSOR_WORKERS",
+        "vector_sync_fast_concurrency": "VECTOR_SYNC_FAST_CONCURRENCY",
+        "vector_sync_structured_concurrency": "VECTOR_SYNC_STRUCTURED_CONCURRENCY",
         "vector_sync_queue_max_size": "VECTOR_SYNC_QUEUE_MAX_SIZE",
         "vector_sync_metrics_refresh_interval": "VECTOR_SYNC_METRICS_REFRESH_INTERVAL",
         "vector_density_snapshot_enabled": "VECTOR_DENSITY_SNAPSHOT_ENABLED",

--- a/nextcloud_mcp_server/document_processors/_native_locks.py
+++ b/nextcloud_mcp_server/document_processors/_native_locks.py
@@ -1,0 +1,59 @@
+"""Process-global serialization for the non-thread-safe native PDF libraries.
+
+pypdfium2 (PDFium) and pymupdf (MuPDF) each keep process-global state — a single
+library instance per process; pypdfium2 additionally mutates an *unlocked*
+module-global object tracker on every object open/close. The ingest worker
+offloads their CPU-bound work to the shared anyio thread pool, and once a tier
+runs with ``concurrency > 1`` (or the ``ocr`` tier's existing ``concurrency:
+24``), multiple jobs can drive the same native library from different threads at
+once — a data race that segfaults or corrupts output.
+
+These module-level ``threading.Lock``\\s serialize each library's native calls.
+Two *separate* locks (the libraries are independent) let a PDFium parse and a
+MuPDF bbox overlap across concurrent documents while forbidding same-library
+concurrency. A ``threading.Lock`` (not an anyio ``CapacityLimiter``) is used
+deliberately: some MuPDF work runs on the event loop (the escalation classifier's
+``image_coverage_per_page``), not only in worker threads, so the primitive must
+be acquirable from both — an async limiter cannot be awaited from sync-on-loop
+code.
+
+Observability: the wait to acquire each lock is recorded to
+``astrolabe_pdf_native_lock_wait_seconds{library=...}`` so lock contention under
+concurrency is visible in Prometheus. The offload's *total* time already appears
+in the enclosing OTel span (e.g. ``vector_sync.compute_chunk_bboxes``,
+``document_processor.parse``), and each document keeps its own trace id, so
+concurrent jobs stay attributable in traces/logs.
+"""
+
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+
+from nextcloud_mcp_server.observability.metrics import record_pdf_native_lock_wait
+
+# Independent process-global native libraries → independent locks, so a PDFium
+# parse and a MuPDF bbox may overlap across concurrent documents.
+PDFIUM_LOCK = threading.Lock()
+PYMUPDF_LOCK = threading.Lock()
+
+
+@contextmanager
+def _serialized(lock: threading.Lock, library: str) -> Iterator[None]:
+    start = time.perf_counter()
+    lock.acquire()
+    record_pdf_native_lock_wait(library, time.perf_counter() - start)
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+def pdfium_serialized() -> AbstractContextManager[None]:
+    """Serialize a pypdfium2 (PDFium) native section across threads."""
+    return _serialized(PDFIUM_LOCK, "pdfium")
+
+
+def pymupdf_serialized() -> AbstractContextManager[None]:
+    """Serialize a pymupdf (MuPDF) native section across threads and the loop."""
+    return _serialized(PYMUPDF_LOCK, "pymupdf")

--- a/nextcloud_mcp_server/document_processors/classifier.py
+++ b/nextcloud_mcp_server/document_processors/classifier.py
@@ -246,7 +246,12 @@ def classify_pdf(content: bytes) -> DocClassification:
     """
     import pymupdf  # noqa: PLC0415 -- keep the heavy import lazy / off module load
 
-    with pymupdf.open("pdf", content) as doc:
+    from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+        pymupdf_serialized,
+    )
+
+    # MuPDF is not thread-safe; serialize against concurrent bbox/parse threads.
+    with pymupdf_serialized(), pymupdf.open("pdf", content) as doc:
         page_count = doc.page_count
         indices = _sample_indices(page_count)
         pages: list[PageSignals] = []
@@ -330,8 +335,14 @@ def image_coverage_per_page(content: bytes) -> list[float]:
     """
     import pymupdf  # noqa: PLC0415 -- keep the heavy import lazy
 
+    from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+        pymupdf_serialized,
+    )
+
     cov: list[float] = []
-    with pymupdf.open("pdf", content) as doc:
+    # MuPDF is not thread-safe. This runs on the event loop during escalation, so
+    # the lock also serializes it against concurrent bbox/parse worker threads.
+    with pymupdf_serialized(), pymupdf.open("pdf", content) as doc:
         for n in range(min(doc.page_count, MAX_SAMPLED_PAGES)):
             cov.append(_page_image_coverage(doc.load_page(n)))
     return cov

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -118,15 +118,27 @@ class PyMuPDFProcessor(DocumentProcessor):
             # immediately (try/finally so a failure in _extract_metadata can't
             # leak it). The heavy extraction below works from ``content`` bytes
             # in the isolated worker, so ``doc`` is not needed past this point.
-            doc = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
-                lambda: pymupdf.open("pdf", content)
+            # Read metadata entirely inside ONE worker thread, serialized against
+            # other MuPDF work: pymupdf is not thread-safe, and a doc opened in one
+            # thread must not be touched from another. (The heavy page extraction
+            # below runs in an isolated subprocess, so it needs no lock.)
+            def _read_metadata() -> tuple[dict[str, Any], int]:
+                from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+                    pymupdf_serialized,
+                )
+
+                with pymupdf_serialized():
+                    doc = pymupdf.open("pdf", content)
+                    try:
+                        meta = self._extract_metadata(doc, filename)
+                        meta["file_size"] = len(content)
+                        return meta, doc.page_count
+                    finally:
+                        doc.close()
+
+            metadata, page_count = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
+                _read_metadata
             )
-            try:
-                metadata = self._extract_metadata(doc, filename)
-                metadata["file_size"] = len(content)
-                page_count = doc.page_count
-            finally:
-                doc.close()
 
             if progress_callback:
                 await progress_callback(10, 100, f"Extracting {page_count} pages")

--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -35,24 +35,32 @@ def _extract(content: bytes) -> tuple[str, dict[str, Any]]:
     """
     import pypdfium2 as pdfium  # noqa: PLC0415 -- keep the native import lazy
 
-    pdf = pdfium.PdfDocument(content)
-    try:
-        page_texts: list[str] = []
-        for i in range(len(pdf)):
-            page = pdf[i]
-            try:
-                textpage = page.get_textpage()
+    from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+        pdfium_serialized,
+    )
+
+    # PDFium is not thread-safe (shared process-global library + an unlocked
+    # module-global object tracker), so serialize: concurrent ingest jobs must not
+    # drive it from two worker threads at once.
+    with pdfium_serialized():
+        pdf = pdfium.PdfDocument(content)
+        try:
+            page_texts: list[str] = []
+            for i in range(len(pdf)):
+                page = pdf[i]
                 try:
-                    page_texts.append(textpage.get_text_bounded() or "")
+                    textpage = page.get_textpage()
+                    try:
+                        page_texts.append(textpage.get_text_bounded() or "")
+                    finally:
+                        textpage.close()
                 finally:
-                    textpage.close()
-            finally:
-                # Outer finally so the page handle is freed even if
-                # get_textpage() raises on a corrupt page.
-                page.close()
-        doc_meta = pdf.get_metadata_dict() or {}
-    finally:
-        pdf.close()
+                    # Outer finally so the page handle is freed even if
+                    # get_textpage() raises on a corrupt page.
+                    page.close()
+            doc_meta = pdf.get_metadata_dict() or {}
+        finally:
+            pdf.close()
 
     page_boundaries: list[dict[str, Any]] = []
     offset = 0

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -632,6 +632,22 @@ db_operation_duration_seconds = Histogram(
     buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
 )
 
+# pypdfium2 / pymupdf are not thread-safe; concurrent ingest jobs serialize their
+# native calls on per-library locks (see document_processors/_native_locks.py).
+# This surfaces the resulting contention so per-tier `concurrency` can be tuned.
+pdf_native_lock_wait_seconds = Histogram(
+    "astrolabe_pdf_native_lock_wait_seconds",
+    "Time spent waiting to acquire a native PDF library lock",
+    ["library"],  # library: pdfium | pymupdf
+    buckets=(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5),
+)
+
+
+def record_pdf_native_lock_wait(library: str, seconds: float) -> None:
+    """Record the wait to acquire the PDFium/MuPDF serialization lock."""
+    pdf_native_lock_wait_seconds.labels(library=library).observe(seconds)
+
+
 # =============================================================================
 # External Dependency Health Metrics
 # =============================================================================

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1755,13 +1755,23 @@ async def _index_document(
 
                 logger.info("Computing chunk bboxes for %s PDF chunks", len(chunk_data))
 
-                batch_results = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
-                    lambda: PDFHighlighter.compute_chunk_bboxes_batch(
-                        pdf_bytes=content_bytes,
-                        chunks=chunk_data,
-                        page_boundaries=page_boundaries_list,
-                        full_text=content,
+                # pymupdf is not thread-safe; run the bbox batch under the shared
+                # MuPDF lock so concurrent ingest jobs serialize their native work.
+                def _compute_bboxes():
+                    from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+                        pymupdf_serialized,
                     )
+
+                    with pymupdf_serialized():
+                        return PDFHighlighter.compute_chunk_bboxes_batch(
+                            pdf_bytes=content_bytes,
+                            chunks=chunk_data,
+                            page_boundaries=page_boundaries_list,
+                            full_text=content,
+                        )
+
+                batch_results = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
+                    _compute_bboxes
                 )
 
                 for chunk_index, (bboxes, _) in batch_results.items():

--- a/tests/unit/test_cli_worker_concurrency.py
+++ b/tests/unit/test_cli_worker_concurrency.py
@@ -1,0 +1,44 @@
+"""Unit tests for per-tier worker concurrency resolution.
+
+``cli._resolve_worker_concurrency`` picks the procrastinate worker concurrency:
+explicit ``--concurrency`` (the chart's per-tier arg) > per-tier setting override
+(fast/structured) > global ``vector_sync_processor_workers``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nextcloud_mcp_server.cli import _resolve_worker_concurrency
+
+pytestmark = pytest.mark.unit
+
+
+def _resolve(cli=None, tier=None, *, fast=None, structured=None, default=3):
+    return _resolve_worker_concurrency(
+        cli, tier, fast=fast, structured=structured, default=default
+    )
+
+
+def test_cli_flag_wins_over_everything():
+    assert _resolve(cli=9, tier="fast", fast=4, default=3) == 9
+
+
+def test_fast_tier_override_used_when_no_flag():
+    assert _resolve(tier="fast", fast=4, structured=2, default=3) == 4
+
+
+def test_structured_tier_override_used():
+    assert _resolve(tier="structured", fast=4, structured=2, default=3) == 2
+
+
+def test_falls_back_to_global_default():
+    assert _resolve(tier="fast", fast=None, default=3) == 3  # no fast override
+    assert _resolve(tier="ocr", fast=4, structured=2, default=3) == 3  # ocr not exposed
+    assert _resolve(tier=None, fast=4, default=3) == 3  # all-tiers worker
+
+
+def test_zero_override_never_yields_zero():
+    # A bogus 0 must fall through, not run the worker with concurrency=0.
+    assert _resolve(tier="fast", fast=0, default=3) == 3
+    assert _resolve(cli=0, tier="fast", fast=4, default=3) == 4

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -416,6 +416,53 @@ class TestChunkConfigValidation:
         with pytest.raises(ValidationError, match="DOCUMENT_CHUNK_OVERLAP"):
             _reload_config()
 
+    def test_tier_concurrency_defaults_to_none(self):
+        """Unset per-tier overrides fall through to VECTOR_SYNC_PROCESSOR_WORKERS."""
+        with patch.dict(os.environ, {}, clear=True):
+            _reload_config()
+            settings = get_settings()
+            assert settings.vector_sync_fast_concurrency is None
+            assert settings.vector_sync_structured_concurrency is None
+
+    def test_tier_concurrency_valid_value_accepted(self):
+        """A positive per-tier override loads normally."""
+        with patch.dict(
+            os.environ,
+            {
+                "VECTOR_SYNC_FAST_CONCURRENCY": "2",
+                "VECTOR_SYNC_STRUCTURED_CONCURRENCY": "3",
+            },
+            clear=True,
+        ):
+            _reload_config()
+            settings = get_settings()
+            assert settings.vector_sync_fast_concurrency == 2
+            assert settings.vector_sync_structured_concurrency == 3
+
+    @patch.dict(
+        os.environ,
+        {"VECTOR_SYNC_FAST_CONCURRENCY": "0"},
+        clear=True,
+    )
+    def test_zero_fast_concurrency_raises_error(self):
+        """0 is rejected at startup rather than reaching the worker (>=1 when set)."""
+        from dynaconf import ValidationError
+
+        with pytest.raises(ValidationError, match="VECTOR_SYNC_FAST_CONCURRENCY"):
+            _reload_config()
+
+    @patch.dict(
+        os.environ,
+        {"VECTOR_SYNC_STRUCTURED_CONCURRENCY": "-1"},
+        clear=True,
+    )
+    def test_negative_structured_concurrency_raises_error(self):
+        """A negative per-tier override raises ValidationError via dynaconf."""
+        from dynaconf import ValidationError
+
+        with pytest.raises(ValidationError, match="VECTOR_SYNC_STRUCTURED_CONCURRENCY"):
+            _reload_config()
+
     def test_small_chunk_size_warning(self, caplog):
         """Test that chunk size < 512 triggers warning."""
 

--- a/tests/unit/test_native_locks.py
+++ b/tests/unit/test_native_locks.py
@@ -1,0 +1,75 @@
+"""Unit tests for the native PDF-library serialization locks (concurrency safety).
+
+pypdfium2 / pymupdf are not thread-safe; these locks serialize their native calls
+so per-tier ingest concurrency (>1) can't drive a library from two threads at
+once. See ``document_processors/_native_locks.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+import nextcloud_mcp_server.document_processors._native_locks as native_locks
+from nextcloud_mcp_server.document_processors._native_locks import (
+    PDFIUM_LOCK,
+    PYMUPDF_LOCK,
+    pdfium_serialized,
+    pymupdf_serialized,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _max_concurrency(cm_factory, n: int = 8) -> int:
+    """Run ``n`` threads through the context manager; return the max seen in-flight."""
+    state_lock = threading.Lock()
+    current = 0
+    max_seen = 0
+
+    def worker() -> None:
+        nonlocal current, max_seen
+        with cm_factory():
+            with state_lock:
+                current += 1
+                max_seen = max(max_seen, current)
+            time.sleep(0.01)  # widen the critical-section window so a race would show
+            with state_lock:
+                current -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return max_seen
+
+
+def test_pymupdf_serialized_admits_one_thread_at_a_time():
+    assert _max_concurrency(pymupdf_serialized) == 1
+
+
+def test_pdfium_serialized_admits_one_thread_at_a_time():
+    assert _max_concurrency(pdfium_serialized) == 1
+
+
+def test_pdfium_and_pymupdf_locks_are_independent():
+    """Separate locks let a PDFium parse and a MuPDF bbox overlap across documents."""
+    assert PDFIUM_LOCK is not PYMUPDF_LOCK
+    # Holding the MuPDF lock must not block acquiring the PDFium one.
+    with pymupdf_serialized():
+        acquired = PDFIUM_LOCK.acquire(blocking=False)
+        assert acquired is True
+        PDFIUM_LOCK.release()
+
+
+def test_wait_metric_recorded_per_library(mocker):
+    spy = mocker.spy(native_locks, "record_pdf_native_lock_wait")
+    with pymupdf_serialized():
+        pass
+    with pdfium_serialized():
+        pass
+    assert [c.args[0] for c in spy.call_args_list] == ["pymupdf", "pdfium"]
+    assert all(c.args[1] >= 0 for c in spy.call_args_list)  # non-negative wait


### PR DESCRIPTION
## Why

The fast/structured ingest tiers are I/O-bound, so per-worker **concurrency** (more docs in flight per pod, overlapping their I/O) is the cheap throughput lever. But it isn't safe today: procrastinate `concurrency=N` runs N job coroutines on **one event loop**, and the CPU-heavy PDF work is offloaded to the **shared anyio thread pool with no serialization**. **pypdfium2 (PDFium)** and **pymupdf (MuPDF)** are *not* thread-safe — process-global library state, and pypdfium2 mutates an unlocked module-global object tracker on every open/close — so `concurrency>1` would drive them from multiple threads at once → data races / segfaults / corruption. It's safe today only because concurrency is effectively 1 and parallelism comes from replicas. (The `ocr` tier already ships `concurrency:24`, so the serialization gap is a latent risk regardless of this change.)

Setting concurrency is chart/values-only, but making it *safe* — and letting fast/structured be tuned independently — needs this server change.

## What

**1. Serialize the native PDF libraries** — `document_processors/_native_locks.py` (new)
Two module-level `threading.Lock`s, `PDFIUM_LOCK` and `PYMUPDF_LOCK`. Separate locks (the libraries are independent) let a PDFium parse and a MuPDF bbox overlap across concurrent documents while forbidding same-library concurrency. Every native call now runs under the right lock:
- `pypdfium2_fast.py` — fast-tier parse (PDFium).
- `vector/processor.py` — highlight bbox (PyMuPDF), under the lock in the worker thread.
- `document_processors/pymupdf.py` — structured-tier metadata read, refactored so the doc is **opened, used, and closed entirely inside one worker thread** (fixes a latent cross-thread MuPDF access, not just locking).
- `document_processors/classifier.py` — the escalation `image_coverage_per_page` / scan-detection PyMuPDF passes.

A **`threading.Lock`** (not an anyio `CapacityLimiter`) is used deliberately: the classifier's PyMuPDF runs **on the event loop** during escalation (not only in worker threads), and a sync-on-loop call can still race a thread-based one — the primitive must be acquirable from both. Caveat: when the on-loop classifier waits on a concurrent bbox, it briefly blocks the loop; a follow-up could move that pass off-loop to eliminate the wait. The structured tier's heavy page extraction already runs in an isolated subprocess (`_isolation.py`) and needs no lock.

**2. Observability for concurrency** — `observability/metrics.py`
New `astrolabe_pdf_native_lock_wait_seconds{library}` histogram records the wait to acquire each lock, so contention under concurrency is visible in Prometheus and per-tier `concurrency` can be tuned. (The offload's *total* time already shows in the enclosing OTel span, and every document keeps its own trace id, so concurrent jobs stay attributable across traces/logs.)

**3. Optional per-tier concurrency overrides** — `config.py`, `cli.py`
New optional settings `VECTOR_SYNC_FAST_CONCURRENCY` / `VECTOR_SYNC_STRUCTURED_CONCURRENCY`, resolved by `_resolve_worker_concurrency()` with precedence: explicit `--concurrency` (the chart's per-tier arg) > per-tier setting override > global `vector_sync_processor_workers`. A 0/None override falls through, so a bogus value can never run the worker at `concurrency=0`.

## Testing

- `tests/unit/test_native_locks.py`: threads hammer each lock and assert **max in-flight == 1**; the two locks are independent (holding one doesn't block the other); the wait metric is recorded per library.
- `tests/unit/test_cli_worker_concurrency.py`: the resolution precedence (CLI > tier override > global; 0 never yields 0).
- Existing parse/classifier/bbox tests stay green (the locks are transparent to output).
- Full unit suite green; `ruff` + `ty` clean. No API / MCP / Pact surface change → no contract/e2e tier.

## Follow-on (separate, gitops)

After this ships: set `ingest.worker.tiers[fast|structured].concurrency` (or the new settings) modestly (~2–3), **after** raising the fast/structured tier memory — `concurrency>1` reintroduces the OOM pressure that pinned `processorWorkers:1` (BM25 model + per-doc PyMuPDF/pdfium buffers). Watch `astrolabe_pdf_native_lock_wait_seconds`, memory, throughput, and zero worker segfaults.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
