### PR TITLE
perf(observability): split DB connect from execute; fix 1s bucket ceiling

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -85,8 +85,27 @@ The Helm chart has moved to a [separate repository](https://github.com/cbcoutinh
 
 ### Database Metrics
 
-- `mcp_db_operations_total` - DB operations (SQLite, Qdrant)
-- `mcp_db_operation_duration_seconds` - DB latency
+- `mcp_db_operations_total` - DB operations (SQLite, Postgres, Qdrant)
+- `mcp_db_operation_duration_seconds` - DB latency, **including connection
+  acquisition**
+- `mcp_db_connect_duration_seconds` - Connection-acquisition latency alone
+
+Postgres uses `NullPool` (ADR-026), so a connection is opened per operation and
+`mcp_db_connect_duration_seconds` fires once per op — its `_count` rate tracking
+the operation rate is expected, not a leak. Compare the two histograms to split
+"the query is slow" from "getting a connection is slow":
+
+```promql
+# What fraction of an operation is spent just getting a connection?
+sum(rate(mcp_db_connect_duration_seconds_sum{db="postgresql"}[5m]))
+  / sum(rate(mcp_db_operation_duration_seconds_sum{db="postgresql"}[5m]))
+```
+
+A high ratio means the cost is the handshake (network path, TLS, pooler
+placement), not the SQL. Deck #678 was exactly this: a PgBouncer replica
+scheduled in another region made ~50% of connects pay a transatlantic TLS
+handshake (~600ms vs ~30ms), which presented as a "slow `usage_events` insert"
+because one span covered both halves.
 
 ### Dependency Health
 

--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -59,7 +59,11 @@ from nextcloud_mcp_server.config import (
     mask_db_password,
 )
 from nextcloud_mcp_server.migrations import stamp_database, upgrade_database
-from nextcloud_mcp_server.observability.metrics import record_db_operation
+from nextcloud_mcp_server.observability.metrics import (
+    record_db_connect,
+    record_db_operation,
+)
+from nextcloud_mcp_server.observability.tracing import trace_db_connect
 
 logger = logging.getLogger(__name__)
 
@@ -643,10 +647,29 @@ class RefreshTokenStorage:
         ``?`` placeholders, ``commit``, cursor with ``fetchone`` /
         ``fetchall`` / ``rowcount``) so the existing storage method bodies
         work against either SQLite or Postgres without per-call rewrites.
