### PR TITLE
fix(ingest): stream document downloads instead of buffering them

### DIFF
--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -332,6 +332,31 @@ def _init_worker_observability(settings: Settings) -> None:
     )
 
 
+def _sweep_spools_at_startup(settings) -> int:
+    """Clear ingest spool files left behind by a previous worker; returns count.
+
+    A SIGKILLed worker cannot run its own cleanup, and the spool directory is an
+    emptyDir that survives container restarts within the pod, so a crash-looping
+    worker would otherwise accumulate whole documents on disk until the volume
+    filled. Skipped when streaming is off, since nothing spools then.
+    """
+    if not settings.document_stream_download_enabled:
+        return 0
+
+    from nextcloud_mcp_server.document_processors.source import (  # noqa: PLC0415
+        sweep_orphaned_spools,
+    )
+
+    swept = sweep_orphaned_spools(settings.document_spool_dir)
+    if swept:
+        logger.warning(
+            "Removed %d orphaned ingest spool file(s) at startup "
+            "(previous worker exited without cleaning up)",
+            swept,
+        )
+    return swept
+
+
 def _resolve_worker_concurrency(
     cli_concurrency: int | None,
     tier: str | None,
@@ -408,22 +433,7 @@ def worker(concurrency: int | None, tier: str | None):
     # docstring). Done after the queue check so a misconfig fails fast.
     _init_worker_observability(settings)
 
-    # Clear spool files left by a previous run. A SIGKILLed worker cannot run its
-    # own cleanup, and the spool directory is an emptyDir that survives container
-    # restarts within the pod, so a crash-looping worker would otherwise
-    # accumulate whole documents on disk until the volume filled.
-    if settings.document_stream_download_enabled:
-        from nextcloud_mcp_server.document_processors.source import (  # noqa: PLC0415
-            sweep_orphaned_spools,
-        )
-
-        swept = sweep_orphaned_spools(settings.document_spool_dir)
-        if swept:
-            logger.warning(
-                "Removed %d orphaned ingest spool file(s) at startup "
-                "(previous worker exited without cleaning up)",
-                swept,
-            )
+    _sweep_spools_at_startup(settings)
 
     from nextcloud_mcp_server.vector.queue.procrastinate import (  # noqa: PLC0415
         ALL_INGEST_QUEUES,

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -408,6 +408,23 @@ def worker(concurrency: int | None, tier: str | None):
     # docstring). Done after the queue check so a misconfig fails fast.
     _init_worker_observability(settings)
 
+    # Clear spool files left by a previous run. A SIGKILLed worker cannot run its
+    # own cleanup, and the spool directory is an emptyDir that survives container
+    # restarts within the pod, so a crash-looping worker would otherwise
+    # accumulate whole documents on disk until the volume filled.
+    if settings.document_stream_download_enabled:
+        from nextcloud_mcp_server.document_processors.source import (  # noqa: PLC0415
+            sweep_orphaned_spools,
+        )
+
+        swept = sweep_orphaned_spools(settings.document_spool_dir)
+        if swept:
+            logger.warning(
+                "Removed %d orphaned ingest spool file(s) at startup "
+                "(previous worker exited without cleaning up)",
+                swept,
+            )
+
     from nextcloud_mcp_server.vector.queue.procrastinate import (  # noqa: PLC0415
         ALL_INGEST_QUEUES,
         INGEST_QUEUE_MAINTENANCE,

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -203,27 +203,26 @@ class BaseNextcloudClient(ABC):
         max_retries = 5
         for attempt in range(1, max_retries + 1):
             start_time = time.time()
+            # Status is recorded in a finally so the request is metered however
+            # the block ends. Without that, a failure raised by the CALLER's body
+            # loop (OversizeDownload, or the short-read RemoteProtocolError) is
+            # neither an HTTPStatusError nor a normal return, so the request went
+            # entirely unrecorded on mcp_nextcloud_api_requests_total.
+            status_code = 0
             try:
                 with trace_nextcloud_api_call(
                     app=self.app_name, method=method, path=url
                 ):
                     async with self._client.stream(method, url, **kwargs) as response:
+                        status_code = response.status_code
                         # Raised inside the stream context so the connection is
                         # released before the 429 handler sleeps and retries.
                         response.raise_for_status()
                         yield response
-                        record_nextcloud_api_call(
-                            app=self.app_name,
-                            method=method,
-                            status_code=response.status_code,
-                            duration=time.time() - start_time,
-                        )
                 return
             except HTTPStatusError as e:
-                if (
-                    e.response.status_code == codes.TOO_MANY_REQUESTS
-                    and attempt < max_retries
-                ):
+                status_code = e.response.status_code
+                if status_code == codes.TOO_MANY_REQUESTS and attempt < max_retries:
                     logger.warning(
                         "429 Too Many Requests on streaming download, attempt %s",
                         attempt,
@@ -231,13 +230,16 @@ class BaseNextcloudClient(ABC):
                     record_nextcloud_api_retry(app=self.app_name, reason="429")
                     await anyio.sleep(5)
                     continue
+                raise
+            finally:
+                # A retried 429 is metered as its own attempt, matching how
+                # retry_on_429 accounts for the buffered path.
                 record_nextcloud_api_call(
                     app=self.app_name,
                     method=method,
-                    status_code=e.response.status_code,
+                    status_code=status_code,
                     duration=time.time() - start_time,
                 )
-                raise
         raise RuntimeError(
             f"Maximum number of retries ({max_retries}) exceeded without success"
         )

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -215,6 +215,10 @@ _DEFAULTS: dict[str, Any] = {
     "document_parse_page_window": 100,
     # Concurrent isolated parse subprocesses (see document_parse_process_slots).
     "document_parse_process_slots": 2,
+    # Stream ingest downloads to disk instead of buffering them in memory.
+    "document_stream_download_enabled": True,
+    # Directory for ingest spool files (default: the system temp dir).
+    "document_spool_dir": None,
     # Tier-0 classifier (records classification metrics on the tiered path)
     "document_classify_enabled": True,
     # Tiered PDF pipeline: pypdfium2 is the default/only hot-path extractor;
@@ -1161,6 +1165,15 @@ class Settings:
     # instead. 2 covers the per-tier worker concurrency actually deployed (1-3)
     # while capping the pathological case; raise it only with headroom to spare.
     document_parse_process_slots: int = 2
+    # Stream ingest downloads to a spool file rather than buffering the whole
+    # response in memory. read_file holds the entire document (a real 1040 MB
+    # file cost ~1.1 GB resident before a page was read); streaming keeps that
+    # at one chunk. Set false to fall back to the buffered path without a revert.
+    document_stream_download_enabled: bool = True
+    # Where spool files are written. None = tempfile.gettempdir(). In the
+    # container that is the /tmp emptyDir, which must have room for roughly
+    # (worker concurrency x the largest document).
+    document_spool_dir: str | None = None
     # Tier-0 classifier. Records classification metrics (recommended_tier,
     # text-quality) on the tiered path, derived from the tier-1 extraction.
     document_classify_enabled: bool = True
@@ -1968,6 +1981,8 @@ def _build_settings() -> Settings:
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
         "document_parse_process_slots": "DOCUMENT_PARSE_PROCESS_SLOTS",
+        "document_stream_download_enabled": "DOCUMENT_STREAM_DOWNLOAD_ENABLED",
+        "document_spool_dir": "DOCUMENT_SPOOL_DIR",
         "document_classify_enabled": "DOCUMENT_CLASSIFY_ENABLED",
         "document_tier1_engine": "DOCUMENT_TIER1_ENGINE",
         "document_ocr_enabled": "DOCUMENT_OCR_ENABLED",

--- a/nextcloud_mcp_server/document_processors/classifier.py
+++ b/nextcloud_mcp_server/document_processors/classifier.py
@@ -322,6 +322,26 @@ def classify_pdf(content: bytes) -> DocClassification:
     )
 
 
+def image_coverage_per_page_from_path(source_path: str) -> list[float]:
+    """:func:`image_coverage_per_page` reading from a path instead of bytes.
+
+    Scan detection re-opens the document, so on the streamed ingest path it can
+    read the spool file directly rather than forcing the caller to materialise a
+    large scan purely to classify it.
+    """
+    import pymupdf  # noqa: PLC0415
+
+    from nextcloud_mcp_server.document_processors._native_locks import (  # noqa: PLC0415
+        pymupdf_serialized,
+    )
+
+    cov: list[float] = []
+    with pymupdf_serialized(), pymupdf.open(source_path) as doc:
+        for n in range(min(doc.page_count, MAX_SAMPLED_PAGES)):
+            cov.append(_page_image_coverage(doc.load_page(n)))
+    return cov
+
+
 def image_coverage_per_page(content: bytes) -> list[float]:
     """Raster-image coverage in ``[0, 1]`` for every page (document order).
 

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -26,6 +26,8 @@ from .source import DocumentSource
 
 logger = logging.getLogger(__name__)
 
+PDF_MIME_TYPE = "application/pdf"
+
 
 class ProcessorRegistry:
     """Central registry for document processors.
@@ -168,7 +170,7 @@ class ProcessorRegistry:
 
         # PDFs go through the tiered pipeline (tier-0 classify -> tier-1 fast ->
         # tier-3 OCR escalation). Everything else uses priority selection.
-        if content_type.split(";")[0].strip().lower() == "application/pdf":
+        if content_type.split(";")[0].strip().lower() == PDF_MIME_TYPE:
             return await self._process_pdf(
                 content, content_type, filename, options, progress_callback
             )
@@ -187,7 +189,7 @@ class ProcessorRegistry:
         """First registered processor of ``tier`` that handles PDFs."""
         for name in self._priority_order:
             processor = self._processors[name][0]
-            if processor.tier == tier and processor.supports("application/pdf"):
+            if processor.tier == tier and processor.supports(PDF_MIME_TYPE):
                 return processor
         return None
 
@@ -616,7 +618,7 @@ class ProcessorRegistry:
         PDFs run the inline tiered pipeline, which is bytes-based, so they are
         materialised here -- see the note below.
         """
-        if source.content_type.split(";")[0].strip().lower() == "application/pdf":
+        if source.content_type.split(";")[0].strip().lower() == PDF_MIME_TYPE:
             # TODO: give _process_pdf a source-based twin. The inline pipeline is
             # the escalation-disabled path (in-process/memory pool), not the
             # per-tier worker fleet that production runs, so the memory win lands

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -14,7 +14,12 @@ from nextcloud_mcp_server.observability.metrics import (
 from nextcloud_mcp_server.observability.tracing import trace_operation
 
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
-from .classifier import DocClassification, classify_from_text, image_coverage_per_page
+from .classifier import (
+    DocClassification,
+    classify_from_text,
+    image_coverage_per_page,
+    image_coverage_per_page_from_path,
+)
 from .escalation import TIER_LADDER, EscalationDecision
 from .ocr import OCR_BATCH_PENDING_KEY
 
@@ -463,6 +468,7 @@ class ProcessorRegistry:
         *,
         record: bool,
         filename: str | None = None,
+        source: Any | None = None,
     ) -> DocClassification | None:
         """Tier-0 classification of a parse result (text-only, cheap).
 
@@ -481,7 +487,11 @@ class ProcessorRegistry:
             # Scan detection feeds the OCR tier, so run it whenever OCR is enabled.
             if settings.document_ocr_enabled and settings.document_ocr_detect_scanned:
                 try:
-                    image_coverage = image_coverage_per_page(content)
+                    image_coverage = (
+                        image_coverage_per_page_from_path(str(source.path()))
+                        if source is not None
+                        else image_coverage_per_page(content)
+                    )
                 except Exception:
                     # Best-effort: fall back to text-only signals. WARNING (not
                     # DEBUG) so a systematic scan-detection failure on an
@@ -576,6 +586,81 @@ class ProcessorRegistry:
                 return tier
         return None
 
+    async def process_source(
+        self,
+        source: Any,
+        options: dict[str, Any] | None = None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ) = None,
+    ) -> ProcessingResult:
+        """Inline (non-tiered) processing of a file-backed source.
+
+        Non-PDFs go straight to their processor by source, so nothing is
+        materialised. PDFs still run the inline tiered pipeline, which is
+        bytes-based, so they are materialised here -- see the note below.
+        """
+        if source.content_type.split(";")[0].strip().lower() == "application/pdf":
+            # TODO: give _process_pdf a source-based twin. The inline pipeline is
+            # the escalation-disabled path (in-process/memory pool), not the
+            # per-tier worker fleet that production runs, so the memory win lands
+            # where it matters first; this keeps behaviour identical meanwhile.
+            from anyio.to_thread import run_sync  # noqa: PLC0415
+
+            content = await run_sync(source.read_bytes)
+            return await self._process_pdf(
+                content,
+                source.content_type,
+                source.filename,
+                options,
+                progress_callback,
+            )
+
+        processor = self.find_processor(source.content_type)
+        if not processor:
+            raise ProcessorError(
+                f"No processor found for type: {source.content_type}. "
+                f"Registered processors: {', '.join(self.list_processors())}"
+            )
+        return await self._run_processor_source(
+            processor, source, options, progress_callback
+        )
+
+    async def process_tier_source(
+        self,
+        source: Any,
+        tier: str,
+        options: dict[str, Any] | None = None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ) = None,
+    ) -> ProcessingResult:
+        """Run exactly ONE tier against a file-backed source.
+
+        The path-based twin of :meth:`process_tier`. Applying the size guard to
+        ``source.size`` avoids materialising a document only to reject it, and
+        handing the processor the source lets the PDF engines open by path
+        instead of holding the bytes.
+        """
+        oversize = self.oversize_result_for_size(
+            source.size, source.filename, get_settings()
+        )
+        if oversize is not None:
+            return oversize
+        processor = self._pdf_processor_for_tier(tier)
+        if processor is None:
+            raise ProcessorError(
+                f"No '{tier}'-tier PDF processor registered "
+                f"(available: {', '.join(self.list_processors())})"
+            )
+        return await self._run_processor_source(
+            processor,
+            source,
+            options,
+            progress_callback,
+            escalated=(tier != TIER_LADDER[0]),
+        )
+
     async def process_tier(
         self,
         content: bytes,
@@ -614,6 +699,22 @@ class ProcessorRegistry:
             escalated=(tier != TIER_LADDER[0]),
         )
 
+    def evaluate_escalation_source(
+        self,
+        result: ProcessingResult,
+        source: Any,
+        current_tier: str,
+        settings: Any,
+    ) -> EscalationDecision | None:
+        """:meth:`evaluate_escalation` against a file-backed source.
+
+        Scan detection re-opens the document; giving it the path keeps that off
+        the bytes, so a large scan is not materialised just to be classified.
+        """
+        return self._evaluate_escalation(
+            result, b"", current_tier, settings, filename=source.filename, source=source
+        )
+
     def evaluate_escalation(
         self,
         result: ProcessingResult,
@@ -622,6 +723,21 @@ class ProcessorRegistry:
         settings: Any,
         *,
         filename: str | None = None,
+    ) -> EscalationDecision | None:
+        """Bytes-based adapter; see :meth:`_evaluate_escalation`."""
+        return self._evaluate_escalation(
+            result, content, current_tier, settings, filename=filename
+        )
+
+    def _evaluate_escalation(
+        self,
+        result: ProcessingResult,
+        content: bytes,
+        current_tier: str,
+        settings: Any,
+        *,
+        filename: str | None = None,
+        source: Any | None = None,
     ) -> EscalationDecision | None:
         """Decide whether ``current_tier``'s result must escalate (external path).
 
@@ -659,6 +775,7 @@ class ProcessorRegistry:
             settings,
             record=(current_tier == TIER_LADDER[0]),
             filename=filename,
+            source=source,
         )
         if classification is None or classification.recommended_tier not in (
             "structured",
@@ -694,6 +811,29 @@ class ProcessorRegistry:
             return EscalationDecision("suppressed", ideal, reason)
         return None
 
+    async def _run_processor_source(
+        self,
+        processor: DocumentProcessor,
+        source: Any,
+        options: dict[str, Any] | None = None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ) = None,
+        *,
+        escalated: bool = False,
+    ) -> ProcessingResult:
+        """Run one processor against a file-backed source."""
+        return await self._run_processor(
+            processor,
+            b"",
+            source.content_type,
+            source.filename,
+            options,
+            progress_callback,
+            escalated=escalated,
+            source=source,
+        )
+
     async def _run_processor(
         self,
         processor: DocumentProcessor,
@@ -706,8 +846,18 @@ class ProcessorRegistry:
         ) = None,
         *,
         escalated: bool = False,
+        source: Any | None = None,
     ) -> ProcessingResult:
-        """Run one processor with the per-processor span + parse metrics."""
+        """Run one processor with the per-processor span + parse metrics.
+
+        When ``source`` is given the processor is driven through
+        ``process_source`` (so a PDF engine opens by path rather than holding the
+        bytes) and ``content`` is ignored. The instrumentation is identical
+        either way, which is why this is one method rather than two.
+        """
+        if source is not None:
+            content_type = source.content_type
+            filename = source.filename
         tier = processor.tier
         logger.info(
             "Processing with '%s' processor",
@@ -719,7 +869,7 @@ class ProcessorRegistry:
             },
         )
 
-        byte_size = len(content)
+        byte_size = source.size if source is not None else len(content)
         start_time = time.time()
         with trace_operation(
             "document_processor.parse",
@@ -733,9 +883,14 @@ class ProcessorRegistry:
             record_exception=True,
         ) as span:
             try:
-                result = await processor.process(
-                    content, content_type, filename, options, progress_callback
-                )
+                if source is not None:
+                    result = await processor.process_source(
+                        source, options, progress_callback
+                    )
+                else:
+                    result = await processor.process(
+                        content, content_type, filename, options, progress_callback
+                    )
             except Exception:
                 duration = time.time() - start_time
                 record_document_parse(

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -606,9 +606,15 @@ class ProcessorRegistry:
     ) -> ProcessingResult:
         """Inline (non-tiered) processing of a file-backed source.
 
-        Non-PDFs go straight to their processor by source, so nothing is
-        materialised. PDFs still run the inline tiered pipeline, which is
-        bytes-based, so they are materialised here -- see the note below.
+        Non-PDFs are handed the source directly. Note that only the two PDF
+        engines override ``process_source`` today, so any other processor still
+        materialises the document via the base-class default -- off the event
+        loop through ``run_sync``, so it no longer blocks, but the memory is
+        still proportional to document size until that processor grows a
+        path-based override.
+
+        PDFs run the inline tiered pipeline, which is bytes-based, so they are
+        materialised here -- see the note below.
         """
         if source.content_type.split(";")[0].strip().lower() == "application/pdf":
             # TODO: give _process_pdf a source-based twin. The inline pipeline is

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -22,6 +22,7 @@ from .classifier import (
 )
 from .escalation import TIER_LADDER, EscalationDecision
 from .ocr import OCR_BATCH_PENDING_KEY
+from .source import DocumentSource
 
 logger = logging.getLogger(__name__)
 
@@ -468,7 +469,7 @@ class ProcessorRegistry:
         *,
         record: bool,
         filename: str | None = None,
-        source: Any | None = None,
+        source: DocumentSource | None = None,
     ) -> DocClassification | None:
         """Tier-0 classification of a parse result (text-only, cheap).
 
@@ -487,11 +488,20 @@ class ProcessorRegistry:
             # Scan detection feeds the OCR tier, so run it whenever OCR is enabled.
             if settings.document_ocr_enabled and settings.document_ocr_detect_scanned:
                 try:
-                    image_coverage = (
-                        image_coverage_per_page_from_path(str(source.path()))
-                        if source is not None
-                        else image_coverage_per_page(content)
-                    )
+                    # Pick the access that does no I/O for this source type:
+                    # a spooled document hands over its path for free, while an
+                    # in-memory one hands over its buffer for free. Calling
+                    # path() on an in-memory source would write the whole buffer
+                    # to disk -- and this runs synchronously on the event loop,
+                    # so that would stall every other in-flight document.
+                    if source is None:
+                        image_coverage = image_coverage_per_page(content)
+                    elif source.is_file_backed:
+                        image_coverage = image_coverage_per_page_from_path(
+                            str(source.path())
+                        )
+                    else:
+                        image_coverage = image_coverage_per_page(source.read_bytes())
                 except Exception:
                     # Best-effort: fall back to text-only signals. WARNING (not
                     # DEBUG) so a systematic scan-detection failure on an
@@ -588,7 +598,7 @@ class ProcessorRegistry:
 
     async def process_source(
         self,
-        source: Any,
+        source: DocumentSource,
         options: dict[str, Any] | None = None,
         progress_callback: (
             Callable[[float, float | None, str | None], Awaitable[None]] | None
@@ -628,7 +638,7 @@ class ProcessorRegistry:
 
     async def process_tier_source(
         self,
-        source: Any,
+        source: DocumentSource,
         tier: str,
         options: dict[str, Any] | None = None,
         progress_callback: (
@@ -702,7 +712,7 @@ class ProcessorRegistry:
     def evaluate_escalation_source(
         self,
         result: ProcessingResult,
-        source: Any,
+        source: DocumentSource,
         current_tier: str,
         settings: Any,
     ) -> EscalationDecision | None:
@@ -737,7 +747,7 @@ class ProcessorRegistry:
         settings: Any,
         *,
         filename: str | None = None,
-        source: Any | None = None,
+        source: DocumentSource | None = None,
     ) -> EscalationDecision | None:
         """Decide whether ``current_tier``'s result must escalate (external path).
 
@@ -814,7 +824,7 @@ class ProcessorRegistry:
     async def _run_processor_source(
         self,
         processor: DocumentProcessor,
-        source: Any,
+        source: DocumentSource,
         options: dict[str, Any] | None = None,
         progress_callback: (
             Callable[[float, float | None, str | None], Awaitable[None]] | None
@@ -846,7 +856,7 @@ class ProcessorRegistry:
         ) = None,
         *,
         escalated: bool = False,
-        source: Any | None = None,
+        source: DocumentSource | None = None,
     ) -> ProcessingResult:
         """Run one processor with the per-processor span + parse metrics.
 

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -167,7 +167,19 @@ async def resolve_path(source: DocumentSource) -> Path:
 
 @contextmanager
 def spool_target(spool_dir: str | None = None) -> Iterator[Path]:
-    """Yield a fresh spool path, removing it (and any partial file) on exit."""
+    """Yield a fresh spool path; the file is removed when the block exits.
+
+    **This block owns the file for its whole lifetime**, on success as well as
+    failure. That is deliberate and is the answer to the ownership question the
+    :meth:`DocumentProcessor.process_source` contract raises: rather than handing
+    a live path to a caller who must remember to unlink it, the document is
+    processed *inside* the block and the file cannot outlive it.
+
+    So do not return the path (or a :class:`SpooledDocumentSource` wrapping it)
+    out of the block expecting the file to still be there -- open a wider block
+    instead. ``vector.spool.spooled_document`` is the ingest-path wrapper that
+    does exactly that: it spans download, parse, embed and bbox extraction.
+    """
     directory = spool_dir or tempfile.gettempdir()
     fd, name = tempfile.mkstemp(prefix=SPOOL_PREFIX, suffix=".bin", dir=directory)
     os.close(fd)

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -132,6 +132,11 @@ class MemoryDocumentSource:
     content: bytes
     content_type: str
     filename: str | None = None
+    #: Where :meth:`path` materialises. Must be the same directory the worker
+    #: sweeps at startup, or an in-process cleanup missed by a SIGKILL leaves an
+    #: orphan nothing will ever collect -- and the buffered path's disk usage
+    #: escapes the volume the spool budget sizes. None = system temp dir.
+    spool_dir: str | None = None
     _materialised: Path | None = field(default=None, repr=False)
 
     @property
@@ -140,7 +145,11 @@ class MemoryDocumentSource:
 
     def path(self) -> Path:
         if self._materialised is None:
-            fd, name = tempfile.mkstemp(prefix=SPOOL_PREFIX, suffix=".bin")
+            fd, name = tempfile.mkstemp(
+                prefix=SPOOL_PREFIX,
+                suffix=".bin",
+                dir=self.spool_dir or tempfile.gettempdir(),
+            )
             with os.fdopen(fd, "wb") as fh:
                 fh.write(self.content)
             self._materialised = Path(name)

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -35,7 +35,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Iterator, Protocol, runtime_checkable
+from typing import IO, ClassVar, Iterator, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,12 @@ class DocumentSource(Protocol):
 
     content_type: str
     filename: str | None
+
+    #: True when the document already lives on disk, so :meth:`path` is a free
+    #: attribute read and :meth:`read_bytes` costs a full read. False when it is
+    #: already in memory, where the costs are reversed. Sync callers use this to
+    #: pick the access that does no I/O, rather than blocking the event loop.
+    is_file_backed: bool
 
     @property
     def size(self) -> int:
@@ -82,6 +88,8 @@ class DocumentSource(Protocol):
 @dataclass
 class SpooledDocumentSource:
     """A document streamed to a local file, removed by :meth:`cleanup`."""
+
+    is_file_backed: ClassVar[bool] = True
 
     spool_path: Path
     content_type: str
@@ -118,6 +126,8 @@ class MemoryDocumentSource:
     ``path()`` materialises a temp file only if something actually asks for one,
     so the common small-document case never touches the disk.
     """
+
+    is_file_backed: ClassVar[bool] = False
 
     content: bytes
     content_type: str

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -203,11 +203,16 @@ def spool_target(spool_dir: str | None = None) -> Iterator[Path]:
 def sweep_orphaned_spools(spool_dir: str | None = None) -> int:
     """Delete spool files left behind by a previous run; returns the count.
 
-    Intended for a worker's startup path: a SIGKILLed worker cannot run its own
-    cleanup, and the spool directory is an emptyDir that survives container
-    restarts within the pod, so a crash-looping worker would otherwise accumulate
-    whole documents on disk. NOT yet called anywhere -- it lands with the change
-    that wires streaming downloads into the ingest path.
+    Called from the worker's startup path (``cli._sweep_spools_at_startup``): a
+    SIGKILLed worker cannot run its own cleanup, and the spool directory
+    survives container restarts within the pod, so a crash-looping worker would
+    otherwise accumulate whole documents on disk.
+
+    Assumes the spool directory belongs to THIS worker. The glob has no liveness
+    check, so a directory shared between concurrently-running replicas would let
+    one worker's startup sweep unlink a peer's in-flight spool file. That holds
+    today (the default is an unshared per-pod temp dir) and must keep holding if
+    the volume becomes a PVC -- see Deck #693.
     """
     directory = Path(spool_dir or tempfile.gettempdir())
     removed = 0

--- a/nextcloud_mcp_server/search/pdf_highlighter.py
+++ b/nextcloud_mcp_server/search/pdf_highlighter.py
@@ -783,10 +783,11 @@ class PDFHighlighter:
 
     @staticmethod
     def compute_chunk_bboxes_batch(
-        pdf_bytes: bytes,
+        pdf_bytes: bytes | None,
         chunks: list[tuple[int, int, int, int | None, str]],
         page_boundaries: list[dict],
         full_text: str,
+        pdf_path: Path | None = None,
     ) -> dict[int, tuple[list[tuple[float, float, float, float]], int]]:
         """Compute normalized bounding boxes for chunks without rendering.
 
@@ -797,12 +798,15 @@ class PDFHighlighter:
         no PNG bytes are produced.
 
         Args:
-            pdf_bytes: PDF file bytes.
+            pdf_bytes: PDF file bytes. May be None when ``pdf_path`` is given.
             chunks: List of (chunk_index, start_offset, end_offset,
                 stored_page_number, chunk_text). chunk_index is the dict key.
             page_boundaries: Pre-computed page boundaries from the document
                 processor; each entry is {"page", "start_offset", "end_offset"}.
             full_text: Full document text (for cross-page chunk handling).
+            pdf_path: Path to the PDF, used in preference to ``pdf_bytes``. The
+                ingest path already has the document spooled on disk, so passing
+                the path skips writing a second copy of it to a temp file.
 
         Returns:
             dict mapping chunk_index to (normalized_bboxes, page_number).
@@ -818,11 +822,17 @@ class PDFHighlighter:
         temp_pdf_path = None
         doc = None
         try:
-            temp_dir = Path(tempfile.mkdtemp(prefix="pdf_bbox_batch_"))
-            temp_pdf_path = temp_dir / "pdf.pdf"
-            temp_pdf_path.write_bytes(pdf_bytes)
+            if pdf_path is not None:
+                source_path = pdf_path
+            else:
+                if pdf_bytes is None:
+                    raise ValueError("one of pdf_bytes or pdf_path is required")
+                temp_dir = Path(tempfile.mkdtemp(prefix="pdf_bbox_batch_"))
+                temp_pdf_path = temp_dir / "pdf.pdf"
+                temp_pdf_path.write_bytes(pdf_bytes)
+                source_path = temp_pdf_path
 
-            doc = pymupdf.open(temp_pdf_path)
+            doc = pymupdf.open(source_path)
 
             # Per-page (token, word) cache: get_text("words") + tokenisation is the
             # dominant per-page cost. Extract each page once and reuse it across all

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -20,10 +20,16 @@ if TYPE_CHECKING:
     from nextcloud_mcp_server.document_processors.base import ProcessingResult
     from nextcloud_mcp_server.document_processors.registry import ProcessorRegistry
 
+from contextlib import AsyncExitStack
+
 from nextcloud_mcp_server.acl_hash import compute_acl_hash
 from nextcloud_mcp_server.capabilities import allowed_doc_types, is_doc_type_allowed
 from nextcloud_mcp_server.client import NextcloudClient
 from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.document_processors.source import (
+    DocumentSource,
+    MemoryDocumentSource,
+)
 from nextcloud_mcp_server.embedding import get_bm25_service, get_embedding_service
 from nextcloud_mcp_server.models.deck import DeckCard
 from nextcloud_mcp_server.observability.metrics import (
@@ -77,6 +83,7 @@ from nextcloud_mcp_server.vector.sharing_state import (
     file_title_from_path,
     release_document_for_user,
 )
+from nextcloud_mcp_server.vector.spool import spooled_document
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +149,7 @@ def _is_pdf(content_type: str) -> bool:
 
 async def _parse_pdf_tier(
     registry: "ProcessorRegistry",
-    content: bytes,
-    content_type: str,
-    filename: str | None,
+    source: Any,
     tier: str,
     settings: Any,
     options: dict[str, Any] | None = None,
@@ -183,15 +188,12 @@ async def _parse_pdf_tier(
     # ``options`` threads per-document identity (user_id/doc_id/doc_type/etag) to
     # the OCR tier so batch mode can key its job-tracking table (Deck #332). Other
     # tiers ignore it. The inline path (registry.process) passes None.
-    result = await registry.process_tier(
-        content, content_type, filename, tier, options=options
-    )
+    filename = source.filename
+    result = await registry.process_tier_source(source, tier, options=options)
     if result.metadata.get(OCR_BATCH_PENDING_KEY):
         raise BatchPending(retry_in=int(result.metadata[OCR_BATCH_RETRY_IN_KEY]))
     if result.success:
-        decision = registry.evaluate_escalation(
-            result, content, tier, settings, filename=filename
-        )
+        decision = registry.evaluate_escalation_source(result, source, tier, settings)
         if decision is not None:
             if decision.kind == "suppressed":
                 # The ideal next tier (e.g. ocr) is disabled, so we do NOT hop:
@@ -333,6 +335,20 @@ def should_use_page_aware(
     return page_aware_enabled and doc_type == "file" and bool(page_boundaries)
 
 
+def _download_ceiling(settings: Any) -> int | None:
+    """Hard byte ceiling for a streamed download, or ``None`` when uncapped.
+
+    The pre-flight gate acts on the size the server advertised at scan time;
+    this acts on what actually arrives, so it still holds when Content-Length is
+    absent or wrong. Sized generously above the parse cap -- its job is to stop
+    a runaway transfer filling the spool volume, not to duplicate the cap.
+    """
+    max_pdf_mb = settings.document_max_pdf_size_mb
+    if not max_pdf_mb or max_pdf_mb <= 0:
+        return None
+    return int(max_pdf_mb * 1024 * 1024 * 2)
+
+
 def preflight_oversize_result(
     doc_task: Any, file_path: str | None, settings: Any
 ) -> Any:
@@ -371,17 +387,19 @@ def preflight_oversize_result(
     return result
 
 
-def ingested_byte_size(content_bytes: bytes | None, content: str) -> int:
+def ingested_byte_size(source_size: int | None, content: str) -> int:
     """Bytes ingested for one document (card #401).
 
-    Files carry their raw WebDAV binary in ``content_bytes`` — that raw size is
-    what the customer ingested. Text doc types (note, deck card, news item, mail
-    message) have no binary (``content_bytes is None``), so fall back to the
-    UTF-8 size of the extracted text. Selecting on ``content_bytes is not None``
-    (not ``doc_type``) keeps this correct for any future binary-backed type.
+    Files report the size of the raw WebDAV document — that is what the customer
+    ingested — which the caller reads off the document source rather than a
+    resident buffer, since a streamed document is never fully in memory. Text
+    doc types (note, deck card, news item, mail message) have no binary
+    (``source_size is None``), so fall back to the UTF-8 size of the extracted
+    text. Selecting on ``source_size is not None`` (not ``doc_type``) keeps this
+    correct for any future binary-backed type.
     """
-    if content_bytes is not None:
-        return len(content_bytes)
+    if source_size is not None:
+        return source_size
     return len(content.encode("utf-8"))
 
 
@@ -980,6 +998,29 @@ async def _index_document(
     *,
     tier: str | None = None,
 ) -> bool | None:
+    """Index a single document, owning any spooled download for its lifetime.
+
+    A streamed document lives in a spool file that must survive parse, chunking,
+    embedding and bbox extraction, then be removed however this call ends. The
+    exit stack scopes exactly that, so the file cannot outlive the document it
+    belongs to and no caller has to remember to unlink it (see
+    ``document_processors.source.spool_target``).
+    """
+    async with AsyncExitStack() as stack:
+        return await _index_document_inner(
+            doc_task, nc_client, qdrant_client, tier=tier, exit_stack=stack
+        )
+    return None  # pragma: no cover - AsyncExitStack never swallows here
+
+
+async def _index_document_inner(
+    doc_task: DocumentTask,
+    nc_client: NextcloudClient,
+    qdrant_client,
+    *,
+    tier: str | None,
+    exit_stack: AsyncExitStack,
+) -> bool | None:
     """
     Index a single document (called by process_document with retry).
 
@@ -1001,6 +1042,9 @@ async def _index_document(
     # from its scanned size; substituted for the parse result further down so the
     # existing terminal/dead-letter handling is reached unchanged.
     preflight_failure = None
+    # The document handle for files; None for text doc types (note, deck card,
+    # news item, mail message), which carry no binary.
+    source: DocumentSource | None = None
 
     # Fetch document content
     with trace_operation(
@@ -1273,20 +1317,35 @@ async def _index_document(
             # scanner already captured, so the download is never paid for. Falls
             # through to the post-download guard when the size is unknown.
             preflight_failure = preflight_oversize_result(doc_task, file_path, settings)
-            if preflight_failure is None:
-                # Read file content via WebDAV
+            if preflight_failure is not None:
+                content_bytes, content_type = b"", PDF_MIME_TYPE
+            elif settings.document_stream_download_enabled:
+                # Stream to a spool file: resident memory stays at one chunk
+                # instead of the whole document. The stack owns the file until
+                # this document is fully indexed.
+                source = await exit_stack.enter_async_context(
+                    spooled_document(
+                        nc_client,
+                        file_path,
+                        spool_dir=settings.document_spool_dir,
+                        max_bytes=_download_ceiling(settings),
+                    )
+                )
+                content_type = source.content_type
+                content_bytes = None
+            else:
+                # Buffered fallback (DOCUMENT_STREAM_DOWNLOAD_ENABLED=false).
                 content_bytes, content_type = await nc_client.webdav.read_file(
                     file_path
                 )
-            else:
-                content_bytes, content_type = b"", PDF_MIME_TYPE
+                source = MemoryDocumentSource(content_bytes, content_type, file_path)
         else:
             raise ValueError(f"Unsupported doc_type: {doc_task.doc_type}")
 
     # Process file content (text extraction)
     if doc_task.doc_type == "file":
-        # Type narrowing: content_bytes and content_type are set for files
-        assert content_bytes is not None
+        # Type narrowing: content_type/file_path are set for files. content_bytes
+        # is None on the streamed path -- the document lives in ``source``.
         assert content_type is not None
         assert file_path is not None
 
@@ -1296,7 +1355,9 @@ async def _index_document(
                 "vector_sync.content_type": content_type,
                 # The scanned size when known, so a document rejected before its
                 # download still reports its real size rather than 0.
-                "vector_sync.file_size": doc_task.size_bytes or len(content_bytes),
+                "vector_sync.file_size": (
+                    source.size if source is not None else (doc_task.size_bytes or 0)
+                ),
             },
         ):
             # The registry runs the tiered PDF pipeline and records
@@ -1341,19 +1402,13 @@ async def _index_document(
                     }
                     result = await _parse_pdf_tier(
                         registry,
-                        content_bytes,
-                        content_type,
-                        file_path,
+                        source,
                         tier,
                         settings,
                         options=doc_identity_options,
                     )
                 else:
-                    result = await registry.process(
-                        content=content_bytes,
-                        content_type=content_type,
-                        filename=file_path,
-                    )
+                    result = await registry.process_source(source)
 
                 # A permanent parse failure (e.g. an isolated-worker OOM/timeout
                 # on a pathological PDF) returns success=False rather than
@@ -1718,8 +1773,9 @@ async def _index_document(
         if not is_pdf:
             return
 
-        # Type narrowing: content_bytes is set for PDF files
-        assert content_bytes is not None
+        # The document is in ``source`` (streamed path) or ``content_bytes``
+        # (buffered fallback); both are set for PDF files.
+        assert source is not None
 
         # Lazy import (mirrors _parse_pdf_tier): keep the document stack off the
         # module load path; this runs only for PDFs on the indexing path.
@@ -1735,7 +1791,7 @@ async def _index_document(
             attributes={
                 _ATTR_CHUNK_COUNT: len(chunks),
                 "vector_sync.is_pdf": is_pdf,
-                "vector_sync.pdf_size": len(content_bytes),
+                "vector_sync.pdf_size": source.size,
             },
         ) as highlights_span:
 
@@ -1799,7 +1855,7 @@ async def _index_document(
                 "vector_sync.compute_chunk_bboxes",
                 attributes={
                     _ATTR_CHUNK_COUNT: len(chunks),
-                    "vector_sync.pdf_size": len(content_bytes),
+                    "vector_sync.pdf_size": source.size,
                 },
             ):
                 chunk_data: list[tuple[int, int, int, int | None, str]] = [
@@ -1835,7 +1891,8 @@ async def _index_document(
 
                     with pymupdf_serialized():
                         return PDFHighlighter.compute_chunk_bboxes_batch(
-                            pdf_bytes=content_bytes,
+                            pdf_bytes=None,
+                            pdf_path=source.path(),
                             chunks=chunk_data,
                             page_boundaries=page_boundaries_list,
                             full_text=content,
@@ -1910,7 +1967,7 @@ async def _index_document(
         # bytes_ingested: raw source size at ingestion (raw WebDAV binary for
         # files, UTF-8 text size for text doc types — note, deck_card,
         # news_item, mail_message). See helper.
-        bytes_ingested=ingested_byte_size(content_bytes, content),
+        bytes_ingested=ingested_byte_size(source.size if source else None, content),
         # bytes_stored: UTF-8 size of the chunk texts persisted as Qdrant payload
         # excerpts (includes chunk-overlap duplication).
         bytes_stored=sum(len(t.encode("utf-8")) for t in chunk_texts),
@@ -1925,7 +1982,7 @@ async def _index_document(
     # for text doc types). Computed once here and reused for both the ingest-time
     # density metric and the per-point payload (payload_keys.SOURCE_BYTES) so the
     # current-corpus density snapshot can recompute chunks-per-MB from Qdrant.
-    source_bytes = ingested_byte_size(content_bytes, content)
+    source_bytes = ingested_byte_size(source.size if source else None, content)
 
     # Observability-only cost signals (card #624), independent of USAGE_METERING.
     # Best-effort and self-contained in the helper so a metrics failure can never

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -149,7 +149,7 @@ def _is_pdf(content_type: str) -> bool:
 
 async def _parse_pdf_tier(
     registry: "ProcessorRegistry",
-    source: Any,
+    source: DocumentSource,
     tier: str,
     settings: Any,
     options: dict[str, Any] | None = None,
@@ -1339,6 +1339,12 @@ async def _index_document_inner(
                     file_path
                 )
                 source = MemoryDocumentSource(content_bytes, content_type, file_path)
+                # Same lifetime guarantee as the streamed branch. path() lazily
+                # materialises the buffer to a temp file -- both PDF engines and
+                # the bbox step call it -- so without this the kill-switch path
+                # leaks one file per document, which is the very failure mode the
+                # streaming side's exit-stack scoping exists to prevent.
+                exit_stack.callback(source.cleanup)
         else:
             raise ValueError(f"Unsupported doc_type: {doc_task.doc_type}")
 
@@ -1390,6 +1396,9 @@ async def _index_document_inner(
                     # size became known.
                     result = preflight_failure
                 elif tier is not None and _is_pdf(content_type):
+                    # Narrowing: the download branch above always sets ``source``
+                    # when it did not short-circuit on the pre-flight gate.
+                    assert source is not None
                     # Per-document identity, forwarded to every tier's processor.
                     # Only the OCR tier reads it (batch mode keys its job-tracking
                     # table on it, Deck #332); fast/structured ignore it, so it's
@@ -1408,6 +1417,7 @@ async def _index_document_inner(
                         options=doc_identity_options,
                     )
                 else:
+                    assert source is not None
                     result = await registry.process_source(source)
 
                 # A permanent parse failure (e.g. an isolated-worker OOM/timeout

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1338,7 +1338,12 @@ async def _index_document_inner(
                 content_bytes, content_type = await nc_client.webdav.read_file(
                     file_path
                 )
-                source = MemoryDocumentSource(content_bytes, content_type, file_path)
+                source = MemoryDocumentSource(
+                    content_bytes,
+                    content_type,
+                    file_path,
+                    spool_dir=settings.document_spool_dir,
+                )
                 # Same lifetime guarantee as the streamed branch. path() lazily
                 # materialises the buffer to a temp file -- both PDF engines and
                 # the bbox step call it -- so without this the kill-switch path

--- a/nextcloud_mcp_server/vector/spool.py
+++ b/nextcloud_mcp_server/vector/spool.py
@@ -1,0 +1,60 @@
+"""Spooled document downloads for the ingest path.
+
+``read_file`` buffers a whole WebDAV response, so peak memory scaled with
+document size: a 531 MB PDF OOMKilled a fast-tier worker mid-download, before
+its size was ever evaluated. Streaming the body to a local file instead keeps
+resident memory at one chunk regardless of how large the document is.
+
+Lives in ``vector`` rather than ``document_processors`` because it needs the
+Nextcloud client, and ``document_processors`` must not import ``vector`` (see
+the layering note in ``document_processors/escalation.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from nextcloud_mcp_server.document_processors.source import (
+    SpooledDocumentSource,
+    spool_target,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def spooled_document(
+    nc_client: Any,
+    file_path: str,
+    *,
+    spool_dir: str | None = None,
+    max_bytes: int | None = None,
+) -> AsyncIterator[SpooledDocumentSource]:
+    """Stream ``file_path`` to a spool file and yield it as a document source.
+
+    The block owns the spool for its whole duration and removes it on exit,
+    success or failure. Callers must therefore keep everything that touches the
+    document -- parse, chunking, embedding, bbox extraction -- inside the block;
+    nothing may hold the path afterwards.
+
+    ``max_bytes`` aborts the transfer once the limit is exceeded. This is the
+    guard that still holds when ``Content-Length`` is absent or untrue: the
+    pre-flight size gate can only act on what the server advertised at scan
+    time, whereas this acts on what actually arrives.
+    """
+    with spool_target(spool_dir) as target:
+        written, content_type = await nc_client.webdav.stream_to_file(
+            file_path, target, max_bytes=max_bytes
+        )
+        logger.debug(
+            "Spooled %s to %s (%s bytes, %s)", file_path, target, written, content_type
+        )
+        yield SpooledDocumentSource(
+            spool_path=target,
+            content_type=content_type,
+            filename=file_path,
+            _size=written,
+        )

--- a/nextcloud_mcp_server/vector/spool.py
+++ b/nextcloud_mcp_server/vector/spool.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def spooled_document(
-    nc_client: Any,
+    nc_client: Any,  # NextcloudClient; typed loosely to avoid a client import
     file_path: str,
     *,
     spool_dir: str | None = None,

--- a/tests/unit/test_cli_worker_concurrency.py
+++ b/tests/unit/test_cli_worker_concurrency.py
@@ -7,6 +7,8 @@ explicit ``--concurrency`` (the chart's per-tier arg) > per-tier setting overrid
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from nextcloud_mcp_server.cli import _resolve_worker_concurrency
@@ -42,3 +44,41 @@ def test_zero_override_never_yields_zero():
     # A bogus 0 must fall through, not run the worker with concurrency=0.
     assert _resolve(tier="fast", fast=0, default=3) == 3
     assert _resolve(cli=0, tier="fast", fast=4, default=3) == 4
+
+
+# --- startup spool sweep ------------------------------------------------------
+# A SIGKILLed worker cannot clean up its own spool files, and the spool dir is an
+# emptyDir that survives container restarts within the pod, so without this a
+# crash-looping worker fills the volume with whole documents.
+
+
+def test_startup_sweep_runs_when_streaming_is_enabled(mocker, tmp_path):
+    from nextcloud_mcp_server import cli
+
+    sweep = mocker.patch(
+        "nextcloud_mcp_server.document_processors.source.sweep_orphaned_spools",
+        return_value=3,
+    )
+    settings = SimpleNamespace(
+        document_stream_download_enabled=True,
+        document_spool_dir=str(tmp_path),
+    )
+
+    assert cli._sweep_spools_at_startup(settings) == 3
+    sweep.assert_called_once_with(str(tmp_path))
+
+
+def test_startup_sweep_skipped_when_streaming_is_disabled(mocker):
+    """Nothing spools on the buffered path, so there is nothing to sweep."""
+    from nextcloud_mcp_server import cli
+
+    sweep = mocker.patch(
+        "nextcloud_mcp_server.document_processors.source.sweep_orphaned_spools"
+    )
+    settings = SimpleNamespace(
+        document_stream_download_enabled=False,
+        document_spool_dir=None,
+    )
+
+    assert cli._sweep_spools_at_startup(settings) == 0
+    sweep.assert_not_called()

--- a/tests/unit/test_document_source.py
+++ b/tests/unit/test_document_source.py
@@ -133,3 +133,32 @@ def test_memory_source_free_access_does_not_touch_disk():
 
     assert source.read_bytes() == b"hello"
     assert source._materialised is None
+
+
+def test_memory_source_materialises_into_the_configured_spool_dir(tmp_path):
+    """Both source types must land in the directory the worker actually sweeps.
+
+    The startup sweep only globs ``document_spool_dir``. If an in-memory source
+    materialised to the system temp dir instead, a SIGKILL on the buffered path
+    would leave an orphan nothing ever collects -- and that disk usage would sit
+    outside the volume the spool budget sizes.
+    """
+    source = MemoryDocumentSource(b"hello", "text/plain", spool_dir=str(tmp_path))
+    try:
+        path = source.path()
+        assert path.parent == tmp_path
+        assert path.name.startswith(SPOOL_PREFIX)
+        # ...and therefore the sweep can actually find it.
+        assert sweep_orphaned_spools(str(tmp_path)) == 1
+    finally:
+        source.cleanup()
+
+
+def test_memory_source_defaults_to_the_system_temp_dir():
+    import tempfile as _tempfile
+
+    source = MemoryDocumentSource(b"hello", "text/plain")
+    try:
+        assert source.path().parent == Path(_tempfile.gettempdir())
+    finally:
+        source.cleanup()

--- a/tests/unit/test_document_source.py
+++ b/tests/unit/test_document_source.py
@@ -111,3 +111,25 @@ def test_sweep_removes_orphans_but_leaves_other_files(tmp_path):
 
 def test_sweep_on_empty_directory_is_a_noop(tmp_path):
     assert sweep_orphaned_spools(str(tmp_path)) == 0
+
+
+def test_is_file_backed_distinguishes_the_two_sources(tmp_path):
+    """Sync callers use this to pick the access that does no I/O.
+
+    A spooled source hands over its path for free; an in-memory one hands over
+    its buffer for free. Choosing wrong means a blocking whole-buffer disk write
+    on the shared event loop (registry._classify_result is a plain def).
+    """
+    spooled = _spooled(tmp_path)
+    memory = MemoryDocumentSource(b"hello", "text/plain")
+
+    assert spooled.is_file_backed is True
+    assert memory.is_file_backed is False
+
+
+def test_memory_source_free_access_does_not_touch_disk():
+    """read_bytes on an in-memory source must not materialise anything."""
+    source = MemoryDocumentSource(b"hello", "text/plain")
+
+    assert source.read_bytes() == b"hello"
+    assert source._materialised is None

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -44,16 +44,18 @@ def _events(store_spy):
 
 @pytest.mark.unit
 def test_ingested_byte_size_files_use_raw_binary():
-    """A file's bytes_ingested is its raw binary size, not the text size."""
-    # Raw bytes longer than the decoded text would suggest (e.g. PDF overhead):
-    # the helper must report the binary length, ignoring `content`.
-    raw = b"%PDF-1.7 ...binary..." + b"\x00" * 500
-    assert processor.ingested_byte_size(raw, "short extracted text") == len(raw)
+    """A file's bytes_ingested is its raw binary size, not the text size.
+
+    Takes the size rather than the bytes: a streamed document is never fully
+    resident, so the caller reads it off the document source.
+    """
+    raw_size = len(b"%PDF-1.7 ...binary..." + b"\x00" * 500)
+    assert processor.ingested_byte_size(raw_size, "short extracted text") == raw_size
 
 
 @pytest.mark.unit
 def test_ingested_byte_size_text_uses_utf8_length():
-    """Text doc types (content_bytes=None) fall back to UTF-8 byte length."""
+    """Text doc types (no source size) fall back to UTF-8 byte length."""
     # Multibyte char: 1 code point, 2 UTF-8 bytes — len(str) would undercount.
     text = "café"
     assert processor.ingested_byte_size(None, text) == len(text.encode("utf-8"))

--- a/tests/unit/vector/test_parse_pdf_tier.py
+++ b/tests/unit/vector/test_parse_pdf_tier.py
@@ -117,10 +117,11 @@ async def test_ocr_batch_pending_sentinel_raises_batch_pending():
         success=False,
     )
     reg = _registry(result, decision=None)
+    source = _source(filename="scan.pdf")
+    settings = object()
+
     with pytest.raises(BatchPending) as ei:
-        await processor._parse_pdf_tier(
-            reg, _source(filename="scan.pdf"), "ocr", settings=object()
-        )
+        await processor._parse_pdf_tier(reg, source, "ocr", settings=settings)
     assert ei.value.retry_in == 90
     reg.evaluate_escalation_source.assert_not_called()
 

--- a/tests/unit/vector/test_parse_pdf_tier.py
+++ b/tests/unit/vector/test_parse_pdf_tier.py
@@ -20,10 +20,17 @@ from nextcloud_mcp_server.vector import processor
 pytestmark = pytest.mark.unit
 
 
+def _source(content: bytes = b"%PDF", filename: str = "f.pdf"):
+    """A file-backed handle standing in for a spooled download."""
+    from nextcloud_mcp_server.document_processors.source import MemoryDocumentSource
+
+    return MemoryDocumentSource(content, "application/pdf", filename)
+
+
 def _registry(result: ProcessingResult, decision):
     reg = MagicMock()
-    reg.process_tier = AsyncMock(return_value=result)
-    reg.evaluate_escalation = MagicMock(return_value=decision)
+    reg.process_tier_source = AsyncMock(return_value=result)
+    reg.evaluate_escalation_source = MagicMock(return_value=decision)
     return reg
 
 
@@ -34,9 +41,7 @@ async def test_good_parse_returns_result(monkeypatch):
     monkeypatch.setattr(processor, "record_document_escalation_suppressed", sup)
     result = ProcessingResult(text="clean", metadata={}, processor="fast")
     reg = _registry(result, decision=None)
-    out = await processor._parse_pdf_tier(
-        reg, b"%PDF", "application/pdf", "f.pdf", "fast", settings=object()
-    )
+    out = await processor._parse_pdf_tier(reg, _source(), "fast", settings=object())
     assert out is result
     rec.assert_not_called()
     sup.assert_not_called()
@@ -48,9 +53,7 @@ async def test_low_quality_parse_raises_escalate(monkeypatch):
     result = ProcessingResult(text="", metadata={}, processor="fast")
     reg = _registry(result, decision=EscalationDecision("hop", "ocr", "empty_text"))
     with pytest.raises(EscalateError) as ei:
-        await processor._parse_pdf_tier(
-            reg, b"%PDF", "application/pdf", "f.pdf", "fast", settings=object()
-        )
+        await processor._parse_pdf_tier(reg, _source(), "fast", settings=object())
     assert ei.value.from_tier == "fast"
     assert ei.value.to_tier == "ocr"
     assert ei.value.reason == "empty_text"
@@ -69,9 +72,7 @@ async def test_suppressed_decision_indexes_without_hop(monkeypatch):
     reg = _registry(
         result, decision=EscalationDecision("suppressed", "ocr", "empty_text")
     )
-    out = await processor._parse_pdf_tier(
-        reg, b"%PDF", "application/pdf", "f.pdf", "fast", settings=object()
-    )
+    out = await processor._parse_pdf_tier(reg, _source(), "fast", settings=object())
     assert out is result  # indexed as terminal, no hop
     sup.assert_called_once_with("fast", "ocr", "empty_text")
     rec.assert_not_called()
@@ -90,11 +91,11 @@ async def test_hard_failure_returns_result_without_escalating(monkeypatch):
     )
     reg = _registry(result, decision=EscalationDecision("hop", "ocr", "empty_text"))
     out = await processor._parse_pdf_tier(
-        reg, b"%PDF", "application/pdf", "big.pdf", "fast", settings=object()
+        reg, _source(filename="big.pdf"), "fast", settings=object()
     )
     # success=False short-circuits: the gate is never consulted, no escalation.
     assert out is result
-    reg.evaluate_escalation.assert_not_called()
+    reg.evaluate_escalation_source.assert_not_called()
     rec.assert_not_called()
     sup.assert_not_called()
 
@@ -118,10 +119,10 @@ async def test_ocr_batch_pending_sentinel_raises_batch_pending():
     reg = _registry(result, decision=None)
     with pytest.raises(BatchPending) as ei:
         await processor._parse_pdf_tier(
-            reg, b"%PDF", "application/pdf", "scan.pdf", "ocr", settings=object()
+            reg, _source(filename="scan.pdf"), "ocr", settings=object()
         )
     assert ei.value.retry_in == 90
-    reg.evaluate_escalation.assert_not_called()
+    reg.evaluate_escalation_source.assert_not_called()
 
 
 async def test_options_threaded_to_process_tier():
@@ -130,7 +131,7 @@ async def test_options_threaded_to_process_tier():
     reg = _registry(result, decision=None)
     opts = {"user_id": "u", "doc_id": "d", "doc_type": "file", "etag": "v"}
     await processor._parse_pdf_tier(
-        reg, b"%PDF", "application/pdf", "f.pdf", "ocr", settings=object(), options=opts
+        reg, _source(), "ocr", settings=object(), options=opts
     )
-    # process_tier(content, content_type, filename, tier, options=...)
-    assert reg.process_tier.await_args.kwargs["options"] == opts
+    # process_tier_source(source, tier, options=...)
+    assert reg.process_tier_source.await_args.kwargs["options"] == opts

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -449,3 +449,38 @@ async def test_batch_ocr_no_pending_job_still_downloads(mocker):
         await processor._index_document(_file_task(), nc, MagicMock(), tier="ocr")
 
     nc.webdav.read_file.assert_awaited_once()  # no in-flight job -> fetched normally
+
+
+async def test_buffered_fallback_cleans_up_its_temp_file(mocker):
+    """DOCUMENT_STREAM_DOWNLOAD_ENABLED=false must not leak a file per document.
+
+    MemoryDocumentSource.path() lazily materialises the buffer to a temp file --
+    both PDF engines reach it via resolve_path, and the bbox step calls it
+    directly -- so the kill-switch path registers cleanup on the exit stack.
+    Without that, every PDF ingested with streaming disabled leaked one file.
+
+    The parse stub calls path() the way a real engine does, so this fails if the
+    cleanup registration is dropped.
+    """
+    _patch_common(mocker, ocr_enabled=False)
+    materialised: list = []
+
+    async def _parse(registry, source, tier, settings, options=None):
+        materialised.append(source.path())  # what a real PDF engine does
+        return ProcessingResult(
+            text="",
+            metadata={"parse_failed_reason": "error", "pipeline_tier": "structured"},
+            processor="pypdfium2_fast",
+            success=False,
+            error="boom",
+        )
+
+    mocker.patch.object(processor, "_parse_pdf_tier", _parse)
+
+    await processor._index_document(
+        _file_task(), _nc_client(), MagicMock(), tier="structured"
+    )
+
+    assert materialised, "the parse stub should have materialised the source"
+    for path in materialised:
+        assert not path.exists(), f"leaked temp file for the buffered path: {path}"

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import anyio
 import pytest
 
 from nextcloud_mcp_server.document_processors.base import ProcessingResult
@@ -466,6 +467,9 @@ async def test_buffered_fallback_cleans_up_its_temp_file(mocker):
     materialised: list = []
 
     async def _parse(registry, source, tier, settings, options=None):
+        # async because it stands in for _parse_pdf_tier; the checkpoint keeps
+        # that explicit rather than leaving a bare `async def` with no await.
+        await anyio.lowlevel.checkpoint()
         materialised.append(source.path())  # what a real PDF engine does
         return ProcessingResult(
             text="",

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -38,6 +38,9 @@ def _settings(*, ocr_enabled: bool) -> SimpleNamespace:
         # skip-redownload guard in process_document inert on these non-batch paths.
         document_ocr_mode="sync",
         document_tier1_engine="pypdfium2",
+        # Buffered path keeps these unit tests on the mocked read_file seam.
+        document_stream_download_enabled=False,
+        document_spool_dir=None,
         # Part of escalation_tiers_signature: raising the cap re-drives
         # previously oversize-dead-lettered documents.
         document_max_pdf_size_mb=50.0,

--- a/tests/unit/vector/test_spooled_document.py
+++ b/tests/unit/vector/test_spooled_document.py
@@ -81,8 +81,10 @@ async def test_spool_is_removed_when_the_download_raises(tmp_path):
     nc.webdav.stream_to_file = AsyncMock(side_effect=OSError("connection reset"))
 
     entered = False
+    manager = spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path))
+
     with pytest.raises(OSError):
-        async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)):
+        async with manager:
             entered = True
 
     assert not entered, "the body must not run when the download fails"

--- a/tests/unit/vector/test_spooled_document.py
+++ b/tests/unit/vector/test_spooled_document.py
@@ -1,0 +1,99 @@
+"""Unit tests for the spooled ingest download.
+
+``spooled_document`` is what keeps peak memory off the document size: the body
+is streamed to a file and the ingest path reads it by path. The properties worth
+pinning are the ones that make that safe -- the spool is removed however the
+block ends, and the yielded source describes the document that actually arrived.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nextcloud_mcp_server.vector.spool import spooled_document
+
+pytestmark = pytest.mark.unit
+
+
+def _nc_client(
+    body: bytes = b"%PDF-1.7 spooled", content_type: str = "application/pdf"
+):
+    """A client whose stream_to_file writes ``body`` to the destination."""
+    nc = MagicMock()
+
+    async def _stream_to_file(path, dest: Path, *, max_bytes=None):
+        dest.write_bytes(body)
+        return len(body), content_type
+
+    nc.webdav.stream_to_file = AsyncMock(side_effect=_stream_to_file)
+    return nc
+
+
+async def test_yields_a_source_backed_by_the_spool_file(tmp_path):
+    body = b"%PDF-1.7" + b"x" * 200
+    nc = _nc_client(body)
+
+    async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)) as source:
+        assert source.path().exists()
+        assert source.path().read_bytes() == body
+        assert source.size == len(body)
+        assert source.content_type == "application/pdf"
+        assert source.filename == "/f.pdf"
+
+
+async def test_spool_is_removed_on_success(tmp_path):
+    nc = _nc_client()
+
+    async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)) as source:
+        spooled = source.path()
+        assert spooled.exists()
+
+    assert not spooled.exists(), "the block owns the spool and must clean it up"
+
+
+async def test_spool_is_removed_when_the_body_raises(tmp_path):
+    """A failure mid-processing must not leak a whole document onto disk."""
+    nc = _nc_client()
+    spooled: Path | None = None
+
+    with pytest.raises(RuntimeError):
+        async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)) as source:
+            spooled = source.path()
+            raise RuntimeError("parse blew up")
+
+    assert spooled is not None
+    assert not spooled.exists()
+
+
+async def test_spool_is_removed_when_the_download_raises(tmp_path):
+    nc = MagicMock()
+    nc.webdav.stream_to_file = AsyncMock(side_effect=OSError("connection reset"))
+
+    with pytest.raises(OSError):
+        async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)):
+            pass
+
+    assert list(tmp_path.iterdir()) == [], "no spool file may survive a failed download"
+
+
+async def test_max_bytes_is_forwarded_to_the_client(tmp_path):
+    """The ceiling must reach the transport -- it is the guard that still holds
+    when Content-Length is absent or wrong."""
+    nc = _nc_client()
+
+    async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path), max_bytes=4096):
+        pass
+
+    assert nc.webdav.stream_to_file.await_args.kwargs["max_bytes"] == 4096
+
+
+async def test_size_comes_from_bytes_written_not_a_stat(tmp_path):
+    """The source reports what actually arrived."""
+    body = b"x" * 321
+    nc = _nc_client(body)
+
+    async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)) as source:
+        assert source.size == 321

--- a/tests/unit/vector/test_spooled_document.py
+++ b/tests/unit/vector/test_spooled_document.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import anyio
 import pytest
 
 from nextcloud_mcp_server.vector.spool import spooled_document
@@ -25,6 +26,9 @@ def _nc_client(
     nc = MagicMock()
 
     async def _stream_to_file(path, dest: Path, *, max_bytes=None):
+        # async because AsyncMock drives it; the checkpoint makes that explicit
+        # rather than leaving a bare `async def` with no await in it.
+        await anyio.lowlevel.checkpoint()
         dest.write_bytes(body)
         return len(body), content_type
 
@@ -57,14 +61,18 @@ async def test_spool_is_removed_on_success(tmp_path):
 async def test_spool_is_removed_when_the_body_raises(tmp_path):
     """A failure mid-processing must not leak a whole document onto disk."""
     nc = _nc_client()
-    spooled: Path | None = None
+    manager = spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path))
+    source = await manager.__aenter__()
+    spooled = source.path()
+    assert spooled.exists()
 
-    with pytest.raises(RuntimeError):
-        async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)) as source:
-            spooled = source.path()
-            raise RuntimeError("parse blew up")
+    # Simulate the parse/embed step blowing up part-way through. __aexit__
+    # returns False ("not suppressed") rather than re-raising -- the `async with`
+    # statement is what re-raises -- so assert on that plus the cleanup.
+    exc = RuntimeError("parse blew up")
+    suppressed = await manager.__aexit__(RuntimeError, exc, exc.__traceback__)
 
-    assert spooled is not None
+    assert not suppressed, "the failure must propagate to the caller"
     assert not spooled.exists()
 
 
@@ -72,10 +80,12 @@ async def test_spool_is_removed_when_the_download_raises(tmp_path):
     nc = MagicMock()
     nc.webdav.stream_to_file = AsyncMock(side_effect=OSError("connection reset"))
 
+    entered = False
     with pytest.raises(OSError):
         async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path)):
-            pass
+            entered = True
 
+    assert not entered, "the body must not run when the download fails"
     assert list(tmp_path.iterdir()) == [], "no spool file may survive a failed download"
 
 
@@ -84,8 +94,10 @@ async def test_max_bytes_is_forwarded_to_the_client(tmp_path):
     when Content-Length is absent or wrong."""
     nc = _nc_client()
 
-    async with spooled_document(nc, "/f.pdf", spool_dir=str(tmp_path), max_bytes=4096):
-        pass
+    async with spooled_document(
+        nc, "/f.pdf", spool_dir=str(tmp_path), max_bytes=4096
+    ) as source:
+        assert source.path().exists()
 
     assert nc.webdav.stream_to_file.await_args.kwargs["max_bytes"] == 4096
 


### PR DESCRIPTION
## Why

Follow-up to #1108, which bounded the **parse** side (page-windowed extraction, 1935 MB → 85 MB) and added `stream_to_file` plus the `DocumentSource` contract — but deliberately left the **download** buffered. `vector/processor.py` still called `read_file`, so a 1040 MB document cost ~1.1 GB resident before a page was read. This wires the two halves together.

Deck card #692.

## Measurements

Real 1040 MB / 4003-page tenant document, fast tier, byte-identical output (4,878,424 chars):

| | after fetch | peak RSS |
|---|---|---|
| buffered bytes (today) | 1132.9 MB | 1209.5 MB |
| spooled path (this PR) | **97.9 MB** | **183.6 MB** |

End to end, that document has gone **3072 MB** (over the 3 GiB pod limit — the original OOM) → ~1230 MB after #1108 → **184 MB** now.

## How it fits together

- **`vector/spool.py`** — `spooled_document()` streams the body to a spool file and yields a `SpooledDocumentSource`. It lives in `vector/` because it needs the Nextcloud client, and `document_processors` must not import `vector`.
- **`_index_document` now scopes an `AsyncExitStack`** and delegates to `_index_document_inner`, so the spool survives parse → chunk → embed → bbox and is removed however the call ends. This is the answer to the ownership question raised in #1108 review round 4: the file cannot outlive its document, and no caller has to remember to unlink it.
- **Registry source-based twins** (`process_source`, `process_tier_source`, `_run_processor_source`, `evaluate_escalation_source`), with the bytes forms kept as adapters so `server/webdav.py` and the inline pipeline are untouched. `_run_processor` is parameterised rather than duplicated — the instrumentation is identical either way.
- **Scan detection reads by path** (`image_coverage_per_page_from_path`), so a large scan isn't materialised purely to classify it.
- **`compute_chunk_bboxes_batch` accepts `pdf_path`** and skips its own `mkdtemp` + `write_bytes` when given one. The ingest path already has the document on disk, so this *removes* a copy.
- **`ingested_byte_size` takes the size**, not the bytes — a streamed document is never fully resident.
- **`DOCUMENT_STREAM_DOWNLOAD_ENABLED`** (default true) falls back to the buffered path without a revert; **`DOCUMENT_SPOOL_DIR`** selects the spool volume.
- **Startup sweep** for orphaned spools: a SIGKILLed worker can't clean up, and the spool dir is an emptyDir that survives container restarts, so a crash-looping worker would otherwise fill the volume with whole documents.

Also closes both round-4 notes from #1108: `spool_target`'s ownership is now documented *and* demonstrated by `spooled_document`, and `_stream_request` records its API-call metric in a `finally` so a failure raised by the caller's body loop (`OversizeDownload`, or the short-read `RemoteProtocolError`) is no longer missed entirely.

## Known interim

`registry.process_source` **materialises for PDFs**, because the inline tiered pipeline (`_process_pdf`) is still bytes-based. That path is the escalation-disabled in-process pool, not the per-tier worker fleet production runs, so the win lands where it matters first. Flagged with a `TODO` in the code.

## Not in this PR

Spool **disk** budget and the pod `ephemeral-storage` / emptyDir `sizeLimit` sizing (Deck #693) — memory pressure has moved to disk, and nothing bounds it yet. That is the co-requisite before this reaches a cluster with a raised cap. Also still open: fast-tier subprocess isolation (#694), the cap raise itself (#695), and OCR for large scans (#697).

## Verification

`ruff`, `ty` and the full unit suite (**2255 passing**) green. New coverage: `spooled_document` lifecycle (cleanup on success, on a processing failure, and on a failed download), `max_bytes` forwarding, and size-from-bytes-written. Existing suites updated for the new signatures rather than worked around.

Not yet verified end-to-end against a running stack — the tenant canary in the plan still applies, and the disk-budget card should land first.

---

_This PR was generated with the help of AI, and reviewed by a Human_
