### PR TITLE
fix(ingest): bound fast-tier PDF ingest memory (windowed parse, pre-flight size gate, streaming download)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -679,12 +679,27 @@ shorter OCR ceiling:
 DOCUMENT_PARSE_TIMEOUT_SECONDS=120    # Wall-clock cap per isolated parse (default: 120)
 DOCUMENT_OCR_TIMEOUT_SECONDS=180      # OCR backend request timeout (default: 180)
 DOCUMENT_MAX_PDF_SIZE_MB=50           # Pre-parse size cap; 0 disables (default: 50)
+DOCUMENT_PARSE_PAGE_WINDOW=100        # Pages per extraction window; 0 disables (default: 100)
 ```
 
 A PDF larger than `DOCUMENT_MAX_PDF_SIZE_MB` fails fast with reason `oversize`
 (exported on `astrolabe_document_parse_failed_total{reason="oversize"}`) instead
 of being handed to the tiers, where a 40+ MB scan would otherwise burn the full
 OCR timeout for zero recovered text.
+
+`DOCUMENT_PARSE_PAGE_WINDOW` bounds the **fast** tier's peak memory. PDFium keeps
+parsed page objects for the lifetime of the open document and `page.close()` does
+not give them back, so extracting a long document in one open makes peak RSS scale
+with page count — measured at ~0.5 MB/page, i.e. 1.9 GB for a real 4003-page
+document, enough to OOM a 3 GiB worker on its own. The extractor therefore
+re-opens the document every `DOCUMENT_PARSE_PAGE_WINDOW` pages; the freed arena is
+reused by the next window, so peak stays flat at roughly one window's worth
+(100 pages ≈ 85 MB) with byte-identical output and no measurable slowdown.
+
+Lower it for very memory-constrained workers, raise it to trade memory for fewer
+re-opens. Note the cost is per *page*, not per byte — a 500 MB / 70-page scan is
+far cheaper than a 100 MB / 4000-page one, so page count, not file size, is what
+this setting tracks.
 
 #### OCR tier configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -687,6 +687,23 @@ A PDF larger than `DOCUMENT_MAX_PDF_SIZE_MB` fails fast with reason `oversize`
 of being handed to the tiers, where a 40+ MB scan would otherwise burn the full
 OCR timeout for zero recovered text.
 
+**Sizing the cap for a tenant.** Two metrics make the corpus visible instead of
+requiring a manual crawl:
+
+- `astrolabe_document_ingest_size_bytes{doc_type}` — a histogram of source sizes,
+  observed **before** the cap is applied, so the over-cap tail is included.
+  Buckets run to 2 GiB.
+- `astrolabe_document_ingest_rejected_total{doc_type,reason="oversize"}` — how
+  many documents the cap turned away.
+
+The fraction of a tenant's corpus blocked by the cap is then a query rather than
+an investigation, e.g.:
+
+```promql
+sum(rate(astrolabe_document_ingest_rejected_total{reason="oversize"}[1h]))
+  / sum(rate(astrolabe_document_ingest_size_bytes_count[1h]))
+```
+
 > **Changing `DOCUMENT_MAX_PDF_SIZE_MB` re-drives dead-lettered documents.** The
 > cap is part of the escalation-tier signature that keys the document dead-letter
 > marker, so raising it makes previously-oversize documents retryable without

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -680,7 +680,18 @@ DOCUMENT_PARSE_TIMEOUT_SECONDS=120    # Wall-clock cap per isolated parse (defau
 DOCUMENT_OCR_TIMEOUT_SECONDS=180      # OCR backend request timeout (default: 180)
 DOCUMENT_MAX_PDF_SIZE_MB=50           # Pre-parse size cap; 0 disables (default: 50)
 DOCUMENT_PARSE_PAGE_WINDOW=100        # Pages per extraction window; 0 disables (default: 100)
+DOCUMENT_PARSE_PROCESS_SLOTS=2        # Concurrent isolated parse subprocesses (default: 2)
 ```
+
+`DOCUMENT_PARSE_PROCESS_SLOTS` bounds how many isolated parse subprocesses run at
+once. Without it anyio defaults to an `os.cpu_count()`-wide pool, which is
+constrained by neither the worker's `--concurrency` nor the pod memory limit: on
+an 8-core node that permits `8 × DOCUMENT_PARSE_MEM_LIMIT_MB` (~12 GiB of address
+space) inside a 3 GiB pod. `RLIMIT_AS` caps virtual address space rather than
+resident memory, so that is a ceiling rather than a reservation — but it is still
+well beyond what the pod can survive. Keep
+`DOCUMENT_PARSE_PROCESS_SLOTS × DOCUMENT_PARSE_MEM_LIMIT_MB` within the pod's
+memory limit. The limiter is created once per worker, so a change needs a restart.
 
 A PDF larger than `DOCUMENT_MAX_PDF_SIZE_MB` fails fast with reason `oversize`
 (exported on `astrolabe_document_parse_failed_total{reason="oversize"}`) instead

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -687,6 +687,15 @@ A PDF larger than `DOCUMENT_MAX_PDF_SIZE_MB` fails fast with reason `oversize`
 of being handed to the tiers, where a 40+ MB scan would otherwise burn the full
 OCR timeout for zero recovered text.
 
+> **Changing `DOCUMENT_MAX_PDF_SIZE_MB` re-drives dead-lettered documents.** The
+> cap is part of the escalation-tier signature that keys the document dead-letter
+> marker, so raising it makes previously-oversize documents retryable without
+> waiting for their etag to change (which, for an archive of scanned documents,
+> never happens). The trade-off is that a cap change invalidates *all* dead
+> letters for the tenant, not just oversize ones, so genuinely corrupt files are
+> re-attempted once too. On a large tenant that is a thundering herd — roll the
+> change out one tenant at a time and watch ingest queue depth.
+
 `DOCUMENT_PARSE_PAGE_WINDOW` bounds the **fast** tier's peak memory. PDFium keeps
 parsed page objects for the lifetime of the open document and `page.close()` does
 not give them back, so extracting a long document in one open makes peak RSS scale

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -83,6 +83,25 @@ The Helm chart has moved to a [separate repository](https://github.com/cbcoutinh
 - `mcp_vector_sync_queue_size` - Current queue depth
 - `mcp_qdrant_operations_total` - Qdrant DB operations
 
+### Document Ingest Metrics
+
+Throughput at the parse boundary, labelled by `processor` and `tier`
+(`fast` | `structured` | `ocr`). Throughput counters accrue only on a full
+success, so partial extractions and in-flight batch-OCR polls never inflate them.
+
+- `astrolabe_document_parse_total{status}` - Parse attempts (doc rate)
+- `astrolabe_document_pages_processed_total` - Pages extracted (page rate)
+- `astrolabe_document_chars_processed_total` - Characters extracted
+- `astrolabe_document_bytes_processed_total` - Source bytes parsed
+- `astrolabe_document_parse_duration_seconds` - Parse latency per document
+- `astrolabe_document_parse_failed_total{reason}` - Hard failures
+  (`timeout` | `oom` | `error` | `oversize`)
+
+Corpus shape, recorded before the oversize gate so the over-cap tail is visible:
+
+- `astrolabe_document_ingest_size_bytes{doc_type}` - Source size distribution
+- `astrolabe_document_ingest_rejected_total{doc_type,reason}` - Rejected pre-parse
+
 ### Database Metrics
 
 - `mcp_db_operations_total` - DB operations (SQLite, Qdrant)
@@ -159,6 +178,40 @@ topk(10, sum(rate(mcp_tool_calls_total[5m])) by (tool_name))
 **Nextcloud API Health**:
 ```promql
 sum(rate(mcp_nextcloud_api_requests_total{status_code!~"2.."}[5m])) by (app)
+```
+
+**Ingest throughput — documents/s and pages/s**:
+
+Both are counters, so the per-second rate comes from `rate()` rather than a
+gauge. Pages/s is the more stable capacity signal, because documents vary from
+one page to several thousand.
+
+```promql
+# documents/s by tier
+sum(rate(astrolabe_document_parse_total{status="success"}[5m])) by (tier)
+
+# pages/s by tier
+sum(rate(astrolabe_document_pages_processed_total[5m])) by (tier)
+
+# mean pages per document (how page-heavy this tenant's corpus is)
+sum(rate(astrolabe_document_pages_processed_total[5m]))
+  / sum(rate(astrolabe_document_parse_total{status="success"}[5m]))
+
+# seconds per page — compare tiers, or spot a slow corpus
+sum(rate(astrolabe_document_parse_duration_seconds_sum{status="success"}[5m]))
+  / sum(rate(astrolabe_document_pages_processed_total[5m]))
+```
+
+**Corpus size distribution and how much the cap turns away**:
+```promql
+# p50 / p99 source size
+histogram_quantile(0.99,
+  sum(rate(astrolabe_document_ingest_size_bytes_bucket[1h])) by (le)
+)
+
+# fraction of documents rejected as oversize
+sum(rate(astrolabe_document_ingest_rejected_total{reason="oversize"}[1h]))
+  / sum(rate(astrolabe_document_ingest_size_bytes_count[1h]))
 ```
 
 ## Alerts

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -208,10 +208,8 @@ class BaseNextcloudClient(ABC):
                     app=self.app_name, method=method, path=url
                 ):
                     async with self._client.stream(method, url, **kwargs) as response:
