### PR TITLE
fix(ingest): gate markdown reconstruction on page count

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -681,6 +681,7 @@ DOCUMENT_OCR_TIMEOUT_SECONDS=180      # OCR backend request timeout (default: 18
 DOCUMENT_MAX_PDF_SIZE_MB=50           # Pre-parse size cap; 0 disables (default: 50)
 DOCUMENT_PARSE_PAGE_WINDOW=100        # Pages per extraction window; 0 disables (default: 100)
 DOCUMENT_PARSE_PROCESS_SLOTS=2        # Concurrent isolated parse subprocesses (default: 2)
+DOCUMENT_MARKDOWN_MAX_PAGES=150       # Structured-tier markdown page ceiling; <=0 disables markdown (default: 150)
 ```
 
 `DOCUMENT_PARSE_PROCESS_SLOTS` bounds how many isolated parse subprocesses run at
@@ -723,6 +724,56 @@ sum(rate(astrolabe_document_ingest_rejected_total{reason="oversize"}[1h]))
 > letters for the tenant, not just oversize ones, so genuinely corrupt files are
 > re-attempted once too. On a large tenant that is a thundering herd — roll the
 > change out one tenant at a time and watch ingest queue depth.
+
+#### Markdown page ceiling (structured tier)
+
+`DOCUMENT_MARKDOWN_MAX_PAGES` bounds the **structured** tier. Above it, the tier
+skips `pymupdf4llm.to_markdown` and returns the raw text layer instead; `<=0`
+disables markdown entirely.
+
+`to_markdown` is **superlinear in page count** — the per-page rate itself grows
+with document size. Measured across an 866-file corpus of scanned documents:
+
+| Pages | to_markdown | Whole document |
+|---|---|---|
+| 22–31 | 0.48–1.48 s/page | 13–33 s |
+| 136–158 | 0.60–0.94 s/page | 95–149 s |
+| 364–419 | 0.91–1.06 s/page | 331–444 s |
+| 1111–1898 | 1.48–3.11 s/page | 27–98 min |
+| 4003 | 5.92 s/page | **6.6 hours** |
+
+Raw `get_text` is ~4.5 ms/page and flat. On that corpus it recovered 116,375 of
+the 145,199 characters markdown produced — markdown's value is structure, not
+completeness.
+
+Without a ceiling, a large document burns the whole
+`DOCUMENT_PARSE_TIMEOUT_SECONDS` and then dead-letters `reason="timeout"`,
+discarding a text layer that was extractable in under a second.
+
+The gate is expressed in **pages rather than predicted seconds** deliberately:
+seconds depend on node CPU, so a seconds-based threshold drifts silently between
+node types and needs recalibration, while a page count is deterministic and
+reviewable. Pick it from the tier's real budget — at ~1 s/page on a throttled
+2-core pod, a 120 s timeout is roughly 120 pages.
+
+Above the ceiling no images are written either, since markdown reconstruction is
+what emits them — so `has_images` is `False` for a gated document even when the
+processor was constructed with `extract_images=True`.
+
+Which path ran is exported on `astrolabe_document_parse_mode_total{mode}`
+(`markdown` | `text_only`) and recorded on the result as `parse_mode`. Skipping
+markdown is a **successful** parse, so it is deliberately not counted as a parse
+failure:
+
+```promql
+sum by (mode) (rate(astrolabe_document_parse_mode_total[1h]))
+```
+
+> **Changing `DOCUMENT_MARKDOWN_MAX_PAGES` also re-drives dead letters.** Like
+> the size cap it is part of the escalation-tier signature: lowering it lets a
+> previously-timing-out document take the raw-text path and succeed, so the
+> documents dead-lettered under the old value must become retryable. The same
+> thundering-herd caveat applies.
 
 `DOCUMENT_PARSE_PAGE_WINDOW` bounds the **fast** tier's peak memory. PDFium keeps
 parsed page objects for the lifetime of the open document and `page.close()` does

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -681,7 +681,7 @@ DOCUMENT_OCR_TIMEOUT_SECONDS=180      # OCR backend request timeout (default: 18
 DOCUMENT_MAX_PDF_SIZE_MB=50           # Pre-parse size cap; 0 disables (default: 50)
 DOCUMENT_PARSE_PAGE_WINDOW=100        # Pages per extraction window; 0 disables (default: 100)
 DOCUMENT_PARSE_PROCESS_SLOTS=2        # Concurrent isolated parse subprocesses (default: 2)
-DOCUMENT_MARKDOWN_MAX_PAGES=150       # Structured-tier markdown page ceiling; <=0 disables markdown (default: 150)
+DOCUMENT_MARKDOWN_MAX_PAGES=150       # Structured-tier markdown page ceiling; 0 disables markdown (default: 150)
 ```
 
 `DOCUMENT_PARSE_PROCESS_SLOTS` bounds how many isolated parse subprocesses run at
@@ -728,8 +728,9 @@ sum(rate(astrolabe_document_ingest_rejected_total{reason="oversize"}[1h]))
 #### Markdown page ceiling (structured tier)
 
 `DOCUMENT_MARKDOWN_MAX_PAGES` bounds the **structured** tier. Above it, the tier
