### PR TITLE
fix(tests): make CI actually run every test under tests/unit/

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,33 @@
 """Unit test configuration — shared fixtures for all unit tests."""
 
+from pathlib import Path
+
 import pytest
 
 # Re-export the parametrized storage backend fixture so it's auto-discovered
 # by every unit test that names it as a parameter, without each test module
 # having to import it explicitly.
 from tests.fixtures.storage_backend import storage_backend  # noqa: F401
+
+_UNIT_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items):
+    """Mark everything under ``tests/unit/`` as ``unit``.
+
+    CI selects this tier by marker (``pytest -m unit``), not by path, so a file
+    that forgot ``pytestmark = pytest.mark.unit`` was silently deselected and
+    never ran — 263 tests across 9 files were invisible this way, two of them
+    failing on master for over a week. Applying the marker by location makes the
+    directory the single source of truth, so a new file cannot reopen the hole
+    by omission.
+
+    Note this hook fires once with *every* collected item, not just this
+    directory's, so it must filter by path.
+    """
+    for item in items:
+        if _UNIT_DIR in Path(str(item.fspath)).parents:
+            item.add_marker(pytest.mark.unit)
 
 
 @pytest.fixture

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -78,7 +78,6 @@ class TestEnumValidation:
             ("collection_metadata_source", "redis"),
             ("document_tier1_engine", "mupdf"),
             ("document_ocr_provider", "gatway"),
-            ("search_mode", "fulltext"),
             ("docling_pipeline", "vllm"),
         ],
     )

--- a/tests/unit/test_payload_backfill.py
+++ b/tests/unit/test_payload_backfill.py
@@ -39,9 +39,12 @@ async def test_backfill_happy_path_sets_keys_and_sentinel(mocker):
     mocker.patch.object(mod, "get_qdrant_client", return_value=qdrant)
     embed = mocker.MagicMock()
     embed.get_dimension.return_value = 4
-    mocker.patch(
-        "nextcloud_mcp_server.embedding.get_embedding_service", return_value=embed
-    )
+    # Patch the name bound in `mod`, not in nextcloud_mcp_server.embedding: the
+    # module does `from ...embedding import get_embedding_service` at import
+    # time, so patching the source module leaves mod's reference pointing at the
+    # real function. That made the real call raise, the endpoint's
+    # `except Exception` swallow it, and the sentinel never get upserted.
+    mocker.patch.object(mod, "get_embedding_service", return_value=embed)
     # upsert_sentinel uses the same qdrant client; it is an AsyncMock so .upsert
     # is awaitable. Patch upsert_sentinel to assert it was invoked.
     sentinel = mocker.patch.object(mod, "upsert_sentinel", new=mocker.AsyncMock())


### PR DESCRIPTION
## Problem

The `unit-test` check runs `uv run pytest -v -m unit` — **marker-based, not path-based**. Nine files under `tests/unit/` never declared `pytestmark = pytest.mark.unit`, so CI collected **2117 of 2794** tests and **263 tests under `tests/unit/` had never run in CI at all**.

That is why the check stayed green while a plain `pytest tests/unit/` run failed locally — the two are not the same test set.

Two of the invisible tests were **failing on `origin/master`** (verified by checking out master directly). Both are test-side bugs; no product code is wrong:

| Test | Failure | Cause |
|---|---|---|
| `test_decomposition_config.py::TestEnumValidation::test_invalid_enum_rejected[search_mode-fulltext]` | `TypeError: Settings.__init__() got an unexpected keyword argument 'search_mode'` | `e8772bbb` (ADR-031, per-document index mode) removed the `search_mode` setting and updated this very file, but left one `parametrize` entry behind. The test asserts a `ValueError`; the now-nonexistent field raises `TypeError`. Undetected for 8 days. |
| `test_payload_backfill.py::test_backfill_happy_path_sets_keys_and_sentinel` | `AssertionError: Expected mock to have been awaited once. Awaited 0 times.` | The test patched `nextcloud_mcp_server.embedding.get_embedding_service`, but `payload_backfill.py:31` does `from ...embedding import get_embedding_service`, binding the name at import time — so the patch never took effect. The real call raised, the endpoint's `except Exception` swallowed it, and `upsert_sentinel` was never awaited. |

The unmarked files are the config/validation cluster — `test_config.py` (~78 tests), `test_config_validators.py` (~52), `test_decomposition_config.py` (~37), `test_acl_hash.py` (~27), `test_ssl_config.py` (~23), `test_config_paths.py` (~12), `test_payload_backfill.py` (~3), and two under `vector/`. Config validation is exactly the code least safe to leave unguarded.

Found while verifying CI for #1091 (the pact broker flake); unrelated to that fix.

## Changes

- **`tests/unit/conftest.py`** — apply the `unit` marker **by location** via `pytest_collection_modifyitems`. This closes the hole at its source: a new file cannot silently opt out by omission. Chosen over adding `pytestmark` to nine files, which is the exact thing that drifted in the first place and would drift again.
  - The hook fires once with *every* collected item, not just this directory's, so it filters by path.
  - Verified no file under `tests/unit/` carries a conflicting tier marker (`integration`/`smoke`/`oauth`/`contract`/`ldap`), so blanket-marking the directory is safe.
- **`test_decomposition_config.py`** — drop the stale `("search_mode", "fulltext")` case.
- **`test_payload_backfill.py`** — patch the name bound in the module under test, with a comment explaining why patching the source module silently no-ops.

## Verification

| | before (master) | after |
|---|---|---|
| CI unit selection (`-m unit`) | **2117** collected, 677 deselected | **2379** collected, 414 deselected |
| Unmarked under `tests/unit/` | 263 | **0** |
| `pytest -m unit` (exact CI command) | — | **2379 passed** |

- ✅ Exact CI command run locally: `uv run pytest -m unit -o "addopts=-p no:asyncio"` → 2379 passed in 4m23s.
- ✅ `pytest tests/unit/ -m "not unit"` → *no tests collected* (nothing escapes the marker).
- ✅ The two previously-broken files → 39 passed.
- ✅ ruff / ruff format / ty / commitizen clean; `sonar analyze secrets` clean.

## Notes

- Net collected count is 2379 rather than 2380 because the stale `search_mode` parametrize case is removed — the arithmetic is consistent (+263 newly-marked, −1 deleted).
- No product code changed; both failures were test bugs.

Refs: Deck #676

---

_This PR was generated with the help of AI, and reviewed by a Human_