### PR TITLE
fix(client): stop the response log hook buffering every body

### DIFF
--- a/nextcloud_mcp_server/client/__init__.py
+++ b/nextcloud_mcp_server/client/__init__.py
@@ -13,6 +13,7 @@ from httpx import (
 
 from ..controllers.notes_search import NotesSearchController
 from ..http import nextcloud_httpx_transport
+from .base import STREAMING_REQUEST_EXTENSION
 from .calendar import CalendarClient
 from .collectives import CollectivesClient
 from .contacts import ContactsClient
@@ -43,6 +44,29 @@ async def log_request(request: Request):
 
 
 async def log_response(response: Response):
+    """Log the response body at DEBUG, without ever consuming a streamed one.
+
+    Two bugs lived in the three lines this replaces, and together they defeated
+    the entire streamed-download path in production:
+
+    1. ``aread()`` ran **unconditionally**, while only the logging was gated by
+       DEBUG. Every response in the app was therefore fully buffered and
+       stringified regardless of log level, purely to serve a line nobody saw.
+    2. httpx invokes response hooks BEFORE the body is fetched, so on a streamed
+       GET that ``aread()`` pulled the whole document into memory and left the
+       caller's ``aiter_bytes()`` loop with nothing to stream. A 1 GB ingest
+       download became a 1 GB buffer plus its decoded ``.text`` copy -- ~3.6x the
+       file size resident -- which OOMKilled the fast-tier ingest workers.
+
+    So: bail out before the read when DEBUG is off, and never read a request the
+    caller marked as streaming.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    if response.request.extensions.get(STREAMING_REQUEST_EXTENSION):
+        # Reading here would consume the stream the caller is about to iterate.
+        logger.debug("Response [%s] <streaming; body not read>", response.status_code)
+        return
     await response.aread()
     logger.debug("Response [%s] %s", response.status_code, response.text)
 

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -17,6 +17,14 @@ from nextcloud_mcp_server.observability.metrics import (
 )
 from nextcloud_mcp_server.observability.tracing import trace_nextcloud_api_call
 
+#: Marks a request whose body the caller intends to consume incrementally.
+#:
+#: httpx runs response event hooks BEFORE the body is fetched, so a hook that
+#: calls ``aread()`` pulls the whole body into memory and leaves nothing for the
+#: caller's ``aiter_bytes()`` loop -- silently turning a streamed download into a
+#: buffered one. ``log_response`` checks for this marker and skips reading.
+STREAMING_REQUEST_EXTENSION = "nextcloud_mcp_streaming"
+
 logger = logging.getLogger(__name__)
 
 
@@ -200,6 +208,15 @@ class BaseNextcloudClient(ABC):
         url = self._resolve_url(url)
         logger.debug("Making streaming %s request to %s", method, url)
 
+        # Tell the response event hook to keep its hands off this body. Without
+        # it, log_response's aread() consumes the whole document before the
+        # caller's aiter_bytes() loop runs -- the download is then buffered, not
+        # streamed, and peak memory scales with file size again.
+        stream_extensions = {
+            **kwargs.pop("extensions", {}),
+            STREAMING_REQUEST_EXTENSION: True,
+        }
+
         max_retries = 5
         for attempt in range(1, max_retries + 1):
             start_time = time.time()
@@ -213,7 +230,9 @@ class BaseNextcloudClient(ABC):
                 with trace_nextcloud_api_call(
                     app=self.app_name, method=method, path=url
                 ):
-                    async with self._client.stream(method, url, **kwargs) as response:
+                    async with self._client.stream(
+                        method, url, extensions=stream_extensions, **kwargs
+                    ) as response:
                         status_code = response.status_code
                         # Raised inside the stream context so the connection is
                         # released before the 429 handler sleeps and retries.

--- a/tests/unit/client/test_log_response_hook.py
+++ b/tests/unit/client/test_log_response_hook.py
@@ -134,7 +134,7 @@ async def test_stream_survives_the_real_hook_end_to_end(tmp_path):
     assert received == len(body)
 
 
-async def test_unmarked_stream_would_be_consumed(tmp_path):
+async def test_unmarked_stream_would_be_consumed(caplog):
     """Pins WHY the marker is required, so its removal fails loudly.
 
     Without the extension the hook cannot tell a streamed request apart and
@@ -153,7 +153,11 @@ async def test_unmarked_stream_would_be_consumed(tmp_path):
         event_hooks={"response": [log_response]},
     )
 
