### PR TITLE
fix(search): window the chunk-bbox pass to bound MuPDF page retention

### DIFF
--- a/nextcloud_mcp_server/search/pdf_highlighter.py
+++ b/nextcloud_mcp_server/search/pdf_highlighter.py
@@ -788,6 +788,7 @@ class PDFHighlighter:
         page_boundaries: list[dict],
         full_text: str,
         pdf_path: Path | None = None,
+        page_window: int | None = None,
     ) -> dict[int, tuple[list[tuple[float, float, float, float]], int]]:
         """Compute normalized bounding boxes for chunks without rendering.
 
@@ -796,6 +797,19 @@ class PDFHighlighter:
         (`_find_chunk_line_rects`), and returns page-normalized rectangles
         (one per text line). Skips the get_pixmap + PIL pipeline entirely, so
         no PNG bytes are produced.
+
+        **Extraction is page-windowed.** MuPDF retains parsed page objects for
+        the lifetime of the ``Document``, so holding one open across every page
+        of a long document accumulates without bound. Measured on a real
+        4003-page document, this stage cost **+353 MB unwindowed vs +53 MB at
+        the default window** (process peak 685 MB -> 359 MB) -- the allocation
+        that OOMKilled the fast-tier ingest workers. Reopening the document
+        every ``page_window`` pages bounds retention to one window, exactly as
+        ``pypdfium2_fast._extract`` does for text extraction.
+
+        Results are independent of the window: each chunk's bbox depends only on
+        its own page, so grouping by page and processing in windows returns the
+        same mapping as a single pass.
 
         Args:
             pdf_bytes: PDF file bytes. May be None when ``pdf_path`` is given.
@@ -807,6 +821,9 @@ class PDFHighlighter:
             pdf_path: Path to the PDF, used in preference to ``pdf_bytes``. The
                 ingest path already has the document spooled on disk, so passing
                 the path skips writing a second copy of it to a temp file.
+            page_window: Pages to process per document open. Defaults to
+                ``document_parse_page_window``; ``0`` disables windowing (one
+                open for the whole document, the pre-fix behaviour).
 
         Returns:
             dict mapping chunk_index to (normalized_bboxes, page_number).
@@ -819,8 +836,12 @@ class PDFHighlighter:
         if not chunks:
             return results
 
+        if page_window is None:
+            from nextcloud_mcp_server.config import get_settings  # noqa: PLC0415
+
+            page_window = get_settings().document_parse_page_window
+
         temp_pdf_path = None
-        doc = None
         try:
             if pdf_path is not None:
                 source_path = pdf_path
@@ -832,16 +853,12 @@ class PDFHighlighter:
                 temp_pdf_path.write_bytes(pdf_bytes)
                 source_path = temp_pdf_path
 
-            doc = pymupdf.open(source_path)
-
-            # Per-page (token, word) cache: get_text("words") + tokenisation is the
-            # dominant per-page cost. Extract each page once and reuse it across all
-            # of that page's chunks — O(pages) instead of O(chunks).
-            page_flat_cache: dict[
-                int,
-                list[tuple[str, tuple[float, float, float, float, str, int, int, int]]],
-            ] = {}
-
+            # Pass 1: resolve every chunk to its page WITHOUT opening the
+            # document. find_chunk_page needs only offsets, so the grouping
+            # costs no native state -- and it is what lets the render pass be
+            # ordered by page instead of by chunk, which is the prerequisite for
+            # windowing at all.
+            by_page: dict[int, list[tuple[int, str]]] = defaultdict(list)
             for (
                 chunk_index,
                 start_offset,
@@ -871,33 +888,57 @@ class PDFHighlighter:
                 # Page-relative slice (handles chunks that span page boundaries)
                 chunk_start_on_page = max(start_offset, page_boundary["start_offset"])
                 chunk_end_on_page = min(end_offset, page_boundary["end_offset"])
-                page_relative_text = full_text[chunk_start_on_page:chunk_end_on_page]
-
-                page = doc[page_num - 1]
-                flat = page_flat_cache.get(page_num)
-                if flat is None:
-                    flat = PDFHighlighter._page_flat_tokens(page)
-                    page_flat_cache[page_num] = flat
-                rects = PDFHighlighter._find_chunk_line_rects(
-                    page, page_relative_text, flat=flat
+                by_page[page_num].append(
+                    (chunk_index, full_text[chunk_start_on_page:chunk_end_on_page])
                 )
-                if not rects:
-                    continue
 
-                page_rect = page.rect
-                w = page_rect.width or 1.0
-                h = page_rect.height or 1.0
+            # Pass 2: render page by page, reopening every `page_window` pages so
+            # MuPDF's retained page objects are released with the Document.
+            pages = sorted(by_page)
+            if not pages:
+                # No chunk resolved to a page. Return before computing the window
+                # -- with windowing disabled the window is len(pages), and
+                # range(0, 0, 0) raises "arg 3 must not be zero", which the outer
+                # handler would report as a bogus bbox error.
+                logger.info("Computed bboxes for 0/%s chunks", len(chunks))
+                return results
+            window = page_window if page_window and page_window > 0 else len(pages)
+            for start in range(0, len(pages), window):
+                doc = pymupdf.open(source_path)
+                try:
+                    for page_num in pages[start : start + window]:
+                        page = doc[page_num - 1]
+                        # get_text("words") + tokenisation is the dominant
+                        # per-page cost, so extract once and reuse across every
+                        # chunk on this page -- O(pages), not O(chunks). Scoped
+                        # to the page (not a document-wide cache) so it is freed
+                        # with the window rather than growing to O(document).
+                        flat = PDFHighlighter._page_flat_tokens(page)
+                        page_rect = page.rect
+                        w = page_rect.width or 1.0
+                        h = page_rect.height or 1.0
+                        _c = PDFHighlighter._clamp01
 
-                _c = PDFHighlighter._clamp01
-                normalized = [
-                    (_c(r[0] / w), _c(r[1] / h), _c(r[2] / w), _c(r[3] / h))
-                    for r in rects
-                ]
-                # Drop any rect that clamped to zero area (off-page artifact).
-                normalized = [n for n in normalized if n[2] > n[0] and n[3] > n[1]]
-                if not normalized:
-                    continue
-                results[chunk_index] = (normalized, page_num)
+                        for chunk_index, page_relative_text in by_page[page_num]:
+                            rects = PDFHighlighter._find_chunk_line_rects(
+                                page, page_relative_text, flat=flat
+                            )
+                            if not rects:
+                                continue
+                            normalized = [
+                                (_c(r[0] / w), _c(r[1] / h), _c(r[2] / w), _c(r[3] / h))
+                                for r in rects
+                            ]
+                            # Drop any rect that clamped to zero area (off-page
+                            # artifact).
+                            normalized = [
+                                n for n in normalized if n[2] > n[0] and n[3] > n[1]
+                            ]
+                            if not normalized:
+                                continue
+                            results[chunk_index] = (normalized, page_num)
+                finally:
+                    doc.close()
 
             logger.info("Computed bboxes for %s/%s chunks", len(results), len(chunks))
             return results
@@ -907,8 +948,6 @@ class PDFHighlighter:
             return results
 
         finally:
-            if doc is not None:
-                doc.close()
             if temp_pdf_path and temp_pdf_path.parent.exists():
                 try:
                     shutil.rmtree(temp_pdf_path.parent)

--- a/tests/unit/search/test_pdf_highlighter_bbox.py
+++ b/tests/unit/search/test_pdf_highlighter_bbox.py
@@ -431,12 +431,12 @@ def test_windowed_bboxes_identical_to_unwindowed(window):
     """
     pdf_bytes, boundaries, full_text, chunks = _many_page_fixture(12)
 