+
+        The connect is measured and traced separately from the operation it
+        serves. Under ``NullPool`` (ADR-026) ``engine.connect()`` *is* the
+        physical connect, so this is a genuine per-operation cost — one that
+        callers' spans previously bundled with execute, hiding a ~600ms
+        handshake inside an apparently slow insert (Deck #678). Instrumenting
+        here rather than at the call sites covers every caller for free.
         """
         assert self.engine is not None, "RefreshTokenStorage.initialize() not called"
-        async with self.engine.connect() as conn:
+        start = time.time()
+        try:
+            with trace_db_connect(self._dialect):
+                conn = await self.engine.connect()
+        finally:
+            # Recorded in a finally so a connect that fails *slowly* — a timeout,
+            # an unreachable host — is still measured. Those are precisely the
+            # samples worth seeing; dropping them would leave the histogram
+            # reporting only the healthy connects.
+            record_db_connect(self._dialect, time.time() - start)
+        try:
             yield _DBConn(conn)
+        finally:
+            await conn.close()
 
     def acquire(self) -> AbstractAsyncContextManager["_DBConn"]:
         """Public alias for :meth:`_db`: a backend-agnostic connection cm.

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -622,14 +622,68 @@ document_download_truncated_total = Counter(
 db_operations_total = Counter(
     "mcp_db_operations_total",
     "Total database operations",
-    ["db", "operation", "status"],  # db: sqlite | qdrant; operation varies
+    # db: sqlite | postgresql | qdrant; operation varies
+    ["db", "operation", "status"],
 )
 
+# Buckets deliberately reach 10s. The original ceiling was 1.0s, which made this
+# histogram blind to the only incident it ever needed to catch: a per-operation
+# regression from 65ms to ~1.9s (Deck #678) put ~50% of Postgres samples in the
+# +Inf bucket, so p95/p99 were unusable and the regression was visible only in
+# Tempo. Every original edge is retained so historical series stay comparable.
+# The 0.75/1.5 edges straddle a 1s TCP RTO on purpose: a network-retry stall
+# piles up against them, which distinguishes it from genuinely slow DB work.
 db_operation_duration_seconds = Histogram(
     "mcp_db_operation_duration_seconds",
-    "Database operation duration in seconds",
+    "Database operation duration in seconds (includes connection acquisition)",
     ["db", "operation"],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+    buckets=(
+        0.001,
+        0.0025,
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.5,
+        2.5,
+        5.0,
+        10.0,
+    ),
+)
+
+# Connection acquisition, split out from the operation it serves. Under NullPool
+# (ADR-026) every operation opens a fresh connection, so this is a real per-op
+# cost, not a startup cost — and `db_operation_duration_seconds` above bundles it
+# with execute, which is exactly why a ~600ms connect hid inside a "slow insert"
+# for a day (Deck #678: one PgBouncer replica was scheduled in another
+# continent; ~50% of connections paid a transatlantic TLS handshake).
+# Labelled by dialect only: an "operation" is meaningless for a connect.
+db_connect_duration_seconds = Histogram(
+    "mcp_db_connect_duration_seconds",
+    "Database connection acquisition duration in seconds",
+    ["db"],
+    buckets=(
+        0.001,
+        0.0025,
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.5,
+        2.5,
+        5.0,
+        10.0,
+    ),
 )
 
 # pypdfium2 / pymupdf are not thread-safe; concurrent ingest jobs serialize their
@@ -777,14 +831,32 @@ def record_db_operation(
     """
     Record a database operation.
 
+    Note that ``duration`` covers connection acquisition as well as execution;
+    use :func:`record_db_connect` to attribute the acquire half.
+
     Args:
-        db: Database type ("sqlite" or "qdrant")
+        db: Database type ("sqlite", "postgresql", or "qdrant")
         operation: Operation type (e.g., "insert", "select", "upsert", "search")
         duration: Operation duration in seconds
         status: "success" or "error"
     """
     db_operations_total.labels(db=db, operation=operation, status=status).inc()
     db_operation_duration_seconds.labels(db=db, operation=operation).observe(duration)
+
+
+def record_db_connect(db: str, duration: float) -> None:
+    """
+    Record a database connection acquisition.
+
+    Under NullPool this fires once per operation, so a rising ``_count`` rate is
+    normal. If connection pooling is ever reintroduced, that rate collapsing
+    toward zero is the signal the pool is actually being reused.
+
+    Args:
+        db: Database type ("sqlite" or "postgresql")
+        duration: Time to acquire the connection, in seconds
+    """
+    db_connect_duration_seconds.labels(db=db).observe(duration)
 
 
 def set_dependency_health(dependency: str, is_healthy: bool) -> None:

--- a/nextcloud_mcp_server/observability/tracing.py
+++ b/nextcloud_mcp_server/observability/tracing.py
@@ -295,7 +295,7 @@ def trace_db_operation(
             pass
 
     Args:
-        db: Database type (sqlite, qdrant)
+        db: Database type (sqlite, postgresql, qdrant)
         operation: Operation type (insert, select, update, delete, upsert, search)
         table: Optional table/collection name
 
@@ -311,6 +311,29 @@ def trace_db_operation(
         attributes["db.table"] = table
 
     return trace_operation(f"db.{db}.{operation}", attributes)
+
+
+def trace_db_connect(db: str):
+    """
+    Create a span for acquiring a database connection.
+
+    Nests inside :func:`trace_db_operation`, splitting "how long did the query
+    take" from "how long did it take to get a connection at all". Deck #678: a
+    single span covering both hid a ~600ms connect inside an apparently slow
+    insert, because under NullPool (ADR-026) every operation opens a fresh
+    connection and pays the full TCP + TLS + auth handshake.
+
+    Usage:
+        with trace_db_connect("postgresql"):
+            conn = await engine.connect()
+
+    Args:
+        db: Database type (sqlite, postgresql)
+
+    Returns:
+        Context manager for the span
+    """
+    return trace_operation(f"db.{db}.connect", {"db.system": db})
 
 
 def add_span_attribute(key: str, value: Any) -> None:

--- a/tests/unit/test_db_metrics.py
+++ b/tests/unit/test_db_metrics.py
@@ -1,0 +1,97 @@
+"""Unit tests for the DB observability metrics (Deck #678).
+
+These pin the two properties whose absence made a real incident invisible:
+
+1. The duration histograms must resolve latencies well above 1 second. The
+   original ``mcp_db_operation_duration_seconds`` topped out at 1.0s, so when
+   per-operation latency regressed from 65ms to ~1.9s, ~50% of samples landed
+   in ``+Inf`` — p95/p99 were unusable and the regression showed up only in
+   Tempo traces.
+2. Connection acquisition must be observable independently of execution. A
+   single measurement spanning acquire+execute hid a ~600ms connect inside an
+   apparently slow insert.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nextcloud_mcp_server.observability.metrics import (
+    db_connect_duration_seconds,
+    db_operation_duration_seconds,
+    record_db_connect,
+    record_db_operation,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _upper_bounds(histogram, **labels) -> list[str]:
+    return [
+        sample.labels["le"]
+        for metric in histogram.collect()
+        for sample in metric.samples
+        if sample.name.endswith("_bucket")
+        and all(sample.labels.get(k) == v for k, v in labels.items())
+    ]
+
+
+def _bucket_count(histogram, le: str, **labels) -> float:
+    for metric in histogram.collect():
+        for sample in metric.samples:
+            if (
+                sample.name.endswith("_bucket")
+                and sample.labels.get("le") == le
+                and all(sample.labels.get(k) == v for k, v in labels.items())
+            ):
+                return sample.value
+    return 0.0
+
+
+@pytest.mark.parametrize(
+    "histogram",
+    [db_operation_duration_seconds, db_connect_duration_seconds],
+    ids=["operation", "connect"],
+)
+def test_duration_buckets_resolve_multi_second_latency(histogram):
+    """A multi-second DB stall must be resolvable, not dumped into +Inf.
+
+    Guards the Deck #678 defect directly: with a 1.0s ceiling, a 1.9s insert is
+    indistinguishable from a 60s hang.
+    """
+    record_db_connect("postgresql", 0.001)  # ensure the child metric exists
+    record_db_operation("postgresql", "select", 0.001)
+
+    bounds = [
+        float(le) for le in _upper_bounds(histogram, db="postgresql") if le != "+Inf"
+    ]
+    assert bounds, "histogram exposed no finite buckets"
+    assert max(bounds) >= 5.0, (
+        f"largest finite bucket is {max(bounds)}s — a multi-second stall would "
+        "fall into +Inf and be unmeasurable (Deck #678)"
+    )
+    # The 1s TCP RTO is a common stall floor; keep an edge on each side of it so
+    # a retry-shaped latency is distinguishable from slow-but-healthy work.
+    assert any(b < 1.0 for b in bounds) and any(b > 1.0 for b in bounds)
+
+
+def test_slow_operation_lands_in_a_finite_bucket():
+    """A 1.9s operation — the observed Deck #678 latency — is counted below +Inf."""
+    before = _bucket_count(
+        db_operation_duration_seconds, "2.5", db="postgresql", operation="insert"
+    )
+    record_db_operation("postgresql", "insert", 1.9)
+    after = _bucket_count(
+        db_operation_duration_seconds, "2.5", db="postgresql", operation="insert"
+    )
+    assert after == pytest.approx(before + 1), (
+        "a 1.9s insert must be resolvable below +Inf"
+    )
+
+
+def test_connect_duration_is_recorded_independently():
+    """``record_db_connect`` observes the acquire half on its own histogram."""
+    before = _bucket_count(db_connect_duration_seconds, "1.0", db="postgresql")
+    record_db_connect("postgresql", 0.6)  # the observed transatlantic handshake
+    after = _bucket_count(db_connect_duration_seconds, "1.0", db="postgresql")
+    assert after == pytest.approx(before + 1)

--- a/tests/unit/test_usage_store.py
+++ b/tests/unit/test_usage_store.py
@@ -23,6 +23,7 @@ from cryptography.fernet import Fernet
 
 import nextcloud_mcp_server.usage.store as store_module
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
+from nextcloud_mcp_server.observability.metrics import db_connect_duration_seconds
 from nextcloud_mcp_server.usage.store import UsageEvent, UsageEventStore
 
 pytestmark = pytest.mark.unit
@@ -72,6 +73,19 @@ def _set_metering(monkeypatch, enabled: bool) -> None:
         usage_metering_enabled = enabled
 
     monkeypatch.setattr(store_module, "get_settings", lambda: _Settings())
+
+
+def _connect_observations(dialect: str) -> float:
+    """How many connects the ``mcp_db_connect_duration_seconds`` histogram saw.
+
+    Read as a delta around the call under test: the registry is process-wide and
+    other tests in the session also open connections.
+    """
+    for metric in db_connect_duration_seconds.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_count") and sample.labels.get("db") == dialect:
+                return sample.value
+    return 0.0
 
 
 async def _count(storage: RefreshTokenStorage) -> int:
@@ -326,6 +340,46 @@ async def test_batch_is_traced(storage, monkeypatch, mocker):
     spy = mocker.spy(store_module, "trace_db_operation")
     await store.record_usage_events([UsageEvent("pages_embedded", 1)])
     spy.assert_called_once_with(storage.dialect, "insert", "usage_events")
+
+
+async def test_batch_records_connect_duration_separately(storage, monkeypatch):
+    """Connection acquisition is measured on its own, not folded into execute.
+
+    Deck #678: one span/metric covering acquire+execute hid a ~600ms connect
+    inside an apparently slow insert. The connect must be independently
+    observable, or that class of regression is invisible in Prometheus.
+    """
+    _set_metering(monkeypatch, True)
+    before = _connect_observations(storage.dialect)
+
+    store = UsageEventStore(storage)
+    await store.record_usage_events(
+        [UsageEvent("tokens_embedded", 1), UsageEvent("pages_embedded", 2)]
+    )
+
+    # Exactly one connect for the whole batch: the acquire is amortized across
+    # the events (Deck #667), and it is now attributable on its own.
+    assert _connect_observations(storage.dialect) == pytest.approx(before + 1)
+
+
+async def test_failed_connect_is_still_measured(storage, monkeypatch):
+    """A connect that fails is recorded too — a slow timeout is the sample
+    you most want to see, so it must not be dropped from the histogram."""
+    _set_metering(monkeypatch, True)
+    before = _connect_observations(storage.dialect)
+
+    class _UnreachableEngine:
+        async def connect(self):
+            raise RuntimeError("connection refused")
+
+    # ``AsyncEngine.connect`` is read-only, so swap the engine itself.
+    monkeypatch.setattr(storage, "engine", _UnreachableEngine())
+
+    store = UsageEventStore(storage)
+    # Best-effort contract still holds: the failure must not reach the caller.
+    await store.record_usage_events([UsageEvent("pages_embedded", 1)])
+
+    assert _connect_observations(storage.dialect) == pytest.approx(before + 1)
 
 
 async def test_batch_flag_off_is_noop(storage, monkeypatch, mocker):


### PR DESCRIPTION
## Context

Deck [#678](https://cloud.coutinho.io/apps/deck/#/board/7) reported the `usage_events` insert as a **~1.9s wait, ~64% of every ingested document** (up from 65ms). It surfaced after gateway v0.31.0 removed dense-embed as the dominant per-doc cost and unmasked it.

**The investigation reframed the card — both of its central premises were wrong:**

1. **Not insert-specific, and not about metering.** `select` averaged ~0.78–0.82s too, on the API pod as well as the ingest worker. *Every* Postgres operation paid the same toll; `usage_events` was just where it became visible, because ingest does it once per document.
2. **A DB histogram already existed** (added by #1084). It missed the regression not because it was absent, but because its **buckets capped at 1.0s** — ~50% of samples landed in `+Inf`.

## Root cause: infrastructure, not code

Confirmed by direct in-pod measurement on cloudfleet/dev. One PgBouncer replica had been scheduled in `ash` (US) while Postgres and every workload run in Germany. The pooler ClusterIP round-robins, so **~50% of connections paid a transatlantic TLS handshake** — then hopped back to Postgres in Nuremberg.

| Pooler replica | Region | TCP-only p50 | Full connect p50 |
|---|---|---|---|
| `renewing-earwig` | **nbg1** 🇩🇪 | 6ms | **30ms** |
| `new-mole` | **ash** (US) 🇺🇸 | 100ms | **603ms** |

This reproduces the reported numbers exactly: connect 600ms + 4 INSERT round-trips × 100ms + commit ≈ **1.1s** (observed 1.12s). The "quantized plateaus" in the incident note are multiples of that ~100ms RTT. It was invisible to `pgbouncer_pools_client_maxwait_seconds` (=0) because that metric only counts *after* a client is connected and authenticated — and both Postgres and PgBouncer looked idle because this was **speed of light, not load**.

**The node fleet has since been restricted to Europe**, which resolved it:
- connect p50: **611ms → 53ms**
- `backend` select: **0.823s → 0.325s**

## What this PR changes

Infra fixed the incident; this PR fixes the two **observability defects that let it hide for a day**. No behavior change.

- **Bucket ceiling.** `mcp_db_operation_duration_seconds` now spans 1ms–10s. Every original edge is retained so historical series stay comparable. The `0.75`/`1.5` edges deliberately straddle a 1s TCP RTO, so a retry-shaped stall is distinguishable from slow-but-healthy work.
- **Connect vs execute.** Adds `mcp_db_connect_duration_seconds` and a `db.<dialect>.connect` child span at the `_db()` seam — the single point every caller funnels through, so this covers the read paths too, not just metering. Under NullPool (ADR-026) `engine.connect()` *is* the physical connect, so this is a genuine per-op cost.
- A **failed** connect is recorded too (in a `finally`) — a connect that times out is the sample most worth seeing.
- Fixes stale `db: sqlite | qdrant` labels/docstrings (`postgresql` has been passed since ADR-026) and documents the connect/execute ratio query in `docs/observability.md`.

## Test coverage

- `tests/unit/test_db_metrics.py` (new) — guards the bucket ceiling directly: a 1.9s insert must land in a finite bucket. This test fails against the old config.
- `tests/unit/test_usage_store.py` — connect measured once per batch (preserving #1084's batching contract), and the failed-connect path.
- Verified against **real Postgres**: `TEST_DATABASE_URL=... pytest tests/integration/test_storage_postgres.py` → 45 passed, including the advisory-lock and engine-disposal guards. Full unit suite green (2196).

Per the repo's API-surface rule: this PR adds **no** MCP tool, HTTP route, or cross-service boundary — it only changes metric/span instrumentation — so no new e2e or Pact coverage is required.

## Deliberately NOT in this PR

The `NullPool` → pooling rework (a connection per operation still costs ~30ms × ~6 ops/doc). With the transatlantic replica gone that is no longer urgent, and it carries real risk: it must not regress the cross-loop crash `8cd3092e` fixed, and long-lived connections would unmask psycopg3 auto-prepare behind transaction-mode PgBouncer (Deck #424). Left to be judged on its own merits.

**Follow-up (gitops, not this repo):** both poolers are now in Europe but split across hel1/nbg1, so ~50% of connects still pay ~185ms vs ~40ms. Co-locating the poolers with Postgres in nbg1 (nodeAffinity / `trafficDistribution: PreferClose`) would remove the remaining mode. The pooler Deployment currently has **no** `nodeSelector`/`affinity`/`topologySpreadConstraints`, which is what let a replica land in the US in the first place.

---

_This PR was generated with the help of AI, and reviewed by a Human_