-skips `pymupdf4llm.to_markdown` and returns the raw text layer instead; `<=0`
-disables markdown entirely.
+skips `pymupdf4llm.to_markdown` and returns the raw text layer instead; `0`
+disables markdown entirely. A negative value is rejected at startup, so a typo
+cannot quietly turn markdown off across the fleet.
 
 `to_markdown` is **superlinear in page count** — the per-page rate itself grows
 with document size. Measured across an 866-file corpus of scanned documents:

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -543,6 +543,10 @@ _dynaconf = Dynaconf(
         Validator("DOCUMENT_MAX_PDF_SIZE_MB", gte=0),
         # 0 disables page-windowed extraction; otherwise it must be positive.
         Validator("DOCUMENT_PARSE_PAGE_WINDOW", gte=0),
+        # 0 disables markdown reconstruction; otherwise it must be positive. A
+        # negative value must fail fast rather than silently disable markdown
+        # fleet-wide -- the same silent-disarm class this setting exists to fix.
+        Validator("DOCUMENT_MARKDOWN_MAX_PAGES", gte=0),
         # At least one parse must be able to run.
         Validator("DOCUMENT_PARSE_PROCESS_SLOTS", gte=1),
         # >=1: pymupdf4llm treats graphics_limit=0 as "no cap", which would
@@ -1148,9 +1152,11 @@ class Settings:
     # the OCR timeout for 0 chars. 0 disables the guard.
     document_max_pdf_size_mb: float = 50.0
     # Page ceiling above which the structured tier skips pymupdf4llm.to_markdown
-    # and returns the raw text layer instead. <=0 disables markdown entirely
+    # and returns the raw text layer instead. 0 disables markdown entirely
     # (every document takes the raw-text path), matching how
-    # document_max_pdf_size_mb treats 0 as "guard off".
+    # document_max_pdf_size_mb treats 0 as "guard off"; a NEGATIVE value is
+    # rejected at startup by the DOCUMENT_MARKDOWN_MAX_PAGES validator, so a
+    # typo cannot silently turn markdown off everywhere.
     #
     # to_markdown is SUPERLINEAR in page count -- the per-page rate itself grows
     # with document size. Measured across a 866-file scanned corpus: 0.48-1.48

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -211,6 +211,8 @@ _DEFAULTS: dict[str, Any] = {
     # "oversize" instead of burning the OCR timeout to 0 chars on a pathological
     # file. 0 disables the guard.
     "document_max_pdf_size_mb": 50.0,
+    # Page ceiling for markdown reconstruction (see document_markdown_max_pages).
+    "document_markdown_max_pages": 150,
     # Pages per pypdfium2 extraction window (see document_parse_page_window).
     "document_parse_page_window": 100,
     # Concurrent isolated parse subprocesses (see document_parse_process_slots).
@@ -1145,6 +1147,29 @@ class Settings:
     # being handed to the fast/OCR tiers, where a pathological large file burns
     # the OCR timeout for 0 chars. 0 disables the guard.
     document_max_pdf_size_mb: float = 50.0
+    # Page ceiling above which the structured tier skips pymupdf4llm.to_markdown
+    # and returns the raw text layer instead. <=0 disables markdown entirely
+    # (every document takes the raw-text path), matching how
+    # document_max_pdf_size_mb treats 0 as "guard off".
+    #
+    # to_markdown is SUPERLINEAR in page count -- the per-page rate itself grows
+    # with document size. Measured across a 866-file scanned corpus: 0.48-1.48
+    # s/page at 22-31 pages, ~1.0 s/page at 400, 3.11 s/page at 1898, and 5.92
+    # s/page at 4003 (6.6 hours for one document). Raw ``get_text`` is ~4.5
+    # ms/page flat, and on that corpus recovered 116,375 of the 145,199 chars
+    # markdown produced -- markdown's value is structure, not completeness.
+    #
+    # Without a ceiling a large document burns the whole parse timeout and then
+    # dead-letters with reason="timeout", discarding a text layer that was
+    # already extractable in under a second (Deck #399). The gate is expressed in
+    # PAGES rather than predicted seconds deliberately: seconds depend on node
+    # CPU, so a seconds-based threshold silently drifts between node types and
+    # needs recalibration, while a page count is deterministic and reviewable.
+    #
+    # Default 150: roughly the point where markdown costs >~120s on a throttled
+    # 2-core pod, and it keeps markdown for the small/prose documents that
+    # actually benefit from table reconstruction.
+    document_markdown_max_pages: int = 150
     # RLIMIT_AS in the parse subprocess (below the pod limit). Applied once per
     # worker for its lifetime, so changing it needs a pod restart.
     document_parse_mem_limit_mb: int = 1536
@@ -1978,6 +2003,7 @@ def _build_settings() -> Settings:
         "document_parse_timeout_seconds": "DOCUMENT_PARSE_TIMEOUT_SECONDS",
         "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
+        "document_markdown_max_pages": "DOCUMENT_MARKDOWN_MAX_PAGES",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
         "document_parse_process_slots": "DOCUMENT_PARSE_PROCESS_SLOTS",

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -127,7 +127,9 @@ def _text_only_chunks(doc: Any) -> list[dict[str, Any]]:
     for i in range(doc.page_count):
         try:
             text = doc[i].get_text("text")
-        except Exception:  # noqa: BLE001 -- per-page best effort, mirrors the markdown path
+        # Per-page best effort, mirroring the markdown path above: one
+        # unreadable page degrades to "" rather than failing the document.
+        except Exception:  # noqa: BLE001
             text = ""
         chunks.append({"text": text, "metadata": {"page": i + 1}})
     return chunks

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -98,6 +98,41 @@ def _recover_underextracted_pages(doc: Any, chunks: list[dict[str, Any]]) -> Non
             chunk["text"] = raw
 
 
+def uses_markdown(page_count: int, markdown_max_pages: int) -> bool:
+    """Whether a document of ``page_count`` pages gets markdown reconstruction.
+
+    Single source of truth for the page gate (Deck #399). The worker uses it to
+    choose the parse path; ``PyMuPDFProcessor`` uses it to label
+    ``astrolabe_document_parse_mode_total``. Duplicating the comparison would let
+    the metric drift from the decision it claims to describe.
+
+    ``markdown_max_pages <= 0`` disables markdown entirely; the bound is
+    inclusive, so a document exactly at the ceiling still gets markdown.
+    """
+    return markdown_max_pages > 0 and page_count <= markdown_max_pages
+
+
+def _text_only_chunks(doc: Any) -> list[dict[str, Any]]:
+    """Build ``page_chunks``-shaped output from the raw text layer alone.
+
+    Emits the same contract ``to_markdown(page_chunks=True)`` does, as far as
+    callers actually consume it: ``PyMuPDFProcessor._build_page_boundaries``
+    reads only ``chunk["text"]`` and ``chunk["metadata"]["page"]`` (with a
+    positional fallback for the latter), so page boundaries, the chunker and
+    bbox computation are unaffected by which path produced the list.
+
+    ``metadata.page`` is 1-based to match pymupdf4llm.
+    """
+    chunks: list[dict[str, Any]] = []
+    for i in range(doc.page_count):
+        try:
+            text = doc[i].get_text("text")
+        except Exception:  # noqa: BLE001 -- per-page best effort, mirrors the markdown path
+            text = ""
+        chunks.append({"text": text, "metadata": {"page": i + 1}})
+    return chunks
+
+
 class PdfParseFailed(Exception):
     """A PDF parse failed in the isolated worker.
 
@@ -140,8 +175,14 @@ def _parse_pdf_worker(
     image_path: str | None,
     graphics_limit: int,
     mem_limit_mb: int,
+    markdown_max_pages: int,
 ) -> list[dict[str, Any]]:
-    """Run pymupdf4llm.to_markdown in the worker subprocess (positional args only).
+    """Extract a PDF in the worker subprocess (positional args only).
+
+    Runs ``pymupdf4llm.to_markdown`` when :func:`uses_markdown` allows it for this
+    document's page count, and falls back to the raw text layer
+    (:func:`_text_only_chunks`) otherwise. Both paths return the same
+    ``page_chunks`` shape, so the caller does not branch.
 
     Takes a PATH, not bytes. Passing bytes meant every argument crossing the
     ``to_process`` pipe was a full copy of the document -- one in the parent, one
@@ -164,6 +205,16 @@ def _parse_pdf_worker(
 
     doc = pymupdf.open(source_path)
     try:
+        # Page gate (Deck #399). to_markdown is superlinear in page count, so a
+        # large document burns the entire parse timeout and then dead-letters
+        # reason="timeout" -- discarding a text layer that get_text extracts in
+        # ~4.5 ms/page. Decide from page_count BEFORE parsing: a runtime budget
+        # would still pay the full timeout on every doomed document to learn
+        # what page_count gives for free. page_count is metadata, so this costs
+        # nothing beyond the open we already did.
+        if not uses_markdown(doc.page_count, markdown_max_pages):
+            return _text_only_chunks(doc)
+
         # page_chunks=True makes to_markdown return list[dict], not str.
         chunks = cast(
             "list[dict[str, Any]]",
@@ -190,6 +241,7 @@ async def run_isolated_pdf_parse(
     graphics_limit: int,
     timeout_seconds: float,
     mem_limit_mb: int,
+    markdown_max_pages: int,
     process_slots: int = 2,
 ) -> list[dict[str, Any]]:
     """Parse a PDF in an isolated worker subprocess with a memory cap and timeout.
@@ -200,6 +252,10 @@ async def run_isolated_pdf_parse(
     ``process_slots`` bounds how many parses run concurrently. Without it anyio
     defaults to an ``os.cpu_count()``-wide pool, which neither the worker's
     ``--concurrency`` nor the pod memory limit constrains.
+
+    ``markdown_max_pages`` is required rather than defaulted: <=0 legitimately
+    means "never run to_markdown", so a default would silently pick a parse mode
+    for any caller that forgot to pass one.
     """
     with anyio.move_on_after(timeout_seconds):
         try:
@@ -210,6 +266,7 @@ async def run_isolated_pdf_parse(
                 str(image_path) if image_path is not None else None,
                 graphics_limit,
                 mem_limit_mb,
+                markdown_max_pages,
                 cancellable=True,
                 limiter=parse_process_limiter(process_slots),
             )

--- a/nextcloud_mcp_server/document_processors/escalation.py
+++ b/nextcloud_mcp_server/document_processors/escalation.py
@@ -63,6 +63,17 @@ def escalation_tiers_signature(settings: Any) -> str:
     means a cap change is a thundering herd on a large tenant and should be rolled
     out one tenant at a time.
 
+    ``document_markdown_max_pages`` is included for the same reason (Deck #399).
+    A structured-tier ``timeout`` is terminal, and lowering the page ceiling makes
+    a previously-timing-out document take the raw-text path and succeed -- so
+    without the ceiling here it would stay dead-lettered until its etag changed,
+    which for an archive of scanned documents never happens. Any change to the
+    value invalidates dead letters, in either direction: raising it can also turn
+    a text-only document back into a markdown parse. Formatted with ``:g`` for the
+    same reason as the cap: a settings source that yields ``150.0`` instead of
+    ``150`` must not change the fingerprint (and ``:d`` would raise on a float,
+    breaking the dead-letter key for the whole tenant).
+
     TODO: when a future setting can make a previously-terminal document parseable,
     fold it in here so raising it auto-retries existing dead-letters. Known
     remaining candidate: a new escalation tier becoming toggleable (e.g. the
@@ -71,7 +82,8 @@ def escalation_tiers_signature(settings: Any) -> str:
     return (
         f"ocr={int(bool(settings.document_ocr_enabled))};"
         f"t1={settings.document_tier1_engine};"
-        f"maxmb={settings.document_max_pdf_size_mb:g}"
+        f"maxmb={settings.document_max_pdf_size_mb:g};"
+        f"mdpages={settings.document_markdown_max_pages:g}"
     )
 
 

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -17,8 +17,9 @@ import anyio
 import pymupdf
 
 from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.observability.metrics import record_document_parse_mode
 
-from ._isolation import PdfParseFailed, run_isolated_pdf_parse
+from ._isolation import PdfParseFailed, run_isolated_pdf_parse, uses_markdown
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 from .source import DocumentSource, MemoryDocumentSource, resolve_path
 
@@ -231,6 +232,7 @@ class PyMuPDFProcessor(DocumentProcessor):
                     timeout_seconds=settings.document_parse_timeout_seconds,
                     mem_limit_mb=settings.document_parse_mem_limit_mb,
                     process_slots=settings.document_parse_process_slots,
+                    markdown_max_pages=settings.document_markdown_max_pages,
                 )
             except PdfParseFailed as exc:
                 logger.warning(
@@ -253,6 +255,23 @@ class PyMuPDFProcessor(DocumentProcessor):
                     success=False,
                     error=f"isolated parse failed ({exc.reason}): {exc}",
                 )
+
+            # Both paths emit exactly one chunk per page, so the page count is
+            # recoverable here without the worker reporting its mode back over
+            # the process boundary (a Counter incremented in the subprocess
+            # would never reach this process's registry). Shares the worker's
+            # predicate so the label cannot drift from the actual decision.
+            #
+            # Note the gated path also writes no images, so ``has_images`` is
+            # False for a large PDF even with extract_images=True -- markdown
+            # reconstruction is what emits them.
+            mode = (
+                "markdown"
+                if uses_markdown(len(page_chunks), settings.document_markdown_max_pages)
+                else "text_only"
+            )
+            metadata["parse_mode"] = mode
+            record_document_parse_mode(mode)
 
             if progress_callback:
                 await progress_callback(90, 100, "Building result")

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -256,10 +256,13 @@ class PyMuPDFProcessor(DocumentProcessor):
                     error=f"isolated parse failed ({exc.reason}): {exc}",
                 )
 
-            # Both paths emit exactly one chunk per page, so the page count is
-            # recoverable here without the worker reporting its mode back over
-            # the process boundary (a Counter incremented in the subprocess
-            # would never reach this process's registry). Shares the worker's
+            # Recompute the worker's decision here rather than have it report a
+            # mode back: a Counter incremented in the subprocess would never
+            # reach this process's registry. Uses ``page_count`` from the
+            # metadata read -- the same authoritative value the worker's own
+            # ``doc.page_count`` gate saw -- rather than ``len(page_chunks)``,
+            # which would silently mislabel the metric if pymupdf4llm ever
+            # stopped emitting exactly one chunk per page. Shares the worker's
             # predicate so the label cannot drift from the actual decision.
             #
             # Note the gated path also writes no images, so ``has_images`` is
@@ -267,7 +270,7 @@ class PyMuPDFProcessor(DocumentProcessor):
             # reconstruction is what emits them.
             mode = (
                 "markdown"
-                if uses_markdown(len(page_chunks), settings.document_markdown_max_pages)
+                if uses_markdown(page_count, settings.document_markdown_max_pages)
                 else "text_only"
             )
             metadata["parse_mode"] = mode

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -330,6 +330,12 @@ document_ingest_rejected_total = Counter(
     ["doc_type", "reason"],  # reason: oversize
 )
 
+document_parse_mode_total = Counter(
+    "astrolabe_document_parse_mode_total",
+    "Structured-tier parses by extraction mode",
+    ["mode"],  # markdown | text_only
+)
+
 # --- Escalation (tiered-pipeline readiness; ~0 until extra tiers exist) --------
 
 document_escalation_total = Counter(
@@ -1084,6 +1090,18 @@ def record_document_ingest_rejected(doc_type: str, reason: str) -> None:
     investigation.
     """
     document_ingest_rejected_total.labels(doc_type=doc_type, reason=reason).inc()
+
+
+def record_document_parse_mode(mode: str) -> None:
+    """Record which extraction mode the structured tier used.
+
+    Deliberately NOT folded into ``document_parse_failed_total``: skipping
+    markdown is a successful parse, not a failure. Without its own signal the
+    page gate (``document_markdown_max_pages``) is invisible -- there is no way
+    to tell "markdown is off for most of this tenant" from "markdown is running
+    fine", which is exactly the question an operator asks after tuning it.
+    """
+    document_parse_mode_total.labels(mode=mode).inc()
 
 
 def record_document_dead_lettered(reason: str) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -349,6 +349,13 @@ class TestChunkConfigValidation:
             _reload_config()
             assert get_settings().document_max_pdf_size_mb == pytest.approx(12.5)
 
+    def test_markdown_max_pages_default_and_env_override(self):
+        """document_markdown_max_pages defaults to 150 and reads its env var."""
+        assert Settings().document_markdown_max_pages == 150
+        with patch.dict(os.environ, {"DOCUMENT_MARKDOWN_MAX_PAGES": "40"}, clear=True):
+            _reload_config()
+            assert get_settings().document_markdown_max_pages == 40
+
     def test_glyph_corruption_ratio_default_and_env_override(self):
         """document_glyph_corruption_ratio defaults to 0.02 and reads its env var.
 
@@ -772,6 +779,19 @@ class TestDynaconfValidators:
         from dynaconf import ValidationError
 
         with pytest.raises(ValidationError, match="DOCUMENT_MAX_PDF_SIZE_MB"):
+            _reload_config()
+
+    @patch.dict(os.environ, {"DOCUMENT_MARKDOWN_MAX_PAGES": "-1"}, clear=True)
+    def test_markdown_max_pages_negative_rejected(self):
+        """DOCUMENT_MARKDOWN_MAX_PAGES=-1 fails the gte=0 validator (0 = disabled).
+
+        Without this, a typo silently disables markdown reconstruction for the
+        whole fleet instead of failing fast -- the same silent-disarm class the
+        page gate exists to fix.
+        """
+        from dynaconf import ValidationError
+
+        with pytest.raises(ValidationError, match="DOCUMENT_MARKDOWN_MAX_PAGES"):
             _reload_config()
 
     @patch.dict(os.environ, {"METRICS_PORT": "8080"}, clear=True)

--- a/tests/unit/test_escalation_signature.py
+++ b/tests/unit/test_escalation_signature.py
@@ -20,12 +20,17 @@ pytestmark = pytest.mark.unit
 
 
 def _settings(
-    *, ocr: bool, engine: str = "pypdfium2", max_pdf_mb: float = 50.0
+    *,
+    ocr: bool,
+    engine: str = "pypdfium2",
+    max_pdf_mb: float = 50.0,
+    markdown_max_pages: int = 150,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         document_ocr_enabled=ocr,
         document_tier1_engine=engine,
         document_max_pdf_size_mb=max_pdf_mb,
+        document_markdown_max_pages=markdown_max_pages,
     )
 
 
@@ -69,3 +74,20 @@ def test_disabling_size_cap_changes_signature() -> None:
     assert escalation_tiers_signature(
         _settings(ocr=False, max_pdf_mb=50.0)
     ) != escalation_tiers_signature(_settings(ocr=False, max_pdf_mb=0))
+
+
+def test_markdown_page_gate_change_changes_signature() -> None:
+    # A structured-tier timeout is terminal, so lowering the page ceiling (which
+    # sends the document down the raw-text path and lets it succeed) must
+    # re-drive documents dead-lettered under the old value -- for a scanned
+    # archive the etag never changes, so nothing else would.
+    assert escalation_tiers_signature(
+        _settings(ocr=False, markdown_max_pages=150)
+    ) != escalation_tiers_signature(_settings(ocr=False, markdown_max_pages=50))
+
+
+def test_disabling_markdown_changes_signature() -> None:
+    # 0 == "never run to_markdown" is a distinct configuration, not a no-op.
+    assert escalation_tiers_signature(
+        _settings(ocr=False, markdown_max_pages=150)
+    ) != escalation_tiers_signature(_settings(ocr=False, markdown_max_pages=0))

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -260,6 +260,12 @@ async def test_processor_reports_parse_mode(monkeypatch):
 
 
 async def test_processor_reports_text_only_mode_above_ceiling(monkeypatch):
+    """A REAL 5-page document against a 4-page ceiling.
+
+    The mode is derived from the authoritative ``page_count`` read off the
+    document, not from ``len(page_chunks)``, so this must feed a genuinely
+    multi-page PDF rather than a fake chunk list.
+    """
     from types import SimpleNamespace
 
     from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
@@ -281,7 +287,7 @@ async def test_processor_reports_text_only_mode_above_ceiling(monkeypatch):
     monkeypatch.setattr(pymupdf_proc, "get_settings", fake_settings)
 
     proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
-    result = await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
+    result = await proc.process(_pdf_with_pages(5), "application/pdf", filename="t.pdf")
     assert result.metadata["parse_mode"] == "text_only"
 
 

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -213,6 +213,19 @@ def test_isolation_imports_on_windows_without_resource(monkeypatch):
     assert mod.resource is None
 
 
+def _fake_parse_returning(n_pages: int):
+    """Build a ``run_isolated_pdf_parse`` double yielding ``n_pages`` chunks.
+
+    Must be a coroutine function -- the production call site awaits it -- which
+    is why it has no ``await`` of its own.
+    """
+
+    async def fake_parse(content, **kwargs):
+        return [{"text": "x", "metadata": {"page": i + 1}} for i in range(n_pages)]
+
+    return fake_parse
+
+
 # --- PyMuPDF processor wiring ------------------------------------------------
 
 
@@ -249,11 +262,10 @@ async def test_processor_reports_parse_mode(monkeypatch):
     """
     from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
 
-    async def fake_parse(content, **kwargs):
-        # 3 pages against the default 150-page ceiling -> markdown.
-        return [{"text": "x", "metadata": {"page": i + 1}} for i in range(3)]
-
-    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    # 3 pages against the default 150-page ceiling -> markdown.
+    monkeypatch.setattr(
+        pymupdf_proc, "run_isolated_pdf_parse", _fake_parse_returning(3)
+    )
     proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
     result = await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
     assert result.metadata["parse_mode"] == "markdown"
@@ -270,9 +282,6 @@ async def test_processor_reports_text_only_mode_above_ceiling(monkeypatch):
 
     from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
 
-    async def fake_parse(content, **kwargs):
-        return [{"text": "x", "metadata": {"page": i + 1}} for i in range(5)]
-
     def fake_settings():
         # Only the attributes process_source reads from settings.
         return SimpleNamespace(
@@ -283,7 +292,9 @@ async def test_processor_reports_text_only_mode_above_ceiling(monkeypatch):
             document_markdown_max_pages=4,  # 5 pages > 4 -> text_only
         )
 
-    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    monkeypatch.setattr(
+        pymupdf_proc, "run_isolated_pdf_parse", _fake_parse_returning(5)
+    )
     monkeypatch.setattr(pymupdf_proc, "get_settings", fake_settings)
 
     proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
@@ -586,10 +597,9 @@ async def test_parse_mode_counter_increments(monkeypatch):
 
     before = _value("markdown")
 
-    async def fake_parse(content, **kwargs):
-        return [{"text": "x", "metadata": {"page": 1}}]
-
-    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    monkeypatch.setattr(
+        pymupdf_proc, "run_isolated_pdf_parse", _fake_parse_returning(1)
+    )
     proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
     await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
 

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -60,6 +60,7 @@ async def _run(monkeypatch, fake_run_sync) -> list:
         graphics_limit=5000,
         timeout_seconds=5,
         mem_limit_mb=1536,
+        markdown_max_pages=150,
     )
 
 
@@ -116,6 +117,7 @@ async def test_timeout_kills_and_classifies_as_timeout(monkeypatch):
             graphics_limit=5000,
             timeout_seconds=0.2,
             mem_limit_mb=1536,
+            markdown_max_pages=150,
         )
     assert exc.value.reason == "timeout"
 
@@ -235,6 +237,52 @@ async def test_processor_success_builds_page_boundaries(monkeypatch):
     assert seen["graphics_limit"] == 1000
     assert seen["timeout_seconds"] == 120
     assert seen["mem_limit_mb"] == 1536
+    assert seen["markdown_max_pages"] == 150
+
+
+async def test_processor_reports_parse_mode(monkeypatch):
+    """The mode must be observable: a silent gate is untunable.
+
+    Derived in the parent from the returned page count (both worker paths emit
+    one chunk per page) because a Counter incremented in the subprocess would
+    never reach this process's registry.
+    """
+    from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
+
+    async def fake_parse(content, **kwargs):
+        # 3 pages against the default 150-page ceiling -> markdown.
+        return [{"text": "x", "metadata": {"page": i + 1}} for i in range(3)]
+
+    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
+    result = await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
+    assert result.metadata["parse_mode"] == "markdown"
+
+
+async def test_processor_reports_text_only_mode_above_ceiling(monkeypatch):
+    from types import SimpleNamespace
+
+    from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
+
+    async def fake_parse(content, **kwargs):
+        return [{"text": "x", "metadata": {"page": i + 1}} for i in range(5)]
+
+    def fake_settings():
+        # Only the attributes process_source reads from settings.
+        return SimpleNamespace(
+            document_pdf_graphics_limit=1000,
+            document_parse_timeout_seconds=120.0,
+            document_parse_mem_limit_mb=1536,
+            document_parse_process_slots=2,
+            document_markdown_max_pages=4,  # 5 pages > 4 -> text_only
+        )
+
+    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    monkeypatch.setattr(pymupdf_proc, "get_settings", fake_settings)
+
+    proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
+    result = await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
+    assert result.metadata["parse_mode"] == "text_only"
 
 
 async def test_processor_parse_failure_returns_success_false(monkeypatch):
@@ -399,8 +447,144 @@ async def test_isolated_parse_uses_the_bounded_limiter(mocker):
         graphics_limit=1000,
         timeout_seconds=5.0,
         mem_limit_mb=512,
+        markdown_max_pages=150,
         process_slots=2,
     )
 
     limiter = run_sync.await_args.kwargs["limiter"]
     assert limiter.total_tokens == 2