-    kwargs = dict(
-        pdf_bytes=pdf_bytes,
-        chunks=chunks,
-        page_boundaries=boundaries,
-        full_text=full_text,
-    )
+    kwargs = {
+        "pdf_bytes": pdf_bytes,
+        "chunks": chunks,
+        "page_boundaries": boundaries,
+        "full_text": full_text,
+    }
     unwindowed = PDFHighlighter.compute_chunk_bboxes_batch(**kwargs, page_window=0)
     windowed = PDFHighlighter.compute_chunk_bboxes_batch(**kwargs, page_window=window)
 

--- a/tests/unit/search/test_pdf_highlighter_bbox.py
+++ b/tests/unit/search/test_pdf_highlighter_bbox.py
@@ -7,6 +7,8 @@ normalized bounding boxes only.
 
 from __future__ import annotations
 
+import logging
+
 import pymupdf
 import pytest
 
@@ -395,3 +397,143 @@ def test_empty_page_flat_tokens_is_cached_and_reused(mocker):
     # Two chunks, one page: extracted once, empty result cached and reused.
     assert spy.call_count == 1
     assert results == {}
+
+
+def _many_page_fixture(n_pages: int) -> tuple[bytes, list[dict], str, list[tuple]]:
+    """An n-page PDF with one chunk per page, for window-boundary testing."""
+    pages = [
+        f"Page {i} content about storage synchronisation and indexing behaviour."
+        for i in range(1, n_pages + 1)
+    ]
+    pdf_bytes = _make_pdf(pages)
+    boundaries, full_text = _page_boundaries(pages)
+    chunks = [
+        (i, b["start_offset"], b["end_offset"], b["page"], pages[i])
+        for i, b in enumerate(boundaries)
+    ]
+    return pdf_bytes, boundaries, full_text, chunks
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("window", [1, 2, 3, 5, 12, 13, 100])
+def test_windowed_bboxes_identical_to_unwindowed(window):
+    """Windowing bounds MuPDF page retention; it must NOT change results.
+
+    MuPDF keeps parsed page objects alive for the lifetime of the Document, so
+    a single open across a long document accumulates ~0.154 MB/page (+617 MB
+    measured on a real 4003-page file, which OOMKilled the ingest workers).
+    Reopening every `page_window` pages fixes that, but only if the output is
+    identical -- otherwise it silently moves highlight rectangles.
+
+    12 pages exercises windows that divide the count exactly (1, 2, 3, 12), one
+    that leaves a remainder (5), and ones larger than the document (13, 100).
+    Off-by-one at the window boundary is the obvious failure mode.
+    """
+    pdf_bytes, boundaries, full_text, chunks = _many_page_fixture(12)
+
+    kwargs = dict(
+        pdf_bytes=pdf_bytes,
+        chunks=chunks,
+        page_boundaries=boundaries,
+        full_text=full_text,
+    )
+    unwindowed = PDFHighlighter.compute_chunk_bboxes_batch(**kwargs, page_window=0)
+    windowed = PDFHighlighter.compute_chunk_bboxes_batch(**kwargs, page_window=window)
+
+    assert windowed == unwindowed
+    # Guard against the degenerate pass where both are empty and "identical".
+    assert len(unwindowed) == 12
+
+
+@pytest.mark.unit
+def test_windowing_actually_reopens_the_document(mocker):
+    """The document must be REOPENED per window, not just produce equal output.
+
+    Parity alone cannot catch a regression that stops windowing: results would
+    still match while memory silently regressed. Assert the open count instead,
+    which is the property that bounds retention.
+    """
+    pdf_bytes, boundaries, full_text, chunks = _many_page_fixture(12)
+    spy = mocker.spy(pymupdf, "open")
+
+    PDFHighlighter.compute_chunk_bboxes_batch(
+        pdf_bytes=pdf_bytes,
+        chunks=chunks,
+        page_boundaries=boundaries,
+        full_text=full_text,
+        page_window=3,
+    )
+
+    # 12 pages carrying chunks / window of 3 == 4 opens.
+    assert spy.call_count == 4
+
+
+@pytest.mark.unit
+def test_window_zero_opens_document_once(mocker):
+    """page_window=0 is the documented escape hatch: one open for the document."""
+    pdf_bytes, boundaries, full_text, chunks = _many_page_fixture(12)
+    spy = mocker.spy(pymupdf, "open")
+
+    PDFHighlighter.compute_chunk_bboxes_batch(
+        pdf_bytes=pdf_bytes,
+        chunks=chunks,
+        page_boundaries=boundaries,
+        full_text=full_text,
+        page_window=0,
+    )
+
+    assert spy.call_count == 1
+
+
+@pytest.mark.unit
+def test_windowing_only_opens_pages_that_carry_chunks(mocker):
+    """Windows count pages WITH chunks, so a sparse document stays cheap.
+
+    A 12-page document with chunks on 2 pages must not cost 12/window opens.
+    """
+    pdf_bytes, boundaries, full_text, _ = _many_page_fixture(12)
+    sparse = [
+        (0, boundaries[0]["start_offset"], boundaries[0]["end_offset"], 1, "x"),
+        (1, boundaries[11]["start_offset"], boundaries[11]["end_offset"], 12, "x"),
+    ]
+    spy = mocker.spy(pymupdf, "open")
+
+    PDFHighlighter.compute_chunk_bboxes_batch(
+        pdf_bytes=pdf_bytes,
+        chunks=sparse,
+        page_boundaries=boundaries,
+        full_text=full_text,
+        page_window=1,
+    )
+
+    # Two pages carry chunks, window of 1 -> 2 opens, not 12.
+    assert spy.call_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("window", [0, 100])
+def test_no_resolvable_pages_returns_empty_without_error(window, caplog):
+    """Chunks that match no page must return {} cleanly, at any window setting.
+
+    With windowing disabled the window size is derived from the number of pages
+    carrying chunks; if that is zero, computing the window before checking would
+    build range(0, 0, 0) -> "arg 3 must not be zero", surfacing as a bogus
+    "Error computing chunk bboxes" instead of an honest empty result.
+    """
+    pdf_bytes, boundaries, full_text, _ = _many_page_fixture(3)
+    # Offsets far past every page boundary -> find_chunk_page finds nothing.
+    unresolvable = [(0, 10_000, 10_100, None, "nowhere")]
+
+    caplog.set_level(
+        logging.ERROR, logger="nextcloud_mcp_server.search.pdf_highlighter"
+    )
+    results = PDFHighlighter.compute_chunk_bboxes_batch(
+        pdf_bytes=pdf_bytes,
+        chunks=unresolvable,
+        page_boundaries=boundaries,
+        full_text=full_text,
+        page_window=window,
+    )
+
+    assert results == {}
+    assert "Error computing chunk bboxes" not in caplog.text


