### PR TITLE
ci: make the pinned pact CLI version renovate-managed

### DIFF
--- a/.github/workflows/pact-record-deployment.yml
+++ b/.github/workflows/pact-record-deployment.yml
@@ -64,7 +64,7 @@ jobs:
           # now and is no longer maintained). The cargo-dist installer appends
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the record-deployment step below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
           echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
           "$HOME/.pact/bin/pact" --help > /dev/null
 

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
           # now and is no longer maintained). The cargo-dist installer appends
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the broker steps below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
           echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
           "$HOME/.pact/bin/pact" --help > /dev/null
 
@@ -212,7 +212,7 @@ jobs:
           # now and is no longer maintained). The cargo-dist installer appends
           # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
           # for the broker steps below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.5/pact-installer.sh | sh
+          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
           echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
           "$HOME/.pact/bin/pact" --help > /dev/null
 

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,18 @@
       "packageNameTemplate": "docker.io/library/nextcloud",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Unified pact CLI installer URL pinned in the pact workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "https://github\\.com/pact-foundation/pact-cli/releases/download/(?<currentValue>v[^/]+)/pact-installer\\.sh"
+      ],
+      "depNameTemplate": "pact-foundation/pact-cli",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## Context

This repo already migrated to the unified `pact` CLI ahead of the other two — but the pinned installer version is **invisible to Renovate**, so nothing has ever proposed a bump.

The only `customManager` in `renovate.json` targets the Nextcloud image matrix, scoped to `test.yml`:

```
managerFilePatterns: ["/^\\.github/workflows/test\\.yml$/"]
matchStrings:        ["nextcloud_version: …"]
```

It matches neither `pact.yml` nor `pact-record-deployment.yml`, and no built-in manager picks up a bare `curl` URL inside a `run:` block. The result is an unmanaged pin that had already drifted **two patch releases** behind — `v0.10.5` while current is `v0.10.7` — with no dependency-dashboard entry to surface it.

This is exactly the failure mode the sibling PRs were written to avoid, so this closes the gap fleet-wide.

## Changes

- `renovate.json`: add a `customManager` matching the pact-cli release-download URL. The file pattern `^\.github/workflows/.+\.ya?ml$` covers both pact workflows in one entry, so all three install sites stay in sync automatically.
- Bump the three pinned installer URLs `v0.10.5` → `v0.10.7`.

No behavioural change — the install mechanism and every `pact broker <sub>` invocation are untouched.

## Verification

- `renovate.json` parses; `customManagers` now has 2 entries.
- The regex captures `v0.10.7` cleanly from the pinned URL (`(?<currentValue>v[^/]+)` stops at the next `/`).
- This repo's existing **"Verify pact broker CLI flags"** step asserts `--consumer-app-version`, `--branch`, `--to-environment` and `--environment` still exist before the broker steps run, so the version bump is guarded by CI rather than by assertion.

CI tooling only — no API surface or contract behaviour changes, so no new e2e/Pact coverage applies. The pact jobs on this PR are the end-to-end check.

Companion to astrolabe-cloud-website#712 and astrolabe#252. Deck card #732 (board 11 — Contract Testing).

---

_This PR was generated with the help of AI, and reviewed by a Human_