-    logging.getLogger(HOOK_LOGGER).setLevel(logging.DEBUG)
+    # caplog.set_level, not Logger.setLevel: the latter is a global mutation
+    # that outlives the test and would leave this logger at DEBUG for the rest
+    # of the session -- reinstating, inside the suite, the very "read on every
+    # response regardless of level" cost this change removes.
+    caplog.set_level(logging.DEBUG, logger=HOOK_LOGGER)
     request = http.build_request("GET", "/f.pdf")  # deliberately unmarked
     response = await http.send(request, stream=True)
     try:

--- a/tests/unit/client/test_log_response_hook.py
+++ b/tests/unit/client/test_log_response_hook.py
@@ -1,0 +1,163 @@
+"""The response event hook must never consume a streamed body.
+
+httpx runs response event hooks BEFORE the body is fetched. ``log_response``
+called ``response.aread()`` unconditionally, which meant:
+
+* every response in the app was buffered and stringified regardless of log
+  level, purely to serve a DEBUG line nobody saw; and
+* a streamed download was fully materialised by the hook before the caller's
+  ``aiter_bytes()`` loop ran -- so ``stream_to_file`` was not, in production,
+  streaming at all. A 1 GB ingest download cost ~3.6x the file size resident and
+  OOMKilled the fast-tier workers.
+
+The load-bearing property here is *not* what gets logged, it is that a streamed
+response reaches the caller unconsumed. These tests pin that directly, with the
+real hook attached to a real client, because every prior local reproduction
+built its own hook-free client and therefore proved nothing about production.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.client import log_response
+from nextcloud_mcp_server.client.base import STREAMING_REQUEST_EXTENSION
+
+pytestmark = pytest.mark.unit
+
+HOOK_LOGGER = "nextcloud_mcp_server.client"
+
+
+class _AsyncStream(httpx.AsyncByteStream):
+    """A not-yet-read response body.
+
+    ``httpx.Response(content=...)`` is consumed the moment it is constructed, so
+    it cannot show whether the hook read anything. A stream-backed response
+    starts with ``is_stream_consumed`` False, which is what makes the assertion
+    meaningful -- and it is also what an over-the-wire response actually is.
+    """
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def __aiter__(self):
+        yield self._body
+
+
+def _response(*, streaming: bool, body: bytes = b"payload") -> httpx.Response:
+    extensions = {STREAMING_REQUEST_EXTENSION: True} if streaming else {}
+    request = httpx.Request("GET", "https://nc/f.pdf", extensions=extensions)
+    return httpx.Response(200, stream=_AsyncStream(body), request=request)
+
+
+async def test_streamed_response_is_left_unconsumed(caplog):
+    """The hook must not read a body the caller marked as streaming."""
+    response = _response(streaming=True)
+    caplog.set_level(logging.DEBUG, logger=HOOK_LOGGER)
+
+    await log_response(response)
+
+    assert not response.is_stream_consumed
+    assert "streaming; body not read" in caplog.text
+
+
+async def test_non_streamed_response_is_still_logged(caplog):
+    """Ordinary responses keep the previous behaviour at DEBUG."""
+    response = _response(streaming=False, body=b"hello")
+    caplog.set_level(logging.DEBUG, logger=HOOK_LOGGER)
+
+    await log_response(response)
+
+    assert response.is_stream_consumed
+    assert "hello" in caplog.text
+
+
+async def test_no_read_when_debug_is_disabled(caplog):
+    """With DEBUG off the hook must not touch the body at all.
+
+    This is the half of the bug that made it expensive at INFO in production:
+    the read was unconditional while only the logging was gated.
+    """
+    response = _response(streaming=False, body=b"hello")
+    caplog.set_level(logging.INFO, logger=HOOK_LOGGER)
+
+    await log_response(response)
+
+    assert not response.is_stream_consumed
+    assert "hello" not in caplog.text
+
+
+async def test_stream_survives_the_real_hook_end_to_end(tmp_path):
+    """A streamed download through a client carrying the REAL hooks.
+
+    This is the test that would have caught the production bug. Asserting on
+    ``log_response`` in isolation is not enough -- the failure only appears once
+    the hook is attached to the client and something tries to iterate the body.
+    """
+    body = b"x" * (512 * 1024)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # stream=, not content=: a Response built with content= is consumed on
+        # construction, so it would look "buffered" no matter what the hook did
+        # and the test could never fail.
+        return httpx.Response(200, stream=_AsyncStream(body))
+
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://nc",
+        event_hooks={"response": [log_response]},
+    )
+
+    received = 0
+    request = http.build_request(
+        "GET", "/f.pdf", extensions={STREAMING_REQUEST_EXTENSION: True}
+    )
+    response = await http.send(request, stream=True)
+    try:
+        # THE assertion. Counting bytes afterwards proves nothing: once httpx
+        # has buffered a body it replays it from response.content, so the byte
+        # count matches whether or not the hook ate the stream. Only the
+        # unconsumed state distinguishes streaming from buffering, and it is
+        # what bounds memory.
+        assert not response.is_stream_consumed
+
+        async for chunk in response.aiter_bytes():
+            received += len(chunk)
+    finally:
+        await response.aclose()
+        await http.aclose()
+
+    assert received == len(body)
+
+
+async def test_unmarked_stream_would_be_consumed(tmp_path):
+    """Pins WHY the marker is required, so its removal fails loudly.
+
+    Without the extension the hook cannot tell a streamed request apart and
+    reads it -- which is precisely the production failure. If a future change
+    makes the marker unnecessary (e.g. httpx exposes stream intent on the
+    request), this test should be updated deliberately, not silently.
+    """
+    body = b"y" * 4096
+
+    transport = httpx.MockTransport(
+        lambda r: httpx.Response(200, stream=_AsyncStream(body))
+    )
+    http = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://nc",
+        event_hooks={"response": [log_response]},
+    )
+
+    logging.getLogger(HOOK_LOGGER).setLevel(logging.DEBUG)
+    request = http.build_request("GET", "/f.pdf")  # deliberately unmarked
+    response = await http.send(request, stream=True)
+    try:
+        assert response.is_stream_consumed
+    finally:
+        await response.aclose()
+        await http.aclose()


### PR DESCRIPTION
**Root cause of the fast-tier ingest OOMs.** `nextcloud_mcp_server/client/__init__.py:45-47`:

```python
async def log_response(response: Response):
    await response.aread()                                    # unconditional
    logger.debug("Response [%s] %s", response.status_code, response.text)
```

Registered globally as an httpx response event hook. Two problems, one fatal:

1. **The read ran unconditionally** — only the *logging* was gated on DEBUG. Every response in the app was fully read and stringified regardless of log level, to produce a line nobody saw at INFO.
2. **httpx invokes response hooks before the body is fetched**, so on a streamed GET the hook consumed the entire document before the caller's `aiter_bytes()` loop ran. `stream_to_file` was never actually streaming in production, whatever the settings said.

## Evidence

| observation | explanation |
|---|---|
| `Streaming file to` logged **7×**, `Streamed … (N bytes)` **0×** | hook consumes the body before the loop starts |
| ~2.5 GB anonymous RSS on a ~700 MB document (~3.6×) | raw body + decoded `.text` copy |
| spool file created but empty; one orphan swept per crash | `spool_target` opened it, nothing written |
| OOMs predate turning DEBUG on | `aread()` is unconditional |
| local reproductions flat at 45 MB | bare `AsyncClient`, **no event hooks** |

It also explains why three correct fixes didn't help: streamed download, path-based parse and windowed bbox were all bypassed at the transport layer.

## Fix

Return before the read when DEBUG is off, and never read a request the caller marked as streaming. `_stream_request` tags requests with `STREAMING_REQUEST_EXTENSION` — httpx exposes no stream intent on the request otherwise.

## On the tests

The tests assert the property that matters: **a streamed response reaches the caller unconsumed**, with the real hook attached to a real client.

Two things I got wrong first, both caught by mutation testing and worth stating because they are easy traps:

- **Counting bytes after iteration does not detect this.** Once httpx buffers a body it replays it from `response.content`, so the byte count matches whether or not the hook ate the stream. My first end-to-end test passed under the mutant. Only `is_stream_consumed` distinguishes streaming from buffering.
- **`httpx.Response(content=...)` is consumed at construction**, so a `MockTransport` handler built that way looks buffered no matter what the hook does — the test could never fail. The mock has to return a `stream=`-backed response.

Mutation-verified: restoring the unconditional `aread()` fails **3 of 5** tests, including the end-to-end one.

`ruff`, `ruff format`, `ty` clean; **2292 unit tests pass**.

## After merge

Worth re-checking fast-tier working set on a multi-thousand-page document before drawing conclusions about the 2 GiB cap — this is the first change that lets the earlier streaming work actually take effect, so the previous measurements were all taken against a buffered path.

Also note `log_request` logs `request.content`, which has the same shape of problem for streamed *uploads*. Not touched here — no streaming upload path exists today.

---

_This PR was generated with the help of AI, and reviewed by a Human_