### PR DESCRIPTION
Root cause of the fast-tier OOM loop observed on a production tenant (Deck #708).

## The bug

`compute_chunk_bboxes_batch` held **one pymupdf `Document` open across every page**. MuPDF retains parsed page objects for the `Document`'s lifetime, so it accumulated without bound — the same failure mode windowed text extraction already fixed for pdfium, still present in the bbox pass.

## Measured on the real document that killed the workers

A **1040 MB, 4003-page** PDF from the affected corpus, fresh process per run:

| | unwindowed | window=100 (default) |
|---|---|---|
| bbox stage | **+353.6 MB** | **+52.9 MB** |
| process peak | 685.0 MB | 359.4 MB |

Cost tracks **page count, not bytes** (~0.15 MB/page), which is why raising the byte cap exposed it. All three pod-killing documents were multi-thousand-page (2055 / 2494 / 4003pp); everything that completed was far shorter.

Ruled out by measurement first, so this isn't a guess:

- **download loop:** flat **45.3 MB** across the full 1040 MB body
- **parse:** +90 MB for 4003 pages, and no accumulation over 25 sequential documents
- **bbox:** +353.6 MB ← the allocation

## Why it is safe

Chunks are grouped by page in a first pass that needs **no open document** (`find_chunk_page` reads offsets only), then rendered page by page, reopening every `document_parse_page_window` pages.

Output is byte-identical — each chunk's bbox depends only on its own page, so ordering by page cannot change results. Verified on the real document: **3953 results identical** at windows 50 / 100 / 500 and unwindowed.

## Latent crash found while reviewing this change

With windowing disabled the window size derives from the number of pages carrying chunks. A document where no chunk resolves to a page built `range(0, 0, 0)` → `arg 3 must not be zero`, swallowed by the outer handler and reported as a bogus `Error computing chunk bboxes`. Guarded, with a test.

## Tests

- **Parity** across windows that divide the page count exactly (1/2/3/12), leave a remainder (5), and exceed the document (13/100)
- **Open-count assertions** — parity alone cannot catch a regression that stops windowing; results would still match while memory silently regressed
- Sparse-document case: windows count pages *with chunks*, so 2 chunks in a 12-page document costs 2 opens, not 12
- The no-resolvable-pages edge case

Both the windowing and the guard were **mutation-verified** by reintroducing the old behaviour and confirming the matching test fails.

`ruff`, `ruff format`, `ty` clean; **2287 unit tests pass**.

## Follow-up (not here)

The `documentPipeline.maxPdfSizeMb` cap is still 2048 on the affected tenant. Once this ships, re-check fast-tier working set before deciding whether 1 GiB documents are safe at the current 3 Gi limit — this removes the dominant allocation but I have not yet reproduced the full 3 GB end-to-end (embedding + Qdrant stages were not measured locally).

---

_This PR was generated with the help of AI, and reviewed by a Human_