+
+
+# --- markdown page gate (Deck #399) -----------------------------------------
+#
+# to_markdown is superlinear in page count, so a large document burns the whole
+# parse timeout and dead-letters reason="timeout" -- throwing away a text layer
+# get_text extracts in ~4.5 ms/page. These drive the REAL worker against real
+# PDFs (no mocked to_markdown) so the gate is verified end to end.
+
+
+def _pdf_with_pages(n: int, text: str = "Hello world") -> bytes:
+    doc = pymupdf.open()
+    for i in range(n):
+        page = doc.new_page(width=595, height=842)
+        page.insert_text((50, 50), f"{text} {i + 1}")
+    data: bytes = doc.tobytes()
+    doc.close()
+    return data
+
+
+def _write(tmp_path, data: bytes) -> str:
+    p = tmp_path / "doc.pdf"
+    p.write_bytes(data)
+    return str(p)
+
+
+def test_gate_uses_text_only_above_ceiling(tmp_path):
+    from nextcloud_mcp_server.document_processors._isolation import _parse_pdf_worker
+
+    path = _write(tmp_path, _pdf_with_pages(5))
+    chunks = _parse_pdf_worker(path, False, None, 1000, 0, 2)
+
+    # One chunk per page, 1-based page numbers, real text recovered.
+    assert len(chunks) == 5
+    assert [c["metadata"]["page"] for c in chunks] == [1, 2, 3, 4, 5]
+    assert "Hello world 1" in chunks[0]["text"]
+    assert "Hello world 5" in chunks[4]["text"]
+
+
+def test_gate_runs_markdown_at_or_below_ceiling(tmp_path):
+    from nextcloud_mcp_server.document_processors._isolation import _parse_pdf_worker
+
+    path = _write(tmp_path, _pdf_with_pages(3))
+    chunks = _parse_pdf_worker(path, False, None, 1000, 0, 3)
+
+    # Boundary is inclusive: page_count == ceiling still gets markdown, which
+    # carries pymupdf4llm's richer metadata (the text-only path emits only
+    # "page").
+    assert len(chunks) == 3
+    assert set(chunks[0]["metadata"]) > {"page"}
+
+
+def test_gate_zero_disables_markdown_entirely(tmp_path):
+    from nextcloud_mcp_server.document_processors._isolation import _parse_pdf_worker
+
+    path = _write(tmp_path, _pdf_with_pages(2))
+    chunks = _parse_pdf_worker(path, False, None, 1000, 0, 0)
+
+    assert len(chunks) == 2
+    assert chunks[0]["metadata"] == {"page": 1}
+    assert "Hello world 1" in chunks[0]["text"]
+
+
+def test_text_only_chunks_match_markdown_page_count_and_order(tmp_path):
+    """Both paths must agree on shape -- page_boundaries depends on it."""
+    from nextcloud_mcp_server.document_processors._isolation import _parse_pdf_worker
+
+    path = _write(tmp_path, _pdf_with_pages(4))
+    md = _parse_pdf_worker(path, False, None, 1000, 0, 100)
+    raw = _parse_pdf_worker(path, False, None, 1000, 0, 1)
+
+    assert len(md) == len(raw) == 4
+    assert [c["metadata"]["page"] for c in md] == [c["metadata"]["page"] for c in raw]
+    # Text layer is the source of truth: the raw path must not lose content.
+    for m, r in zip(md, raw, strict=True):
+        assert m["text"].strip()
+        assert r["text"].strip()
+
+
+def test_text_only_path_survives_a_page_that_cannot_be_read(monkeypatch):
+    """A per-page failure degrades that page, never the whole document."""
+    from nextcloud_mcp_server.document_processors._isolation import _text_only_chunks
+
+    class _Page:
+        def __init__(self, ok: bool) -> None:
+            self._ok = ok
+
+        def get_text(self, _mode: str) -> str:
+            if not self._ok:
+                raise RuntimeError("corrupt page")
+            return "fine"
+
+    class _Doc:
+        page_count = 3
+
+        def __getitem__(self, i: int) -> _Page:
+            return _Page(ok=(i != 1))
+
+    chunks = _text_only_chunks(_Doc())
+    assert [c["text"] for c in chunks] == ["fine", "", "fine"]
+    assert [c["metadata"]["page"] for c in chunks] == [1, 2, 3]
+
+
+def test_uses_markdown_is_the_single_source_of_truth():
+    """The worker and the metric label must agree; both call this predicate."""
+    from nextcloud_mcp_server.document_processors._isolation import uses_markdown
+
+    assert uses_markdown(page_count=1, markdown_max_pages=150) is True
+    assert uses_markdown(page_count=150, markdown_max_pages=150) is True  # inclusive
+    assert uses_markdown(page_count=151, markdown_max_pages=150) is False
+    # <=0 disables markdown entirely, however small the document.
+    assert uses_markdown(page_count=1, markdown_max_pages=0) is False
+    assert uses_markdown(page_count=1, markdown_max_pages=-5) is False
+
+
+async def test_parse_mode_counter_increments(monkeypatch):
+    """The gate must be observable in Prometheus, not just on the result."""
+    from nextcloud_mcp_server.document_processors import pymupdf as pymupdf_proc
+    from nextcloud_mcp_server.observability import metrics
+
+    def _value(mode: str) -> float:
+        return (
+            metrics.document_parse_mode_total.labels(mode=mode)._value.get()  # noqa: SLF001
+        )
+
+    before = _value("markdown")
+
+    async def fake_parse(content, **kwargs):
+        return [{"text": "x", "metadata": {"page": 1}}]
+
+    monkeypatch.setattr(pymupdf_proc, "run_isolated_pdf_parse", fake_parse)
+    proc = pymupdf_proc.PyMuPDFProcessor(extract_images=False)
+    await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
+
+    assert _value("markdown") == before + 1

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -45,6 +45,9 @@ def _settings(*, ocr_enabled: bool) -> SimpleNamespace:
         # Part of escalation_tiers_signature: raising the cap re-drives
         # previously oversize-dead-lettered documents.
         document_max_pdf_size_mb=50.0,