-                        if response.status_code == codes.TOO_MANY_REQUESTS:
-                            # Raise inside the context so the connection is
-                            # released before sleeping and retrying.
-                            response.raise_for_status()
+                        # Raised inside the stream context so the connection is
+                        # released before the 429 handler sleeps and retries.
                         response.raise_for_status()
                         yield response
                         record_nextcloud_api_call(

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -4,6 +4,7 @@ import logging
 import time
 import xml.etree.ElementTree as ET
 from abc import ABC
+from contextlib import asynccontextmanager
 from functools import wraps
 from urllib.parse import unquote
 
@@ -181,6 +182,67 @@ class BaseNextcloudClient(ABC):
         if url.startswith("/apps/"):
             return "/index.php" + url
         return url
+
+    @asynccontextmanager
+    async def _stream_request(self, method: str, url: str, **kwargs):
+        """Streaming sibling of :meth:`_make_request`, yielding an unread Response.
+
+        Shares ``_resolve_url``, tracing and the API-call metric, so a streamed
+        download is not a second, untraced transport path. The body is NOT read
+        here -- the caller consumes ``aiter_bytes()`` inside the ``async with``.
+
+        ``retry_on_429`` deliberately does not apply: it re-invokes a coroutine
+        that returns a fully-read Response, and a partially-consumed stream
+        cannot be replayed. Retry only the connect+status phase instead, before
+        any body byte is yielded; a mid-body failure surfaces as the retryable
+        transport error it already is.
+        """
+        url = self._resolve_url(url)
+        logger.debug("Making streaming %s request to %s", method, url)
+
+        max_retries = 5
+        for attempt in range(1, max_retries + 1):
+            start_time = time.time()
+            try:
+                with trace_nextcloud_api_call(
+                    app=self.app_name, method=method, path=url
+                ):
+                    async with self._client.stream(method, url, **kwargs) as response:
+                        if response.status_code == codes.TOO_MANY_REQUESTS:
+                            # Raise inside the context so the connection is
+                            # released before sleeping and retrying.
+                            response.raise_for_status()
+                        response.raise_for_status()
+                        yield response
+                        record_nextcloud_api_call(
+                            app=self.app_name,
+                            method=method,
+                            status_code=response.status_code,
+                            duration=time.time() - start_time,
+                        )
+                return
+            except HTTPStatusError as e:
+                if (
+                    e.response.status_code == codes.TOO_MANY_REQUESTS
+                    and attempt < max_retries
+                ):
+                    logger.warning(
+                        "429 Too Many Requests on streaming download, attempt %s",
+                        attempt,
+                    )
+                    record_nextcloud_api_retry(app=self.app_name, reason="429")
+                    await anyio.sleep(5)
+                    continue
+                record_nextcloud_api_call(
+                    app=self.app_name,
+                    method=method,
+                    status_code=e.response.status_code,
+                    duration=time.time() - start_time,
+                )
+                raise
+        raise RuntimeError(
+            f"Maximum number of retries ({max_retries}) exceeded without success"
+        )
 
     @retry_on_429
     async def _make_request(self, method: str, url: str, **kwargs):

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -4,6 +4,7 @@ import logging
 import mimetypes
 import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, unquote
 from xml.sax.saxutils import escape as xml_escape
@@ -18,6 +19,15 @@ from nextcloud_mcp_server.observability.metrics import (
 from .base import BaseNextcloudClient
 
 logger = logging.getLogger(__name__)
+
+
+class OversizeDownload(Exception):
+    """A streamed download exceeded its byte budget and was aborted.
+
+    Distinct from the pre-flight size gate: that acts on the size the server
+    advertised at scan time, this acts on what actually arrives, so it still
+    holds when ``Content-Length`` is absent or untrue.
+    """
 
 
 def _read_complete_body(response: Response, label: str) -> bytes:
@@ -43,41 +53,65 @@ def _read_complete_body(response: Response, label: str) -> bytes:
     responses (see #1099).
     """
     content = response.content
+    _verify_content_length(response, len(content), label)
+    return content
+
+
+def _expected_content_length(response: Response) -> int | None:
+    """The comparable ``Content-Length``, or ``None`` when the check can't apply.
+
+    Returns ``None`` for a compressed response (the header describes the
+    compressed size on the wire, not the decompressed bytes httpx hands back --
+    see #1099), a missing header (e.g. ``Transfer-Encoding: chunked``), a
+    malformed one, or a degenerate negative length.
+    """
     content_encoding = response.headers.get("content-encoding")
     if content_encoding is not None and content_encoding.lower() != "identity":
-        return content
+        return None
     declared = response.headers.get("content-length")
     if declared is None:
-        return content
+        return None
     try:
         expected = int(declared)
     except ValueError:
         # Malformed header — nothing reliable to compare against, so don't
         # raise spuriously; let the (possibly fine) body through.
-        return content
+        return None
     if expected < 0:
         # Degenerate header (negative length) — can't be a real short-read
         # signal and would always trip the check below; ignore it.
-        return content
-    if len(content) != expected:
-        document_download_truncated_total.inc()
-        # Log here, not just in the message: both callers funnel this through a
-        # generic ``except Exception`` that would otherwise report it as an
-        # opaque "Unexpected error reading file".
-        logger.warning(
-            "Truncated download for %r: expected %d bytes, got %d "
-            "(poisoned keep-alive connection? set NEXTCLOUD_HTTP_KEEPALIVE=false "
-            "— see #965)",
-            label,
-            expected,
-            len(content),
-        )
-        raise RemoteProtocolError(
-            f"Truncated download for {label!r}: expected {expected} bytes, "
-            f"got {len(content)} (poisoned keep-alive connection? see #965)",
-            request=response.request,
-        )
-    return content
+        return None
+    return expected
+
+
+def _verify_content_length(response: Response, received: int, label: str) -> None:
+    """Raise :class:`RemoteProtocolError` when ``received`` is a short read.
+
+    Shared by the buffered (:func:`_read_complete_body`) and streaming
+    (``WebDavClient.stream_to_file``) download paths so the #965 truncation
+    guard and the #1099 content-encoding carve-out cannot drift apart between
+    them.
+    """
+    expected = _expected_content_length(response)
+    if expected is None or received == expected:
+        return
+    document_download_truncated_total.inc()
+    # Log here, not just in the message: callers funnel this through a
+    # generic ``except Exception`` that would otherwise report it as an
+    # opaque "Unexpected error reading file".
+    logger.warning(
+        "Truncated download for %r: expected %d bytes, got %d "
+        "(poisoned keep-alive connection? set NEXTCLOUD_HTTP_KEEPALIVE=false "
+        "— see #965)",
+        label,
+        expected,
+        received,
+    )
+    raise RemoteProtocolError(
+        f"Truncated download for {label!r}: expected {expected} bytes, "
+        f"got {received} (poisoned keep-alive connection? see #965)",
+        request=response.request,
+    )
 
 
 # Paging defaults for WebDAV SEARCH. Nextcloud's SEARCH returns a server-default
@@ -449,6 +483,58 @@ class WebDAVClient(BaseNextcloudClient):
         except Exception as e:
             logger.error("Unexpected error listing directory '%s': %s", webdav_path, e)
             raise e
+
+    async def stream_to_file(
+        self, path: str, dest: Path, *, max_bytes: int | None = None
+    ) -> Tuple[int, str]:
+        """Stream a WebDAV GET straight to ``dest``, never holding the whole body.
+
+        :meth:`read_file` buffers the entire response (``response.content``), so
+        peak memory scales with file size -- a 531 MB PDF OOMKilled an ingest
+        worker mid-download. Streaming keeps resident memory at one chunk
+        regardless of how large the document is.
+
+        ``max_bytes`` aborts the transfer as soon as the limit is exceeded and
+        removes the partial file. This is the guard that survives an absent or
+        untrue ``Content-Length``: the pre-flight size gate can only act on what
+        the server advertised at scan time, whereas this acts on what actually
+        arrives.
+
+        Returns ``(bytes_written, content_type)``. Raises
+        :class:`OversizeDownload` if ``max_bytes`` is exceeded, or
+        :class:`httpx.RemoteProtocolError` on a short read (#965).
+        """
+        await self._ensure_principal_id()
+        webdav_path = self._webdav_path(path)
+
+        logger.debug("Streaming file to %s: %s", dest, path)
+
+        written = 0
+        try:
+            async with self._stream_request("GET", webdav_path) as response:
+                content_type = response.headers.get(
+                    "content-type", "application/octet-stream"
+                )
+                with dest.open("wb") as fh:
+                    async for chunk in response.aiter_bytes():
+                        written += len(chunk)
+                        if max_bytes is not None and written > max_bytes:
+                            raise OversizeDownload(
+                                f"Download of {path!r} exceeded {max_bytes} bytes "
+                                f"(aborted after {written})"
+                            )
+                        fh.write(chunk)
+                # Same short-read guard as the buffered path, against bytes
+                # written rather than bytes held in memory.
+                _verify_content_length(response, written, path)
+        except BaseException:
+            # Never leave a partial or over-cap file behind for the parser to
+            # read as a valid (truncated) document.
+            dest.unlink(missing_ok=True)
+            raise
+
+        logger.debug("Streamed '%s' to %s (%s bytes)", path, dest, written)
+        return written, content_type
 
     async def read_file(self, path: str) -> Tuple[bytes, str]:
         """Read a file's content via WebDAV GET."""

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, unquote
 from xml.sax.saxutils import escape as xml_escape
 
+import anyio
 from httpx import HTTPStatusError, RemoteProtocolError, Response
 
 from nextcloud_mcp_server.observability.metrics import (
@@ -515,7 +516,11 @@ class WebDAVClient(BaseNextcloudClient):
                 content_type = response.headers.get(
                     "content-type", "application/octet-stream"
                 )
-                with dest.open("wb") as fh:
+                # anyio's async file wrapper, not pathlib.Path.open: the writes
+                # run on a worker thread, so streaming a multi-hundred-MB
+                # document does not block the event loop (and with it every other
+                # in-flight job on this worker) for the duration of the download.
+                async with await anyio.open_file(dest, "wb") as fh:
                     async for chunk in response.aiter_bytes():
                         written += len(chunk)
                         if max_bytes is not None and written > max_bytes:
@@ -523,7 +528,7 @@ class WebDAVClient(BaseNextcloudClient):
                                 f"Download of {path!r} exceeded {max_bytes} bytes "
                                 f"(aborted after {written})"
                             )
-                        fh.write(chunk)
+                        await fh.write(chunk)
                 # Same short-read guard as the buffered path, against bytes
                 # written rather than bytes held in memory.
                 _verify_content_length(response, written, path)

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -211,6 +211,8 @@ _DEFAULTS: dict[str, Any] = {
     # "oversize" instead of burning the OCR timeout to 0 chars on a pathological
     # file. 0 disables the guard.
     "document_max_pdf_size_mb": 50.0,
+    # Pages per pypdfium2 extraction window (see document_parse_page_window).
+    "document_parse_page_window": 100,
     # Tier-0 classifier (records classification metrics on the tiered path)
     "document_classify_enabled": True,
     # Tiered PDF pipeline: pypdfium2 is the default/only hot-path extractor;
@@ -531,6 +533,8 @@ _dynaconf = Dynaconf(
         Validator("DOCUMENT_PARSE_MEM_LIMIT_MB", gte=128),
         # 0 disables the pre-parse PDF size cap; otherwise it must be positive.
         Validator("DOCUMENT_MAX_PDF_SIZE_MB", gte=0),
+        # 0 disables page-windowed extraction; otherwise it must be positive.
+        Validator("DOCUMENT_PARSE_PAGE_WINDOW", gte=0),
         # >=1: pymupdf4llm treats graphics_limit=0 as "no cap", which would
         # re-expose the OOM this guards against.
         Validator("DOCUMENT_PDF_GRAPHICS_LIMIT", gte=1),
@@ -1136,6 +1140,14 @@ class Settings:
     # RLIMIT_AS in the parse subprocess (below the pod limit). Applied once per
     # worker for its lifetime, so changing it needs a pod restart.
     document_parse_mem_limit_mb: int = 1536
+    # Pages per pypdfium2 extraction window. PDFium retains parsed page objects
+    # for the document's lifetime (~0.5 MB/page measured) and page.close() does
+    # not give them back, so extracting a large document in one open scales peak
+    # RSS with page count: a real 4003-page file cost 1914 MB. Re-opening the
+    # document every N pages caps that at one window's worth (100 pages -> 63 MB,
+    # a 30x reduction) with no measurable time cost and byte-identical output.
+    # 0 disables windowing (single open, pre-0.141 behaviour).
+    document_parse_page_window: int = 100
     # Tier-0 classifier. Records classification metrics (recommended_tier,
     # text-quality) on the tiered path, derived from the tier-1 extraction.
     document_classify_enabled: bool = True
@@ -1941,6 +1953,7 @@ def _build_settings() -> Settings:
         "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
+        "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
         "document_classify_enabled": "DOCUMENT_CLASSIFY_ENABLED",
         "document_tier1_engine": "DOCUMENT_TIER1_ENGINE",
         "document_ocr_enabled": "DOCUMENT_OCR_ENABLED",

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -213,6 +213,8 @@ _DEFAULTS: dict[str, Any] = {
     "document_max_pdf_size_mb": 50.0,
     # Pages per pypdfium2 extraction window (see document_parse_page_window).
     "document_parse_page_window": 100,
+    # Concurrent isolated parse subprocesses (see document_parse_process_slots).
+    "document_parse_process_slots": 2,
     # Tier-0 classifier (records classification metrics on the tiered path)
     "document_classify_enabled": True,
     # Tiered PDF pipeline: pypdfium2 is the default/only hot-path extractor;
@@ -535,6 +537,8 @@ _dynaconf = Dynaconf(
         Validator("DOCUMENT_MAX_PDF_SIZE_MB", gte=0),
         # 0 disables page-windowed extraction; otherwise it must be positive.
         Validator("DOCUMENT_PARSE_PAGE_WINDOW", gte=0),
+        # At least one parse must be able to run.
+        Validator("DOCUMENT_PARSE_PROCESS_SLOTS", gte=1),
         # >=1: pymupdf4llm treats graphics_limit=0 as "no cap", which would
         # re-expose the OOM this guards against.
         Validator("DOCUMENT_PDF_GRAPHICS_LIMIT", gte=1),
@@ -1148,6 +1152,15 @@ class Settings:
     # a 30x reduction) with no measurable time cost and byte-identical output.
     # 0 disables windowing (single open, pre-0.141 behaviour).
     document_parse_page_window: int = 100
+    # Concurrent isolated parse subprocesses. anyio's default process limiter is
+    # os.cpu_count(), which is decoupled from both --concurrency and the pod
+    # memory limit: on an 8-core node that permits 8 x document_parse_mem_limit_mb
+    # (~12 GiB of address space) inside a 3 GiB pod. RLIMIT_AS bounds virtual
+    # address space rather than RSS, so that is a ceiling and not a reservation,
+    # but it is still far above anything the pod can survive. Bound it explicitly
+    # instead. 2 covers the per-tier worker concurrency actually deployed (1-3)
+    # while capping the pathological case; raise it only with headroom to spare.
+    document_parse_process_slots: int = 2
     # Tier-0 classifier. Records classification metrics (recommended_tier,
     # text-quality) on the tiered path, derived from the tier-1 extraction.
     document_classify_enabled: bool = True
@@ -1954,6 +1967,7 @@ def _build_settings() -> Settings:
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
+        "document_parse_process_slots": "DOCUMENT_PARSE_PROCESS_SLOTS",
         "document_classify_enabled": "DOCUMENT_CLASSIFY_ENABLED",
         "document_tier1_engine": "DOCUMENT_TIER1_ENGINE",
         "document_ocr_enabled": "DOCUMENT_OCR_ENABLED",

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -135,13 +135,21 @@ def _apply_mem_limit(mem_limit_mb: int) -> None:
 
 
 def _parse_pdf_worker(
-    content: bytes,
+    source_path: str,
     write_images: bool,
     image_path: str | None,
     graphics_limit: int,
     mem_limit_mb: int,
 ) -> list[dict[str, Any]]:
     """Run pymupdf4llm.to_markdown in the worker subprocess (positional args only).
+
+    Takes a PATH, not bytes. Passing bytes meant every argument crossing the
+    ``to_process`` pipe was a full copy of the document -- one in the parent, one
+    pickled into the pipe, one in the child -- so a large file breached the
+    child's RLIMIT_AS before pymupdf4llm ran at all. Measured on a real 1040 MB
+    document: the worker died during initialisation in 0.9s while the parent
+    peaked at 2185 MB. Opening the path uses ``fz_open_file``, which reads
+    incrementally, so the rlimit now bounds parse working set as intended.
 
     Returns the ``page_chunks`` list (picklable dicts of text + metadata). Imports
     pymupdf lazily so the parent process isn't forced to load them here.
@@ -154,7 +162,7 @@ def _parse_pdf_worker(
     import pymupdf  # noqa: PLC0415
     import pymupdf4llm  # noqa: PLC0415
 
-    doc = pymupdf.open("pdf", content)
+    doc = pymupdf.open(source_path)
     try:
         # page_chunks=True makes to_markdown return list[dict], not str.
         chunks = cast(
@@ -175,7 +183,7 @@ def _parse_pdf_worker(
 
 
 async def run_isolated_pdf_parse(
-    content: bytes,
+    source_path: str,
     *,
     write_images: bool,
     image_path: Path | None,
@@ -197,7 +205,7 @@ async def run_isolated_pdf_parse(
         try:
             return await anyio.to_process.run_sync(
                 _parse_pdf_worker,
-                content,
+                source_path,
                 write_images,
                 str(image_path) if image_path is not None else None,
                 graphics_limit,

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -19,7 +19,8 @@ from typing import Any, cast
 
 import anyio
 import anyio.to_process
-from anyio import BrokenWorkerProcess
+from anyio import BrokenWorkerProcess, CapacityLimiter
+from anyio.lowlevel import RunVar
 
 # ``resource`` is a Unix-only stdlib module -- it does not exist on Windows, and
 # importing it unconditionally crashed Windows startup (#877). The RLIMIT_AS cap
@@ -34,6 +35,31 @@ logger = logging.getLogger(__name__)
 
 # Guard so the address-space limit is applied once per (reused) worker process.
 _MEM_LIMIT_APPLIED = False
+
+# Bounds how many parse subprocesses may run at once. anyio's default process
+# limiter is os.cpu_count(), which is decoupled from both the worker's
+# --concurrency and the pod memory limit: on an 8-core node that allows 8 x
+# document_parse_mem_limit_mb of address space inside a 3 GiB pod. A CapacityLimiter
+# belongs to the event loop that created it, so hold it in a RunVar (the same
+# mechanism anyio uses for its own default) rather than a module global.
+_PARSE_LIMITER: RunVar[CapacityLimiter] = RunVar("_pdf_parse_process_limiter")
+
+
+def parse_process_limiter(slots: int) -> CapacityLimiter:
+    """The per-event-loop limiter bounding concurrent parse subprocesses.
+
+    Created on first use from ``document_parse_process_slots``. Later changes to
+    the setting do not resize an existing limiter -- like the RLIMIT_AS cap it
+    pairs with, it is fixed for the worker's lifetime and a change needs a
+    restart.
+    """
+    try:
+        return _PARSE_LIMITER.get()
+    except LookupError:
+        limiter = CapacityLimiter(max(1, slots))
+        _PARSE_LIMITER.set(limiter)
+        return limiter
+
 
 # pymupdf4llm reconstructs reading-order markdown, which can DROP most of the text
 # on non-prose layouts (engineering drawings, scattered labels): observed 598 of a
@@ -156,11 +182,16 @@ async def run_isolated_pdf_parse(
     graphics_limit: int,
     timeout_seconds: float,
     mem_limit_mb: int,
+    process_slots: int = 2,
 ) -> list[dict[str, Any]]:
     """Parse a PDF in an isolated worker subprocess with a memory cap and timeout.
 
     Raises ``PdfParseFailed`` (reason ``timeout`` | ``oom`` | ``error``) instead of
     taking the pod down. On timeout the worker process is killed (``cancellable``).
+
+    ``process_slots`` bounds how many parses run concurrently. Without it anyio
+    defaults to an ``os.cpu_count()``-wide pool, which neither the worker's
+    ``--concurrency`` nor the pod memory limit constrains.
     """
     with anyio.move_on_after(timeout_seconds):
         try:
@@ -172,6 +203,7 @@ async def run_isolated_pdf_parse(
                 graphics_limit,
                 mem_limit_mb,
                 cancellable=True,
+                limiter=parse_process_limiter(process_slots),
             )
         except MemoryError as e:
             # A clean rlimit breach: the worker raised MemoryError and stays

--- a/nextcloud_mcp_server/document_processors/base.py
+++ b/nextcloud_mcp_server/document_processors/base.py
@@ -105,6 +105,13 @@ class DocumentProcessor(ABC):
         the two PDF engines relies on this default, so once streaming downloads
         are wired in a large non-PDF document would otherwise block the shared
         event loop for the full read.
+
+        Ownership: the CALLER owns ``source`` and is responsible for its
+        ``cleanup()``. Implementations must not clean up a source they were
+        handed -- they do not know whether the caller still needs it (e.g. for a
+        subsequent tier or bbox extraction). The bytes-based ``process()``
+        wrappers create their own :class:`MemoryDocumentSource` and clean it up
+        themselves.
         """
         from anyio.to_thread import run_sync  # noqa: PLC0415 -- keep imports light
 

--- a/nextcloud_mcp_server/document_processors/base.py
+++ b/nextcloud_mcp_server/document_processors/base.py
@@ -2,7 +2,10 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from .source import DocumentSource
 
 from pydantic import BaseModel
 
@@ -77,6 +80,33 @@ class DocumentProcessor(ABC):
         Examples: {"application/pdf", "image/jpeg", "image/png"}
         """
         pass
+
+    async def process_source(
+        self,
+        source: "DocumentSource",
+        options: dict[str, Any] | None = None,
+        progress_callback: Callable[[float, float | None, str | None], Awaitable[None]]
+        | None = None,
+    ) -> ProcessingResult:
+        """Process a document from a file-backed handle.
+
+        Concrete on purpose: the default materialises the source and delegates to
+        :meth:`process`, so every existing processor keeps working untouched and
+        each can be migrated to a path-based parse independently. Override it
+        where opening by path avoids holding the whole document in memory (the
+        PDF engines); leave it alone where the processor genuinely needs bytes
+        (OCR base64, HTTP upload backends).
+
+        Note the default is where peak memory still scales with document size --
+        ``read_bytes`` is deliberately greppable for that reason.
+        """
+        return await self.process(
+            source.read_bytes(),
+            source.content_type,
+            source.filename,
+            options,
+            progress_callback,
+        )
 
     @abstractmethod
     async def process(

--- a/nextcloud_mcp_server/document_processors/base.py
+++ b/nextcloud_mcp_server/document_processors/base.py
@@ -99,9 +99,18 @@ class DocumentProcessor(ABC):
 
         Note the default is where peak memory still scales with document size --
         ``read_bytes`` is deliberately greppable for that reason.
+
+        The read is offloaded to a worker thread: for a spooled source it is a
+        synchronous disk read of the whole document, and every processor except
+        the two PDF engines relies on this default, so once streaming downloads
+        are wired in a large non-PDF document would otherwise block the shared
+        event loop for the full read.
         """
+        from anyio.to_thread import run_sync  # noqa: PLC0415 -- keep imports light
+
+        content = await run_sync(source.read_bytes)
         return await self.process(
-            source.read_bytes(),
+            content,
             source.content_type,
             source.filename,
             options,

--- a/nextcloud_mcp_server/document_processors/escalation.py
+++ b/nextcloud_mcp_server/document_processors/escalation.py
@@ -49,16 +49,29 @@ def escalation_tiers_signature(settings: Any) -> str:
     pathological-but-OCR-recoverable documents dead-lettered while OCR was off are
     re-attempted automatically.
 
+    ``document_max_pdf_size_mb`` is included for the same reason: an oversize PDF
+    is always-terminal (``vector/processor.py`` never escalates ``oversize``), so
+    without the cap here a document stays dead-lettered until its etag changes
+    even after an operator allows bigger files -- and for an archive of scanned
+    documents the etag never changes. Formatted with ``:g`` so ``50`` and ``50.0``
+    fingerprint identically and a float-repr change cannot spuriously invalidate
+    every dead letter.
+
+    Note the blast radius: changing the cap invalidates ALL dead letters, not just
+    oversize ones, so genuinely corrupt documents are re-attempted once too. That
+    is the intended trade -- the alternative is a bespoke backfill path -- but it
+    means a cap change is a thundering herd on a large tenant and should be rolled
+    out one tenant at a time.
+
     TODO: when a future setting can make a previously-terminal document parseable,
-    fold it in here so raising it auto-retries existing dead-letters. Two known
-    candidates: a new escalation tier becoming toggleable (e.g. the reserved
-    ``llm`` rung in ``TIER_LADDER``), and a raised oversize cap (an oversize PDF is
-    always-terminal, so without the cap in this signature it stays dead-lettered
-    until its etag changes even after an operator allows bigger files).
+    fold it in here so raising it auto-retries existing dead-letters. Known
+    remaining candidate: a new escalation tier becoming toggleable (e.g. the
+    reserved ``llm`` rung in ``TIER_LADDER``).
     """
     return (
         f"ocr={int(bool(settings.document_ocr_enabled))};"
-        f"t1={settings.document_tier1_engine}"
+        f"t1={settings.document_tier1_engine};"
+        f"maxmb={settings.document_max_pdf_size_mb:g}"
     )
 
 

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -165,6 +165,7 @@ class PyMuPDFProcessor(DocumentProcessor):
                     graphics_limit=settings.document_pdf_graphics_limit,
                     timeout_seconds=settings.document_parse_timeout_seconds,
                     mem_limit_mb=settings.document_parse_mem_limit_mb,
+                    process_slots=settings.document_parse_process_slots,
                 )
             except PdfParseFailed as exc:
                 logger.warning(

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -20,7 +20,7 @@ from nextcloud_mcp_server.config import get_settings
 
 from ._isolation import PdfParseFailed, run_isolated_pdf_parse
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
-from .source import DocumentSource, MemoryDocumentSource
+from .source import DocumentSource, MemoryDocumentSource, resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,31 @@ class PyMuPDFProcessor(DocumentProcessor):
         finally:
             source.cleanup()
 
+    def _read_metadata_sync(
+        self, source_path: str, filename: Optional[str], size: int
+    ) -> tuple[dict[str, Any], int]:
+        """Read metadata + page count, then close the document immediately.
+
+        Runs entirely inside ONE worker thread, serialized against other MuPDF
+        work: pymupdf is not thread-safe and a doc opened in one thread must not
+        be touched from another. The heavy page extraction re-opens the same path
+        in an isolated subprocess, so it needs no lock and ``doc`` is not needed
+        past this point. try/finally so a failure in _extract_metadata cannot
+        leak the handle.
+        """
+        from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+            pymupdf_serialized,
+        )
+
+        with pymupdf_serialized():
+            doc = pymupdf.open(source_path)
+            try:
+                meta = self._extract_metadata(doc, filename)
+                meta["file_size"] = size
+                return meta, doc.page_count
+            finally:
+                doc.close()
+
     async def process_source(
         self,
         source: "DocumentSource",
@@ -129,36 +154,16 @@ class PyMuPDFProcessor(DocumentProcessor):
             ProcessorError: If PDF processing fails
         """
 
-        source_path = str(source.path())
+        # Off the event loop: materialising an in-memory source writes the
+        # whole buffer to disk, which would stall every other in-flight job.
+        source_path = str(await resolve_path(source))
         filename = source.filename
         try:
             if progress_callback:
                 await progress_callback(0, 100, "Opening PDF document")
 
-            # Open document only to read metadata + page count, then close it
-            # immediately (try/finally so a failure in _extract_metadata can't
-            # leak it). The heavy extraction below re-opens the same path in the
-            # isolated worker, so ``doc`` is not needed past this point.
-            # Read metadata entirely inside ONE worker thread, serialized against
-            # other MuPDF work: pymupdf is not thread-safe, and a doc opened in one
-            # thread must not be touched from another. (The heavy page extraction
-            # below runs in an isolated subprocess, so it needs no lock.)
-            def _read_metadata() -> tuple[dict[str, Any], int]:
-                from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
-                    pymupdf_serialized,
-                )
-
-                with pymupdf_serialized():
-                    doc = pymupdf.open(source_path)
-                    try:
-                        meta = self._extract_metadata(doc, filename)
-                        meta["file_size"] = source.size
-                        return meta, doc.page_count
-                    finally:
-                        doc.close()
-
             metadata, page_count = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
-                _read_metadata
+                self._read_metadata_sync, source_path, filename, source.size
             )
 
             if progress_callback:

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -131,6 +131,45 @@ class PyMuPDFProcessor(DocumentProcessor):
             finally:
                 doc.close()
 
+    def _build_text_and_metadata(
+        self,
+        page_chunks: list[dict[str, Any]],
+        pdf_image_dir: Optional[pathlib.Path],
+        metadata: dict[str, Any],
+    ) -> str:
+        """Join per-page markdown and record boundaries + images on ``metadata``.
+
+        ``page_boundaries`` offsets index into the joined text with no separator,
+        so they stay exact -- the contract ``search/pdf_highlighter`` and the
+        chunker rely on.
+        """
+        page_texts: list[str] = []
+        page_boundaries: list[dict[str, Any]] = []
+        current_offset = 0
+        for chunk in page_chunks:
+            text = chunk.get("text", "")
+            page_num = chunk.get("metadata", {}).get("page", len(page_texts) + 1)
+            page_texts.append(text)
+            page_boundaries.append(
+                {
+                    "page": page_num,
+                    "start_offset": current_offset,
+                    "end_offset": current_offset + len(text),
+                }
+            )
+            current_offset += len(text)
+
+        image_paths = []
+        if pdf_image_dir and pdf_image_dir.exists():
+            image_paths = [str(p) for p in pdf_image_dir.glob("*")]
+
+        metadata["has_images"] = len(image_paths) > 0
+        if image_paths:
+            metadata["image_count"] = len(image_paths)
+            metadata["image_paths"] = image_paths
+        metadata["page_boundaries"] = page_boundaries
+        return "".join(page_texts)
+
     async def process_source(
         self,
         source: "DocumentSource",
@@ -218,35 +257,9 @@ class PyMuPDFProcessor(DocumentProcessor):
             if progress_callback:
                 await progress_callback(90, 100, "Building result")
 
-            # Extract page texts and build boundaries from chunks
-            page_texts: list[str] = []
-            page_boundaries: list[dict[str, Any]] = []
-            current_offset = 0
-            for chunk in page_chunks:
-                text = chunk.get("text", "")
-                page_num = chunk.get("metadata", {}).get("page", len(page_texts) + 1)
-                page_texts.append(text)
-                page_boundaries.append(
-                    {
-                        "page": page_num,
-                        "start_offset": current_offset,
-                        "end_offset": current_offset + len(text),
-                    }
-                )
-                current_offset += len(text)
-
-            # Collect image paths
-            image_paths = []
-            if pdf_image_dir and pdf_image_dir.exists():
-                image_paths = [str(p) for p in pdf_image_dir.glob("*")]
-
-            # Build final text and metadata
-            md_text = "".join(page_texts)
-            metadata["has_images"] = len(image_paths) > 0
-            if image_paths:
-                metadata["image_count"] = len(image_paths)
-                metadata["image_paths"] = image_paths
-            metadata["page_boundaries"] = page_boundaries
+            md_text = self._build_text_and_metadata(
+                page_chunks, pdf_image_dir, metadata
+            )
 
             if progress_callback:
                 await progress_callback(100, 100, "Processing complete")

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -20,6 +20,7 @@ from nextcloud_mcp_server.config import get_settings
 
 from ._isolation import PdfParseFailed, run_isolated_pdf_parse
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
+from .source import DocumentSource, MemoryDocumentSource
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +95,30 @@ class PyMuPDFProcessor(DocumentProcessor):
             Callable[[float, Optional[float], Optional[str]], Awaitable[None]]
         ] = None,
     ) -> ProcessingResult:
+        """Bytes-based entry point: materialise a path and delegate.
+
+        The parse itself is path-based (see :meth:`process_source`), because the
+        isolated worker must not be handed a copy of the document.
+        """
+        source = MemoryDocumentSource(content, content_type, filename)
+        try:
+            return await self.process_source(source, options, progress_callback)
+        finally:
+            source.cleanup()
+
+    async def process_source(
+        self,
+        source: "DocumentSource",
+        options: Optional[dict[str, Any]] = None,
+        progress_callback: Optional[
+            Callable[[float, Optional[float], Optional[str]], Awaitable[None]]
+        ] = None,
+    ) -> ProcessingResult:
         """Process a PDF document and extract text, metadata, and images.
 
         Args:
-            content: PDF document bytes
-            content_type: MIME type (should be application/pdf)
-            filename: Optional filename for better error messages
+            source: File-backed handle to the PDF. Opened by path so neither the
+                metadata read nor the isolated worker holds a copy of it.
             options: Processing options (currently unused)
             progress_callback: Optional callback for progress updates
 
@@ -110,14 +129,16 @@ class PyMuPDFProcessor(DocumentProcessor):
             ProcessorError: If PDF processing fails
         """
 
+        source_path = str(source.path())
+        filename = source.filename
         try:
             if progress_callback:
                 await progress_callback(0, 100, "Opening PDF document")
 
             # Open document only to read metadata + page count, then close it
             # immediately (try/finally so a failure in _extract_metadata can't
-            # leak it). The heavy extraction below works from ``content`` bytes
-            # in the isolated worker, so ``doc`` is not needed past this point.
+            # leak it). The heavy extraction below re-opens the same path in the
+            # isolated worker, so ``doc`` is not needed past this point.
             # Read metadata entirely inside ONE worker thread, serialized against
             # other MuPDF work: pymupdf is not thread-safe, and a doc opened in one
             # thread must not be touched from another. (The heavy page extraction
@@ -128,10 +149,10 @@ class PyMuPDFProcessor(DocumentProcessor):
                 )
 
                 with pymupdf_serialized():
-                    doc = pymupdf.open("pdf", content)
+                    doc = pymupdf.open(source_path)
                     try:
                         meta = self._extract_metadata(doc, filename)
-                        meta["file_size"] = len(content)
+                        meta["file_size"] = source.size
                         return meta, doc.page_count
                     finally:
                         doc.close()
@@ -159,7 +180,7 @@ class PyMuPDFProcessor(DocumentProcessor):
             settings = get_settings()
             try:
                 page_chunks: list[dict[str, Any]] = await run_isolated_pdf_parse(
-                    content,
+                    source_path,
                     write_images=self.extract_images,
                     image_path=pdf_image_dir if self.extract_images else None,
                     graphics_limit=settings.document_pdf_graphics_limit,
@@ -237,7 +258,7 @@ class PyMuPDFProcessor(DocumentProcessor):
                     "pages": metadata["page_count"],
                     "chars": len(md_text),
                     "images": metadata.get("image_count", 0),
-                    "byte_size": len(content),
+                    "byte_size": source.size,
                 },
             )
 

--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -24,12 +24,13 @@ import anyio
 from nextcloud_mcp_server.config import get_settings
 
 from .base import DocumentProcessor, ProcessingResult
+from .source import DocumentSource
 
 logger = logging.getLogger(__name__)
 
 
 def _extract_window(
-    pdfium: Any, content: bytes, start: int, end: int, page_texts: list[str]
+    pdfium: Any, content: bytes | str, start: int, end: int, page_texts: list[str]
 ) -> None:
     """Extract pages ``[start, end)`` into ``page_texts`` from a fresh document.
 
@@ -54,8 +55,16 @@ def _extract_window(
         pdf.close()
 
 
-def _extract(content: bytes, page_window: int = 100) -> tuple[str, dict[str, Any]]:
+def _extract(
+    content: bytes | str, page_window: int = 100
+) -> tuple[str, dict[str, Any]]:
     """Extract concatenated text + metadata from a PDF (runs in a worker thread).
+
+    ``content`` is either the PDF bytes or a path to it. A path is preferable:
+    ``PdfDocument(path)`` uses ``FPDF_LoadDocument``, which reads incrementally,
+    whereas the bytes form uses ``FPDF_LoadMemDocument64`` and pins the whole
+    buffer for the document's lifetime. Note this bounds the *input* copy only --
+    the parse working set is bounded by ``page_window`` below.
 
     ``page_boundaries`` offsets index into the returned text, which is the page
     texts joined with no separator so the offsets stay exact (the contract
@@ -132,12 +141,38 @@ class Pypdfium2FastProcessor(DocumentProcessor):
     def supported_mime_types(self) -> set[str]:
         return {"application/pdf"}
 
+    async def process_source(
+        self,
+        source: DocumentSource,
+        options: dict[str, Any] | None = None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ) = None,
+    ) -> ProcessingResult:
+        """Extract from the source's path, so the bytes are never materialised."""
+        return await self._extract_to_result(
+            str(source.path()), source.size, source.filename, progress_callback
+        )
+
     async def process(
         self,
         content: bytes,
         content_type: str,
         filename: str | None = None,
         options: dict[str, Any] | None = None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ) = None,
+    ) -> ProcessingResult:
+        return await self._extract_to_result(
+            content, len(content), filename, progress_callback
+        )
+
+    async def _extract_to_result(
+        self,
+        content: bytes | str,
+        size: int,
+        filename: str | None,
         progress_callback: (
             Callable[[float, float | None, str | None], Awaitable[None]] | None
         ) = None,
@@ -163,7 +198,7 @@ class Pypdfium2FastProcessor(DocumentProcessor):
                 success=False,
                 error=f"{type(e).__name__}: {e}",
             )
-        metadata["file_size"] = len(content)
+        metadata["file_size"] = size
         if progress_callback:
             await progress_callback(100, 100, "Done")
         return ProcessingResult(text=full_text, metadata=metadata, processor=self.name)

--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -24,7 +24,7 @@ import anyio
 from nextcloud_mcp_server.config import get_settings
 
 from .base import DocumentProcessor, ProcessingResult
-from .source import DocumentSource
+from .source import DocumentSource, resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -150,8 +150,11 @@ class Pypdfium2FastProcessor(DocumentProcessor):
         ) = None,
     ) -> ProcessingResult:
         """Extract from the source's path, so the bytes are never materialised."""
+        # resolve_path, not source.path(): an in-memory source materialises by
+        # writing to disk, which must not block the shared event loop.
+        source_path = await resolve_path(source)
         return await self._extract_to_result(
-            str(source.path()), source.size, source.filename, progress_callback
+            str(source_path), source.size, source.filename, progress_callback
         )
 
     async def process(

--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -21,17 +21,53 @@ from typing import Any
 
 import anyio
 
+from nextcloud_mcp_server.config import get_settings
+
 from .base import DocumentProcessor, ProcessingResult
 
 logger = logging.getLogger(__name__)
 
 
-def _extract(content: bytes) -> tuple[str, dict[str, Any]]:
+def _extract_window(
+    pdfium: Any, content: bytes, start: int, end: int, page_texts: list[str]
+) -> None:
+    """Extract pages ``[start, end)`` into ``page_texts`` from a fresh document.
+
+    Opening and closing the document per window is what bounds memory -- see
+    ``_extract``. Callers hold the pdfium lock.
+    """
+    pdf = pdfium.PdfDocument(content)
+    try:
+        for i in range(start, end):
+            page = pdf[i]
+            try:
+                textpage = page.get_textpage()
+                try:
+                    page_texts.append(textpage.get_text_bounded() or "")
+                finally:
+                    textpage.close()
+            finally:
+                # Outer finally so the page handle is freed even if
+                # get_textpage() raises on a corrupt page.
+                page.close()
+    finally:
+        pdf.close()
+
+
+def _extract(content: bytes, page_window: int = 100) -> tuple[str, dict[str, Any]]:
     """Extract concatenated text + metadata from a PDF (runs in a worker thread).
 
     ``page_boundaries`` offsets index into the returned text, which is the page
     texts joined with no separator so the offsets stay exact (the contract
     ``search/pdf_highlighter`` and the chunker rely on).
+
+    Pages are extracted in windows of ``page_window``, re-opening the document
+    for each window. PDFium retains parsed page objects for the document's
+    lifetime -- ``page.close()`` does not return them -- so a single open scales
+    peak RSS with page count (a real 4003-page file measured 1914 MB). Windowing
+    caps that at one window's worth; the freed arena is reused by the next
+    window, so peak stays flat (100 pages -> 63 MB, unchanged output). Pass 0 to
+    disable and extract in a single open.
     """
     import pypdfium2 as pdfium  # noqa: PLC0415 -- keep the native import lazy
 
@@ -41,26 +77,26 @@ def _extract(content: bytes) -> tuple[str, dict[str, Any]]:
 
     # PDFium is not thread-safe (shared process-global library + an unlocked
     # module-global object tracker), so serialize: concurrent ingest jobs must not
-    # drive it from two worker threads at once.
+    # drive it from two worker threads at once. The lock is taken per window
+    # rather than for the whole extraction: no pdfium object is held across a
+    # window boundary, so releasing there is safe and stops one large document
+    # blocking every other ingest job for the duration of its parse.
     with pdfium_serialized():
         pdf = pdfium.PdfDocument(content)
         try:
-            page_texts: list[str] = []
-            for i in range(len(pdf)):
-                page = pdf[i]
-                try:
-                    textpage = page.get_textpage()
-                    try:
-                        page_texts.append(textpage.get_text_bounded() or "")
-                    finally:
-                        textpage.close()
-                finally:
-                    # Outer finally so the page handle is freed even if
-                    # get_textpage() raises on a corrupt page.
-                    page.close()
+            page_count = len(pdf)
             doc_meta = pdf.get_metadata_dict() or {}
         finally:
             pdf.close()
+
+    page_texts: list[str] = []
+    window = page_window if page_window > 0 else page_count
+    start = 0
+    while start < page_count:
+        end = min(start + window, page_count)
+        with pdfium_serialized():
+            _extract_window(pdfium, content, start, end, page_texts)
+        start = end
 
     page_boundaries: list[dict[str, Any]] = []
     offset = 0
@@ -108,9 +144,10 @@ class Pypdfium2FastProcessor(DocumentProcessor):
     ) -> ProcessingResult:
         if progress_callback:
             await progress_callback(0, 100, "Extracting text (pypdfium2)")
+        settings = get_settings()
         try:
             full_text, metadata = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]
-                _extract, content
+                _extract, content, settings.document_parse_page_window
             )
         except Exception as e:
             # Fast path is best-effort: a failure here escalates rather than

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -402,24 +402,24 @@ class ProcessorRegistry:
 
         return result
 
