### PR TITLE
fix(client): skip Content-Length truncation check on compressed responses

### DIFF
--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -35,8 +35,17 @@ def _read_complete_body(response: Response, label: str) -> bytes:
     mitigation for connection poisoning is ``NEXTCLOUD_HTTP_KEEPALIVE=false``.)
     A missing or malformed header (e.g. ``Transfer-Encoding: chunked``) skips
     the check so legitimately header-less responses never raise.
+
+    ``Content-Length`` on a compressed response describes the compressed
+    size on the wire, not the decompressed ``response.content`` httpx hands
+    back — comparing the two would misfire on every compressible file
+    Nextcloud happens to gzip, so the check only applies to identity-encoded
+    responses (see #1099).
     """
     content = response.content
+    content_encoding = response.headers.get("content-encoding")
+    if content_encoding is not None and content_encoding.lower() != "identity":
+        return content
     declared = response.headers.get("content-length")
     if declared is None:
         return content

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -653,6 +653,30 @@ async def test_read_file_accepts_matching_content_length(mocker):
 
 
 @pytest.mark.unit
+async def test_read_file_accepts_gzip_response_shorter_than_content_length(mocker):
+    """A gzip response's Content-Length is the compressed wire size, not the
+    decompressed body httpx hands back in ``response.content`` — comparing
+    the two would misfire on every compressible file Nextcloud gzips (#1099).
+    """
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    body = b'{"key": "value"} ' * 2000  # compressible enough to be gzipped
+    mock_response = AsyncMock()
+    mock_response.content = body  # httpx already decompressed this
+    mock_response.headers = {
+        "content-type": "application/json",
+        "content-encoding": "gzip",
+        "content-length": "128",  # compressed size on the wire, << len(body)
+    }
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    content, _ = await client.read_file("Documents/index.json")
+    assert content == body
+
+
+@pytest.mark.unit
 async def test_read_file_skips_check_without_content_length(mocker):
     """A header-less (e.g. chunked) response must not raise — nothing to compare."""
     mock_http_client = AsyncMock()


### PR DESCRIPTION
Fixes #1099.

## Problem

`_read_complete_body` compares `len(response.content)` — httpx already
decompresses gzip/deflate responses before this point — against the raw
`Content-Length` header. For a compressed response that header is the size
on the wire (before decompression), so the two numbers can never match.
Every compressible file Nextcloud decides to gzip fails this check
deterministically, misreported as the keep-alive poisoning this guard was
built for (#965) — it's unrelated: reproduced with a byte-identical copy at
a brand-new path/file id, and confirmed via direct `curl` that the gzip
response's `Content-Length` is the compressed size while the identity
response's is the full size. See #1099 for the full repro (curl output,
compression-ratio math).

## Fix

Skip the length check when `Content-Encoding` is present and not
`identity`. httpx already raises during decompression on a genuinely
truncated compressed stream, so the extra guard is only meaningful — and
only correct — for uncompressed responses.

## Testing

- Added `test_read_file_accepts_gzip_response_shorter_than_content_length`,
  mirroring the existing `test_read_file_accepts_matching_content_length` /
  `test_read_file_raises_on_truncated_body` pattern in
  `tests/unit/client/test_webdav.py`.
- Confirmed this new test fails with the pre-fix code (same
  `RemoteProtocolError` as the real-world report) and passes with the fix.
- Full `tests/unit/client/test_webdav.py` suite (36 tests) passes.
- `ruff check` / `ruff format --check` clean on both changed files.