+        # Also part of escalation_tiers_signature (Deck #399): changing the
+        # markdown page ceiling re-drives timeout-dead-lettered documents.
+        document_markdown_max_pages=150,
         get_collection_name=lambda: "c",
     )
 


### PR DESCRIPTION
## Why

The structured tier calls `pymupdf4llm.to_markdown`, whose cost is **superlinear in page count** — the per-page rate itself grows with document size. A large document burns the whole `DOCUMENT_PARSE_TIMEOUT_SECONDS` and then dead-letters `reason="timeout"`, discarding a text layer that raw `get_text` extracts in under a second.

Deck card #399, found while investigating why `tenant-blackbox-demo` indexes only 13.8% of its corpus text.

## Measurements

Stratified sample across an 866-file corpus of scanned PDFs (62.3 GB, 219,776 pages), plus one full-document run to calibrate:

| Pages | to_markdown | Whole document |
|---|---|---|
| 22–31 | 0.48–1.48 s/page | 13–33 s |
| 136–158 | 0.60–0.94 s/page | 95–149 s |
| 364–419 | 0.91–1.06 s/page | 331–444 s |
| 1111–1898 | 1.48–3.11 s/page | 27–98 min |
| 4003 | 5.92 s/page | **6.6 hours** |

Raw `get_text` is ~4.5 ms/page and flat: **1000 s for the entire corpus** vs 46–69 h via `to_markdown`.

