### PR TITLE
fix(api): stop broad handlers masking faults in the webhook/admin surface

### DIFF
--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -238,8 +238,11 @@ def _sanitize_error_for_client(error: Exception, context: str = "") -> str:
     Returns:
         Generic error message safe for client consumption
     """
-    # Log detailed error for debugging
-    logger.error("Error in %s: %s", context, error)
+    # Log detailed error for debugging. logger.exception (not logger.error) so the
+    # traceback survives: this helper backs every catch-all 500 in the management /
+    # access surface, and the client deliberately gets only the generic message
+    # below, so this log line is the *sole* record of what actually failed.
+    logger.exception("Error in %s: %s", context, error)
 
     # Return generic message
     return "An internal error occurred. Please contact your administrator."

--- a/nextcloud_mcp_server/api/webhooks.py
+++ b/nextcloud_mcp_server/api/webhooks.py
@@ -188,23 +188,41 @@ async def create_webhook(request: Request) -> JSONResponse:
             status_code=401,
         )
 
+    # Parse the body before the try below: a malformed payload is a *caller* fault
+    # (400), but inside that block it would be swallowed by the catch-all and
+    # reported as 500 "Internal error" — telling the client the server is broken
+    # when the client sent bad JSON. Mirrors the int() guard in delete_webhook.
     try:
-        # Parse request body
         body = await request.json()
-        event = body.get("event")
-        uri = body.get("uri")
-        # Accept both camelCase (eventFilter) and snake_case (event_filter)
-        event_filter = body.get("eventFilter") or body.get("event_filter")
+    except (ValueError, UnicodeDecodeError) as e:
+        logger.warning("Create-webhook payload was not valid JSON: %s", e)
+        return JSONResponse(
+            {"error": "Bad request", "message": "Invalid JSON"},
+            status_code=400,
+        )
 
-        if not event or not uri:
-            return JSONResponse(
-                {
-                    "error": "Bad request",
-                    "message": "Missing required fields: event, uri",
-                },
-                status_code=400,
-            )
+    # A JSON scalar/array parses fine but has no .get — also a caller fault, not a 500.
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"error": "Bad request", "message": "Request body must be a JSON object"},
+            status_code=400,
+        )
 
+    event = body.get("event")
+    uri = body.get("uri")
+    # Accept both camelCase (eventFilter) and snake_case (event_filter)
+    event_filter = body.get("eventFilter") or body.get("event_filter")
+
+    if not event or not uri:
+        return JSONResponse(
+            {
+                "error": "Bad request",
+                "message": "Missing required fields: event, uri",
+            },
+            status_code=400,
+        )
+
+    try:
         username, app_password = await get_basic_auth_for_user(user_id)
 
         oauth_ctx = request.app.state.oauth_context

--- a/nextcloud_mcp_server/api/webhooks.py
+++ b/nextcloud_mcp_server/api/webhooks.py
@@ -38,6 +38,9 @@ from ..http import nextcloud_httpx_client
 
 logger = logging.getLogger(__name__)
 
+# Client-fault error label, shared by every 400 in this module (python:S1192).
+_BAD_REQUEST = "Bad request"
+
 
 async def get_installed_apps(request: Request) -> JSONResponse:
     """GET /api/v1/apps - Get list of installed Nextcloud apps.
@@ -194,17 +197,19 @@ async def create_webhook(request: Request) -> JSONResponse:
     # when the client sent bad JSON. Mirrors the int() guard in delete_webhook.
     try:
         body = await request.json()
-    except (ValueError, UnicodeDecodeError) as e:
+    except ValueError as e:
+        # ValueError alone covers both realistic failures: json.JSONDecodeError and
+        # UnicodeDecodeError are each a ValueError subclass (python:S5713).
         logger.warning("Create-webhook payload was not valid JSON: %s", e)
         return JSONResponse(
-            {"error": "Bad request", "message": "Invalid JSON"},
+            {"error": _BAD_REQUEST, "message": "Invalid JSON"},
             status_code=400,
         )
 
     # A JSON scalar/array parses fine but has no .get — also a caller fault, not a 500.
     if not isinstance(body, dict):
         return JSONResponse(
-            {"error": "Bad request", "message": "Request body must be a JSON object"},
+            {"error": _BAD_REQUEST, "message": "Request body must be a JSON object"},
             status_code=400,
         )
 
