### PR TITLE
refactor(tests): use item.path over the legacy item.fspath

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,7 +26,7 @@ def pytest_collection_modifyitems(items):
     directory's, so it must filter by path.
     """
     for item in items:
-        if _UNIT_DIR in Path(str(item.fspath)).parents:
+        if _UNIT_DIR in item.path.parents:
             item.add_marker(pytest.mark.unit)
 
 


### PR DESCRIPTION
## Context

Follow-up to #1092. The round-1 reviewer raised this nit and I fixed it — but pushed the commit **after** #1092 had already been merged at `6dc56f2d`, so it never landed. Master still carries the legacy line. This PR carries that orphaned commit (`8ad34180`, cherry-picked as `08235132`) onto current master.

Purely cosmetic; #1092's actual fix (CI now runs all 2379 unit tests instead of 2117) is already in master and working.

## Change

`tests/unit/conftest.py` — `item.path` is already a `pathlib.Path`, so round-tripping through the legacy `py.path.local` object was pointless:

```diff
-        if _UNIT_DIR in Path(str(item.fspath)).parents:
+        if _UNIT_DIR in item.path.parents:
```

`Path` is still imported — `_UNIT_DIR` uses it.

## Verification

Re-run against **merged master**, not the pre-merge branch:

- `pytest -m unit -o "addopts=-p no:asyncio" --collect-only` → **2379 collected**, unchanged.
- `pytest tests/unit/ -m "not unit" --collect-only` → **no tests collected** — nothing escapes the marker, which is the property that actually matters here.
- The two previously-broken files → 39 passed.
- ruff / ty clean.

Refs: Deck #676

---

_This PR was generated with the help of AI, and reviewed by a Human_