The document that surfaced this (199 pages, 48.2 MB):

| | time | output |
|---|---|---|
| `get_text` | **0.89 s** | 116,375 chars |
| `to_markdown(write_images=False)` | 150.8 s | 145,199 chars |
| `to_markdown(write_images=True)` | 228.4 s | 155,235 chars + 202 MB images |

Against a 120 s budget, both markdown variants time out and **all 116,375 characters are discarded**. Markdown buys ~25% more characters for ~170× the cost — on scanned forms, mostly layout noise.

## What's here

`DOCUMENT_MARKDOWN_MAX_PAGES` (default 150); `<=0` disables markdown entirely. Above the ceiling the structured tier returns the raw text layer in the same `page_chunks` shape, so `page_boundaries`, the chunker and bbox computation are untouched.

Notable details:

- **The decision is upfront, not a runtime budget.** A budget would still pay the full timeout on every doomed document to learn what `page_count` gives for free. `page_count` is metadata — free after the open the worker already does.
- **Pages, not predicted seconds.** Seconds depend on node CPU, so a seconds-based threshold drifts silently between node types and needs recalibration per hardware. A page count is deterministic and reviewable.
- **`uses_markdown()` is the single source of truth**, shared by the worker's decision and the metric's label so they cannot drift apart.
- **Folded into `escalation_tiers_signature`**, resolving that function's own standing TODO. A structured `timeout` is terminal, so lowering the ceiling must re-drive documents dead-lettered under the old value — for a scanned archive the etag never changes, so nothing else would. Same thundering-herd caveat as the size cap: roll out one tenant at a time.
- **`markdown_max_pages` is required, not defaulted.** `<=0` legitimately means "never run markdown", so any default would silently pick a parse mode for a caller that forgot to pass one. This is the same class of bug that caused the incident behind #1108 — a guard reading an optional field is silently disarmed.
- **`astrolabe_document_parse_mode_total{mode}`** — skipping markdown is a *successful* parse, so it is deliberately not a parse-failure reason. Without its own signal the gate is invisible.