-    def _oversize_result(
-        self, content: bytes, filename: str | None, settings: Any
+    def oversize_result_for_size(
+        self, size_bytes: int, filename: str | None, settings: Any
     ) -> ProcessingResult | None:
-        """Pre-parse size guard, shared by the inline and per-tier paths.
+        """Pre-parse size guard evaluated against a known byte size.
 
-        A pathologically large PDF (e.g. a 42 MB scanned DUDE) burns the OCR
-        timeout for 0 chars. Return an explicit ``oversize`` failure so the
-        caller marks the placeholder "failed" instead of retrying; 0 disables the
-        cap. An explicit ``processor_name`` override (``registry.process``)
-        bypasses tiering entirely and is intentionally not size-gated (power-user
-        escape hatch). Skipping ``_run_processor`` means the rejection is counted
-        on ``astrolabe_document_parse_failed_total{oversize}`` (via
-        ``vector/processor.py``) but deliberately not on the parse-duration
-        histogram -- there is no parse to time.
+        Split out from :meth:`_oversize_result` so the cap can be applied to a
+        size learned *before* the download (WebDAV ``getcontentlength``, carried
+        on ``DocumentTask.size_bytes``). Applying it there means an over-cap
+        document is never fetched at all -- the old byte-based form could only
+        reject a file already fully resident in memory, which is how a 531 MB PDF
+        OOMKilled a worker before the cap was ever evaluated.
+
+        Returns an explicit ``oversize`` failure so the caller marks the
+        placeholder "failed" instead of retrying; 0 disables the cap.
         """
         max_pdf_mb = settings.document_max_pdf_size_mb
-        if max_pdf_mb > 0 and len(content) > max_pdf_mb * 1024 * 1024:
-            size_mb = len(content) / (1024 * 1024)
+        if max_pdf_mb > 0 and size_bytes > max_pdf_mb * 1024 * 1024:
+            size_mb = size_bytes / (1024 * 1024)
             logger.warning(
                 "PDF %s is %.1f MB (> %.1f MB cap); failing fast as oversize",
                 filename or "<bytes>",
@@ -434,6 +434,26 @@ class ProcessorRegistry:
                 error=(f"PDF exceeds size cap: {size_mb:.1f} MB > {max_pdf_mb:.1f} MB"),
             )
         return None
+
+    def _oversize_result(
+        self, content: bytes, filename: str | None, settings: Any
+    ) -> ProcessingResult | None:
+        """Pre-parse size guard, shared by the inline and per-tier paths.
+
+        A pathologically large PDF (e.g. a 42 MB scanned DUDE) burns the OCR
+        timeout for 0 chars. Return an explicit ``oversize`` failure so the
+        caller marks the placeholder "failed" instead of retrying; 0 disables the
+        cap. An explicit ``processor_name`` override (``registry.process``)
+        bypasses tiering entirely and is intentionally not size-gated (power-user
+        escape hatch). Skipping ``_run_processor`` means the rejection is counted
+        on ``astrolabe_document_parse_failed_total{oversize}`` (via
+        ``vector/processor.py``) but deliberately not on the parse-duration
+        histogram -- there is no parse to time.
+
+        Backstop for callers without a pre-fetch size; prefer
+        :meth:`oversize_result_for_size` when the size is known up front.
+        """
+        return self.oversize_result_for_size(len(content), filename, settings)
 
     def _classify_result(
         self,

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -55,7 +55,14 @@ class DocumentSource(Protocol):
         ...
 
     def path(self) -> Path:
-        """A local filesystem path a native library can open."""
+        """A local filesystem path a native library can open.
+
+        May block: for an in-memory source this writes the buffer to a temp
+        file. Call :func:`resolve_path` from async code rather than calling this
+        directly -- ingest workers run many documents on one event loop, so a
+        synchronous multi-hundred-MB write would stall every other in-flight
+        document for its duration.
+        """
         ...
 
     def open(self) -> IO[bytes]:
@@ -143,6 +150,21 @@ class MemoryDocumentSource:
             self._materialised = None
 
 
+async def resolve_path(source: DocumentSource) -> Path:
+    """Await a source's local path without blocking the event loop.
+
+    ``SpooledDocumentSource.path()`` is already just an attribute read, but
+    ``MemoryDocumentSource.path()`` writes the buffer to disk. Ingest workers run
+    multiple documents concurrently on a single event loop, so that write is
+    offloaded to a worker thread -- otherwise materialising one large document
+    stalls every other job on the loop, which is exactly the case this ingest
+    work exists to fix.
+    """
+    from anyio.to_thread import run_sync  # noqa: PLC0415 -- keep imports light
+
+    return await run_sync(source.path)
+
+
 @contextmanager
 def spool_target(spool_dir: str | None = None) -> Iterator[Path]:
     """Yield a fresh spool path, removing it (and any partial file) on exit."""
@@ -159,9 +181,11 @@ def spool_target(spool_dir: str | None = None) -> Iterator[Path]:
 def sweep_orphaned_spools(spool_dir: str | None = None) -> int:
     """Delete spool files left behind by a previous run; returns the count.
 
-    A SIGKILLed worker cannot run its cleanup, and the spool directory is an
-    emptyDir that survives container restarts within the pod, so without a sweep
-    at startup a crash-looping worker would accumulate whole documents on disk.
+    Intended for a worker's startup path: a SIGKILLed worker cannot run its own
+    cleanup, and the spool directory is an emptyDir that survives container
+    restarts within the pod, so a crash-looping worker would otherwise accumulate
+    whole documents on disk. NOT yet called anywhere -- it lands with the change
+    that wires streaming downloads into the ingest path.
     """
     directory = Path(spool_dir or tempfile.gettempdir())
     removed = 0

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -1,0 +1,182 @@
+"""A file-backed handle for a document being ingested.
+
+The ingest path used to carry documents as ``bytes`` end to end, so peak memory
+scaled with document size at every step: the WebDAV body was buffered whole, the
+same buffer stayed live through parse, embed and bbox extraction, and the
+structured tier pickled another two copies of it across the ``to_process`` pipe.
+A 1040 MB document therefore could not be parsed at all -- the isolated worker
+died at startup, before pymupdf4llm ran.
+
+A :class:`DocumentSource` is a *path* plus the metadata callers used to read off
+the buffer (``size``, ``content_type``). Both PDF engines open a path natively
+and read incrementally, so handing the path down replaces those copies with
+demand-paged reads:
+
+* pypdfium2 -- ``FPDF_LoadDocument`` (path) instead of ``FPDF_LoadMemDocument64``
+  (bytes), which pins the buffer for the document's lifetime.
+* pymupdf -- ``fz_open_file`` instead of ``fz_open_memory``; PyMuPDF's own docs
+  warn that the stream form may exhaust memory on large files.
+
+Note that opening by path bounds the *input* copy, not the parse working set:
+PDFium still retains parsed page objects, which is what page-windowed extraction
+in ``pypdfium2_fast`` addresses. The two fixes are complementary.
+
+``MemoryDocumentSource`` keeps the in-memory case first-class -- notes, deck
+cards and small files never touch the disk, and every existing bytes-based test
+keeps working -- while ``SpooledDocumentSource`` owns a temp file for the
+lifetime of one ingest.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Iterator, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+SPOOL_PREFIX = "nc-ingest-"
+
+
+@runtime_checkable
+class DocumentSource(Protocol):
+    """A document available to a processor, by path or in memory."""
+
+    content_type: str
+    filename: str | None
+
+    @property
+    def size(self) -> int:
+        """Size of the document in bytes."""
+        ...
+
+    def path(self) -> Path:
+        """A local filesystem path a native library can open."""
+        ...
+
+    def open(self) -> IO[bytes]:
+        """A binary file object positioned at the start."""
+        ...
+
+    def read_bytes(self) -> bytes:
+        """Materialise the whole document.
+
+        The explicit escape hatch for consumers that genuinely need the bytes
+        (OCR base64, the legacy ``process`` contract). Greppable on purpose: each
+        call is a place where peak memory still scales with document size.
+        """
+        ...
+
+
+@dataclass
+class SpooledDocumentSource:
+    """A document streamed to a local file, removed by :meth:`cleanup`."""
+
+    spool_path: Path
+    content_type: str
+    filename: str | None = None
+    _size: int | None = None
+
+    @property
+    def size(self) -> int:
+        if self._size is None:
+            self._size = self.spool_path.stat().st_size
+        return self._size
+
+    def path(self) -> Path:
+        return self.spool_path
+
+    def open(self) -> IO[bytes]:
+        return self.spool_path.open("rb")
+
+    def read_bytes(self) -> bytes:
+        return self.spool_path.read_bytes()
+
+    def cleanup(self) -> None:
+        """Remove the spool file. Safe to call repeatedly."""
+        try:
+            self.spool_path.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - best effort
+            logger.warning("Could not remove spool file %s", self.spool_path)
+
+
+@dataclass
+class MemoryDocumentSource:
+    """A document already in memory (notes, deck cards, small files, tests).
+
+    ``path()`` materialises a temp file only if something actually asks for one,
+    so the common small-document case never touches the disk.
+    """
+
+    content: bytes
+    content_type: str
+    filename: str | None = None
+    _materialised: Path | None = field(default=None, repr=False)
+
+    @property
+    def size(self) -> int:
+        return len(self.content)
+
+    def path(self) -> Path:
+        if self._materialised is None:
+            fd, name = tempfile.mkstemp(prefix=SPOOL_PREFIX, suffix=".bin")
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(self.content)
+            self._materialised = Path(name)
+        return self._materialised
+
+    def open(self) -> IO[bytes]:
+        import io  # noqa: PLC0415
+
+        return io.BytesIO(self.content)
+
+    def read_bytes(self) -> bytes:
+        return self.content
+
+    def cleanup(self) -> None:
+        if self._materialised is not None:
+            self._materialised.unlink(missing_ok=True)
+            self._materialised = None
+
+
+@contextmanager
+def spool_target(spool_dir: str | None = None) -> Iterator[Path]:
+    """Yield a fresh spool path, removing it (and any partial file) on exit."""
+    directory = spool_dir or tempfile.gettempdir()
+    fd, name = tempfile.mkstemp(prefix=SPOOL_PREFIX, suffix=".bin", dir=directory)
+    os.close(fd)
+    target = Path(name)
+    try:
+        yield target
+    finally:
+        target.unlink(missing_ok=True)
+
+
+def sweep_orphaned_spools(spool_dir: str | None = None) -> int:
+    """Delete spool files left behind by a previous run; returns the count.
+
+    A SIGKILLed worker cannot run its cleanup, and the spool directory is an
+    emptyDir that survives container restarts within the pod, so without a sweep
+    at startup a crash-looping worker would accumulate whole documents on disk.
+    """
+    directory = Path(spool_dir or tempfile.gettempdir())
+    removed = 0
+    try:
+        candidates = list(directory.glob(f"{SPOOL_PREFIX}*"))
+    except OSError:  # pragma: no cover - unreadable spool dir
+        return 0
+    for stale in candidates:
+        try:
+            stale.unlink()
+            removed += 1
+        except OSError:  # pragma: no cover - raced with another sweeper
+            continue
+    if removed:
+        logger.info(
+            "Removed %d orphaned ingest spool file(s) from %s", removed, directory
+        )
+    return removed

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -294,6 +294,42 @@ document_bytes_processed_total = Counter(
     ["processor", "tier"],
 )
 
+# Size distribution of everything a tenant offers for ingest, observed BEFORE the
+# oversize gate so the over-cap tail -- the part that decides caps, spool sizing
+# and worker memory -- is visible rather than silently dropped. Sizing decisions
+# were previously made from a one-off manual crawl (866 files / 66.84 GB, 51%
+# over cap); this makes the same picture a query for every tenant.
+#
+# Buckets are exponential to 2 GiB: an observed corpus spanned 1 MB to 1040 MB,
+# so the tail buckets carry real signal and must not collapse into +Inf.
+# Deliberately NOT labelled by tenant -- Prometheus already attaches the
+# namespace/pod, and a tenant label here would multiply series per bucket.
+document_ingest_size_bytes = Histogram(
+    "astrolabe_document_ingest_size_bytes",
+    "Source size of documents offered for ingest, before the oversize gate",
+    ["doc_type"],
+    buckets=(
+        64 * 1024,
+        256 * 1024,
+        1024 * 1024,
+        4 * 1024 * 1024,
+        16 * 1024 * 1024,
+        32 * 1024 * 1024,
+        64 * 1024 * 1024,
+        128 * 1024 * 1024,
+        256 * 1024 * 1024,
+        512 * 1024 * 1024,
+        1024 * 1024 * 1024,
+        2048 * 1024 * 1024,
+    ),
+)
+
+document_ingest_rejected_total = Counter(
+    "astrolabe_document_ingest_rejected_total",
+    "Documents rejected before parsing, by reason",
+    ["doc_type", "reason"],  # reason: oversize
+)
+
 # --- Escalation (tiered-pipeline readiness; ~0 until extra tiers exist) --------
 
 document_escalation_total = Counter(
@@ -1025,6 +1061,29 @@ def record_document_parse_failed(reason: str) -> None:
         reason: ``timeout`` | ``oom`` | ``error``
     """
     document_parse_failed_total.labels(reason=reason).inc()
+
+
+def record_document_ingest_size(doc_type: str, size_bytes: int) -> None:
+    """Record the source size of a document offered for ingest.
+
+    Called before the oversize gate so the distribution includes documents that
+    are subsequently rejected -- they are exactly the ones that drive cap, spool
+    and memory sizing. A size of 0/None means the source did not report one, and
+    is skipped rather than recorded as a real zero, which would pile a false
+    spike into the smallest bucket.
+    """
+    if size_bytes > 0:
+        document_ingest_size_bytes.labels(doc_type=doc_type).observe(size_bytes)
+
+
+def record_document_ingest_rejected(doc_type: str, reason: str) -> None:
+    """Record a document rejected before parsing (currently ``oversize``).
+
+    Paired with :func:`record_document_ingest_size` so "what fraction of this
+    tenant's corpus is over cap" is a ratio of two metrics rather than an
+    investigation.
+    """
+    document_ingest_rejected_total.labels(doc_type=doc_type, reason=reason).inc()
 
 
 def record_document_dead_lettered(reason: str) -> None:

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -708,6 +708,12 @@ async def _reconcile_tag_event(
 
     doc_task.index_mode = match.get("_index_mode", payload_keys.INDEX_MODE_HYBRID)
     doc_task.file_path = match["path"]
+    # Mirror the scanner's assignment (vector/scanner.py): the SEARCH rows carry
+    # getcontentlength as "size". Without this a webhook-triggered index leaves
+    # size_bytes None, the pre-flight gate short-circuits, and the unbounded
+    # read_file runs -- so tagging a huge PDF for real-time indexing reproduces
+    # the OOM the gate exists to prevent. 0/absent means unknown.
+    doc_task.size_bytes = match.get("size") or None
     if not doc_task.etag:
         doc_task.etag = match.get("etag")
     last_modified = match.get("last_modified_timestamp")

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -328,6 +328,33 @@ def should_use_page_aware(
     return page_aware_enabled and doc_type == "file" and bool(page_boundaries)
 
 
+def preflight_oversize_result(
+    doc_task: Any, file_path: str | None, settings: Any
+) -> Any:
+    """Apply the PDF size cap to the scanned size, before any download.
+
+    ``DocumentTask.size_bytes`` carries the WebDAV ``getcontentlength`` captured
+    at scan time, so an over-cap document can be rejected without fetching it.
+    Previously the cap could only be applied to bytes already fully resident,
+    which meant the guard against pathological files was itself paid for in
+    memory: a 531 MB PDF OOMKilled a worker mid-download, before its size was
+    ever checked.
+
+    Returns the same ``oversize`` :class:`ProcessingResult` the post-download
+    guard produces (so the caller's terminal/dead-letter handling is unchanged),
+    or ``None`` when the size is unknown or within the cap -- in which case the
+    post-download guard still applies as the backstop.
+    """
+    size_bytes = getattr(doc_task, "size_bytes", None)
+    if not size_bytes:
+        return None
+    from nextcloud_mcp_server.document_processors import (  # noqa: PLC0415
+        get_registry,
+    )
+
+    return get_registry().oversize_result_for_size(size_bytes, file_path, settings)
+
+
 def ingested_byte_size(content_bytes: bytes | None, content: str) -> int:
     """Bytes ingested for one document (card #401).
 
@@ -948,6 +975,10 @@ async def _index_document(
         qdrant_client: Qdrant client instance
     """
     settings = get_settings()
+    # Set by the pre-flight size gate (files only) when a document is rejected
+    # from its scanned size; substituted for the parse result further down so the
+    # existing terminal/dead-letter handling is reached unchanged.
+    preflight_failure = None
 
     # Fetch document content
     with trace_operation(
@@ -1216,8 +1247,17 @@ async def _index_document(
                 if retry_in is not None:
                     raise BatchPending(retry_in=retry_in)
 
-            # Read file content via WebDAV
-            content_bytes, content_type = await nc_client.webdav.read_file(file_path)
+            # Pre-flight size gate: reject an over-cap document from the size the
+            # scanner already captured, so the download is never paid for. Falls
+            # through to the post-download guard when the size is unknown.
+            preflight_failure = preflight_oversize_result(doc_task, file_path, settings)
+            if preflight_failure is None:
+                # Read file content via WebDAV
+                content_bytes, content_type = await nc_client.webdav.read_file(
+                    file_path
+                )
+            else:
+                content_bytes, content_type = b"", "application/pdf"
         else:
             raise ValueError(f"Unsupported doc_type: {doc_task.doc_type}")
 
@@ -1232,7 +1272,9 @@ async def _index_document(
             "vector_sync.document_process",
             attributes={
                 "vector_sync.content_type": content_type,
-                "vector_sync.file_size": len(content_bytes),
+                # The scanned size when known, so a document rejected before its
+                # download still reports its real size rather than 0.
+                "vector_sync.file_size": doc_task.size_bytes or len(content_bytes),
             },
         ):
             # The registry runs the tiered PDF pipeline and records
@@ -1257,7 +1299,14 @@ async def _index_document(
                 # queue-hop to the next tier). Everything else -- non-PDF files,
                 # and the in-process/memory pool (tier is None) -- runs the inline
                 # tiered pipeline (fast -> OCR escalation in one call).
-                if tier is not None and _is_pdf(content_type):
+                if preflight_failure is not None:
+                    # Rejected from its scanned size before the download, so
+                    # there is nothing to parse. Substituting the guard's result
+                    # here (rather than returning early) keeps oversize handling
+                    # on the single terminal/dead-letter path below, however the
+                    # size became known.
+                    result = preflight_failure
+                elif tier is not None and _is_pdf(content_type):
                     # Per-document identity, forwarded to every tier's processor.
                     # Only the OCR tier reads it (batch mode keys its job-tracking
                     # table on it, Deck #332); fast/structured ignore it, so it's

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -350,6 +350,11 @@ def preflight_oversize_result(
     or ``None`` when the size is unknown or within the cap -- in which case the
     post-download guard still applies as the backstop.
     """
+    # The cap is PDF-specific, but content type is not known before the download.
+    # Safe because file discovery is PDF-only: _discover_tagged_files passes
+    # mime_type_filter="application/pdf" (vector/scanner.py), so every
+    # doc_type="file" task is a PDF. If discovery is ever broadened to other MIME
+    # types, gate this on content type rather than silently applying a PDF cap.
     size_bytes = getattr(doc_task, "size_bytes", None)
     if not size_bytes:
         return None

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -132,9 +132,12 @@ def _drop_reason(exc: BaseException) -> str:
     return "other"
 
 
+PDF_MIME_TYPE = "application/pdf"
+
+
 def _is_pdf(content_type: str) -> bool:
     """Whether a MIME type is a PDF (parameter-tolerant)."""
-    return content_type.split(";")[0].strip().lower() == "application/pdf"
+    return content_type.split(";")[0].strip().lower() == PDF_MIME_TYPE
 
 
 async def _parse_pdf_tier(
@@ -1265,7 +1268,7 @@ async def _index_document(
                     file_path
                 )
             else:
-                content_bytes, content_type = b"", "application/pdf"
+                content_bytes, content_type = b"", PDF_MIME_TYPE
         else:
             raise ValueError(f"Unsupported doc_type: {doc_task.doc_type}")
 
@@ -1615,7 +1618,7 @@ async def _index_document(
     bbox_source: str | None = None
 
     # Determine if we need PDF highlighting
-    is_pdf = doc_task.doc_type == "file" and content_type == "application/pdf"
+    is_pdf = doc_task.doc_type == "file" and content_type == PDF_MIME_TYPE
 
     # Define async tasks for parallel execution
     async def generate_dense_embeddings():

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -33,6 +33,8 @@ from nextcloud_mcp_server.observability.metrics import (
     record_document_dead_lettered,
     record_document_escalation,
     record_document_escalation_suppressed,
+    record_document_ingest_rejected,
+    record_document_ingest_size,
     record_document_parse_failed,
     record_embedding,
     record_embedding_tokens,
@@ -352,7 +354,13 @@ def preflight_oversize_result(
         get_registry,
     )
 
-    return get_registry().oversize_result_for_size(size_bytes, file_path, settings)
+    # Observe the size BEFORE the cap, so the corpus histogram shows the over-cap
+    # tail rather than only what we accepted.
+    record_document_ingest_size(doc_task.doc_type, size_bytes)
+    result = get_registry().oversize_result_for_size(size_bytes, file_path, settings)
+    if result is not None:
+        record_document_ingest_rejected(doc_task.doc_type, "oversize")
+    return result
 
 
 def ingested_byte_size(content_bytes: bytes | None, content: str) -> int:

--- a/nextcloud_mcp_server/vector/queue/procrastinate.py
+++ b/nextcloud_mcp_server/vector/queue/procrastinate.py
@@ -39,7 +39,7 @@ import warnings
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from procrastinate import (
     App,
@@ -169,8 +169,16 @@ async def process_document_task(
     etag: str | None = None,
     owner_id: str | None = None,
     index_mode: str = payload_keys.INDEX_MODE_HYBRID,
+    size_bytes: int | None = None,
+    **_forward_compat: Any,
 ) -> None:
     """Worker entry: rebuild the DocumentTask, resolve creds, run the pipeline.
+
+    Payload contract: procrastinate invokes this as
+    ``await_func(**job.task_kwargs)``, so every :class:`DocumentTask` field must
+    be accepted here with a default (an older producer's payload omits new
+    fields) and ``**_forward_compat`` absorbs fields a newer producer adds, so a
+    version skew degrades to ignoring them rather than failing the job.
 
     Queue-aware (Deck #323): the tier this worker runs is the tier of the job's
     current queue. A low-quality parse raises ``EscalateError``, which the
@@ -201,6 +209,7 @@ async def process_document_task(
         etag=etag,
         owner_id=owner_id,
         index_mode=index_mode,
+        size_bytes=size_bytes,
     )
     try:
         nc_client = await _resolve_client(user_id)

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -150,6 +150,14 @@ class DocumentTask:
     # "keyword" for files discovered via the ``keyword-index`` tag so the
     # processor skips dense embedding for them. See payload_keys.INDEX_MODE_*.
     index_mode: str = payload_keys.INDEX_MODE_HYBRID
+    # WebDAV getcontentlength at scan time, for files. Lets the processor apply
+    # the oversize cap BEFORE downloading, so an over-cap document costs nothing
+    # instead of being fetched into memory only to be rejected (a 531 MB PDF
+    # OOMKilled a worker mid-download, before the cap was ever evaluated).
+    # None = unknown (deletes, non-file types, webhook-produced tasks, and jobs
+    # deferred by a pre-upgrade producer) -> the post-download guard still
+    # applies. Defaulted so old in-flight job payloads deserialize unchanged.
+    size_bytes: int | None = None
 
 
 # Track documents potentially deleted (grace period before actual deletion)
@@ -1076,6 +1084,12 @@ async def scan_user_documents(
                 # it. Eliminates the per-user reprocessing ping-pong that arises
                 # because chunk point IDs are user-agnostic (note 386945 #5).
                 etag = str(file_info.get("etag") or "")
+                # getcontentlength is already requested and parsed by the WebDAV
+                # discovery calls, so carrying it costs no extra request. The
+                # parser yields 0 when the property is absent; treat that as
+                # "unknown" so the processor falls back to the post-download
+                # guard rather than gating on a bogus zero.
+                size_bytes = file_info.get("size") or None
                 if etag and await claim_existing_index(
                     file_id,
                     "file",
@@ -1132,6 +1146,7 @@ async def scan_user_documents(
                             file_path=file_path,
                             etag=etag,
                             index_mode=index_mode,
+                            size_bytes=size_bytes,
                         )
                     )
                     file_queued += 1
@@ -1239,6 +1254,7 @@ async def scan_user_documents(
                                 file_path=file_path,
                                 etag=etag,
                                 index_mode=index_mode,
+                                size_bytes=size_bytes,
                             )
                         )
                         file_queued += 1

--- a/tests/unit/client/test_webdav_stream_to_file.py
+++ b/tests/unit/client/test_webdav_stream_to_file.py
@@ -36,6 +36,14 @@ def _response(body: bytes, headers: dict[str, str] | None = None) -> httpx.Respo
     )
 
 
+def _client_over(http: httpx.AsyncClient) -> WebDAVClient:
+    """A WebDAVClient over a caller-supplied transport, principal pre-resolved."""
+    client = WebDAVClient(http, "u")
+    client._principal_id = "u"
+    client._principal_discovered = True
+    return client
+
+
 def _client(
     body: bytes, headers: dict[str, str] | None = None, chunk: int = 3
 ) -> WebDAVClient:
@@ -72,16 +80,17 @@ def test_content_length_guard_matches_buffered_path(body, headers, raises):
     """One implementation, so the two download paths cannot drift apart."""
     buffered = _response(body, headers)
     streamed = _response(body, headers)
+    received = len(body)
 
     if raises:
         with pytest.raises(httpx.RemoteProtocolError):
             _read_complete_body(buffered, "f.pdf")
         with pytest.raises(httpx.RemoteProtocolError):
-            _verify_content_length(streamed, len(body), "f.pdf")
+            _verify_content_length(streamed, received, "f.pdf")
     else:
         assert _read_complete_body(buffered, "f.pdf") == body
         # Must not raise for the streaming path either.
-        _verify_content_length(streamed, len(body), "f.pdf")
+        _verify_content_length(streamed, received, "f.pdf")
 
 
 def test_compressed_response_is_exempt_on_both_paths():
@@ -200,3 +209,54 @@ def test_make_request_still_carries_the_429_retry():
     assert not hasattr(BaseNextcloudClient._stream_request, "__wrapped__") or (
         BaseNextcloudClient._stream_request.__wrapped__.__name__ == "_stream_request"
     )
+
+
+async def test_stream_retries_on_429_then_succeeds(tmp_path, mocker):
+    """_stream_request's manual retry loop must actually retry and succeed.
+
+    retry_on_429 cannot decorate a streaming call (a partly-consumed stream is
+    not replayable), so _stream_request retries the connect+status phase itself.
+    The existing decorator guard only pins that _make_request kept its decorator;
+    nothing drove a 429-then-200 sequence through stream_to_file until now.
+    """
+    body = b"%PDF-1.7 recovered"
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        if len(calls) == 1:
+            return httpx.Response(429, content=b"slow down")
+        return httpx.Response(
+            200, content=body, headers={"content-length": str(len(body))}
+        )
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://nc"
+    )
+    client = _client_over(http)
+    # Don't actually wait out the backoff.
+    mocker.patch("nextcloud_mcp_server.client.base.anyio.sleep", new=mocker.AsyncMock())
+    dest = tmp_path / "out.pdf"
+
+    written, _ = await client.stream_to_file("/f.pdf", dest)
+
+    assert len(calls) == 2, "should have retried once after the 429"
+    assert written == len(body)
+    assert dest.read_bytes() == body
+
+
+async def test_stream_gives_up_after_repeated_429(tmp_path, mocker):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, content=b"slow down")
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://nc"
+    )
+    client = _client_over(http)
+    mocker.patch("nextcloud_mcp_server.client.base.anyio.sleep", new=mocker.AsyncMock())
+    dest = tmp_path / "out.pdf"
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.stream_to_file("/f.pdf", dest)
+
+    assert not dest.exists()

--- a/tests/unit/client/test_webdav_stream_to_file.py
+++ b/tests/unit/client/test_webdav_stream_to_file.py
@@ -1,0 +1,199 @@
+"""Unit tests for the streaming WebDAV download.
+
+``stream_to_file`` exists so peak memory stops scaling with document size --
+``read_file`` buffers the whole body, which is how a 531 MB PDF OOMKilled an
+ingest worker mid-download.
+
+The load-bearing property beyond "it writes the file" is that it keeps the two
+guards ``_read_complete_body`` already had: the #965 short-read check and the
+#1099 content-encoding carve-out. Both paths now share
+``_verify_content_length``, and these tests pin that they agree.
+"""
+
+from __future__ import annotations
+
+import gzip
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.client.webdav import (
+    OversizeDownload,
+    WebDAVClient,
+    _read_complete_body,
+    _verify_content_length,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _response(body: bytes, headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=body,
+        headers=headers or {},
+        request=httpx.Request("GET", "http://nc/remote.php/dav/files/u/f.pdf"),
+    )
+
+
+def _client(
+    body: bytes, headers: dict[str, str] | None = None, chunk: int = 3
+) -> WebDAVClient:
+    """A WebDAVClient whose transport streams ``body`` back in small chunks."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, headers=headers or {})
+
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport, base_url="http://nc")
+    client = WebDAVClient(http, "u")
+    # Principal discovery talks to the server; the transport above answers every
+    # request identically, so short-circuit it.
+    client._principal_id = "u"
+    client._principal_discovered = True
+    return client
+
+
+# --- the shared guard: streaming and buffered paths must agree ----------------
+
+
+@pytest.mark.parametrize(
+    ("body", "headers", "raises"),
+    [
+        (b"12345", {"content-length": "5"}, False),
+        (b"123", {"content-length": "5"}, True),  # #965 short read
+        (b"123", {"content-length": "5", "content-encoding": "identity"}, True),
+        (b"123", {}, False),  # no header (chunked)
+        (b"123", {"content-length": "not-a-number"}, False),  # malformed
+        (b"123", {"content-length": "-1"}, False),  # degenerate
+    ],
+)
+def test_content_length_guard_matches_buffered_path(body, headers, raises):
+    """One implementation, so the two download paths cannot drift apart."""
+    if raises:
+        with pytest.raises(httpx.RemoteProtocolError):
+            _read_complete_body(_response(body, headers), "f.pdf")
+        with pytest.raises(httpx.RemoteProtocolError):
+            _verify_content_length(_response(body, headers), len(body), "f.pdf")
+    else:
+        assert _read_complete_body(_response(body, headers), "f.pdf") == body
+        # Must not raise for the streaming path either.
+        _verify_content_length(_response(body, headers), len(body), "f.pdf")
+
+
+def test_compressed_response_is_exempt_on_both_paths():
+    """#1099: Content-Length is the compressed size, so it cannot be compared.
+
+    Uses genuinely gzipped content because httpx decodes the body transparently,
+    so a fake content-encoding header would fail in the decoder rather than
+    exercising the carve-out.
+    """
+    raw = b"decompressed body that is much longer than the compressed form"
+    packed = gzip.compress(raw)
+    headers = {"content-length": str(len(packed)), "content-encoding": "gzip"}
+
+    # Buffered path: returns the decompressed body without raising, even though
+    # len(raw) != the declared (compressed) length.
+    assert _read_complete_body(_response(packed, headers), "f.pdf") == raw
+    # Streaming path: same exemption, checked against bytes written.
+    _verify_content_length(_response(packed, headers), len(raw), "f.pdf")
+
+
+# --- streaming behaviour ------------------------------------------------------
+
+
+async def test_streams_body_to_disk(tmp_path):
+    body = b"%PDF-1.7" + b"x" * 500
+    dest = tmp_path / "out.pdf"
+
+    written, content_type = await _client(
+        body, {"content-length": str(len(body)), "content-type": "application/pdf"}
+    ).stream_to_file("/f.pdf", dest)
+
+    assert written == len(body)
+    assert content_type == "application/pdf"
+    assert dest.read_bytes() == body
+
+
+async def test_short_read_raises_and_removes_partial_file(tmp_path):
+    """#965: a truncated download must not be left on disk to parse as valid."""
+    dest = tmp_path / "out.pdf"
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        await _client(b"short", {"content-length": "9999"}).stream_to_file(
+            "/f.pdf", dest
+        )
+
+    assert not dest.exists()
+
+
+async def test_streaming_compressed_response_skips_the_length_check(tmp_path):
+    """#1099 end-to-end: a gzipped file must not trip the short-read guard."""
+    raw = b"decompressed body, longer than the declared compressed length"
+    packed = gzip.compress(raw)
+    dest = tmp_path / "out.pdf"
+
+    written, _ = await _client(
+        packed, {"content-length": str(len(packed)), "content-encoding": "gzip"}
+    ).stream_to_file("/f.pdf", dest)
+
+    # httpx decodes transparently, so what lands on disk is the real document.
+    assert dest.read_bytes() == raw
+    assert written == len(raw)
+
+
+async def test_max_bytes_aborts_and_removes_the_file(tmp_path):
+    body = b"x" * 5000
+    dest = tmp_path / "out.pdf"
+
+    with pytest.raises(OversizeDownload):
+        await _client(body, {"content-length": str(len(body))}).stream_to_file(
+            "/f.pdf", dest, max_bytes=100
+        )
+
+    assert not dest.exists()
+
+
+async def test_max_bytes_fires_even_when_content_length_lies_small(tmp_path):
+    """The reason max_bytes exists: the advertised size cannot be trusted.
+
+    The pre-flight gate can only act on what the server claimed at scan time, so
+    a server understating the length would otherwise walk straight past it.
+    """
+    body = b"x" * 5000
+    dest = tmp_path / "out.pdf"
+
+    with pytest.raises(OversizeDownload):
+        await _client(body, {"content-length": "10"}).stream_to_file(
+            "/f.pdf", dest, max_bytes=100
+        )
+
+    assert not dest.exists()
+
+
+async def test_exactly_at_the_limit_is_allowed(tmp_path):
+    body = b"x" * 100
+    dest = tmp_path / "out.pdf"
+
+    written, _ = await _client(body, {"content-length": "100"}).stream_to_file(
+        "/f.pdf", dest, max_bytes=100
+    )
+
+    assert written == 100
+
+
+def test_make_request_still_carries_the_429_retry():
+    """Guard: adding _stream_request must not steal _make_request's decorator.
+
+    While introducing the streaming path, the new method was briefly inserted
+    between ``@retry_on_429`` and ``_make_request``, silently moving the retry
+    onto the wrong function. Nothing else in the suite would have caught that.
+    """
+    from nextcloud_mcp_server.client.base import BaseNextcloudClient
+
+    # functools.wraps preserves __name__, so the wrapper is only detectable by
+    # the closure the decorator builds around the original function.
+    assert BaseNextcloudClient._make_request.__wrapped__ is not None
+    assert not hasattr(BaseNextcloudClient._stream_request, "__wrapped__") or (
+        BaseNextcloudClient._stream_request.__wrapped__.__name__ == "_stream_request"
+    )

--- a/tests/unit/client/test_webdav_stream_to_file.py
+++ b/tests/unit/client/test_webdav_stream_to_file.py
@@ -32,7 +32,7 @@ def _response(body: bytes, headers: dict[str, str] | None = None) -> httpx.Respo
         200,
         content=body,
         headers=headers or {},
-        request=httpx.Request("GET", "http://nc/remote.php/dav/files/u/f.pdf"),
+        request=httpx.Request("GET", "https://nc/remote.php/dav/files/u/f.pdf"),
     )
 
 
@@ -45,7 +45,7 @@ def _client(
         return httpx.Response(200, content=body, headers=headers or {})
 
     transport = httpx.MockTransport(handler)
-    http = httpx.AsyncClient(transport=transport, base_url="http://nc")
+    http = httpx.AsyncClient(transport=transport, base_url="https://nc")
     client = WebDAVClient(http, "u")
     # Principal discovery talks to the server; the transport above answers every
     # request identically, so short-circuit it.
@@ -70,15 +70,18 @@ def _client(
 )
 def test_content_length_guard_matches_buffered_path(body, headers, raises):
     """One implementation, so the two download paths cannot drift apart."""
+    buffered = _response(body, headers)
+    streamed = _response(body, headers)
+
     if raises:
         with pytest.raises(httpx.RemoteProtocolError):
-            _read_complete_body(_response(body, headers), "f.pdf")
+            _read_complete_body(buffered, "f.pdf")
         with pytest.raises(httpx.RemoteProtocolError):
-            _verify_content_length(_response(body, headers), len(body), "f.pdf")
+            _verify_content_length(streamed, len(body), "f.pdf")
     else:
-        assert _read_complete_body(_response(body, headers), "f.pdf") == body
+        assert _read_complete_body(buffered, "f.pdf") == body
         # Must not raise for the streaming path either.
-        _verify_content_length(_response(body, headers), len(body), "f.pdf")
+        _verify_content_length(streamed, len(body), "f.pdf")
 
 
 def test_compressed_response_is_exempt_on_both_paths():
@@ -119,10 +122,10 @@ async def test_short_read_raises_and_removes_partial_file(tmp_path):
     """#965: a truncated download must not be left on disk to parse as valid."""
     dest = tmp_path / "out.pdf"
 
+    client = _client(b"short", {"content-length": "9999"})
+
     with pytest.raises(httpx.RemoteProtocolError):
-        await _client(b"short", {"content-length": "9999"}).stream_to_file(
-            "/f.pdf", dest
-        )
+        await client.stream_to_file("/f.pdf", dest)
 
     assert not dest.exists()
 
@@ -146,10 +149,10 @@ async def test_max_bytes_aborts_and_removes_the_file(tmp_path):
     body = b"x" * 5000
     dest = tmp_path / "out.pdf"
 
+    client = _client(body, {"content-length": str(len(body))})
+
     with pytest.raises(OversizeDownload):
-        await _client(body, {"content-length": str(len(body))}).stream_to_file(
-            "/f.pdf", dest, max_bytes=100
-        )
+        await client.stream_to_file("/f.pdf", dest, max_bytes=100)
 
     assert not dest.exists()
 
@@ -163,10 +166,10 @@ async def test_max_bytes_fires_even_when_content_length_lies_small(tmp_path):
     body = b"x" * 5000
     dest = tmp_path / "out.pdf"
 
+    client = _client(body, {"content-length": "10"})
+
     with pytest.raises(OversizeDownload):
-        await _client(body, {"content-length": "10"}).stream_to_file(
-            "/f.pdf", dest, max_bytes=100
-        )
+        await client.stream_to_file("/f.pdf", dest, max_bytes=100)
 
     assert not dest.exists()
 

--- a/tests/unit/client/test_webdav_stream_to_file.py
+++ b/tests/unit/client/test_webdav_stream_to_file.py
@@ -44,9 +44,7 @@ def _client_over(http: httpx.AsyncClient) -> WebDAVClient:
     return client
 
 
-def _client(
-    body: bytes, headers: dict[str, str] | None = None, chunk: int = 3
-) -> WebDAVClient:
+def _client(body: bytes, headers: dict[str, str] | None = None) -> WebDAVClient:
     """A WebDAVClient whose transport streams ``body`` back in small chunks."""
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/unit/test_document_ingest_size_metrics.py
+++ b/tests/unit/test_document_ingest_size_metrics.py
@@ -1,0 +1,125 @@
+"""Unit tests for the corpus size-distribution instrumentation.
+
+``astrolabe_document_ingest_size_bytes`` exists so cap, spool and worker-memory
+sizing can be read off a dashboard instead of a one-off manual crawl. The
+load-bearing property is that it observes sizes **before** the oversize gate --
+if it only counted accepted documents it would be blind to the over-cap tail,
+which is exactly the part those decisions depend on.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nextcloud_mcp_server.observability.metrics import (
+    record_document_ingest_rejected,
+    record_document_ingest_size,
+)
+from nextcloud_mcp_server.vector import processor as proc
+
+pytestmark = pytest.mark.unit
+
+# ``metric_sample`` is provided as a shared fixture in tests/unit/conftest.py.
+
+_SIZE_COUNT = "astrolabe_document_ingest_size_bytes_count"
+_SIZE_BUCKET = "astrolabe_document_ingest_size_bytes_bucket"
+_REJECTED = "astrolabe_document_ingest_rejected_total"
+
+
+def _settings(max_pdf_mb: float = 50.0) -> SimpleNamespace:
+    return SimpleNamespace(document_max_pdf_size_mb=max_pdf_mb)
+
+
+def _task(size_bytes: int | None, doc_type: str = "file") -> SimpleNamespace:
+    return SimpleNamespace(doc_type=doc_type, size_bytes=size_bytes)
+
+
+def test_records_size_observation(metric_sample):
+    before = metric_sample(_SIZE_COUNT, {"doc_type": "file"})
+
+    record_document_ingest_size("file", 5 * 1024 * 1024)
+
+    assert metric_sample(_SIZE_COUNT, {"doc_type": "file"}) == before + 1
+
+
+def test_unknown_size_is_not_recorded_as_zero(metric_sample):
+    """A missing getcontentlength must not pile a false spike into bucket 0."""
+    before = metric_sample(_SIZE_COUNT, {"doc_type": "file"})
+
+    record_document_ingest_size("file", 0)
+
+    assert metric_sample(_SIZE_COUNT, {"doc_type": "file"}) == before
+
+
+def test_large_sizes_land_in_the_tail_buckets(metric_sample):
+    """The 1 GiB tail must be resolvable, not collapsed into +Inf.
+
+    The observed corpus reaches 1040 MB, so a histogram that tops out lower
+    would hide the documents that actually drive the sizing decisions.
+    """
+    # prometheus_client renders bucket bounds with Go float formatting
+    # ("1.073741824e+09"), so ask it rather than guessing the repr.
+    from prometheus_client.utils import floatToGoString
+
+    one_gib = {"doc_type": "file", "le": floatToGoString(1024 * 1024 * 1024)}
+    before = metric_sample(_SIZE_BUCKET, one_gib)
+
+    record_document_ingest_size("file", 900 * 1024 * 1024)
+
+    assert metric_sample(_SIZE_BUCKET, one_gib) == before + 1
+
+
+def test_rejection_counter(metric_sample):
+    labels = {"doc_type": "file", "reason": "oversize"}
+    before = metric_sample(_REJECTED, labels)
+
+    record_document_ingest_rejected("file", "oversize")
+
+    assert metric_sample(_REJECTED, labels) == before + 1
+
+
+def test_oversize_document_is_measured_before_it_is_rejected(metric_sample):
+    """The whole point: an over-cap document is counted, not silently dropped."""
+    size_before = metric_sample(_SIZE_COUNT, {"doc_type": "file"})
+    rejected_before = metric_sample(
+        _REJECTED, {"doc_type": "file", "reason": "oversize"}
+    )
+
+    result = proc.preflight_oversize_result(
+        _task(531 * 1024 * 1024), "/big.pdf", _settings()
+    )
+
+    assert result is not None and result.metadata["parse_failed_reason"] == "oversize"
+    assert metric_sample(_SIZE_COUNT, {"doc_type": "file"}) == size_before + 1
+    assert (
+        metric_sample(_REJECTED, {"doc_type": "file", "reason": "oversize"})
+        == rejected_before + 1
+    )
+
+
+def test_under_cap_document_is_measured_but_not_rejected(metric_sample):
+    size_before = metric_sample(_SIZE_COUNT, {"doc_type": "file"})
+    rejected_before = metric_sample(
+        _REJECTED, {"doc_type": "file", "reason": "oversize"}
+    )
+
+    result = proc.preflight_oversize_result(_task(1024), "/small.pdf", _settings())
+
+    assert result is None
+    assert metric_sample(_SIZE_COUNT, {"doc_type": "file"}) == size_before + 1
+    assert (
+        metric_sample(_REJECTED, {"doc_type": "file", "reason": "oversize"})
+        == rejected_before
+    )
+
+
+def test_unknown_size_skips_the_gate_entirely(metric_sample):
+    """No size means no observation and no gate -- the post-download guard runs."""
+    size_before = metric_sample(_SIZE_COUNT, {"doc_type": "file"})
+
+    result = proc.preflight_oversize_result(_task(None), "/unknown.pdf", _settings())
+
+    assert result is None
+    assert metric_sample(_SIZE_COUNT, {"doc_type": "file"}) == size_before

--- a/tests/unit/test_document_source.py
+++ b/tests/unit/test_document_source.py
@@ -84,15 +84,14 @@ def test_memory_source_path_is_stable_across_calls():
 
 
 def test_spool_target_removes_the_file_even_on_failure(tmp_path):
-    captured: Path | None = None
+    manager = spool_target(str(tmp_path))
+    captured = manager.__enter__()
+    captured.write_bytes(b"partial download")
+    assert captured.exists()
 
-    with pytest.raises(RuntimeError):
-        with spool_target(str(tmp_path)) as target:
-            captured = target
-            target.write_bytes(b"partial download")
-            raise RuntimeError("download blew up")
+    # Simulate a download blowing up part-way through.
+    manager.__exit__(RuntimeError, RuntimeError("download blew up"), None)
 
-    assert captured is not None
     assert not captured.exists(), "a partial download must not be left behind"
 
 

--- a/tests/unit/test_document_source.py
+++ b/tests/unit/test_document_source.py
@@ -1,0 +1,114 @@
+"""Unit tests for the file-backed document handle.
+
+``DocumentSource`` exists so a processor can open a document by path instead of
+receiving its bytes. The properties worth pinning are the ones that keep peak
+memory bounded (a spooled source never materialises), the ones that keep the
+in-memory case cheap (a small document never touches disk unless asked), and the
+cleanup behaviour a crash-looping worker depends on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nextcloud_mcp_server.document_processors.source import (
+    SPOOL_PREFIX,
+    MemoryDocumentSource,
+    SpooledDocumentSource,
+    spool_target,
+    sweep_orphaned_spools,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _spooled(tmp_path: Path, body: bytes = b"%PDF-1.7 body") -> SpooledDocumentSource:
+    target = tmp_path / "doc.bin"
+    target.write_bytes(body)
+    return SpooledDocumentSource(target, "application/pdf", "doc.pdf")
+
+
+def test_spooled_source_exposes_path_size_and_bytes(tmp_path):
+    body = b"%PDF-1.7" + b"x" * 100
+    source = _spooled(tmp_path, body)
+
+    assert source.path().exists()
+    assert source.size == len(body)
+    assert source.read_bytes() == body
+    with source.open() as fh:
+        assert fh.read() == body
+
+
+def test_spooled_size_does_not_read_the_file(tmp_path):
+    """size must come from stat, not from materialising the document."""
+    source = _spooled(tmp_path, b"x" * 4096)
+
+    # Truncating after the first stat would change the answer if size re-read.
+    assert source.size == 4096
+    source.path().write_bytes(b"")
+    assert source.size == 4096, "size should be cached from the initial stat"
+
+
+def test_spooled_cleanup_is_idempotent(tmp_path):
+    source = _spooled(tmp_path)
+
+    source.cleanup()
+    source.cleanup()  # must not raise on an already-removed file
+
+    assert not source.path().exists()
+
+
+def test_memory_source_does_not_touch_disk_until_a_path_is_asked_for(tmp_path):
+    source = MemoryDocumentSource(b"hello", "text/plain", "n.txt")
+
+    assert source.size == 5
+    assert source.read_bytes() == b"hello"
+    assert source._materialised is None, "no path requested -> no temp file"
+
+    path = source.path()
+    try:
+        assert path.exists() and path.read_bytes() == b"hello"
+    finally:
+        source.cleanup()
+    assert not path.exists()
+
+
+def test_memory_source_path_is_stable_across_calls():
+    source = MemoryDocumentSource(b"hello", "text/plain")
+    try:
+        assert source.path() == source.path()
+    finally:
+        source.cleanup()
+
+
+def test_spool_target_removes_the_file_even_on_failure(tmp_path):
+    captured: Path | None = None
+
+    with pytest.raises(RuntimeError):
+        with spool_target(str(tmp_path)) as target:
+            captured = target
+            target.write_bytes(b"partial download")
+            raise RuntimeError("download blew up")
+
+    assert captured is not None
+    assert not captured.exists(), "a partial download must not be left behind"
+
+
+def test_sweep_removes_orphans_but_leaves_other_files(tmp_path):
+    """A SIGKILLed worker cannot clean up, and the spool dir survives restarts."""
+    orphan = tmp_path / f"{SPOOL_PREFIX}abc.bin"
+    orphan.write_bytes(b"leaked document")
+    unrelated = tmp_path / "keep-me.txt"
+    unrelated.write_bytes(b"not ours")
+
+    removed = sweep_orphaned_spools(str(tmp_path))
+
+    assert removed == 1
+    assert not orphan.exists()
+    assert unrelated.exists(), "the sweep must only claim files it created"
+
+
+def test_sweep_on_empty_directory_is_a_noop(tmp_path):
+    assert sweep_orphaned_spools(str(tmp_path)) == 0

--- a/tests/unit/test_escalation_signature.py
+++ b/tests/unit/test_escalation_signature.py
@@ -19,10 +19,13 @@ from nextcloud_mcp_server.document_processors.escalation import (
 pytestmark = pytest.mark.unit
 
 
-def _settings(*, ocr: bool, engine: str = "pypdfium2") -> SimpleNamespace:
+def _settings(
+    *, ocr: bool, engine: str = "pypdfium2", max_pdf_mb: float = 50.0
+) -> SimpleNamespace:
     return SimpleNamespace(
         document_ocr_enabled=ocr,
         document_tier1_engine=engine,
+        document_max_pdf_size_mb=max_pdf_mb,
     )
 
 
@@ -43,3 +46,26 @@ def test_tier1_engine_change_changes_signature() -> None:
     assert escalation_tiers_signature(
         _settings(ocr=False, engine="pypdfium2")
     ) != escalation_tiers_signature(_settings(ocr=False, engine="pymupdf"))
+
+
+def test_raising_size_cap_changes_signature() -> None:
+    # An oversize PDF is always-terminal, so without the cap in the signature it
+    # stays dead-lettered until its etag changes -- which for an archive of
+    # scanned documents is never. Raising the cap must re-drive them.
+    assert escalation_tiers_signature(
+        _settings(ocr=False, max_pdf_mb=50.0)
+    ) != escalation_tiers_signature(_settings(ocr=False, max_pdf_mb=2000.0))
+
+
+def test_size_cap_int_and_float_fingerprint_identically() -> None:
+    # ":g" formatting keeps 50 and 50.0 equal, so a float-repr change cannot
+    # spuriously invalidate every dead letter on the tenant.
+    assert escalation_tiers_signature(
+        _settings(ocr=False, max_pdf_mb=50)
+    ) == escalation_tiers_signature(_settings(ocr=False, max_pdf_mb=50.0))
+
+
+def test_disabling_size_cap_changes_signature() -> None:
+    assert escalation_tiers_signature(
+        _settings(ocr=False, max_pdf_mb=50.0)
+    ) != escalation_tiers_signature(_settings(ocr=False, max_pdf_mb=0))

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -338,3 +338,64 @@ def test_recover_ignores_chunks_beyond_page_count():
     _isolation._recover_underextracted_pages(_FakeDoc([_FakePage(rich)]), chunks)
     assert chunks[0]["text"] == rich  # page 0 recovered
     assert chunks[1]["text"] == "extra"  # extra chunk untouched (loop broke)
+
+
+# --- Parse-subprocess pool bound ---------------------------------------------
+# anyio's default process limiter is os.cpu_count(), which neither --concurrency
+# nor the pod memory limit constrains: on an 8-core node that permits 8 x
+# document_parse_mem_limit_mb of address space inside a 3 GiB pod.
+
+
+async def test_parse_process_limiter_is_bounded_by_setting():
+    from nextcloud_mcp_server.document_processors._isolation import (
+        parse_process_limiter,
+    )
+
+    limiter = parse_process_limiter(3)
+
+    assert limiter.total_tokens == 3
+
+
+async def test_parse_process_limiter_is_reused_within_an_event_loop():
+    """One limiter per loop, or the bound would not actually bind."""
+    from nextcloud_mcp_server.document_processors._isolation import (
+        parse_process_limiter,
+    )
+
+    first = parse_process_limiter(3)
+    second = parse_process_limiter(99)
+
+    assert first is second, "a second call must not mint a fresh, wider limiter"
+
+
+async def test_parse_process_limiter_never_zero():
+    """A zero-slot limiter would deadlock every parse."""
+    from nextcloud_mcp_server.document_processors._isolation import (
+        parse_process_limiter,
+    )
+
+    assert parse_process_limiter(0).total_tokens >= 1
+
+
+async def test_isolated_parse_uses_the_bounded_limiter(mocker):
+    """run_sync must be handed our limiter, not anyio's cpu_count default."""
+    import anyio.to_process
+
+    from nextcloud_mcp_server.document_processors import _isolation
+
+    run_sync = mocker.patch.object(
+        anyio.to_process, "run_sync", new=mocker.AsyncMock(return_value=[])
+    )
+
+    await _isolation.run_isolated_pdf_parse(
+        b"%PDF-1.4",
+        write_images=False,
+        image_path=None,
+        graphics_limit=1000,
+        timeout_seconds=5.0,
+        mem_limit_mb=512,
+        process_slots=2,
+    )
+
+    limiter = run_sync.await_args.kwargs["limiter"]
+    assert limiter.total_tokens == 2

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -347,6 +347,9 @@ def test_recover_ignores_chunks_beyond_page_count():
 
 
 async def test_parse_process_limiter_is_bounded_by_setting():
+    # async because the limiter is stored in a RunVar, which requires a running
+    # event loop -- a sync test raises NoCurrentAsyncBackend.
+    await anyio.lowlevel.checkpoint()
     from nextcloud_mcp_server.document_processors._isolation import (
         parse_process_limiter,
     )
@@ -358,6 +361,7 @@ async def test_parse_process_limiter_is_bounded_by_setting():
 
 async def test_parse_process_limiter_is_reused_within_an_event_loop():
     """One limiter per loop, or the bound would not actually bind."""
+    await anyio.lowlevel.checkpoint()  # RunVar needs a running loop
     from nextcloud_mcp_server.document_processors._isolation import (
         parse_process_limiter,
     )
@@ -370,6 +374,7 @@ async def test_parse_process_limiter_is_reused_within_an_event_loop():
 
 async def test_parse_process_limiter_never_zero():
     """A zero-slot limiter would deadlock every parse."""
+    await anyio.lowlevel.checkpoint()  # RunVar needs a running loop
     from nextcloud_mcp_server.document_processors._isolation import (
         parse_process_limiter,
     )

--- a/tests/unit/test_pypdfium2_fast.py
+++ b/tests/unit/test_pypdfium2_fast.py
@@ -5,6 +5,7 @@ import pytest
 
 from nextcloud_mcp_server.document_processors.pypdfium2_fast import (
     Pypdfium2FastProcessor,
+    _extract,
 )
 
 pytestmark = pytest.mark.unit
@@ -57,3 +58,48 @@ async def test_malformed_pdf_returns_success_false():
 
 async def test_health_check():
     assert await Pypdfium2FastProcessor().health_check() is True
+
+
+# Page-windowed extraction (see _extract). PDFium retains parsed page objects for
+# the document's lifetime, so the extractor re-opens the document every N pages to
+# bound peak RSS. Windowing must not change a single byte of the output, and the
+# page_boundaries offsets must keep indexing exactly into the joined text --
+# search/pdf_highlighter and PageAwareChunker both depend on that contract.
+@pytest.mark.parametrize("window", [0, 1, 2, 3, 7, 100])
+def test_page_window_output_is_identical(window: int):
+    content = _digital_pdf(pages=7)
+
+    baseline_text, baseline_meta = _extract(content, 0)
+    text, meta = _extract(content, window)
+
+    assert text == baseline_text
+    assert meta["page_count"] == baseline_meta["page_count"] == 7
+    assert meta["page_boundaries"] == baseline_meta["page_boundaries"]
+
+
+@pytest.mark.parametrize("window", [1, 2, 3, 7, 100])
+def test_page_window_boundaries_stay_contiguous(window: int):
+    # A window that does not divide the page count is the off-by-one risk.
+    content = _digital_pdf(pages=7)
+
+    text, meta = _extract(content, window)
+
+    boundaries = meta["page_boundaries"]
+    assert len(boundaries) == 7
+    assert boundaries[0]["start_offset"] == 0
+    assert boundaries[-1]["end_offset"] == len(text)
+    for prev, nxt in zip(boundaries, boundaries[1:]):
+        assert prev["end_offset"] == nxt["start_offset"]
+
+
+def test_page_window_handles_empty_document():
+    doc = pymupdf.open()
+    doc.new_page(width=595, height=842)
+    content: bytes = doc.tobytes()
+    doc.close()
+
+    text, meta = _extract(content, 100)
+
+    assert meta["page_count"] == 1
+    assert meta["page_boundaries"][0]["start_offset"] == 0
+    assert meta["page_boundaries"][-1]["end_offset"] == len(text)

--- a/tests/unit/test_pypdfium2_fast.py
+++ b/tests/unit/test_pypdfium2_fast.py
@@ -103,3 +103,29 @@ def test_page_window_handles_empty_document():
     assert meta["page_count"] == 1
     assert meta["page_boundaries"][0]["start_offset"] == 0
     assert meta["page_boundaries"][-1]["end_offset"] == len(text)
+
+
+async def test_process_source_parses_from_a_path_not_bytes(tmp_path):
+    """The path form must produce the same result as the bytes form.
+
+    PdfDocument(path) uses FPDF_LoadDocument, which reads incrementally, while
+    PdfDocument(bytes) uses FPDF_LoadMemDocument64 and pins the buffer for the
+    document's lifetime.
+    """
+    from nextcloud_mcp_server.document_processors.source import SpooledDocumentSource
+
+    content = _digital_pdf(pages=4)
+    spool = tmp_path / "doc.pdf"
+    spool.write_bytes(content)
+    source = SpooledDocumentSource(spool, "application/pdf", "doc.pdf")
+    processor = Pypdfium2FastProcessor()
+
+    from_path = await processor.process_source(source)
+    from_bytes = await processor.process(content, "application/pdf", "doc.pdf")
+
+    assert from_path.success is True
+    assert from_path.text == from_bytes.text
+    assert (
+        from_path.metadata["page_boundaries"] == from_bytes.metadata["page_boundaries"]
+    )
+    assert from_path.metadata["file_size"] == len(content)

--- a/tests/unit/test_registry_tiering.py
+++ b/tests/unit/test_registry_tiering.py
@@ -137,6 +137,39 @@ async def test_oversize_pdf_fails_fast_without_parsing(monkeypatch):
     assert ran is False, "size guard must short-circuit before the fast tier runs"
 
 
+def test_oversize_result_for_size_matches_byte_form(monkeypatch):
+    """The size-only guard must be behaviourally identical to the bytes form.
+
+    ``oversize_result_for_size`` is what the pre-download gate calls, so any
+    divergence would mean a document rejected before the fetch behaves
+    differently from one rejected after it.
+    """
+    settings = _Settings(max_pdf_size_mb=0.001)
+    r = _registry((_Fake("fast", "fast"), 20))
+    content = b"%PDF-1.7" + b"0" * 2048
+
+    by_bytes = r._oversize_result(content, "big.pdf", settings)
+    by_size = r.oversize_result_for_size(len(content), "big.pdf", settings)
+
+    assert by_bytes is not None and by_size is not None
+    assert by_size.success is by_bytes.success is False
+    assert by_size.metadata == by_bytes.metadata
+    assert by_size.processor == by_bytes.processor == "size_guard"
+    assert by_size.error == by_bytes.error
+
+
+def test_oversize_result_for_size_passes_under_cap_and_when_disabled():
+    r = _registry((_Fake("fast", "fast"), 20))
+
+    under = r.oversize_result_for_size(1024, "small.pdf", _Settings(max_pdf_size_mb=50))
+    disabled = r.oversize_result_for_size(
+        10 * 1024 * 1024 * 1024, "huge.pdf", _Settings(max_pdf_size_mb=0)
+    )
+
+    assert under is None
+    assert disabled is None, "cap of 0 disables the guard"
+
+
 async def test_under_cap_pdf_still_parses(monkeypatch):
     """A PDF under the cap is unaffected by the guard."""
     monkeypatch.setattr(

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -244,10 +244,7 @@ async def test_non_terminal_failure_escalates_to_next_tier(mocker):
         AsyncMock(
             return_value=ProcessingResult(
                 text="",
-                metadata={
-                    "parse_failed_reason": "error",
-                    "pipeline_tier": "structured",
-                },
+                metadata={"parse_failed_reason": "error", "pipeline_tier": "fast"},
                 processor="pypdfium2",
                 success=False,
                 error="isolated parse failed (error)",

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -38,6 +38,9 @@ def _settings(*, ocr_enabled: bool) -> SimpleNamespace:
         # skip-redownload guard in process_document inert on these non-batch paths.
         document_ocr_mode="sync",
         document_tier1_engine="pypdfium2",
+        # Part of escalation_tiers_signature: raising the cap re-drives
+        # previously oversize-dead-lettered documents.
+        document_max_pdf_size_mb=50.0,
         get_collection_name=lambda: "c",
     )
 

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -130,6 +130,106 @@ async def test_terminal_failure_dead_letters(mocker):
     spies.escalation.assert_not_called()
 
 
+async def test_preflight_oversize_dead_letters_without_downloading(mocker):
+    """An over-cap document must be rejected from its scanned size, no download.
+
+    This is the regression guard for the production OOM: the size cap could only
+    be applied to bytes already resident, so a 531 MB PDF was fetched into memory
+    and OOMKilled the worker mid-download, before the cap was ever evaluated.
+    """
+    spies = _patch_common(mocker, ocr_enabled=False)
+    parse = mocker.patch.object(processor, "_parse_pdf_tier", AsyncMock())
+    nc = _nc_client()
+    task = _file_task()
+    task.size_bytes = 531 * 1024 * 1024  # over the 50 MB cap
+
+    result = await processor._index_document(task, nc, MagicMock(), tier="fast")
+
+    assert result is False
+    # The whole point of the gate: the over-cap file is never fetched or parsed.
+    nc.webdav.read_file.assert_not_awaited()
+    parse.assert_not_awaited()
+    # Same terminal handling as the post-download guard: dead-lettered oversize.
+    spies.mark.assert_awaited_once()
+    assert spies.mark.await_args.args[4] == "oversize"
+    spies.dead_metric.assert_called_once_with("oversize")
+    spies.parse_failed.assert_called_once_with("oversize")
+    spies.escalation.assert_not_called()
+
+
+async def test_preflight_gate_allows_under_cap_file_through(mocker):
+    _patch_common(mocker, ocr_enabled=False)
+    # A terminal failure result keeps the assertion focused on the gate: the
+    # document is fetched and parsed (which is what is under test) and then
+    # stops on the harness's supported dead-letter path rather than running the
+    # full chunk/embed/index pipeline.
+    parse = mocker.patch.object(
+        processor,
+        "_parse_pdf_tier",
+        AsyncMock(
+            return_value=ProcessingResult(
+                text="",
+                metadata={
+                    "parse_failed_reason": "error",
+                    "pipeline_tier": "structured",
+                },
+                processor="pypdfium2_fast",
+                success=False,
+                error="boom",
+            )
+        ),
+    )
+    nc = _nc_client()
+    task = _file_task()
+    task.size_bytes = 1024  # well under the cap
+
+    # structured with OCR off is terminal, so the failure stops here instead of
+    # escalating (#399) -- keeps the test about the gate, not the ladder.
+    await processor._index_document(task, nc, MagicMock(), tier="structured")
+
+    nc.webdav.read_file.assert_awaited_once()
+    parse.assert_awaited_once()
+
+
+async def test_preflight_gate_falls_back_when_size_unknown(mocker):
+    """size_bytes=None (webhook task, or a source without the property) still runs.
+
+    The post-download guard remains the backstop, so an unknown size must never
+    short-circuit the fetch.
+    """
+    _patch_common(mocker, ocr_enabled=False)
+    # A terminal failure result keeps the assertion focused on the gate: the
+    # document is fetched and parsed (which is what is under test) and then
+    # stops on the harness's supported dead-letter path rather than running the
+    # full chunk/embed/index pipeline.
+    parse = mocker.patch.object(
+        processor,
+        "_parse_pdf_tier",
+        AsyncMock(
+            return_value=ProcessingResult(
+                text="",
+                metadata={
+                    "parse_failed_reason": "error",
+                    "pipeline_tier": "structured",
+                },
+                processor="pypdfium2_fast",
+                success=False,
+                error="boom",
+            )
+        ),
+    )
+    nc = _nc_client()
+    task = _file_task()
+    assert task.size_bytes is None
+
+    # structured with OCR off is terminal, so the failure stops here instead of
+    # escalating (#399) -- keeps the test about the gate, not the ladder.
+    await processor._index_document(task, nc, MagicMock(), tier="structured")
+
+    nc.webdav.read_file.assert_awaited_once()
+    parse.assert_awaited_once()
+
+
 async def test_non_terminal_failure_escalates_to_next_tier(mocker):
     """fast tier fails while structured is still available -> escalate (#399).
 
@@ -144,7 +244,10 @@ async def test_non_terminal_failure_escalates_to_next_tier(mocker):
         AsyncMock(
             return_value=ProcessingResult(
                 text="",
-                metadata={"parse_failed_reason": "error", "pipeline_tier": "fast"},
+                metadata={
+                    "parse_failed_reason": "error",
+                    "pipeline_tier": "structured",
+                },
                 processor="pypdfium2",
                 success=False,
                 error="isolated parse failed (error)",

--- a/tests/unit/vector/test_tag_reconcile.py
+++ b/tests/unit/vector/test_tag_reconcile.py
@@ -36,6 +36,10 @@ async def test_reconcile_tagged_file_becomes_index():
         "path": "/alice/files/Docs/report.pdf",
         "etag": "abc123",
         "last_modified_timestamp": 1762850245,
+        # WebDAV SEARCH returns getcontentlength as "size"; the reconcile must
+        # carry it so the pre-flight oversize gate applies to webhook-triggered
+        # indexing too, not just scheduled scans.
+        "size": 4096,
     }
     nc_client = MagicMock()
     nc_client.find_files_by_tag = AsyncMock(
@@ -52,6 +56,9 @@ async def test_reconcile_tagged_file_becomes_index():
     assert task.file_path == "/alice/files/Docs/report.pdf"
     assert task.etag == "abc123"
     assert task.modified_at == 1762850245
+    # Without this the pre-flight oversize gate is bypassed for every
+    # webhook-triggered index, and a tagged huge PDF still gets fully downloaded.
+    assert task.size_bytes == 4096
     nc_client.find_files_by_tag.assert_any_await(
         "vector-index", mime_type_filter="application/pdf"
     )
@@ -91,3 +98,27 @@ async def test_reconcile_preserves_existing_etag():
 
     assert task.etag == "preset"
     assert task.file_path == "/alice/files/r.pdf"
+
+
+@pytest.mark.unit
+async def test_reconcile_treats_absent_size_as_unknown():
+    """A SEARCH row without getcontentlength must not gate on a bogus zero."""
+    nc_client = MagicMock()
+    nc_client.find_files_by_tag = AsyncMock(
+        side_effect=lambda tag, mime_type_filter=None: (
+            [{"id": "478087", "path": "/alice/files/Docs/report.pdf", "etag": "abc"}]
+            if tag == "vector-index"
+            else []
+        )
+    )
+    task = DocumentTask(
+        user_id="alice",
+        doc_id="478087",
+        doc_type="file",
+        operation="index",
+        modified_at=0,
+    )
+
+    await _reconcile_tag_event(task, nc_client)
+
+    assert task.size_bytes is None, "unknown size falls back to the post-download guard"


### PR DESCRIPTION
## Why

Fast-tier ingest workers for `tenant-blackbox-demo` were OOMKilling in a loop. Reducing per-worker concurrency 2 → 1 did **not** help: a `--concurrency 1` pod still reached `restartCount: 4` with `lastState: OOMKilled` (exit 137) against a 3 GiB limit.

Two independent causes, both measured rather than guessed:

1. **The size cap was enforced after the file was already in memory.** `vector/processor.py` buffered the whole WebDAV body (`response.content`) and only then compared its length to `DOCUMENT_MAX_PDF_SIZE_MB`. The confirmed fatal document (531 MB) died *mid-download*, before its size was ever evaluated.
2. **Parse memory scaled with page count and nothing bounded it.** PDFium retains parsed page objects for the life of the open document and `page.close()` does not return them.

A PROPFIND crawl of the tenant showed the cap was not protecting against a rare pathological file — it was rejecting the corpus: **444 of 866 files (56.2 GB, ~84% of bytes) over cap and permanently dead-lettered**.

## Measurements

Real tenant document `MISC.PDF` — 1040 MB, **4003 pages**, and it does carry a text layer (4.88M chars):

| | parse Δ RSS | total peak | output |
|---|---|---|---|
| before | 1934.7 MB | **3072.6 MB** | 4,878,424 chars |
| after (window=100) | **84.5 MB** | 1230.6 MB | 4,878,424 chars |

The old path peaked at 3072.6 MB against a **3072 MB** pod limit — that document OOMs a worker on its own, regardless of the cap. Output is byte-identical at every window size (verified by SHA, and at window sizes that don't divide the page count).

Peak tracks **pages, not bytes**: ~0.47 MB/page for pypdfium2, so a 507 MB/70-page scan retained 0.97× its size while this 1040 MB/4003-page file retained 1.8×.

## What's here

| Commit | Change |
|---|---|
| 1 | Page-windowed extraction (`DOCUMENT_PARSE_PAGE_WINDOW`, default 100) |
| 2 | Fold the size cap into the escalation signature so raising it re-drives dead letters |
| 3 | Pre-flight size gate — reject over-cap documents before downloading |
| 4 | `astrolabe_document_ingest_size_bytes` histogram + documented pages/s and docs/s queries |
| 5 | Bound the isolated-parse subprocess pool (`DOCUMENT_PARSE_PROCESS_SLOTS`) |
| 6 | `WebDAVClient.stream_to_file` — streaming download with `max_bytes` |
| 7 | `DocumentSource` — parse PDFs from a path instead of bytes |

Notable details:

- **The size cap now re-drives dead letters.** It's part of `escalation_tiers_signature`, resolving that function's own TODO. Raising the cap invalidates *all* dead letters for a tenant (not just oversize ones), so it's a thundering herd — documented, roll out one tenant at a time.
- **`getcontentlength` was already being fetched and discarded**, so the pre-flight gate costs no extra request.
- **The #965 truncation guard and #1099 encoding carve-out are shared, not reimplemented** — `_verify_content_length` is used by both download paths, with a parametrised test asserting they agree case for case.
- **The parse-subprocess pool was unbounded by anything meaningful**: anyio defaults to `os.cpu_count()`, so an 8-core node permitted 8 × 1536 MB of address space in a 3 GiB pod, independent of `--concurrency`.
- **Stage 2 migration is additive**: `process_source` is concrete and defaults to `read_bytes()` + `process()`, so no existing processor needed changing and the full suite passes without edits.

## Not in this PR

- **The streaming download is not yet wired into the ingest path.** `stream_to_file` and `DocumentSource` exist and the engines use them, but `vector/processor.py` still calls `read_file`, so the ~1.1 GB download buffer remains. That wiring is the next step.
- Spool disk budget, fast-tier subprocess isolation, and the cap raise itself.
- OCR for large scans — base64 is ~5× file size and needs a gateway-side multipart change (cross-repo).

## Verification

`ruff`, `ty` and the full unit suite (**2246 passing**) green at every commit. New coverage: windowing parity across window sizes, the pre-flight gate (including the unknown-size fallback), streaming/buffered guard parity, `ByteBudget`-style limiter bounds, and `DocumentSource` lifecycle.

Not yet verified end-to-end against a running stack — the integration tier and a tenant canary are still to do, and the plan carries a staged rollout (reindex one known-good file for byte-parity, then etag-canary the 531 MB document, then the re-drive).

**A correction I want visible:** I initially reported the structured tier fails on large files *because* `_isolation` pickled the bytes into the subprocess. That was wrong — the same worker-init error reproduces on a 3-page PDF and on the parent commit, so it's a sandbox limitation here, not a size-dependent defect. The parent-side 2185 → 104 MB reduction is real; the child-side claim was not. The structured tier's large-file profile remains unmeasured, so its cap should not move yet.

Tracked on Deck card #687 (board 7, Ingest Pipeline Scaling).

---

_This PR was generated with the help of AI, and reviewed by a Human_