@@ -216,7 +221,7 @@ async def create_webhook(request: Request) -> JSONResponse:
     if not event or not uri:
         return JSONResponse(
             {
-                "error": "Bad request",
+                "error": _BAD_REQUEST,
                 "message": "Missing required fields: event, uri",
             },
             status_code=400,
@@ -303,7 +308,7 @@ async def delete_webhook(request: Request) -> JSONResponse:
         webhook_id = request.path_params.get("webhook_id")
         if not webhook_id:
             return JSONResponse(
-                {"error": "Bad request", "message": "Missing webhook_id"},
+                {"error": _BAD_REQUEST, "message": "Missing webhook_id"},
                 status_code=400,
             )
 
@@ -311,7 +316,7 @@ async def delete_webhook(request: Request) -> JSONResponse:
             webhook_id = int(webhook_id)
         except ValueError:
             return JSONResponse(
-                {"error": "Bad request", "message": "Invalid webhook_id"},
+                {"error": _BAD_REQUEST, "message": "Invalid webhook_id"},
                 status_code=400,
             )
 

--- a/nextcloud_mcp_server/auth/webhook_routes.py
+++ b/nextcloud_mcp_server/auth/webhook_routes.py
@@ -184,17 +184,41 @@ async def _register_preset_webhooks(
     """
     auth_method, auth_data = webhook_auth_pair()
     registered_ids: list[int] = []
-    for event_config in preset["events"]:
-        webhook_data = await webhooks_client.create_webhook(
-            event=event_config["event"],
-            uri=webhook_uri,
-            event_filter=event_config["filter"] if event_config["filter"] else None,
-            auth_method=auth_method,
-            auth_data=auth_data,
-        )
-        webhook_id = webhook_data["id"]
-        registered_ids.append(webhook_id)
-        logger.info("Registered webhook %s for %s", webhook_id, event_config["event"])
+    try:
+        for event_config in preset["events"]:
+            webhook_data = await webhooks_client.create_webhook(
+                event=event_config["event"],
+                uri=webhook_uri,
+                event_filter=event_config["filter"] if event_config["filter"] else None,
+                auth_method=auth_method,
+                auth_data=auth_data,
+            )
+            webhook_id = webhook_data["id"]
+            registered_ids.append(webhook_id)
+            logger.info(
+                "Registered webhook %s for %s", webhook_id, event_config["event"]
+            )
+    except Exception:
+        # Roll back the webhooks already created in Nextcloud before re-raising.
+        # Without this, a failure on event N leaves events 1..N-1 live in
+        # Nextcloud while the caller's store_webhook() never runs — orphaned
+        # registrations that the UI cannot see or delete, still delivering. The
+        # caller reports "Failed to enable preset", so the only honest end state
+        # is "nothing enabled". Rollback is best-effort: a failed cleanup must not
+        # replace the original error, which is the one that explains the failure.
+        for webhook_id in registered_ids:
+            try:
+                await webhooks_client.delete_webhook(webhook_id)
+                logger.info(
+                    "Rolled back webhook %s after failed preset enable", webhook_id
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to roll back webhook %s; it is live in Nextcloud but "
+                    "untracked — delete it manually",
+                    webhook_id,
+                )
+        raise
     return registered_ids
 
 
@@ -309,9 +333,16 @@ async def _get_enabled_presets(
 
         return enabled_presets
 
-    except Exception as e:
-        logger.error("Failed to list webhooks: %s", e)
-        return {}
+    except Exception:
+        # Propagate rather than returning {}: an empty map is indistinguishable
+        # from the truthful "no presets are enabled", and both callers act on that
+        # difference. The pane would render "Not Enabled" for presets that are
+        # live, so an admin clicking Enable double-registers every event; the
+        # storage-less disable path would no-op its delete loop and still report
+        # success. Both callers already wrap this in a handler that surfaces an
+        # error, so failing honestly is strictly better than answering wrongly.
+        logger.exception("Failed to determine enabled presets")
+        raise
 
 
 @requires("authenticated", redirect="oauth_login")

--- a/nextcloud_mcp_server/auth/webhook_routes.py
+++ b/nextcloud_mcp_server/auth/webhook_routes.py
@@ -291,7 +291,15 @@ async def _get_enabled_presets(
         storage: Optional RefreshTokenStorage instance
 
     Returns:
-        Dictionary mapping preset_id to list of webhook IDs
+        Dictionary mapping preset_id to list of webhook IDs. An empty dict means
+        genuinely no presets are enabled — a lookup failure raises instead of
+        returning one, because callers act on that difference.
+
+    Raises:
+        Exception: whatever the storage/API lookup raised. Deliberately not
+            swallowed into an empty dict: callers treat {} as "nothing enabled",
+            which would render live presets as disabled (and double-register them
+            on the next Enable). Both callers already surface the error.
     """
     try:
         # Try database first (faster, works offline)
@@ -461,7 +469,7 @@ async def webhook_management_pane(request: Request) -> HTMLResponse:
         return HTMLResponse(content=html_content)
 
     except Exception as e:
-        logger.error("Error loading webhook management pane: %s", e)
+        logger.exception("Error loading webhook management pane: %s", e)
         return HTMLResponse(
             content=f"""
             <div class="warning">
@@ -563,7 +571,7 @@ async def enable_webhook_preset(request: Request) -> HTMLResponse:
             status_code=503,
         )
     except Exception as e:
-        logger.error("Failed to enable preset %s: %s", preset_id, e)
+        logger.exception("Failed to enable preset %s: %s", preset_id, e)
         return HTMLResponse(
             content=f'<div class="warning">Failed to enable preset: {html.escape(str(e))}</div>',
             status_code=500,
@@ -655,7 +663,7 @@ async def disable_webhook_preset(request: Request) -> HTMLResponse:
         )
 
     except Exception as e:
-        logger.error("Failed to disable preset %s: %s", preset_id, e)
+        logger.exception("Failed to disable preset %s: %s", preset_id, e)
         return HTMLResponse(
             content=f'<div class="warning">Failed to disable preset: {html.escape(str(e))}</div>',
             status_code=500,

--- a/tests/unit/api/test_error_sanitizer_logging.py
+++ b/tests/unit/api/test_error_sanitizer_logging.py
@@ -1,0 +1,44 @@
+"""``_sanitize_error_for_client`` must log the traceback.
+
+This helper backs every catch-all 500 in the management/access surface, and the
+client deliberately receives only a generic message — so this log line is the
+sole record of what actually failed. It previously used ``logger.error(...)``,
+which discards the stack, leaving a 500 from a wide try block with no way to
+tell (say) a Qdrant outage from a TypeError in response building.
+"""
+
+import logging
+
+import pytest
+
+from nextcloud_mcp_server.api.management import _sanitize_error_for_client
+
+pytestmark = pytest.mark.unit
+
+
+def test_sanitizer_logs_traceback(caplog):
+    caplog.set_level(logging.ERROR, logger="nextcloud_mcp_server.api.management")
+
+    try:
+        raise RuntimeError("qdrant is down")
+    except RuntimeError as e:
+        _sanitize_error_for_client(e, "some_context")
+
+    record = next(
+        r for r in caplog.records if r.name == "nextcloud_mcp_server.api.management"
+    )
+    # exc_info is what carries the traceback; logger.error(..., e) leaves it None.
+    assert record.exc_info is not None, "traceback was not captured"
+    assert record.exc_info[0] is RuntimeError
+    assert "some_context" in record.getMessage()
+
+
+def test_sanitizer_never_leaks_the_error_to_the_client():
+    """The traceback goes to the log; the caller still gets the generic message."""
+    try:
+        raise RuntimeError("secret-host.internal:5432 refused connection")
+    except RuntimeError as e:
+        msg = _sanitize_error_for_client(e, "some_context")
+
+    assert "secret-host.internal" not in msg
+    assert msg == "An internal error occurred. Please contact your administrator."

--- a/tests/unit/test_webhook_routes_register.py
+++ b/tests/unit/test_webhook_routes_register.py
@@ -87,3 +87,66 @@ async def test_register_returns_ids_in_call_order(monkeypatch, mocker):
     ids = await _register_preset_webhooks(client, preset, "https://example.com/wh")
 
     assert ids == [42, 43, 44]
+
+
+async def test_register_rolls_back_already_created_webhooks_on_failure(
+    monkeypatch, mocker
+):
+    """A mid-loop failure must not leave orphaned webhooks live in Nextcloud.
+
+    ``_register_preset_webhooks`` only returns after every event registers, so
+    the caller's ``store_webhook`` never runs when event N fails — previously
+    leaving events 1..N-1 live in Nextcloud but absent from the DB, invisible to
+    the UI and still delivering, while the handler reported "Failed to enable
+    preset" (i.e. that nothing happened).
+    """
+    _patch_secret(monkeypatch, "supersecret")
+    preset = get_preset("notes_sync")
+    assert preset is not None
+
+    client = mocker.AsyncMock(spec=WebhooksClient)
+    # Events 1 and 2 succeed, event 3 fails.
+    client.create_webhook.side_effect = [
+        {"id": 42},
+        {"id": 43},
+        RuntimeError("nextcloud exploded"),
+    ]
+
+    with pytest.raises(RuntimeError, match="nextcloud exploded"):
+        await _register_preset_webhooks(client, preset, "https://example.com/wh")
+
+    # The two that were created must be deleted again, so the reported end state
+    # ("nothing enabled") matches reality.
+    assert [c.args[0] for c in client.delete_webhook.call_args_list] == [42, 43]
+
+
+async def test_register_rollback_failure_does_not_mask_original_error(
+    monkeypatch, mocker
+):
+    """A failed rollback must not replace the error that explains the failure."""
+    _patch_secret(monkeypatch, "supersecret")
+    preset = get_preset("notes_sync")
+    assert preset is not None
+
+    client = mocker.AsyncMock(spec=WebhooksClient)
+    client.create_webhook.side_effect = [{"id": 42}, RuntimeError("original cause")]
+    client.delete_webhook.side_effect = RuntimeError("cleanup also failed")
+
+    # The original error propagates, not the cleanup error.
+    with pytest.raises(RuntimeError, match="original cause"):
+        await _register_preset_webhooks(client, preset, "https://example.com/wh")
+
+
+async def test_enabled_presets_failure_propagates_rather_than_reporting_none_enabled(
+    mocker,
+):
+    """A listing failure must not masquerade as "no presets are enabled".
+
+    Returning {} made the pane render "Not Enabled" for live presets, so an admin
+    clicking Enable would double-register every event.
+    """
+    client = mocker.AsyncMock(spec=WebhooksClient)
+    client.list_webhooks.side_effect = RuntimeError("nextcloud unreachable")
+
+    with pytest.raises(RuntimeError, match="nextcloud unreachable"):
+        await webhook_routes._get_enabled_presets(client)

--- a/tests/unit/test_webhooks_api_auth.py
+++ b/tests/unit/test_webhooks_api_auth.py
@@ -340,3 +340,47 @@ async def test_get_basic_auth_for_user_raises_when_unprovisioned(mocker):
 
     with pytest.raises(ProvisioningRequiredError):
         await get_basic_auth_for_user("admin")
+
+
+class TestCreateWebhookMalformedBody:
+    """A malformed request body is a caller fault (400), not a server fault (500).
+
+    ``await request.json()`` used to sit inside the handler's catch-all, so a bad
+    payload surfaced as 500 "Internal error" — telling the client the server is
+    broken when the client sent bad JSON, and burying a routine 400 in the error
+    logs. ``delete_webhook`` already guarded its ``int()`` parse this way.
+    """
+
+    def test_malformed_json_returns_400_not_500(self, mocker):
+        _patch_token_validation(mocker)
+        client = TestClient(_build_test_app())
+
+        response = client.post(
+            "/api/v1/webhooks",
+            content=b"{not json",
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Bad request"
+
+    def test_non_object_json_body_returns_400_not_500(self, mocker):
+        """A JSON array parses fine but has no .get() — previously an AttributeError
+        inside the catch-all, i.e. another 500."""
+        _patch_token_validation(mocker)
+        client = TestClient(_build_test_app())
+
+        response = client.post("/api/v1/webhooks", json=[])
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Bad request"
+
+    def test_missing_fields_still_returns_400(self, mocker):
+        """The pre-existing required-field check must survive the refactor."""
+        _patch_token_validation(mocker)
+        client = TestClient(_build_test_app())
+
+        response = client.post("/api/v1/webhooks", json={"event": "SomeEvent"})
+
+        assert response.status_code == 400
+        assert "Missing required fields" in response.json()["message"]


### PR DESCRIPTION
## Context

Follow-up to the reviewer's observation on #1092: a broad `except Exception → return error response` swallowed a real fault in `payload_backfill.py`, so its test failed for a reason unrelated to the actual error. I audited the whole admin/webhook surface (**28 broad-catch sites**) to see how far the pattern ran.

Full inventory + evidence: Nextcloud note **390881**. Card: Deck **#679**.

**Audit tally: 12 masking / 12 too broad / 4 legitimate fail-open. Zero carried a comment justifying the breadth. Zero used `logger.exception` — no traceback was emitted anywhere in this surface, including at catch-all 500s.**

This PR fixes the **reachable** bugs plus the reason none of them were diagnosable. Narrowing the merely-too-broad catches, the 401 conflation, and the 503-vs-500 mapping are left as follow-ups on #679.

## Changes

### 1. `_sanitize_error_for_client`: `logger.error` → `logger.exception` (`management.py:242`)

This helper backs every catch-all 500 in the management/access surface, and the client deliberately receives only a generic message — so **this log line is the sole record of what failed**, and it was discarding the traceback. A 500 from a ~45-line try block gave no way to tell a Qdrant outage from a `TypeError` in response building.

I verified **all 28 call sites are inside `except` blocks**, so the traceback is always live (`logger.exception` outside a handler would log `NoneType: None`). This is a one-line change that reaches all 28.

### 2. `create_webhook`: malformed body is 400, not 500 (`webhooks.py`)

`await request.json()` sat inside the catch-all, so bad JSON returned **500 "Internal error"** — telling the client *the server* is broken when the *client* sent bad JSON, and burying a routine 400 in the error logs. A non-dict body (`[]`) hit `body.get` → `AttributeError` → also 500.

Not a stylistic point: `delete_webhook` **already** guards its `int()` parse exactly this way (`webhooks.py:292-298`), so this was an internal inconsistency, not house style.

### 3. `_register_preset_webhooks`: roll back on failure (`webhook_routes.py`)

The helper returns ids only after *every* event registers. A failure on event N left events 1..N-1 **live in Nextcloud** while the caller's `store_webhook` never ran — orphaned registrations, invisible to the UI, still delivering — while the handler reported "Failed to enable preset", i.e. that nothing happened. Now the already-created webhooks are deleted before re-raising, so the reported end state matches reality. Rollback is best-effort and **never replaces the original error** (that's the one that explains the failure) — there's a test for that.

### 4. `_get_enabled_presets`: propagate instead of returning `{}` (`webhook_routes.py`)

`{}` is indistinguishable from the truthful "no presets are enabled", and both callers act on the difference:
- the pane rendered **"Not Enabled" for presets that are live** → an admin clicking Enable **double-registers every event**;
- the storage-less disable path no-op'd its delete loop and still returned the success card.

Both callers already wrap this in a handler that surfaces an error, so failing honestly is strictly better than answering wrongly. **Behavior change**: a transient listing failure now shows an error in the pane instead of a silently wrong state.

## Two audit findings I did NOT fix (and why)

`access.py:172` (scope update) and `management.py:636` (revoke) *look* like post-write state divergences — a durable write followed by a cache invalidation under one catch, which would report a committed write as a 500 failure. I initially flagged both as security-adjacent bugs. **On checking reachability, both are false positives**: the post-write steps are `_scope_cache.pop(user_id, None)` on a plain dict, and an `await`ed in-memory `del` guarded by an `if user_id in self._cache`. Neither can realistically raise, and `CancelledError` is a `BaseException` so it isn't caught either. If the step *before* them raises, nothing was committed and the 500 is correct.

The structure is fragile and worth tidying, but there is no live bug — recorded as structural nits on #679 rather than churned here.

## Verification

Every fix has a regression test **proven to fail against master's code**:

| Test | Failure on master |
|---|---|
| `test_malformed_json_returns_400_not_500` | `assert 500 == 400` |
| `test_non_object_json_body_returns_400_not_500` | `assert 500 == 400` |
| `test_register_rolls_back_already_created_webhooks_on_failure` | `assert [] == [42, 43]` |
| `test_enabled_presets_failure_propagates_...` | `DID NOT RAISE` |
| `test_sanitizer_logs_traceback` | `traceback was not captured` |

The JSON tests drive a real request through a Starlette `TestClient` against the actual handler, not a mock.

- Exact CI selection green: `uv run pytest -m unit -o "addopts=-p no:asyncio"` → **2387 passed** (2379 baseline + 8 new), no regressions.
- ruff / ruff format / ty / commitizen clean; `sonar analyze secrets` clean.

## Test coverage (ADR-029 gate)

This changes the **behavior** of `POST /api/v1/webhooks` (malformed input now 400 rather than 500). Per CLAUDE.md I'm stating the coverage position explicitly rather than leaving it silent:

- **Unit/e2e-ish**: the new tests exercise the real handler end-to-end via `TestClient`.
- **Contract**: the authenticated `/api/v1/*` surface — including `webhooks` CRUD — is **not** pact-verified today; provider verification covers only the public endpoints pending the ADR-029 phase-4 Bearer-token hook. That gap is pre-existing and already tracked on Deck board 11; this PR does not widen it. The status-code change is in the direction of the HTTP contract (client fault → 4xx), so a future pact should encode 400.

Refs: Deck #679

---

_This PR was generated with the help of AI, and reviewed by a Human_