## Behaviour change worth noting

Above the ceiling no images are written either (markdown reconstruction is what emits them), so `has_images` is `False` for a gated document even with `extract_images=True`. Documented in `docs/configuration.md`.

## Verification

`ruff`, `ruff format`, `ty` and the full unit suite (**2273 passing**) green.

New coverage drives the **real worker against real PDFs** rather than mocking `to_markdown`: above ceiling, at ceiling (inclusive boundary), `0` disables, both paths agree on page count and ordering, a per-page read failure degrades one page rather than the document, the shared predicate, the counter increment, and two escalation-signature tests.

Not yet verified end-to-end against a running stack — no `e2e` tier exists for this path (tracked on Deck board 11). This changes no API surface, so no contract-test impact.

## Not in this PR

- Raising `DOCUMENT_MAX_PDF_SIZE_MB` (Deck #695) — config-only, and the larger lever: 444 of 866 files are over cap. Needs the spool disk budget (#693) first.
- Disabling `extract_images` on the structured tier and re-deriving `DOCUMENT_GLYPH_CORRUPTION_RATIO` (Deck #701).
- Picking the *right* value for this tenant. 150 is a defensible default, not a tuned figure — tuning is now per-tenant config.

---

_This PR was generated with the help of AI, and reviewed by a Human_

