### PR TITLE
feat(vector): per-user paths for shared documents (ADR-033)

### DIFF
--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -193,6 +193,33 @@ explicitly rejected in favour of the single-`folder_id` containment term.
   owner's next scan (owner-scoped, in `claim_existing_index`); searches degrade
   gracefully to the `file_path` fallback in the interim.
 
+## Future cleanup (version-gated, NOT part of this change)
+
+This change is **purely additive** — it removes no index or payload field. It
+does, however, set up two retirements that a **later version** can make, each
+discoverable by version (per "gate on versions, never on merge order") and each
+with a hard precondition that is unsafe to skip:
+
+1. **Retire the `file_path` TEXT payload index** (`qdrant_client.py`
+   `_PAYLOAD_INDEX_FIELDS`). Precondition: every point carries `folder_ancestors`
+   (a completed backfill across all collections) **and** the `MatchText(file_path)`
+   fallback branch in `build_base_filter_conditions` has been dropped **and**
+   free-text path search has been re-homed off `file_path`. Until all three hold,
+   dropping the index breaks folder scoping / free-text path search for
+   un-backfilled points.
+2. **Drop the `MatchText(file_path)` fallback branch** in the folder-scope filter
+   (and, optionally, stop writing the scalar `file_path` once per-user display
+   paths are sourced entirely from `document_paths` with a guaranteed backfill).
+   Precondition: same completed `folder_ancestors` backfill, plus a
+   `document_paths` row guaranteed for every (user, file) that can be returned.
+
+Neither is safe today: un-backfilled points would silently drop out of
+folder-scoped results, and files with no `document_paths` row would lose their
+display path. The trigger to do the cleanup is "a `folder_ancestors` backfill has
+run to completion on all live collections" — record that in the `BREAKING CHANGE:`
+footer / CHANGELOG of the version that performs the removal, and gate any
+consumer on the advertised capability rather than assuming the removal shipped.
+
 ## Test strategy (repo test gate)
 
 - **Unit:** `reconcile_document_path` owner-gating (Phase 1); `document_paths`

--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -113,12 +113,19 @@ New table `document_paths`, one row per `(doc_type, doc_id, user_id)`:
 
 Portable types only (Text + epoch BigInteger), so the one migration runs on both
 self-host SQLite and cloud Postgres via the ADR-026 abstraction — exactly like
-`batch_ocr_jobs` (migration 008). Empty and idle for single-owner corpora.
+`batch_ocr_jobs` (migration 008).
 
 - **Write:** the scanner upserts `(doc_type, doc_id, user_id) -> current_path`
   for every file it sees (dedup hit *or* fresh index). One row per doc per user,
   updated with a single `INSERT ... ON CONFLICT DO UPDATE`. This replaces the
   per-chunk `set_payload` thrash with a single bounded relational write.
+  **Write-volume trade-off:** the upsert is currently *unconditional*, so the
+  table holds ~Σ(files × readers) rows rewritten each scan pass — including for
+  single-owner content, which does not strictly need a row (the owner's path is
+  the Qdrant scalar the fallback serves). This is an accepted swap of a small
+  idempotent relational upsert for the per-chunk Qdrant write it removes; scoping
+  the upsert to genuine cross-user readers (see *Follow-ups*) would make the
+  table sparse and is deferred.
 - **Read:** after Qdrant returns the top-K, batch-fetch the querying user's rows
   for the returned `doc_id`s and override the displayed `file_path`/`title`.
   Falls back to the Qdrant scalar when no row exists (legacy / not-yet-scanned).
@@ -192,6 +199,29 @@ explicitly rejected in favour of the single-`folder_id` containment term.
   immediately for new/re-indexed docs and lazily backfilled for old points by the
   owner's next scan (owner-scoped, in `claim_existing_index`); searches degrade
   gracefully to the `file_path` fallback in the interim.
+
+## Deferred follow-ups (accepted, not part of this change)
+
+These are known, non-blocking, and each documented at its call site:
+
+1. **Scope the `document_paths` upsert to genuine cross-user readers.** Today the
+   scanner upserts unconditionally for every (user, file) on every scan, so the
+   table is not sparse (see the migration's write-volume note). Owner content
+   needs no row — the owner-pinned Qdrant scalar is the fallback — so upserting
+   only when the scanning user is *not* the document's `owner_id` (a real reader
+   of a shared file) would make the table idle for single-owner corpora without
+   changing displayed results.
+2. **Cache / parallelize the search-time `path_prefix -> folder_id` resolution.**
+   `resolve_prefix_folder_ids` issues one synchronous `PROPFIND` per prefix in a
+   sequential loop on the search hot path. A per-user TTL cache (like
+   `list_accessible_owners`) and/or an `anyio` task group to resolve prefixes
+   concurrently would cut worst-case latency; prefix count is typically 1–2, so
+   this is low priority.
+3. **Share an ancestor-resolution cache on the fresh-index path.** The processor
+   resolves `folder_ancestors` per `DocumentTask` (queue worker, decoupled from
+   the scan pass), so sibling files under one tree don't share lookups the way
+   the scanner-side backfill does. A per-worker TTL cache is the fix if the bulk
+   initial scan's PROPFIND volume shows up.
 
 ## Future cleanup (version-gated, NOT part of this change)
 

--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -132,8 +132,13 @@ Add a user-agnostic `folder_ancestors` payload key: the list of ancestor folder
 
 - **Resolution:** at index time, resolve each ancestor folder's `fileid` via a
   `PROPFIND` (Depth 0, `oc:fileid` — `WebDAVClient.get_fileid`) walking up the
-  file's path, memoisable per caller (folder→fileid is stable within a pass).
-  Ancestors of the *shared* folder resolve to the same `fileid`s for every user.
+  file's path. `resolve_folder_ancestors` takes a `cache` dict so shared parent
+  folders resolve once. The scanner threads one per-scan-pass cache into the
+  lazy backfill (`claim_existing_index`); the fresh-index write runs in the
+  queue worker, one `DocumentTask` at a time (decoupled from the scan pass), so
+  it resolves per-document — a per-worker TTL cache is the follow-up if the bulk
+  initial scan's PROPFIND volume shows up. Ancestors of the *shared* folder
+  resolve to the same `fileid`s for every user.
 - **Write:** stamp `folder_ancestors` on every **real (non-placeholder) file
   chunk** in the processor, alongside the existing scalar `file_path`.
   Placeholder points are excluded from search (`get_placeholder_filter`), so they

--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -1,0 +1,193 @@
+# ADR-033: Per-user paths for shared documents
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deck:** board 12 card #737 (this change); card #739 (loose prefix match);
+  card #740 (folder-ancestor filtering — Phase 3 here)
+- **Related:** ADR-027 (rich search filters), ADR-026 (pluggable database
+  backend), note 391147 (Qdrant outage 2026-07-19, where the thrash was found)
+
+## Context
+
+A file visible to more than one user has **one** Nextcloud `fileid` and one
+`etag` for everyone, and our chunk point IDs are user-agnostic
+(`uuid5(...doc_id, chunk_index)` — `vector/payload_keys.py`). So the tenant-wide
+dedup (`vector/sharing_state.py::claim_existing_index`) intentionally stores
+**one point set per `doc_id`**, shared by every reader via the `acl_principals`
+observed-access set. That dedup is correct and must be preserved — it is what
+stops N users re-embedding identical content N times.
+
+The problem is that each shared point carries a **single scalar `file_path`**,
+but the users mount the same file at *different paths* (a share is mounted under
+each recipient's own root). Every user's scan calls `claim_existing_index(...,
+current_path=<their path>)`, which calls `reconcile_document_path`, which
+rewrites the scalar to the caller's path. Nothing is being renamed, yet the
+value flips back and forth once per user per scan pass:
+
+```
+Reconciled path for file_<id> after rename/move: '/A/doc.pdf' -> '/B/A/doc.pdf'
+Reconciled path for file_<id> after rename/move: '/B/A/doc.pdf' -> '/A/doc.pdf'
+```
+
+Observed on blackbox-demo, 2026-07-20, service 0.142.0.
+
+### Impact
+
+1. **Write amplification** — a `set_payload` against Qdrant for every shared
+   doc, for every user, on every scan pass (300 s interval). `file_path` is
+   doc-level data duplicated across every chunk, so one reconcile rewrites every
+   chunk of the document (this tenant: 2,832 docs but ~288k chunks).
+2. **Non-deterministic `file_path`** — it reflects whichever user scanned last.
+   This silently breaks the `path_prefix` / `path_prefixes` search filters
+   (`search/access_filter.py`): a user filtering on their own folder can miss
+   documents they can see, or match on a path that is not theirs.
+3. **Loose prefix semantics (card #739)** — the filter is
+   `MatchText(key="file_path")`, which is token-containment (server Qdrant) or
+   substring (embedded), never a left-anchored prefix. `/TORS` matches any path
+   containing the `TORS` token at any depth.
+
+## Decision
+
+**Access control stays in Qdrant; per-user *display* metadata moves to the
+relational store; path *filtering* becomes user-agnostic folder-ancestor
+containment in Qdrant.** Concretely, every predicate that participates in the
+Qdrant ANN traversal is resolved to a user-agnostic, index-resolved, corpus-flat
+term inside Qdrant (`acl_principals` for visibility, `folder_ancestors` for
+scoping). The relational DB holds only **non-security** metadata and is **never
+a filter**:
+
+1. a `path_prefix -> folder_id` resolution (one small lookup *before* the query);
+2. the per-user *display* path (joined onto the ~10 returned results, *after*
+   retrieval).
+
+Both relational reads are bounded and tiny, so a store inconsistency degrades a
+**displayed path**, never a permission or a retrieval result. Qdrant is the
+system of record; the relational table is a derived cache. That asymmetry is
+what makes the split safe (contrast the 2026-07-19 partial-write incident, where
+a dual-write *did* affect indexed data).
+
+We deliberately keep hybrid dense+BM25 fusion in Qdrant rather than moving
+everything to pgvector — the RRF/DBSF fusion is native to the engine and not
+worth rebuilding at current scale.
+
+### Why not just keep the scalar `file_path` as the filter field?
+
+Because the scalar can only ever be correct for **one** user, and path filtering
+needs to be correct for **every** reader of a shared file. A shared *folder* has
+one canonical Nextcloud `fileid` that is identical for all users who mount it, so
+the **ancestor folder-ID chain is user-agnostic for the shared portion** — which
+is exactly the term that makes filtered-ANN both correct and flat in corpus size.
+
+## Design
+
+### Phase 1 — Deterministic canonical `file_path` (stop the thrash)
+
+Pin the scalar `file_path`/`title` to the **indexer of record** = the point's
+`owner_id`. `reconcile_document_path` is only allowed to rewrite when the caller
+*is* the canonical owner (a genuine owner-side rename), or when the stored path
+is empty (legacy backfill). A reader who observes the file at a different mount
+path no longer overwrites it.
+
+- No schema change, no new store.
+- Idempotent scan: repeated passes over an unchanged shared file issue **no**
+  `set_payload` and log no `Reconciled path`.
+- The scalar becomes deterministic (always the owner's path). Non-owner display
+  paths are handled in Phase 2; non-owner *filtering* in Phase 3.
+
+`claim_existing_index` gains the existing point's `owner_id` (already fetched in
+the dedup payload — no extra round-trip) and passes it to
+`reconcile_document_path`, which becomes a no-op unless
+`caller_user_id == owner_id`.
+
+### Phase 2 — Relational per-user path store (display path)
+
+New table `document_paths`, one row per `(doc_type, doc_id, user_id)`:
+
+| column      | type                | note                                  |
+|-------------|---------------------|---------------------------------------|
+| `doc_type`  | Text (PK)           | e.g. `file`                           |
+| `doc_id`    | Text (PK)           | Nextcloud fileid                      |
+| `user_id`   | Text (PK)           | the reader                            |
+| `file_path` | Text                | this user's mount path                |
+| `updated_at`| BigInteger (epoch s)| observability / staleness            |
+
+Portable types only (Text + epoch BigInteger), so the one migration runs on both
+self-host SQLite and cloud Postgres via the ADR-026 abstraction — exactly like
+`batch_ocr_jobs` (migration 008). Empty and idle for single-owner corpora.
+
+- **Write:** the scanner upserts `(doc_type, doc_id, user_id) -> current_path`
+  for every file it sees (dedup hit *or* fresh index). One row per doc per user,
+  updated with a single `INSERT ... ON CONFLICT DO UPDATE`. This replaces the
+  per-chunk `set_payload` thrash with a single bounded relational write.
+- **Read:** after Qdrant returns the top-K, batch-fetch the querying user's rows
+  for the returned `doc_id`s and override the displayed `file_path`/`title`.
+  Falls back to the Qdrant scalar when no row exists (legacy / not-yet-scanned).
+- **Backfill:** none required up front — the table fills as scans run, and the
+  Qdrant scalar is the fallback. Qdrant remains the source of truth.
+
+### Phase 3 — Folder-ancestor filtering (card #740)
+
+Add a user-agnostic `folder_ancestors` payload key: the list of ancestor folder
+`fileid`s (as strings) of the file's canonical path, KEYWORD-indexed in Qdrant.
+
+- **Resolution:** at index time, resolve each ancestor folder's `fileid` via a
+  `PROPFIND` (Depth 0, `oc:fileid`) walking up the file's path, memoised per
+  scan (folder→fileid is stable within a pass). Ancestors of the *shared* folder
+  resolve to the same `fileid`s for every user.
+- **Write:** stamp `folder_ancestors` on every chunk (processor + placeholder),
+  alongside the existing scalar `file_path`.
+- **Filter:** `path_prefix` is resolved to a `folder_id` (the prefix path's own
+  `fileid`, via the same PROPFIND lookup or the per-user path store), then the
+  Qdrant filter becomes `MatchAny(key="folder_ancestors", any=[folder_id])`.
+  This is a **true containment** filter (fixes card #739's loose match), applied
+  *inside* HNSW traversal (filtered-ANN, the only sound ordering), and
+  user-agnostic. The legacy `MatchText(file_path)` branch is retained as a
+  fallback for points that predate `folder_ancestors` (until backfilled) and for
+  free-text path search.
+- **Backfill:** a payload-only backfill re-resolves `folder_ancestors` for
+  existing points (no re-embed), gated behind admin tooling. **This step must be
+  validated against a live Qdrant** (the KEYWORD index on the new key, and the
+  `MatchAny` selectivity, are only meaningfully verifiable on a real instance —
+  see the design thread on card #737). Until backfilled, a collection degrades
+  to the `MatchText(file_path)` fallback — correct-ish for the owner, unchanged
+  from today for readers.
+
+### Measured budget (card #737 comments, throwaway Qdrant v1.18.3)
+
+`MatchAny` filtering is effectively free at doc granularity across the whole
+corpus; cost is driven by **list length**, ~1 ms / 1,000 ids. The
+`path_prefix -> folder_id` resolution yields a *single* id, so the filter list is
+tiny and the measured threshold never binds. The prefilter approach that *would*
+blow up (passing a per-user `MatchAny(doc_id, [...])` of every visible doc) is
+explicitly rejected in favour of the single-`folder_id` containment term.
+
+## Consequences
+
+- **Positive:** the thrash and its write amplification stop at Phase 1; display
+  paths become per-user-correct at Phase 2; path filtering becomes correct for
+  every reader and truly left-anchored at Phase 3. Dedup (one point set per
+  `doc_id`) is preserved throughout. No re-embedding at any phase.
+- **Negative / risk:** Phase 2 introduces a second store; we mitigate by making
+  it a *derived, non-security* cache (Qdrant is system of record) so an
+  inconsistency can only mis-display a path. Phase 3's backfill touches live
+  collection payloads and must be validated on a real Qdrant before running
+  against a tenant.
+- **Migration:** existing collections need no re-embed. Phase 2's table
+  self-populates. Phase 3's `folder_ancestors` is forward-written immediately and
+  backfilled for old points via admin tooling; searches degrade gracefully to
+  the `file_path` fallback in the interim.
+
+## Test strategy (repo test gate)
+
+- **Unit:** `reconcile_document_path` owner-gating (Phase 1); `document_paths`
+  upsert/read + fallback (Phase 2); `folder_ancestors` filter construction and
+  ancestor resolution (Phase 3).
+- **Integration (full-stack Docker + live Qdrant):** the multi-user shared-file
+  convergence test — index a file shared A+B at different paths, assert repeated
+  scans produce no `Reconciled path` writes, each user's search returns their own
+  display path, and each user's `path_prefix` on their own folder matches while
+  the other's does not (card #737 acceptance criteria; extends the release-
+  convergence test tracked by card #665).
+- **Contract:** no cross-service boundary changes shape here; `/api/v1/search`
+  response fields are unchanged (per-user path is substituted into the existing
+  `file_path`/`title`), so the existing provider verification continues to hold.

--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -43,8 +43,8 @@ Observed on blackbox-demo, 2026-07-20, service 0.142.0.
    documents they can see, or match on a path that is not theirs.
 3. **Loose prefix semantics (card #739)** — the filter is
    `MatchText(key="file_path")`, which is token-containment (server Qdrant) or
-   substring (embedded), never a left-anchored prefix. `/TORS` matches any path
-   containing the `TORS` token at any depth.
+   substring (embedded), never a left-anchored prefix. `/Reports` matches any
+   path containing the `Reports` token at any depth.
 
 ## Decision
 
@@ -131,26 +131,36 @@ Add a user-agnostic `folder_ancestors` payload key: the list of ancestor folder
 `fileid`s (as strings) of the file's canonical path, KEYWORD-indexed in Qdrant.
 
 - **Resolution:** at index time, resolve each ancestor folder's `fileid` via a
-  `PROPFIND` (Depth 0, `oc:fileid`) walking up the file's path, memoised per
-  scan (folder→fileid is stable within a pass). Ancestors of the *shared* folder
-  resolve to the same `fileid`s for every user.
-- **Write:** stamp `folder_ancestors` on every chunk (processor + placeholder),
-  alongside the existing scalar `file_path`.
+  `PROPFIND` (Depth 0, `oc:fileid` — `WebDAVClient.get_fileid`) walking up the
+  file's path, memoisable per caller (folder→fileid is stable within a pass).
+  Ancestors of the *shared* folder resolve to the same `fileid`s for every user.
+- **Write:** stamp `folder_ancestors` on every **real (non-placeholder) file
+  chunk** in the processor, alongside the existing scalar `file_path`.
+  Placeholder points are excluded from search (`get_placeholder_filter`), so they
+  carry no scope key.
 - **Filter:** `path_prefix` is resolved to a `folder_id` (the prefix path's own
-  `fileid`, via the same PROPFIND lookup or the per-user path store), then the
-  Qdrant filter becomes `MatchAny(key="folder_ancestors", any=[folder_id])`.
-  This is a **true containment** filter (fixes card #739's loose match), applied
-  *inside* HNSW traversal (filtered-ANN, the only sound ordering), and
-  user-agnostic. The legacy `MatchText(file_path)` branch is retained as a
-  fallback for points that predate `folder_ancestors` (until backfilled) and for
-  free-text path search.
-- **Backfill:** a payload-only backfill re-resolves `folder_ancestors` for
-  existing points (no re-embed), gated behind admin tooling. **This step must be
-  validated against a live Qdrant** (the KEYWORD index on the new key, and the
-  `MatchAny` selectivity, are only meaningfully verifiable on a real instance —
-  see the design thread on card #737). Until backfilled, a collection degrades
-  to the `MatchText(file_path)` fallback — correct-ish for the owner, unchanged
-  from today for readers.
+  `fileid`, via `resolve_prefix_folder_ids` → `get_fileid`), then the Qdrant
+  filter ORs `MatchAny(key="folder_ancestors", any=[folder_id])` with the legacy
+  `MatchText(file_path)` branch. The `MatchAny` branch is a **true containment**
+  filter (fixes card #739's loose match), applied *inside* HNSW traversal
+  (filtered-ANN, the only sound ordering), and user-agnostic; the `MatchText`
+  branch is retained as a fallback for points that predate `folder_ancestors`
+  (until backfilled) and for free-text path search. **Cost:** resolution is a
+  synchronous PROPFIND per distinct prefix on the search path (currently
+  uncached — a per-user TTL cache like `list_accessible_owners` is the obvious
+  follow-up if it shows up in latency).
+- **Backfill:** rather than a separate admin job (which would lack a per-user
+  WebDAV client to resolve fileids *as that user*), the backfill is **lazy and
+  owner-scoped**, folded into `claim_existing_index`: on a dedup hit for a
+  pre-Phase-3 document, when the scanning user is the owner and the key is
+  absent, the owner's canonical path is resolved and written once
+  (`set_folder_ancestors`). It reuses the payload already fetched for the dedup
+  (no extra scroll), never re-embeds, and is owner-only so a reader's mount
+  prefix never pollutes the (bounded, user-agnostic) ancestor set. Until an owner
+  scan backfills a given doc, search degrades to the `MatchText(file_path)`
+  fallback for it. **The live behaviour of the new KEYWORD index + `MatchAny`
+  selectivity should still be validated against a real Qdrant** (only meaningfully
+  verifiable on a real instance — see the design thread on card #737).
 
 ### Measured budget (card #737 comments, throwaway Qdrant v1.18.3)
 
@@ -173,9 +183,10 @@ explicitly rejected in favour of the single-`folder_id` containment term.
   collection payloads and must be validated on a real Qdrant before running
   against a tenant.
 - **Migration:** existing collections need no re-embed. Phase 2's table
-  self-populates. Phase 3's `folder_ancestors` is forward-written immediately and
-  backfilled for old points via admin tooling; searches degrade gracefully to
-  the `file_path` fallback in the interim.
+  self-populates as scans run. Phase 3's `folder_ancestors` is forward-written
+  immediately for new/re-indexed docs and lazily backfilled for old points by the
+  owner's next scan (owner-scoped, in `claim_existing_index`); searches degrade
+  gracefully to the `file_path` fallback in the interim.
 
 ## Test strategy (repo test gate)
 

--- a/nextcloud_mcp_server/alembic/versions/20260721_1200_009_add_document_paths.py
+++ b/nextcloud_mcp_server/alembic/versions/20260721_1200_009_add_document_paths.py
@@ -15,7 +15,18 @@ per-chunk Qdrant ``set_payload`` path-thrash.
 
 Portable types only (Text + unix-epoch BigInteger), like the rest of this schema
 (cf. ``batch_ocr_jobs``, migration 008), so the same migration runs on both
-self-host SQLite and cloud Postgres. Idle and empty for single-owner corpora.
+self-host SQLite and cloud Postgres.
+
+Write-volume note (accepted trade-off): the scanner currently upserts one row per
+tagged file **per scanning user, on every scan pass** — not only for
+multi-reader documents — so the table holds ~Σ(files × readers) rows, each
+rewritten every scan interval, even on a single-owner corpus. This is a
+deliberate swap of a small, idempotent relational upsert for the per-chunk Qdrant
+``set_payload`` path-thrash it replaces (a shared doc's path used to be rewritten
+across *every chunk* on every reader's pass). Scoping the upsert to actual
+cross-user readers (owner content needs no row — the owner's path is the Qdrant
+scalar the reader falls back to) would make the table genuinely sparse; it is a
+tracked follow-up in ADR-033 rather than part of this change.
 
 Revision ID: 009
 Revises: 008

--- a/nextcloud_mcp_server/alembic/versions/20260721_1200_009_add_document_paths.py
+++ b/nextcloud_mcp_server/alembic/versions/20260721_1200_009_add_document_paths.py
@@ -1,0 +1,67 @@
+"""Add document_paths table for per-user shared-document display paths.
+
+ADR-033 Phase 2 (Deck #737). A file visible to more than one user is mounted at
+a *different* path per user, but the tenant-wide dedup stores one point set per
+``doc_id`` with a single scalar ``file_path`` (pinned to the owner in Phase 1).
+This table holds each reader's own mount path, keyed on
+``(doc_type, doc_id, user_id)``, joined onto the ~10 returned search results
+*after* retrieval so every reader sees their own path. It is a derived,
+non-security cache — Qdrant remains the system of record, and a missing/stale row
+degrades a displayed path, never a permission or a retrieval result.
+
+One row per (document, reader). The scanner upserts a user's observed path on
+every scan (dedup hit or fresh index); a single relational UPDATE replaces the
+per-chunk Qdrant ``set_payload`` path-thrash.
+
+Portable types only (Text + unix-epoch BigInteger), like the rest of this schema
+(cf. ``batch_ocr_jobs``, migration 008), so the same migration runs on both
+self-host SQLite and cloud Postgres. Idle and empty for single-owner corpora.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-07-21 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_paths",
+        # Natural key: one path per (document, reader). The three-column key IS
+        # the primary key and doubles as the ON CONFLICT target the scanner's
+        # upsert relies on.
+        sa.Column("doc_type", sa.Text(), nullable=False),
+        sa.Column("doc_id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Text(), nullable=False),
+        # This reader's mount path for the document. Overwritten in place when the
+        # reader observes a new path (rename/move/re-share) — no history kept.
+        sa.Column("file_path", sa.Text(), nullable=False),
+        # Unix-epoch seconds of the last upsert (observability / staleness only;
+        # never used as a filter).
+        sa.Column("updated_at", sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "doc_type", "doc_id", "user_id", name="pk_document_paths"
+        ),
+    )
+    # Lookup index for the post-retrieval join: given a querying user and a set of
+    # returned doc_ids, fetch their paths. The PK is (doc_type, doc_id, user_id),
+    # so a user-leading index serves the ``user_id = ? AND doc_id IN (...)`` shape
+    # the search join issues.
+    op.create_index(
+        "ix_document_paths_user_doc",
+        "document_paths",
+        ["user_id", "doc_type", "doc_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_paths_user_doc", table_name="document_paths")
+    op.drop_table("document_paths")

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -1553,6 +1553,40 @@ class WebDAVClient(BaseNextcloudClient):
         )
         return len(results) > 0
 
+    async def get_fileid(self, path: str) -> str | None:
+        """Return the Nextcloud fileid of a file/folder path, or None if absent.
+
+        A Depth-0 ``PROPFIND`` for ``oc:fileid`` on the principal-scoped path.
+        Used by the folder-ancestor resolver (ADR-033 Phase 3) to map an ancestor
+        folder path to its canonical fileid — stable across every user who mounts
+        a shared folder, which is what makes the folder-scope search filter
+        user-agnostic. A 404 (path gone/inaccessible) returns None so callers
+        degrade gracefully rather than aborting an index.
+        """
+        await self._ensure_principal_id()
+        webdav_path = self._webdav_path(path)
+        propfind_body = (
+            '<?xml version="1.0"?>'
+            '<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">'
+            "<d:prop><oc:fileid/></d:prop></d:propfind>"
+        )
+        headers = {"Depth": "0", "Content-Type": "text/xml", "OCS-APIRequest": "true"}
+        try:
+            response = await self._make_request(
+                "PROPFIND", webdav_path, content=propfind_body, headers=headers
+            )
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+        root = ET.fromstring(response.content)
+        ns = {"d": "DAV:", "oc": "http://owncloud.org/ns"}
+        fileid_elem = root.find(".//oc:fileid", ns)
+        if fileid_elem is None or not fileid_elem.text:
+            return None
+        return fileid_elem.text.strip()
+
     async def _get_file_info_by_id(self, file_id: int) -> Dict[str, Any]:
         """Get file information by Nextcloud file ID using WebDAV.
 

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -1581,11 +1581,15 @@ class WebDAVClient(BaseNextcloudClient):
                 return None
             raise
         root = ET.fromstring(response.content)
-        ns = {"d": "DAV:", "oc": "http://owncloud.org/ns"}
-        fileid_elem = root.find(".//oc:fileid", ns)
-        if fileid_elem is None or not fileid_elem.text:
-            return None
-        return fileid_elem.text.strip()
+        # Match oc:fileid by local name (namespace-agnostic) rather than a
+        # namespace map, so the owncloud namespace URL is not embedded as a
+        # standalone string literal (it stays only inside the request-body XML).
+        for elem in root.iter():
+            if isinstance(elem.tag, str) and elem.tag.rsplit("}", 1)[-1] == "fileid":
+                text = (elem.text or "").strip()
+                if text:
+                    return text
+        return None
 
     async def _get_file_info_by_id(self, file_id: int) -> Dict[str, Any]:
         """Get file information by Nextcloud file ID using WebDAV.

--- a/nextcloud_mcp_server/search/access_filter.py
+++ b/nextcloud_mcp_server/search/access_filter.py
@@ -28,7 +28,7 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import Iterable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from qdrant_client.models import (
     Condition,
@@ -40,7 +40,11 @@ from qdrant_client.models import (
     Range,
 )
 
+from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.placeholder import get_placeholder_filter
+
+if TYPE_CHECKING:
+    from nextcloud_mcp_server.vector.folder_ancestors import FileIdResolver
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +267,7 @@ def build_base_filter_conditions(
     modified_before: int | None = None,
     path_prefix: str | None = None,
     path_prefixes: Iterable[str] | None = None,
+    path_prefix_folder_ids: list[str] | None = None,
 ) -> list[Condition]:
     """Build the common ``must`` conditions shared by every search algorithm.
 
@@ -328,23 +333,77 @@ def build_base_filter_conditions(
             )
         )
 
-    # One folder ⇒ a single ``must`` condition (the original Phase 2 shape).
-    # Multiple folders ⇒ OR them in a nested ``Filter(should=...)`` so a file
-    # under any selected folder matches, while still AND-ing against the other
-    # ``must`` conditions (ACL, doc_type, date).
+    # Folder scoping (ADR-027 Phase 2 + ADR-033 Phase 3). Two branches are OR-ed:
+    #
+    #   * folder-ancestor containment — when the caller resolved the prefixes to
+    #     folder fileids (``path_prefix_folder_ids``), a single
+    #     ``MatchAny(folder_ancestors, folder_ids)`` gives a TRUE left-anchored
+    #     containment that is user-agnostic (a shared folder's canonical fileid is
+    #     identical for every reader) and evaluated inside HNSW traversal.
+    #   * legacy ``MatchText(file_path)`` per folder — retained as a fallback for
+    #     points that predate ``folder_ancestors`` (until an admin backfill
+    #     populates them) and for prefixes that could not be resolved to a fileid.
+    #
+    # OR-ing keeps recall during migration (an un-backfilled point still matches
+    # via file_path); once a collection is fully backfilled the folder-ancestor
+    # branch is authoritative and the MatchText branch only adds the same-or-
+    # looser matches. The whole disjunction is AND-ed against the other ``must``
+    # conditions (ACL, doc_type, date).
     folders = normalize_path_prefixes(path_prefix, path_prefixes)
-    if len(folders) == 1:
-        conditions.append(
-            FieldCondition(key="file_path", match=MatchText(text=folders[0]))
-        )
-    elif len(folders) > 1:
-        conditions.append(
-            Filter(
-                should=[
-                    FieldCondition(key="file_path", match=MatchText(text=folder))
-                    for folder in folders
-                ]
+    folder_ids = [fid for fid in (path_prefix_folder_ids or []) if fid and fid.strip()]
+    if folders or folder_ids:
+        should: list[Condition] = []
+        if folder_ids:
+            should.append(
+                FieldCondition(
+                    key=payload_keys.FOLDER_ANCESTORS, match=MatchAny(any=folder_ids)
+                )
             )
+        should.extend(
+            FieldCondition(key="file_path", match=MatchText(text=folder))
+            for folder in folders
         )
+        # A single branch attaches directly to ``must`` (the original Phase 2
+        # shape for one folder, no resolved id); multiple branches OR under a
+        # nested ``Filter(should=...)``.
+        if len(should) == 1:
+            conditions.append(should[0])
+        elif should:
+            conditions.append(Filter(should=should))
 
     return conditions
+
+
+async def resolve_prefix_folder_ids(
+    webdav: FileIdResolver,
+    path_prefix: str | None = None,
+    path_prefixes: Iterable[str] | None = None,
+) -> list[str]:
+    """Resolve folder path-prefixes to their canonical Nextcloud fileids.
+
+    ADR-033 Phase 3: the folder-scope filter matches on ``folder_ancestors``
+    (fileids), so a caller resolves the user's path prefixes to folder fileids
+    once, *before* the query, and passes them to
+    ``build_base_filter_conditions(path_prefix_folder_ids=...)``. A shared
+    folder's fileid is identical for every user who mounts it, so the resolved id
+    scopes correctly for owner and readers alike.
+
+    Best-effort: a prefix that does not resolve (404, not a folder, transport
+    error) is omitted — the query then falls back to that prefix's
+    ``MatchText(file_path)`` branch. Returns the resolved fileids in prefix order.
+    """
+    folders = normalize_path_prefixes(path_prefix, path_prefixes)
+    resolved: list[str] = []
+    for folder in folders:
+        try:
+            fileid = await webdav.get_fileid(folder)
+        except Exception as exc:  # noqa: BLE001 — best-effort; fall back to MatchText
+            logger.debug(
+                "Prefix folder-id resolve failed for %r (%s); using file_path match",
+                folder,
+                exc,
+            )
+            fileid = None
+        if fileid:
+            resolved.append(fileid)
+    return resolved

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -172,6 +172,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         modified_before: int | None = None,
         path_prefix: str | None = None,
         path_prefixes: Iterable[str] | None = None,
+        path_prefix_folder_ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """
@@ -252,6 +253,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
             modified_before=modified_before,
             path_prefix=path_prefix,
             path_prefixes=path_prefixes,
+            path_prefix_folder_ids=path_prefix_folder_ids,
         )
 
         query_filter = Filter(must=filter_conditions)

--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -58,6 +58,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
         modified_before: int | None = None,
         path_prefix: str | None = None,
         path_prefixes: Iterable[str] | None = None,
+        path_prefix_folder_ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """Execute semantic search using vector similarity.
@@ -129,6 +130,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
             modified_before=modified_before,
             path_prefix=path_prefix,
             path_prefixes=path_prefixes,
+            path_prefix_folder_ids=path_prefix_folder_ids,
         )
 
         # ACL pre-filter (design §11), opt-in via ACL_PREFILTER_ENABLED and OFF

--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -622,6 +622,52 @@ def get_supported_doc_types() -> set[str]:
     return set(_VERIFIERS.keys())
 
 
+async def _apply_user_display_paths(user_id: str, results: list[SearchResult]) -> None:
+    """Override file results' path/title with the querying user's own mount path.
+
+    ADR-033 Phase 2: a shared file's Qdrant scalar ``file_path`` is pinned to the
+    owner (Phase 1), so a non-owner reader would otherwise see the *owner's* path.
+    Here we look up each returned file's per-user path in the ``document_paths``
+    store and substitute it into the result the reader receives.
+
+    Best-effort and non-security: on any store error, or for a file with no stored
+    row (legacy / not-yet-scanned-by-this-user), the Qdrant scalar already carried
+    on the result stands unchanged. Mutates ``results`` in place (SearchResult is a
+    mutable dataclass). Lazy imports keep the vector/DB layers off this module's
+    import path.
+    """
+    file_docs = [(r.doc_type, r.id) for r in results if r.doc_type == "file"]
+    if not file_docs:
+        return
+    try:
+        from nextcloud_mcp_server.vector.document_path_store import (  # noqa: PLC0415
+            DocumentPathStore,
+        )
+        from nextcloud_mcp_server.vector.sharing_state import (  # noqa: PLC0415
+            file_title_from_path,
+        )
+
+        store = await DocumentPathStore.shared()
+        paths = await store.get_paths_for_user(user_id, file_docs)
+    except Exception as exc:  # noqa: BLE001 — display-only; fall back to the scalar
+        logger.debug(
+            "Per-user display-path override skipped (%s); using stored scalar", exc
+        )
+        return
+    if not paths:
+        return
+    for r in results:
+        if r.doc_type != "file":
+            continue
+        path = paths.get((r.doc_type, r.id))
+        if not path:
+            continue
+        if r.metadata is None:
+            r.metadata = {}
+        r.metadata["path"] = path
+        r.title = file_title_from_path(path)
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -802,5 +848,10 @@ async def verify_search_results(
             async with anyio.create_task_group() as tg:
                 for doc_id, doc_type in inaccessible:
                     tg.start_soon(evict, doc_id, doc_type)
+
+    # ADR-033 Phase 2: substitute each returned file's per-user display path
+    # (the owner-pinned Qdrant scalar would otherwise show the owner's path to a
+    # non-owner reader). Best-effort — a store miss leaves the scalar in place.
+    await _apply_user_display_paths(user_id, kept)
 
     return kept, len(inaccessible)

--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -636,8 +636,8 @@ async def _apply_user_display_paths(user_id: str, results: list[SearchResult]) -
     mutable dataclass). Lazy imports keep the vector/DB layers off this module's
     import path.
     """
-    file_docs = [(r.doc_type, r.id) for r in results if r.doc_type == "file"]
-    if not file_docs:
+    file_ids = [r.id for r in results if r.doc_type == "file"]
+    if not file_ids:
         return
     try:
         from nextcloud_mcp_server.vector.document_path_store import (  # noqa: PLC0415
@@ -648,7 +648,7 @@ async def _apply_user_display_paths(user_id: str, results: list[SearchResult]) -
         )
 
         store = await DocumentPathStore.shared()
-        paths = await store.get_paths_for_user(user_id, file_docs)
+        paths = await store.get_paths_for_user(user_id, "file", file_ids)
     except Exception as exc:  # noqa: BLE001 — display-only; fall back to the scalar
         logger.debug(
             "Per-user display-path override skipped (%s); using stored scalar", exc
@@ -659,7 +659,7 @@ async def _apply_user_display_paths(user_id: str, results: list[SearchResult]) -
     for r in results:
         if r.doc_type != "file":
             continue
-        path = paths.get((r.doc_type, r.id))
+        path = paths.get(r.id)
         if not path:
             continue
         if r.metadata is None:

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -36,6 +36,7 @@ from nextcloud_mcp_server.search.access_filter import (
     MAX_PATH_PREFIXES,
     list_accessible_owners,
     normalize_path_prefixes,
+    resolve_prefix_folder_ids,
 )
 from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
 from nextcloud_mcp_server.search.context import get_chunk_with_context
@@ -321,6 +322,19 @@ def configure_semantic_tools(mcp: FastMCP):
         # doesn't filter out every result (ADR-027 Phase 2).
         folder_prefixes = normalize_path_prefixes(path_prefix, path_prefixes)
 
+        # ADR-033 Phase 3: resolve each folder prefix to its canonical Nextcloud
+        # fileid so the query can scope by folder_ancestors — a true left-anchored
+        # containment that is correct for every reader of a shared folder (its
+        # fileid is user-agnostic). Best-effort: unresolved prefixes fall back to
+        # the file_path MatchText branch inside build_base_filter_conditions.
+        folder_ids = (
+            await resolve_prefix_folder_ids(
+                client.webdav, path_prefixes=folder_prefixes
+            )
+            if folder_prefixes
+            else []
+        )
+
         # Expand the caller's identity to every owner whose content they
         # have read access to via Nextcloud shares. Lets a user find files
         # owners have shared with them without having to re-index those
@@ -399,6 +413,7 @@ def configure_semantic_tools(mcp: FastMCP):
                     modified_after=modified_after_ts,
                     modified_before=modified_before_ts,
                     path_prefixes=folder_prefixes,
+                    path_prefix_folder_ids=folder_ids,
                 )
                 all_results.extend(unverified_results)
             else:
@@ -427,6 +442,7 @@ def configure_semantic_tools(mcp: FastMCP):
                         modified_after=modified_after_ts,
                         modified_before=modified_before_ts,
                         path_prefixes=folder_prefixes,
+                        path_prefix_folder_ids=folder_ids,
                     )
                     all_results.extend(unverified_results)
 

--- a/nextcloud_mcp_server/vector/document_path_store.py
+++ b/nextcloud_mcp_server/vector/document_path_store.py
@@ -1,0 +1,128 @@
+"""Per-user display paths for shared documents (ADR-033 Phase 2, Deck #737).
+
+A file visible to more than one user is mounted at a *different* path per user,
+but the deduped Qdrant point set stores a single scalar ``file_path`` (pinned to
+the owner in Phase 1). This store holds each reader's own mount path in the
+``document_paths`` app-DB table, keyed on ``(doc_type, doc_id, user_id)``, and is
+joined onto the returned search results *after* retrieval so every reader sees
+their own path.
+
+It is a derived, **non-security** cache: Qdrant remains the system of record, and
+a missing/stale row degrades a *displayed* path only — never a permission or a
+retrieval result. So the writer is best-effort (a failed upsert is logged, not
+raised) and the reader falls back to the Qdrant scalar when no row exists.
+
+Engine reuse mirrors :class:`BatchOcrJobStore` /
+:class:`~nextcloud_mcp_server.usage.store.UsageEventStore`: rather than open its
+own engine this store borrows the process-wide :class:`RefreshTokenStorage`
+singleton (``get_shared_storage()``) — same app DB, dialect handling,
+``?``-placeholder shim, and the guarantee that Alembic migrations (incl.
+``document_paths``) already ran.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import anyio
+
+from nextcloud_mcp_server.auth.storage import RefreshTokenStorage, get_shared_storage
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentPathStore:
+    """CRUD for the ``document_paths`` table (one row per document + reader)."""
+
+    _shared_instance: DocumentPathStore | None = None
+    # Lazy-init: anyio primitives must not be created at import time (CLAUDE.md;
+    # mirrors BatchOcrJobStore). Created on first shared() call.
+    _shared_lock: anyio.Lock | None = None
+
+    def __init__(self, storage: RefreshTokenStorage) -> None:
+        self._storage = storage
+
+    @classmethod
+    async def shared(cls) -> DocumentPathStore:
+        """Process-wide store backed by the storage singleton. Tests should
+        construct ``DocumentPathStore(storage)`` directly — the cache is a process
+        global with no teardown hook."""
+        # No await between the None-check and the assignment, so this is atomic
+        # within the single event loop (anyio is cooperative).
+        if cls._shared_lock is None:
+            cls._shared_lock = anyio.Lock()
+        async with cls._shared_lock:
+            if cls._shared_instance is None:
+                cls._shared_instance = cls(await get_shared_storage())
+        return cls._shared_instance
+
+    async def upsert(
+        self,
+        *,
+        user_id: str,
+        doc_id: str,
+        doc_type: str,
+        file_path: str,
+        updated_at: int | None = None,
+    ) -> None:
+        """Record ``user_id``'s mount path for a document (insert or overwrite).
+
+        Idempotent: re-observing the same path rewrites the row with the same
+        value (and a fresh ``updated_at``). ``ON CONFLICT DO UPDATE`` is supported
+        by both SQLite and Postgres; ``excluded`` references the row that would
+        have been inserted.
+        """
+        now = updated_at if updated_at is not None else int(time.time())
+        async with self._storage.acquire() as db:
+            await db.execute(
+                "INSERT INTO document_paths "
+                "(doc_type, doc_id, user_id, file_path, updated_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT (doc_type, doc_id, user_id) DO UPDATE SET "
+                "file_path = excluded.file_path, updated_at = excluded.updated_at",
+                (doc_type, doc_id, user_id, file_path, now),
+            )
+            await db.commit()
+
+    async def get_paths_for_user(
+        self,
+        user_id: str,
+        docs: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], str]:
+        """Return ``{(doc_type, doc_id): file_path}`` for a user's returned docs.
+
+        ``docs`` is the ``(doc_type, doc_id)`` list of the current result page
+        (bounded by the search limit), so the ``IN`` list is small. Documents with
+        no stored row are simply absent from the result — the caller falls back to
+        the Qdrant scalar for those.
+        """
+        if not docs:
+            return {}
+        # De-dupe while preserving the small bounded size; a result page can carry
+        # several chunks of the same document.
+        unique_ids = sorted({doc_id for _doc_type, doc_id in docs})
+        placeholders = ", ".join("?" for _ in unique_ids)
+        # Restrict to file doc_types: only files carry per-user paths (notes/deck
+        # cards are user-agnostic). Callers pass file docs, but scope defensively.
+        sql = (
+            "SELECT doc_type, doc_id, file_path FROM document_paths "
+            f"WHERE user_id = ? AND doc_id IN ({placeholders})"
+        )
+        params: list[str] = [user_id, *unique_ids]
+        result: dict[tuple[str, str], str] = {}
+        async with self._storage.acquire() as db:
+            async with db.execute(sql, params) as cursor:
+                for row in await cursor.fetchall():
+                    result[(row[0], row[1])] = row[2]
+        return result
+
+    async def delete(self, *, user_id: str, doc_id: str, doc_type: str) -> None:
+        """Drop a reader's path row (e.g. when they release the document)."""
+        async with self._storage.acquire() as db:
+            await db.execute(
+                "DELETE FROM document_paths "
+                "WHERE doc_type = ? AND doc_id = ? AND user_id = ?",
+                (doc_type, doc_id, user_id),
+            )
+            await db.commit()

--- a/nextcloud_mcp_server/vector/document_path_store.py
+++ b/nextcloud_mcp_server/vector/document_path_store.py
@@ -88,33 +88,34 @@ class DocumentPathStore:
     async def get_paths_for_user(
         self,
         user_id: str,
-        docs: list[tuple[str, str]],
-    ) -> dict[tuple[str, str], str]:
-        """Return ``{(doc_type, doc_id): file_path}`` for a user's returned docs.
+        doc_type: str,
+        doc_ids: list[str],
+    ) -> dict[str, str]:
+        """Return ``{doc_id: file_path}`` for a user's returned docs of one type.
 
-        ``docs`` is the ``(doc_type, doc_id)`` list of the current result page
-        (bounded by the search limit), so the ``IN`` list is small. Documents with
-        no stored row are simply absent from the result — the caller falls back to
-        the Qdrant scalar for those.
+        ``doc_ids`` is the id list of the current result page (bounded by the
+        search limit), so the ``IN`` list is small. Callers only ever query one
+        ``doc_type`` at a time (only files carry per-user paths), and the query
+        constrains on it so a stored row for a different type whose id collides
+        with this one's can never be returned. Documents with no stored row are
+        simply absent — the caller falls back to the Qdrant scalar for those.
         """
-        if not docs:
+        if not doc_ids:
             return {}
         # De-dupe while preserving the small bounded size; a result page can carry
         # several chunks of the same document.
-        unique_ids = sorted({doc_id for _doc_type, doc_id in docs})
+        unique_ids = sorted(set(doc_ids))
         placeholders = ", ".join("?" for _ in unique_ids)
-        # Restrict to file doc_types: only files carry per-user paths (notes/deck
-        # cards are user-agnostic). Callers pass file docs, but scope defensively.
         sql = (
-            "SELECT doc_type, doc_id, file_path FROM document_paths "
-            f"WHERE user_id = ? AND doc_id IN ({placeholders})"
+            "SELECT doc_id, file_path FROM document_paths "
+            f"WHERE user_id = ? AND doc_type = ? AND doc_id IN ({placeholders})"
         )
-        params: list[str] = [user_id, *unique_ids]
-        result: dict[tuple[str, str], str] = {}
+        params: list[str] = [user_id, doc_type, *unique_ids]
+        result: dict[str, str] = {}
         async with self._storage.acquire() as db:
             async with db.execute(sql, params) as cursor:
                 for row in await cursor.fetchall():
-                    result[(row[0], row[1])] = row[2]
+                    result[row[0]] = row[1]
         return result
 
     async def delete(self, *, user_id: str, doc_id: str, doc_type: str) -> None:

--- a/nextcloud_mcp_server/vector/document_path_store.py
+++ b/nextcloud_mcp_server/vector/document_path_store.py
@@ -9,8 +9,14 @@ their own path.
 
 It is a derived, **non-security** cache: Qdrant remains the system of record, and
 a missing/stale row degrades a *displayed* path only — never a permission or a
-retrieval result. So the writer is best-effort (a failed upsert is logged, not
-raised) and the reader falls back to the Qdrant scalar when no row exists.
+retrieval result. The methods here surface errors normally (so a caller can see a
+genuine DB failure); the *best-effort* contract — a failed write is logged, not
+raised — is applied at the write sites (`scanner.py` wraps the upsert, and
+`release_document_for_user` the delete), since those run on the sync/search hot
+paths where a display-cache hiccup must never be fatal. A new write site must
+wrap the call the same way. The reader (`get_paths_for_user`, via
+`verify_search_results._apply_user_display_paths`) likewise degrades to the
+Qdrant scalar when a row is absent or the lookup fails.
 
 Engine reuse mirrors :class:`BatchOcrJobStore` /
 :class:`~nextcloud_mcp_server.usage.store.UsageEventStore`: rather than open its

--- a/nextcloud_mcp_server/vector/folder_ancestors.py
+++ b/nextcloud_mcp_server/vector/folder_ancestors.py
@@ -1,0 +1,87 @@
+"""Resolve the ancestor folder file-IDs of a file's path (ADR-033 Phase 3).
+
+The folder-scope search filter (Deck #740) matches on ``folder_ancestors`` — the
+list of ancestor folder fileids stamped on every file point — via
+``MatchAny(folder_ancestors, [folder_id])``. A shared folder keeps ONE canonical
+Nextcloud fileid across every user who mounts it, so the ancestor chain is
+user-agnostic for the shared portion: the same ``folder_id`` matches for the
+owner and every reader, which is what makes the filter both correct for all
+readers and flat in corpus size (unlike a per-user path string).
+
+Resolution is a Depth-0 ``PROPFIND`` for ``oc:fileid`` per ancestor folder
+(``WebDAVClient.get_fileid``), memoised via a caller-supplied ``cache`` so
+repeated ancestors collapse to one lookup each. It is best-effort: a folder that
+404s or errors is simply omitted from the returned list (the search then falls
+back to the ``file_path`` MatchText branch for that scope), so a resolution
+hiccup never aborts an index.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import PurePosixPath
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class FileIdResolver(Protocol):
+    """The single WebDAV method this module needs (see WebDAVClient.get_fileid)."""
+
+    async def get_fileid(self, path: str) -> str | None: ...
+
+
+def ancestor_dir_paths(file_path: str) -> list[str]:
+    """Ancestor directory paths of a file, immediate-parent-first, root excluded.
+
+    ``"/A/B/doc.pdf"`` → ``["/A/B", "/A"]``. The user's files root (``"/"``) is
+    omitted: it is a per-user endpoint (each user's own home), never a shared
+    scoping folder, and trivially contains everything — indexing it would bloat
+    every point's ancestor list for no filtering value.
+    """
+    if not file_path:
+        return []
+    parents = [
+        str(parent)
+        for parent in PurePosixPath(file_path).parents
+        if str(parent) not in ("/", ".", "")
+    ]
+    return parents
+
+
+async def resolve_folder_ancestors(
+    webdav: FileIdResolver,
+    file_path: str,
+    *,
+    cache: dict[str, str | None] | None = None,
+) -> list[str]:
+    """Return the ancestor folder fileids of ``file_path`` (immediate-parent-first).
+
+    Best-effort: an ancestor whose fileid cannot be resolved (404, transport
+    error) is skipped, so the returned list may be shorter than the directory
+    depth. ``cache`` (path → fileid|None) memoises lookups within a caller's
+    scope; pass a shared dict across a batch to collapse common ancestors to one
+    PROPFIND each.
+    """
+    if not file_path:
+        return []
+    if cache is None:
+        cache = {}
+    ancestors: list[str] = []
+    for dir_path in ancestor_dir_paths(file_path):
+        if dir_path in cache:
+            fileid = cache[dir_path]
+        else:
+            try:
+                fileid = await webdav.get_fileid(dir_path)
+            except Exception as exc:  # noqa: BLE001 — best-effort; skip this folder
+                logger.debug(
+                    "Ancestor fileid resolve failed for %r (%s); skipping",
+                    dir_path,
+                    exc,
+                )
+                fileid = None
+            cache[dir_path] = fileid
+        if fileid:
+            ancestors.append(fileid)
+    return ancestors

--- a/nextcloud_mcp_server/vector/payload_keys.py
+++ b/nextcloud_mcp_server/vector/payload_keys.py
@@ -42,6 +42,19 @@ INDEX_MODE_KEYWORD = "keyword"
 # reported via the ``uncovered_documents`` gauge until re-ingested.
 SOURCE_BYTES = "source_bytes"
 
+# Ancestor folder file-IDs of a file's canonical path (ADR-033 Phase 3, Deck
+# #740), as a list of stringified Nextcloud fileids from the immediate parent up
+# to the user root. A shared folder keeps ONE canonical fileid across every user
+# who mounts it, so this term is user-agnostic for the shared portion — which is
+# what makes the folder-scope filter both correct for every reader and flat in
+# corpus size. Search resolves a ``path_prefix`` to its folder's fileid and
+# applies MatchAny(folder_ancestors, [folder_id]) — a TRUE left-anchored
+# containment (unlike the token/substring MatchText on file_path, card #739),
+# evaluated inside HNSW traversal. Written forward-only for files; points indexed
+# before this key carry no value and fall back to the file_path MatchText branch
+# until an admin payload backfill populates them (no re-embed).
+FOLDER_ANCESTORS = "folder_ancestors"
+
 # Fixed platform namespace for deterministic chunk point IDs (design §2.2).
 # Derived once from ``uuid5(NAMESPACE_DNS, "astrolabe.cloud/mcp/point-id/v1")``
 # and pinned here as a literal so neither repo recomputes it. DO NOT CHANGE —

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -2052,6 +2052,30 @@ async def _index_document_inner(
         }
     )
 
+    # ADR-033 Phase 3: resolve the file's ancestor folder fileids once per
+    # document (identical for every chunk). Stamped on each file point as
+    # folder_ancestors so search can scope by a folder's canonical fileid — a
+    # user-agnostic, truly left-anchored containment. Best-effort: an empty list
+    # (resolution failure, or a non-file doc type) leaves search on the file_path
+    # MatchText fallback for this doc.
+    _folder_ancestors: list[str] = []
+    if doc_task.doc_type == "file" and file_path:
+        from nextcloud_mcp_server.vector.folder_ancestors import (  # noqa: PLC0415
+            resolve_folder_ancestors,
+        )
+
+        try:
+            _folder_ancestors = await resolve_folder_ancestors(
+                nc_client.webdav, file_path
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort; fall back to file_path
+            logger.debug(
+                "Folder-ancestor resolution failed for %s (%s); "
+                "search falls back to file_path for folder scope",
+                file_path,
+                exc,
+            )
+
     # Surface deck card data quality issues at indexing time rather than
     # only at verification time (where _verify_deck_cards falls through to
     # legacy-data pass-through when board_id/stack_id are missing). This is
@@ -2145,6 +2169,11 @@ async def _index_document_inner(
                     **(
                         {
                             "file_path": file_path,  # Store file path for retrieval
+                            # ADR-033 Phase 3: ancestor folder fileids for the
+                            # folder-scope search filter (same value on every
+                            # chunk). Omitted implicitly when resolution yielded
+                            # nothing — search then uses the file_path fallback.
+                            payload_keys.FOLDER_ANCESTORS: _folder_ancestors,
                             "mime_type": content_type,  # From WebDAV response
                             "file_size": file_metadata.get("file_size"),
                             "page_number": chunk.page_number,

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -2066,6 +2066,17 @@ async def _index_document_inner(
     # lookup here. A per-worker TTL cache is the follow-up if the bulk initial
     # scan's PROPFIND volume shows up (tracked with the search-side resolution
     # cache in ADR-033).
+    #
+    # This first-index write is intentionally ungated (symmetric with file_path /
+    # owner_id, which the processor also writes unconditionally on first index):
+    # it *establishes* the value, so there is nothing to clobber. Only a LATER
+    # divergent overwrite needs guarding, which is exactly what the owner-scoped
+    # backfill does (it fires only when the key is absent, and only for the
+    # indexer-of-record). A shared folder resolves to the same canonical fileid
+    # for whoever walks up to it, so even a non-owner first-indexer yields the
+    # correct shared-folder ids; the only divergence is a bounded handful of that
+    # one principal's own mount-wrapper folder ids, which are harmless (only that
+    # principal can resolve them at query time).
     _folder_ancestors: list[str] = []
     if doc_task.doc_type == "file" and file_path:
         from nextcloud_mcp_server.vector.folder_ancestors import (  # noqa: PLC0415

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -2058,6 +2058,14 @@ async def _index_document_inner(
     # user-agnostic, truly left-anchored containment. Best-effort: an empty list
     # (resolution failure, or a non-file doc type) leaves search on the file_path
     # MatchText fallback for this doc.
+    #
+    # No cross-document ancestor cache here: this runs in the queue worker, one
+    # DocumentTask at a time, decoupled from the scanner's scan pass — so unlike
+    # the scanner-side backfill (which threads a per-scan folder_ancestor_cache
+    # into claim_existing_index), sibling files under a shared tree can't share a
+    # lookup here. A per-worker TTL cache is the follow-up if the bulk initial
+    # scan's PROPFIND volume shows up (tracked with the search-side resolution
+    # cache in ADR-033).
     _folder_ancestors: list[str] = []
     if doc_task.doc_type == "file" and file_path:
         from nextcloud_mcp_server.vector.folder_ancestors import (  # noqa: PLC0415

--- a/nextcloud_mcp_server/vector/qdrant_client.py
+++ b/nextcloud_mcp_server/vector/qdrant_client.py
@@ -101,6 +101,17 @@ _PAYLOAD_INDEX_FIELDS: dict[str, PayloadSchemaType] = {
     # search/access_filter.build_ownership_filter); KEYWORD indexes match array
     # membership element-wise. Idempotent startup migration.
     "acl_principals": PayloadSchemaType.KEYWORD,
+    # folder_ancestors is the ADR-033 Phase 3 folder-scope filter field (Deck
+    # #740): a list of ancestor folder fileids on every file point. Search
+    # resolves a path_prefix to a folder fileid and applies
+    # MatchAny(key="folder_ancestors", any=[folder_id]) — a true left-anchored
+    # containment (contrast the token/substring MatchText on file_path). KEYWORD
+    # indexes match array membership element-wise, exactly like acl_principals.
+    # Written forward-only on file points; Qdrant strict/server mode requires an
+    # index for every filtered field, so the folder filter 400s without it.
+    # Idempotent startup migration like the fields above — existing collections
+    # gain the index with no content re-index (payload backfill populates values).
+    "folder_ancestors": PayloadSchemaType.KEYWORD,
     # index_mode ("hybrid" | "keyword") is the per-document indexing mode written
     # to every non-placeholder point (payload_keys.INDEX_MODE). The vector-RAM
     # observability path (card #624) counts hybrid, dense-bearing chunks via

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -1053,6 +1053,12 @@ async def scan_user_documents(
 
             tiers_sig = escalation_tiers_signature(get_settings())
 
+            # ADR-033 Phase 3: one folder-path -> fileid cache for this whole scan
+            # pass, so the lazy folder-ancestor backfill (in claim_existing_index)
+            # resolves each shared parent folder once instead of re-walking the
+            # ancestor chain per file under the same tree.
+            folder_ancestor_cache: dict[str, str | None] = {}
+
             for file_info in tagged_files:
                 # Files are already filtered by MIME type in find_files_by_tag()
                 file_count += 1
@@ -1121,6 +1127,7 @@ async def scan_user_documents(
                     index_mode=index_mode,
                     current_path=file_path,
                     webdav=nc_client.webdav,
+                    folder_ancestor_cache=folder_ancestor_cache,
                 ):
                     _potentially_deleted.pop((user_id, file_id, "file"), None)
                     logger.debug(

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -1103,6 +1103,11 @@ async def scan_user_documents(
                 # querying user's own path for the owner-pinned Qdrant scalar.
                 # Best-effort and non-security: a failed upsert only means a
                 # reader temporarily sees the owner's path — never a wrong ACL.
+                #
+                # Unconditional by design here (accepted trade-off): this fires
+                # for every file/user/scan, not only shared docs, so the table is
+                # not sparse (see migration 009's write-volume note). Scoping it to
+                # genuine cross-user readers is a tracked ADR-033 follow-up.
                 try:
                     await (await DocumentPathStore.shared()).upsert(
                         user_id=user_id,

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -51,6 +51,7 @@ from nextcloud_mcp_server.vector.queue.ports import TaskProducer
 if TYPE_CHECKING:
     from nextcloud_mcp_server.search.algorithms import NextcloudClientProtocol
 
+from nextcloud_mcp_server.vector.document_path_store import DocumentPathStore
 from nextcloud_mcp_server.vector.sharing_state import (
     ACL_PRINCIPALS_KEY,
     claim_existing_index,
@@ -1090,6 +1091,28 @@ async def scan_user_documents(
                 # "unknown" so the processor falls back to the post-download
                 # guard rather than gating on a bogus zero.
                 size_bytes = file_info.get("size") or None
+
+                # ADR-033 Phase 2: record THIS user's mount path for the file
+                # (dedup hit or fresh index below), so search can substitute the
+                # querying user's own path for the owner-pinned Qdrant scalar.
+                # Best-effort and non-security: a failed upsert only means a
+                # reader temporarily sees the owner's path — never a wrong ACL.
+                try:
+                    await (await DocumentPathStore.shared()).upsert(
+                        user_id=user_id,
+                        doc_id=file_id,
+                        doc_type="file",
+                        file_path=file_path,
+                    )
+                except Exception as exc:  # noqa: BLE001 — display-only; next scan retries
+                    logger.debug(
+                        "Per-user path upsert failed for file %s (ID: %s) (%s); "
+                        "next scan retries",
+                        file_path,
+                        file_id,
+                        exc,
+                    )
+
                 if etag and await claim_existing_index(
                     file_id,
                     "file",

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -1272,11 +1272,19 @@ async def scan_user_documents(
                         # a not-yet-indexed file would just incur a 0-point
                         # set_payload (the real index writes the current path).
                         try:
+                            # existing_metadata is user_id-scoped to this caller
+                            # (query_document_metadata filters on user_id), so this
+                            # path only ever fires for the point's own indexer —
+                            # never the thrash source. Pass the owner-gate params
+                            # (ADR-033 Phase 1) for consistency with the dedup-path
+                            # caller; a no-op today since owner_id == user_id here.
                             await reconcile_document_path(
                                 file_id,
                                 "file",
                                 existing_metadata.get("file_path"),
                                 file_path,
+                                caller_user_id=user_id,
+                                owner_id=existing_metadata.get("owner_id"),
                             )
                         except Exception as exc:  # noqa: BLE001 — non-fatal
                             logger.warning(

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -1120,6 +1120,7 @@ async def scan_user_documents(
                     user_id,
                     index_mode=index_mode,
                     current_path=file_path,
+                    webdav=nc_client.webdav,
                 ):
                     _potentially_deleted.pop((user_id, file_id, "file"), None)
                     logger.debug(

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -310,6 +310,7 @@ async def claim_existing_index(
     index_mode: str = payload_keys.INDEX_MODE_HYBRID,
     current_path: str | None = None,
     webdav: FileIdResolver | None = None,
+    folder_ancestor_cache: dict[str, str | None] | None = None,
 ) -> bool:
     """Tenant-wide dedup claim: skip reprocessing if content is already indexed.
 
@@ -386,7 +387,9 @@ async def claim_existing_index(
                 resolve_folder_ancestors,
             )
 
-            ancestors = await resolve_folder_ancestors(webdav, current_path)
+            ancestors = await resolve_folder_ancestors(
+                webdav, current_path, cache=folder_ancestor_cache
+            )
             if ancestors:
                 await set_folder_ancestors(doc_id, doc_type, ancestors)
                 logger.debug(

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -376,6 +376,15 @@ async def claim_existing_index(
     # user-agnostic and bounded, and (c) reuses the payload already fetched here —
     # no extra scroll, no re-embed. Best-effort: a failure leaves the doc on the
     # file_path MatchText fallback until the next owner scan.
+    #
+    # The gate treats a stored empty list the same as an absent key, so a
+    # root-level file (no ancestor folders -> ancestor_dir_paths returns []) or a
+    # doc whose earlier resolution failed re-enters this branch on every owner
+    # scan. That is intentional and cheap: for the root-level case
+    # resolve_folder_ancestors returns [] immediately with no PROPFIND, and for
+    # the resolution-failure case the retry is exactly what lets it self-heal once
+    # WebDAV recovers. Distinguishing "resolved-but-empty" from "unresolved" would
+    # trade that self-healing for a marginal saving on a no-op.
     if (
         webdav is not None
         and current_path

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -28,8 +28,12 @@ one user untagging a shared file would evict it for everyone still reading it.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+if TYPE_CHECKING:
+    from nextcloud_mcp_server.vector.folder_ancestors import FileIdResolver
 
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.vector import payload_keys
@@ -276,6 +280,28 @@ async def reconcile_document_path(
     return True
 
 
+async def set_folder_ancestors(
+    doc_id: str,
+    doc_type: str,
+    ancestors: list[str],
+) -> None:
+    """Write ``folder_ancestors`` on every real chunk of a document.
+
+    A metadata-only ``set_payload`` (no re-fetch, no re-embed), mirroring
+    ``reconcile_document_path``. Used by the lazy owner-scoped backfill in
+    ``claim_existing_index`` to populate the ADR-033 Phase 3 folder-scope key on
+    documents indexed before it shipped.
+    """
+    qdrant_client = await get_qdrant_client()
+    settings = get_settings()
+    await qdrant_client.set_payload(
+        collection_name=settings.get_collection_name(),
+        payload={payload_keys.FOLDER_ANCESTORS: ancestors},
+        points=_document_filter(doc_id, doc_type, real_only=True),
+        wait=True,
+    )
+
+
 async def claim_existing_index(
     doc_id: str,
     doc_type: str,
@@ -283,6 +309,7 @@ async def claim_existing_index(
     user_id: str,
     index_mode: str = payload_keys.INDEX_MODE_HYBRID,
     current_path: str | None = None,
+    webdav: FileIdResolver | None = None,
 ) -> bool:
     """Tenant-wide dedup claim: skip reprocessing if content is already indexed.
 
@@ -340,6 +367,43 @@ async def claim_existing_index(
                 doc_id,
                 exc,
             )
+
+    # ADR-033 Phase 3: lazily backfill folder_ancestors on a dedup hit for
+    # documents indexed before the key shipped. Owner-scoped and gated on the key
+    # being absent, so it (a) runs at most once per document, (b) uses the owner's
+    # canonical path (never a reader's mount prefix), keeping the ancestor set
+    # user-agnostic and bounded, and (c) reuses the payload already fetched here —
+    # no extra scroll, no re-embed. Best-effort: a failure leaves the doc on the
+    # file_path MatchText fallback until the next owner scan.
+    if (
+        webdav is not None
+        and current_path
+        and not (existing.get(payload_keys.FOLDER_ANCESTORS) or [])
+        and existing.get("owner_id") in (None, user_id)
+    ):
+        try:
+            from nextcloud_mcp_server.vector.folder_ancestors import (  # noqa: PLC0415
+                resolve_folder_ancestors,
+            )
+
+            ancestors = await resolve_folder_ancestors(webdav, current_path)
+            if ancestors:
+                await set_folder_ancestors(doc_id, doc_type, ancestors)
+                logger.debug(
+                    "Backfilled %d folder ancestor(s) for %s_%s",
+                    len(ancestors),
+                    doc_type,
+                    doc_id,
+                )
+        except Exception as exc:  # noqa: BLE001 — non-fatal; owner's next scan retries
+            logger.debug(
+                "Folder-ancestor backfill failed for %s_%s (%s); "
+                "search uses file_path fallback",
+                doc_type,
+                doc_id,
+                exc,
+            )
+
     try:
         await add_principal(doc_id, doc_type, user_id, existing.get(ACL_PRINCIPALS_KEY))
     except Exception as exc:  # noqa: BLE001 — non-fatal; recovered on next scan

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -199,6 +199,9 @@ async def reconcile_document_path(
     doc_type: str,
     stored_path: str | None,
     current_path: str,
+    *,
+    caller_user_id: str | None = None,
+    owner_id: str | None = None,
 ) -> bool:
     """Refresh ``file_path``/``title`` on a renamed/moved file's existing points.
 
@@ -209,13 +212,48 @@ async def reconcile_document_path(
     rewrites ``file_path`` and the derived ``title`` on every real chunk via a
     single metadata-only ``set_payload`` (no re-fetch, no re-embed).
 
-    Returns False (no write attempted) only when the path is unchanged or empty.
-    When the path differs it returns True after issuing the ``set_payload``; that
-    write is itself a Qdrant-side no-op if no real chunks exist yet (e.g. only a
-    placeholder), which the callers tolerate. A legacy point with no stored
-    ``file_path`` is treated as changed, backfilling both fields.
+    Owner-gating (ADR-033 Phase 1): a file visible to more than one user is
+    mounted at a *different* path per user, but the deduped point set stores a
+    single scalar ``file_path``. Without gating, every reader's scan rewrites the
+    scalar to their own mount path, so it flips back and forth once per user per
+    pass (write amplification + a non-deterministic path that breaks the
+    ``path_prefix`` filter). We therefore pin the scalar to the **indexer of
+    record** (``owner_id``): the write is only issued when the caller *is* the
+    canonical owner (a genuine owner-side rename), when the stored path is empty
+    (legacy/placeholder backfill), or when ``owner_id`` is unknown (legacy points
+    predating ``owner_id`` — single-owner, so no thrash to guard against). A
+    non-owner reader observing a divergent path is now a no-op; their per-user
+    display path is served relationally (ADR-033 Phase 2).
+
+    Returns False (no write attempted) when the path is unchanged/empty or the
+    owner-gate suppresses a non-owner's divergent path. When a write is issued it
+    returns True; that write is itself a Qdrant-side no-op if no real chunks exist
+    yet (e.g. only a placeholder), which the callers tolerate. A legacy point with
+    no stored ``file_path`` is treated as changed, backfilling both fields.
     """
     if not current_path or stored_path == current_path:
+        return False
+    # Owner-gate: suppress a non-owner reader's divergent path so the scalar stays
+    # pinned to the owner's path. ``owner_id is None`` (legacy point) and an empty
+    # ``stored_path`` (nothing to thrash) fall through to the old always-reconcile
+    # behaviour so genuine renames and backfills are never missed.
+    if (
+        owner_id is not None
+        and stored_path
+        and caller_user_id is not None
+        and caller_user_id != owner_id
+    ):
+        logger.debug(
+            "Skipping path reconcile for %s_%s: caller user:%s is not the owner "
+            "(user:%s); keeping owner-pinned path %r (reader path %r served "
+            "relationally)",
+            doc_type,
+            doc_id,
+            caller_user_id,
+            owner_id,
+            stored_path,
+            current_path,
+        )
         return False
     qdrant_client = await get_qdrant_client()
     settings = get_settings()
@@ -288,7 +326,12 @@ async def claim_existing_index(
     if current_path:
         try:
             await reconcile_document_path(
-                doc_id, doc_type, existing.get("file_path"), current_path
+                doc_id,
+                doc_type,
+                existing.get("file_path"),
+                current_path,
+                caller_user_id=user_id,
+                owner_id=existing.get("owner_id"),
             )
         except Exception as exc:  # noqa: BLE001 — non-fatal; retried next scan
             logger.warning(

--- a/nextcloud_mcp_server/vector/sharing_state.py
+++ b/nextcloud_mcp_server/vector/sharing_state.py
@@ -374,6 +374,27 @@ async def release_document_for_user(
     settings = get_settings()
     collection = settings.get_collection_name()
 
+    # ADR-033 Phase 2: drop this reader's per-user display-path row (hygiene). A
+    # stale row is harmless — a released doc no longer surfaces to the user, so
+    # it is never joined — but cleaning it up keeps the table bounded. Best-effort
+    # and lazily imported to avoid a vector→DB import at module load.
+    try:
+        from nextcloud_mcp_server.vector.document_path_store import (  # noqa: PLC0415
+            DocumentPathStore,
+        )
+
+        await (await DocumentPathStore.shared()).delete(
+            user_id=user_id, doc_id=doc_id, doc_type=doc_type
+        )
+    except Exception as exc:  # noqa: BLE001 — display-only cleanup; non-fatal
+        logger.debug(
+            "Per-user path-row cleanup failed for %s_%s user:%s (%s)",
+            doc_type,
+            doc_id,
+            user_id,
+            exc,
+        )
+
     points, _ = await qdrant_client.scroll(
         collection_name=collection,
         scroll_filter=_document_filter(doc_id, doc_type, real_only=True),

--- a/tests/integration/test_shared_doc_per_user_paths.py
+++ b/tests/integration/test_shared_doc_per_user_paths.py
@@ -1,0 +1,280 @@
+"""End-to-end per-user paths for a shared document (ADR-033, Deck #737).
+
+Exercises the new code paths together against a real Nextcloud (share lookup +
+verify-on-read) with an in-memory Qdrant standing in for the scanner:
+
+- Phase 1/2: alice's file point stores HER path (owner-pinned scalar). bob, who
+  the file is shared with, gets HIS own mount path substituted onto the result
+  by ``verify_search_results`` from the ``document_paths`` store.
+- Phase 3: the point carries ``folder_ancestors`` (the shared folder's canonical
+  fileid). bob filtering on that folder matches; filtering on an unrelated folder
+  id does not — a true left-anchored containment that is user-agnostic.
+
+The pure filter/store/override matrices live in the unit suites
+(``tests/unit/search/test_access_filter.py``,
+``tests/unit/test_document_path_store.py``,
+``tests/unit/search/test_verification.py``); this test is the glue proving the
+real share → filter → verify → per-user-path chain.
+"""
+
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import BasicAuth
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import Distance, PointStruct, VectorParams
+
+from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
+from nextcloud_mcp_server.client import NextcloudClient
+from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.embedding import SimpleEmbeddingProvider
+from nextcloud_mcp_server.search.access_filter import (
+    build_base_filter_conditions,
+    clear_accessible_owners_cache,
+    list_accessible_owners,
+    resolve_prefix_folder_ids,
+)
+from nextcloud_mcp_server.search.semantic import SemanticSearchAlgorithm
+from nextcloud_mcp_server.search.verification import verify_search_results
+from nextcloud_mcp_server.vector import payload_keys
+from nextcloud_mcp_server.vector.document_path_store import DocumentPathStore
+from tests.integration.conftest import PDF_BYTES
+
+pytestmark = pytest.mark.integration
+
+_DOC_TEXT = "Confidential quarterly infrastructure budget and capacity plan"
+
+
+def _user_client(username: str, password: str) -> NextcloudClient:
+    return NextcloudClient(
+        base_url=os.environ["NEXTCLOUD_HOST"],
+        username=username,
+        auth=BasicAuth(username, password),
+        password=password,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_owners_cache():
+    clear_accessible_owners_cache()
+    yield
+    clear_accessible_owners_cache()
+
+
+@pytest.fixture
+async def acl_users(test_users_setup):
+    clients = {
+        name: _user_client(name, test_users_setup[name]["password"])
+        for name in ("alice", "bob")
+    }
+    try:
+        yield clients
+    finally:
+        for c in clients.values():
+            await c._client.aclose()
+
+
+@pytest.fixture
+async def shared_file(acl_users):
+    """alice creates a nested PDF, tags it, shares the containing folder with bob.
+
+    Sharing the FOLDER (not just the file) means bob mounts it under his own root
+    at a different path — the exact shape that produced the path thrash — and the
+    folder keeps its canonical fileid for both users (the Phase 3 invariant).
+
+    Yields (file_id, folder_id, alice_path, alice_folder_path).
+    """
+    alice = acl_users["alice"]
+    suffix = uuid.uuid4().hex[:8]
+    test_dir = f"share_paths_{suffix}"
+    nested = f"{test_dir}/reports"
+    path = f"{nested}/budget.pdf"
+
+    await alice.webdav.create_directory(test_dir)
+    await alice.webdav.create_directory(nested)
+    await alice.webdav.write_file(path, PDF_BYTES, "application/pdf")
+    file_id = (await alice.webdav.get_file_info(path))["id"]
+    folder_id = await alice.webdav.get_fileid(f"/{nested}")
+    tag = await alice.webdav.get_or_create_tag(
+        name=get_settings().vector_sync_tag,
+        user_visible=True,
+        user_assignable=True,
+    )
+    await alice.webdav.assign_tag_to_file(file_id, tag["id"])
+    # Share the top folder with bob (share_type=0 user, read permission).
+    await alice.sharing.create_share(
+        path=f"/{test_dir}", share_with="bob", share_type=0, permissions=1
+    )
+    try:
+        yield file_id, folder_id, path, nested
+    finally:
+        try:
+            await alice.webdav.remove_tag_from_file(file_id, tag["id"])
+        except Exception:
+            pass
+        await alice.webdav.delete_resource(test_dir)
+
+
+@pytest.fixture
+async def path_store(monkeypatch):
+    """A real DocumentPathStore on temp SQLite, wired into verify_search_results."""
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = RefreshTokenStorage(db_path=str(Path(tmp) / "paths.db"))
+        await storage.initialize()
+        store = DocumentPathStore(storage)
+        monkeypatch.setattr(DocumentPathStore, "shared", AsyncMock(return_value=store))
+        yield store
+
+
+@pytest.fixture
+async def seeded(monkeypatch, shared_file):
+    """In-memory Qdrant carrying alice's owner-pinned point with folder_ancestors."""
+    file_id, folder_id, alice_path, _folder = shared_file
+    provider = SimpleEmbeddingProvider(dimension=384)
+    client = AsyncQdrantClient(":memory:")
+    collection = get_settings().get_collection_name()
+    await client.create_collection(
+        collection_name=collection,
+        vectors_config={"dense": VectorParams(size=384, distance=Distance.COSINE)},
+    )
+    await client.upsert(
+        collection_name=collection,
+        points=[
+            PointStruct(
+                id=int(file_id),
+                vector={"dense": await provider.embed(_DOC_TEXT)},
+                payload={
+                    "doc_id": str(file_id),
+                    "doc_type": "file",
+                    "owner_id": "alice",
+                    "user_id": "alice",
+                    "is_placeholder": False,
+                    # Owner-pinned scalar path (Phase 1): always alice's path.
+                    "file_path": alice_path,
+                    "title": "budget.pdf",
+                    "excerpt": _DOC_TEXT,
+                    "chunk_index": 0,
+                    "total_chunks": 1,
+                    # Phase 3: the shared folder's canonical fileid.
+                    payload_keys.FOLDER_ANCESTORS: [folder_id],
+                },
+            )
+        ],
+        wait=True,
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.semantic.get_qdrant_client",
+        AsyncMock(return_value=client),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.semantic.get_embedding_service",
+        lambda: provider,
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.context.get_qdrant_client",
+        AsyncMock(return_value=client),
+    )
+    yield file_id, folder_id
+    await client.close()
+
+
+async def _search_as(user_client, *, folder_ids=None):
+    accessible_owners = await list_accessible_owners(
+        user_client.sharing, user_client.username
+    )
+    algo = SemanticSearchAlgorithm(score_threshold=0.0)
+    unverified = await algo.search(
+        query=_DOC_TEXT,
+        user_id=user_client.username,
+        limit=10,
+        doc_type="file",
+        accessible_owners=accessible_owners,
+        path_prefix_folder_ids=folder_ids,
+    )
+    kept, _dropped = await verify_search_results(user_client, unverified)
+    return kept
+
+
+async def test_recipient_sees_own_path_for_shared_file(acl_users, seeded, path_store):
+    """bob's result shows HIS mount path, not alice's owner-pinned scalar."""
+    file_id, _folder_id = seeded
+    bob = acl_users["bob"]
+
+    # bob's scanner would have recorded his own mount path; simulate that upsert
+    # by resolving his actual view of the shared file (by its global id).
+    bob_view = await bob.webdav._get_file_info_by_id(int(file_id))
+    bob_relpath = bob_view["path"]
+    await path_store.upsert(
+        user_id="bob", doc_id=str(file_id), doc_type="file", file_path=bob_relpath
+    )
+
+    kept = await _search_as(bob)
+    assert kept, "bob should find the file alice shared with him"
+    result = next(r for r in kept if r.id == str(file_id))
+    # Phase 2: the displayed path is bob's own, not alice's owner-pinned scalar.
+    assert result.metadata["path"] == bob_relpath
+
+
+async def test_owner_still_sees_own_path(acl_users, seeded, path_store):
+    """alice (owner) sees her own path — the store row matches the scalar."""
+    file_id, _folder_id = seeded
+    alice = acl_users["alice"]
+    alice_view = await alice.webdav._get_file_info_by_id(int(file_id))
+    await path_store.upsert(
+        user_id="alice",
+        doc_id=str(file_id),
+        doc_type="file",
+        file_path=alice_view["path"],
+    )
+    kept = await _search_as(alice)
+    result = next(r for r in kept if r.id == str(file_id))
+    assert result.metadata["path"] == alice_view["path"]
+
+
+async def test_folder_filter_matches_by_ancestor_id(acl_users, seeded, path_store):
+    """bob filtering on the shared folder (by its fileid) finds the file; an
+    unrelated folder id does not — true user-agnostic containment (Phase 3)."""
+    file_id, folder_id = seeded
+    bob = acl_users["bob"]
+
+    # bob resolves the SAME shared folder to the SAME canonical fileid, via the
+    # production resolver (resolve_prefix_folder_ids) exactly as the search tool.
+    bob_view = await bob.webdav._get_file_info_by_id(int(file_id))
+    bob_folder = "/".join(bob_view["path"].split("/")[:-1])
+    bob_folder_ids = await resolve_prefix_folder_ids(
+        bob.webdav, path_prefixes=[f"/{bob_folder}"]
+    )
+    assert bob_folder_ids == [folder_id], (
+        "a shared folder must resolve to one canonical fileid for every user"
+    )
+
+    kept = await _search_as(bob, folder_ids=bob_folder_ids)
+    assert any(r.id == str(file_id) for r in kept)
+
+    # An unrelated folder id must not match via folder_ancestors. (There is no
+    # file_path prefix in this query, so no MatchText fallback can rescue it.)
+    kept_none = await _search_as(bob, folder_ids=["999999999"])
+    assert not any(r.id == str(file_id) for r in kept_none)
+
+
+def test_filter_shape_prefers_folder_ancestor_over_matchtext():
+    """Guard: a resolved folder id yields a folder_ancestors MatchAny branch."""
+    conditions = build_base_filter_conditions(
+        "bob", None, path_prefix="/x", path_prefix_folder_ids=["42"]
+    )
+    assert any(
+        getattr(c, "key", None) == payload_keys.FOLDER_ANCESTORS
+        or (
+            hasattr(c, "should")
+            and c.should
+            and any(
+                getattr(sc, "key", None) == payload_keys.FOLDER_ANCESTORS
+                for sc in c.should
+            )
+        )
+        for c in conditions
+    )

--- a/tests/integration/test_shared_doc_per_user_paths.py
+++ b/tests/integration/test_shared_doc_per_user_paths.py
@@ -178,7 +178,7 @@ async def seeded(monkeypatch, shared_file):
         "nextcloud_mcp_server.search.context.get_qdrant_client",
         AsyncMock(return_value=client),
     )
-    yield file_id, folder_id
+    yield file_id, folder_id, alice_path
     await client.close()
 
 
@@ -199,54 +199,60 @@ async def _search_as(user_client, *, folder_ids=None):
     return kept
 
 
+async def _bob_share_mount(bob) -> str:
+    """bob's own mount path for the folder alice shared with him (OCS file_target,
+    e.g. ``/share_paths_<suffix>``) — the recipient-side path, resolved without
+    the DAV meta endpoint (which does not resolve a shared file by global id)."""
+    shares = await bob.sharing.list_shares(shared_with_me=True)
+    for share in shares:
+        target = str(share.get("file_target") or "").rstrip("/")
+        if target.strip("/").startswith("share_paths_"):
+            return target
+    raise AssertionError("bob has no share_paths_* mount from alice")
+
+
 async def test_recipient_sees_own_path_for_shared_file(acl_users, seeded, path_store):
-    """bob's result shows HIS mount path, not alice's owner-pinned scalar."""
-    file_id, _folder_id = seeded
+    """bob's result shows HIS own stored path, not alice's owner-pinned scalar."""
+    file_id, _folder_id, alice_path = seeded
     bob = acl_users["bob"]
 
-    # bob's scanner would have recorded his own mount path; simulate that upsert
-    # by resolving his actual view of the shared file (by its global id).
-    bob_view = await bob.webdav._get_file_info_by_id(int(file_id))
-    bob_relpath = bob_view["path"]
+    # bob's scanner would have recorded his own mount path for the shared file;
+    # simulate that upsert with a path distinct from alice's owner-pinned scalar.
+    bob_path = f"{await _bob_share_mount(bob)}/reports/budget.pdf"
     await path_store.upsert(
-        user_id="bob", doc_id=str(file_id), doc_type="file", file_path=bob_relpath
+        user_id="bob", doc_id=str(file_id), doc_type="file", file_path=bob_path
     )
 
     kept = await _search_as(bob)
     assert kept, "bob should find the file alice shared with him"
     result = next(r for r in kept if r.id == str(file_id))
-    # Phase 2: the displayed path is bob's own, not alice's owner-pinned scalar.
-    assert result.metadata["path"] == bob_relpath
+    # Phase 2: the displayed path is bob's own, substituted over the scalar.
+    assert result.metadata["path"] == bob_path
+    assert result.metadata["path"] != alice_path
 
 
-async def test_owner_still_sees_own_path(acl_users, seeded, path_store):
-    """alice (owner) sees her own path — the store row matches the scalar."""
-    file_id, _folder_id = seeded
+async def test_owner_falls_back_to_scalar_path(acl_users, seeded, path_store):
+    """alice (owner) has no store row, so the display path falls back to the
+    Qdrant scalar — her own owner-pinned path (Phase 2 fallback)."""
+    file_id, _folder_id, alice_path = seeded
     alice = acl_users["alice"]
-    alice_view = await alice.webdav._get_file_info_by_id(int(file_id))
-    await path_store.upsert(
-        user_id="alice",
-        doc_id=str(file_id),
-        doc_type="file",
-        file_path=alice_view["path"],
-    )
     kept = await _search_as(alice)
     result = next(r for r in kept if r.id == str(file_id))
-    assert result.metadata["path"] == alice_view["path"]
+    assert result.metadata["path"] == alice_path
 
 
-async def test_folder_filter_matches_by_ancestor_id(acl_users, seeded, path_store):
-    """bob filtering on the shared folder (by its fileid) finds the file; an
-    unrelated folder id does not — true user-agnostic containment (Phase 3)."""
-    file_id, folder_id = seeded
+async def test_folder_filter_matches_by_ancestor_id(acl_users, seeded):
+    """bob resolves the shared folder to the SAME canonical fileid as alice and
+    filters on it to find the file; an unrelated id does not — true user-agnostic
+    containment (Phase 3)."""
+    file_id, folder_id, _alice_path = seeded
     bob = acl_users["bob"]
 
-    # bob resolves the SAME shared folder to the SAME canonical fileid, via the
-    # production resolver (resolve_prefix_folder_ids) exactly as the search tool.
-    bob_view = await bob.webdav._get_file_info_by_id(int(file_id))
-    bob_folder = "/".join(bob_view["path"].split("/")[:-1])
+    # bob resolves his OWN view of the shared /reports folder to a fileid via the
+    # production resolver — it must equal alice's canonical folder_id.
+    bob_reports = f"{await _bob_share_mount(bob)}/reports"
     bob_folder_ids = await resolve_prefix_folder_ids(
-        bob.webdav, path_prefixes=[f"/{bob_folder}"]
+        bob.webdav, path_prefixes=[bob_reports]
     )
     assert bob_folder_ids == [folder_id], (
         "a shared folder must resolve to one canonical fileid for every user"

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -847,3 +847,59 @@ async def test_find_by_tag_escapes_special_chars_in_tag(mocker):
     )
     assert "R&amp;D" in where
     assert "R&D" not in where  # no bare ampersand
+
+
+@pytest.mark.unit
+async def test_get_fileid_parses_oc_fileid(mocker):
+    """get_fileid returns the oc:fileid of a folder path (ADR-033 Phase 3)."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp = mocker.Mock()
+    resp.content = b"""<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+        <d:response>
+            <d:href>/remote.php/dav/files/testuser/Documents/</d:href>
+            <d:propstat><d:prop><oc:fileid>98765</oc:fileid></d:prop></d:propstat>
+        </d:response>
+    </d:multistatus>"""
+    resp.raise_for_status = mocker.Mock()
+    mocker.patch.object(client, "_make_request", AsyncMock(return_value=resp))
+
+    assert await client.get_fileid("/Documents") == "98765"
+
+
+@pytest.mark.unit
+async def test_get_fileid_returns_none_on_404(mocker):
+    """A gone/inaccessible path resolves to None so the caller degrades."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp404 = mocker.Mock(spec=Response)
+    resp404.status_code = 404
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp404)
+        ),
+    )
+
+    assert await client.get_fileid("/gone") is None
+
+
+@pytest.mark.unit
+async def test_get_fileid_returns_none_when_absent(mocker):
+    """A response with no oc:fileid element yields None, not an error."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp = mocker.Mock()
+    resp.content = b"""<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+        <d:response><d:href>/remote.php/dav/files/testuser/x/</d:href>
+        <d:propstat><d:prop></d:prop></d:propstat></d:response>
+    </d:multistatus>"""
+    resp.raise_for_status = mocker.Mock()
+    mocker.patch.object(client, "_make_request", AsyncMock(return_value=resp))
+
+    assert await client.get_fileid("/x") is None

--- a/tests/unit/search/test_access_filter.py
+++ b/tests/unit/search/test_access_filter.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from qdrant_client.models import FieldCondition, Filter, MatchText, Range
+from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchText, Range
 
 from nextcloud_mcp_server.search import access_filter
 from nextcloud_mcp_server.search.access_filter import (
@@ -16,7 +16,9 @@ from nextcloud_mcp_server.search.access_filter import (
     clear_accessible_owners_cache,
     list_accessible_owners,
     normalize_path_prefixes,
+    resolve_prefix_folder_ids,
 )
+from nextcloud_mcp_server.vector import payload_keys
 
 
 @pytest.fixture(autouse=True)
@@ -392,3 +394,139 @@ class TestNormalizePathPrefixes:
         result = normalize_path_prefixes(None, folders)
         assert len(result) == MAX_PATH_PREFIXES
         assert result == folders[:MAX_PATH_PREFIXES]
+
+
+# ---------------------------------------------------------------------------
+# ADR-033 Phase 3 — folder-ancestor scope filter
+# ---------------------------------------------------------------------------
+
+
+def _folder_ancestor_matchany(conditions) -> list[str] | None:
+    """Return the folder_ancestors MatchAny values from a filter list.
+
+    Looks both at bare must FieldConditions and inside a nested should Filter.
+    """
+    for cond in conditions:
+        if (
+            isinstance(cond, FieldCondition)
+            and cond.key == payload_keys.FOLDER_ANCESTORS
+            and isinstance(cond.match, MatchAny)
+        ):
+            return list(cond.match.any)
+        if isinstance(cond, Filter) and cond.should:
+            for c in cond.should:
+                if (
+                    isinstance(c, FieldCondition)
+                    and c.key == payload_keys.FOLDER_ANCESTORS
+                    and isinstance(c.match, MatchAny)
+                ):
+                    return list(c.match.any)
+    return None
+
+
+class TestFolderAncestorFilter:
+    @pytest.mark.unit
+    def test_folder_id_only_attaches_bare_matchany(self) -> None:
+        # A resolved folder id with no textual prefix -> a single bare
+        # MatchAny(folder_ancestors) condition on must (len(should) == 1).
+        conditions = build_base_filter_conditions(
+            "alice", None, path_prefix_folder_ids=["500"]
+        )
+        assert _folder_ancestor_matchany(conditions) == ["500"]
+        # No file_path condition when there was no textual prefix.
+        assert not any(
+            isinstance(c, FieldCondition) and c.key == "file_path" for c in conditions
+        )
+
+    @pytest.mark.unit
+    def test_folder_id_and_prefix_or_together(self) -> None:
+        # A resolved folder id AND the original prefix string OR under one nested
+        # should: an un-backfilled point still matches via file_path (recall),
+        # a backfilled point matches via folder_ancestors (precision).
+        conditions = build_base_filter_conditions(
+            "alice",
+            None,
+            path_prefix="/Projects/Reports",
+            path_prefix_folder_ids=["500"],
+        )
+        assert _folder_ancestor_matchany(conditions) == ["500"]
+        # The file_path MatchText fallback is retained in the same OR.
+        nested = [
+            c for c in conditions if isinstance(c, Filter) and c.should is not None
+        ]
+        file_path_texts = {
+            c.match.text
+            for f in nested
+            for c in f.should
+            if isinstance(c, FieldCondition)
+            and c.key == "file_path"
+            and isinstance(c.match, MatchText)
+        }
+        assert "/Projects/Reports" in file_path_texts
+
+    @pytest.mark.unit
+    def test_no_folder_ids_keeps_legacy_matchtext_only(self) -> None:
+        # Backward compat: without resolved ids, only the file_path MatchText
+        # branch is emitted (no folder_ancestors condition).
+        conditions = build_base_filter_conditions(
+            "alice", None, path_prefix="/Projects"
+        )
+        assert _folder_ancestor_matchany(conditions) is None
+        path_conds = [
+            c
+            for c in conditions
+            if isinstance(c, FieldCondition) and c.key == "file_path"
+        ]
+        assert len(path_conds) == 1
+        assert isinstance(path_conds[0].match, MatchText)
+
+    @pytest.mark.unit
+    def test_blank_folder_ids_are_ignored(self) -> None:
+        # Defensive: empty strings in the resolved list must not create a bogus
+        # MatchAny(any=[""]) branch.
+        conditions = build_base_filter_conditions(
+            "alice", None, path_prefix_folder_ids=["", "  "]
+        )
+        assert _folder_ancestor_matchany(conditions) is None
+
+
+class _StubWebdav:
+    def __init__(self, mapping, raises=None):
+        self._mapping = mapping
+        self._raises = raises or set()
+
+    async def get_fileid(self, path: str):
+        if path in self._raises:
+            raise RuntimeError("boom")
+        return self._mapping.get(path)
+
+
+class TestResolvePrefixFolderIds:
+    @pytest.mark.unit
+    async def test_resolves_each_prefix(self) -> None:
+        webdav = _StubWebdav({"/Projects": "500", "/Archive": "600"})
+        got = await resolve_prefix_folder_ids(
+            webdav, path_prefixes=["/Projects", "/Archive"]
+        )
+        assert got == ["500", "600"]
+
+    @pytest.mark.unit
+    async def test_unresolved_prefix_skipped(self) -> None:
+        webdav = _StubWebdav({"/Projects": "500", "/Gone": None})
+        got = await resolve_prefix_folder_ids(
+            webdav, path_prefixes=["/Projects", "/Gone"]
+        )
+        assert got == ["500"]  # falls back to MatchText for /Gone
+
+    @pytest.mark.unit
+    async def test_error_is_best_effort(self) -> None:
+        webdav = _StubWebdav({"/Projects": "500"}, raises={"/Bad"})
+        got = await resolve_prefix_folder_ids(
+            webdav, path_prefixes=["/Projects", "/Bad"]
+        )
+        assert got == ["500"]
+
+    @pytest.mark.unit
+    async def test_no_prefixes_returns_empty(self) -> None:
+        webdav = _StubWebdav({})
+        assert await resolve_prefix_folder_ids(webdav, path_prefixes=[]) == []

--- a/tests/unit/search/test_verification.py
+++ b/tests/unit/search/test_verification.py
@@ -1317,12 +1317,12 @@ async def test_verify_search_results_passes_semaphore_to_verifier(mocker):
 
 
 class _StubPathStore:
-    """Stands in for DocumentPathStore; returns a fixed per-user path map."""
+    """Stands in for DocumentPathStore; returns a fixed {doc_id: path} map."""
 
     def __init__(self, paths: dict) -> None:
         self._paths = paths
 
-    async def get_paths_for_user(self, user_id, docs):
+    async def get_paths_for_user(self, user_id, doc_type, doc_ids):
         return self._paths
 
 
@@ -1340,7 +1340,7 @@ async def test_apply_display_paths_overrides_file_with_user_path(mocker):
     r_file = _make_result(1, "file", metadata={"path": "/alice/doc.pdf"})
     r_file.title = "doc.pdf"
     r_note = _make_result(2, "note", metadata={"foo": "bar"})
-    _patch_store(mocker, _StubPathStore({("file", "1"): "/bob/alice/doc.pdf"}))
+    _patch_store(mocker, _StubPathStore({"1": "/bob/alice/doc.pdf"}))
 
     await verification._apply_user_display_paths("bob", [r_file, r_note])
 

--- a/tests/unit/search/test_verification.py
+++ b/tests/unit/search/test_verification.py
@@ -1,6 +1,7 @@
 """Unit tests for verify-on-read (ADR-019)."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import anyio
 import httpx
@@ -1308,3 +1309,71 @@ async def test_verify_search_results_passes_semaphore_to_verifier(mocker):
     await verify_search_results(client, [_make_result(1)], max_concurrent=5)
 
     assert isinstance(captured["sem"], anyio.Semaphore)
+
+
+# ---------------------------------------------------------------------------
+# ADR-033 Phase 2 — per-user display-path override
+# ---------------------------------------------------------------------------
+
+
+class _StubPathStore:
+    """Stands in for DocumentPathStore; returns a fixed per-user path map."""
+
+    def __init__(self, paths: dict) -> None:
+        self._paths = paths
+
+    async def get_paths_for_user(self, user_id, docs):
+        return self._paths
+
+
+def _patch_store(mocker, stub_or_exc) -> None:
+    target = "nextcloud_mcp_server.vector.document_path_store.DocumentPathStore.shared"
+    if isinstance(stub_or_exc, Exception):
+        mocker.patch(target, new=AsyncMock(side_effect=stub_or_exc))
+    else:
+        mocker.patch(target, new=AsyncMock(return_value=stub_or_exc))
+
+
+async def test_apply_display_paths_overrides_file_with_user_path(mocker):
+    # A shared file whose Qdrant scalar carries the OWNER's path; the reader gets
+    # their own mount path substituted.
+    r_file = _make_result(1, "file", metadata={"path": "/alice/doc.pdf"})
+    r_file.title = "doc.pdf"
+    r_note = _make_result(2, "note", metadata={"foo": "bar"})
+    _patch_store(mocker, _StubPathStore({("file", "1"): "/bob/alice/doc.pdf"}))
+
+    await verification._apply_user_display_paths("bob", [r_file, r_note])
+
+    assert r_file.metadata["path"] == "/bob/alice/doc.pdf"
+    assert r_file.title == "doc.pdf"  # basename recomputed from the reader's path
+    # Non-file results are untouched.
+    assert r_note.metadata == {"foo": "bar"}
+
+
+async def test_apply_display_paths_keeps_scalar_when_no_row(mocker):
+    r_file = _make_result(1, "file", metadata={"path": "/alice/doc.pdf"})
+    _patch_store(mocker, _StubPathStore({}))  # no per-user row for this file
+
+    await verification._apply_user_display_paths("bob", [r_file])
+
+    assert r_file.metadata["path"] == "/alice/doc.pdf"  # unchanged fallback
+
+
+async def test_apply_display_paths_best_effort_on_store_error(mocker):
+    r_file = _make_result(1, "file", metadata={"path": "/alice/doc.pdf"})
+    _patch_store(mocker, RuntimeError("db down"))
+
+    # Must not raise — display-only override degrades to the stored scalar.
+    await verification._apply_user_display_paths("bob", [r_file])
+
+    assert r_file.metadata["path"] == "/alice/doc.pdf"
+
+
+async def test_apply_display_paths_noop_without_file_results(mocker):
+    # No file results -> the store is never consulted.
+    shared = mocker.patch(
+        "nextcloud_mcp_server.vector.document_path_store.DocumentPathStore.shared",
+        new=AsyncMock(),
+    )
+    await verification._apply_user_display_paths("bob", [_make_result(1, "note")])
+    shared.assert_not_awaited()

--- a/tests/unit/test_config_paths.py
+++ b/tests/unit/test_config_paths.py
@@ -24,13 +24,23 @@ from nextcloud_mcp_server.config import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_ephemeral_state(monkeypatch):
+def _reset_ephemeral_state(monkeypatch, tmp_path):
     """Reset module-global ephemeral tempfile state between tests.
 
     get_token_db_path() memoizes its result in a module-level global and
     registers an atexit hook for cleanup. Tests need an isolated slate so
     assertions about "already allocated" vs "not yet" are meaningful.
+
+    Also pin ``tempfile.tempdir`` to a per-test directory: get_token_db_path
+    allocates its ephemeral db via ``tempfile.mkstemp`` in the system tempdir,
+    and the ``nextcloud-mcp-tokens-<pid>-*.db`` glob assertions below would
+    otherwise pick up stray ephemeral dbs leaked into that shared tempdir by
+    *other* tests in a full-suite run (a pytest-ordering flake — the assertions
+    pass in isolation but not always under the CI collection order). Isolating
+    the tempdir per test makes both the allocation and the glob see only this
+    test's own files.
     """
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
     old = cfg._ephemeral_db_path
     cfg._ephemeral_db_path = None
     monkeypatch.delenv("TOKEN_STORAGE_DB", raising=False)

--- a/tests/unit/test_document_path_store.py
+++ b/tests/unit/test_document_path_store.py
@@ -1,0 +1,103 @@
+"""Unit tests for the per-user document-path store (ADR-033 Phase 2, Deck #737).
+
+Runs against a real temp-SQLite ``RefreshTokenStorage`` (its ``initialize()``
+applies the migrations, incl. ``document_paths`` / revision 009), so this also
+exercises the migration and the ON CONFLICT upsert SQL on real SQLite.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
+from nextcloud_mcp_server.vector.document_path_store import DocumentPathStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+async def store():
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = RefreshTokenStorage(db_path=str(Path(tmp) / "paths.db"))
+        await storage.initialize()
+        yield DocumentPathStore(storage)
+
+
+async def test_get_missing_returns_empty(store):
+    assert await store.get_paths_for_user("alice", [("file", "1")]) == {}
+
+
+async def test_empty_docs_short_circuits(store):
+    assert await store.get_paths_for_user("alice", []) == {}
+
+
+async def test_upsert_then_get(store):
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/alice/doc.pdf"
+    )
+    paths = await store.get_paths_for_user("alice", [("file", "1")])
+    assert paths == {("file", "1"): "/alice/doc.pdf"}
+
+
+async def test_upsert_overwrites_in_place(store):
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/alice/old.pdf"
+    )
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/alice/new.pdf"
+    )
+    paths = await store.get_paths_for_user("alice", [("file", "1")])
+    assert paths == {("file", "1"): "/alice/new.pdf"}
+
+
+async def test_paths_are_per_user(store):
+    # The same shared file (doc_id 1) at a different mount path per user.
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/alice/doc.pdf"
+    )
+    await store.upsert(
+        user_id="bob", doc_id="1", doc_type="file", file_path="/bob/alice/doc.pdf"
+    )
+    assert await store.get_paths_for_user("alice", [("file", "1")]) == {
+        ("file", "1"): "/alice/doc.pdf"
+    }
+    assert await store.get_paths_for_user("bob", [("file", "1")]) == {
+        ("file", "1"): "/bob/alice/doc.pdf"
+    }
+
+
+async def test_get_returns_only_requested_subset(store):
+    for doc_id, path in (("1", "/a/1.pdf"), ("2", "/a/2.pdf"), ("3", "/a/3.pdf")):
+        await store.upsert(
+            user_id="alice", doc_id=doc_id, doc_type="file", file_path=path
+        )
+    # Only the two requested docs come back, keyed by (doc_type, doc_id).
+    got = await store.get_paths_for_user("alice", [("file", "1"), ("file", "3")])
+    assert got == {("file", "1"): "/a/1.pdf", ("file", "3"): "/a/3.pdf"}
+
+
+async def test_get_tolerates_duplicate_and_missing_ids(store):
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/a/1.pdf"
+    )
+    # Duplicate (multiple chunks of one doc) + an id with no row.
+    got = await store.get_paths_for_user(
+        "alice", [("file", "1"), ("file", "1"), ("file", "99")]
+    )
+    assert got == {("file", "1"): "/a/1.pdf"}
+
+
+async def test_delete_removes_only_that_user_row(store):
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/alice/doc.pdf"
+    )
+    await store.upsert(
+        user_id="bob", doc_id="1", doc_type="file", file_path="/bob/alice/doc.pdf"
+    )
+    await store.delete(user_id="alice", doc_id="1", doc_type="file")
+    assert await store.get_paths_for_user("alice", [("file", "1")]) == {}
+    # Bob's row is untouched.
+    assert await store.get_paths_for_user("bob", [("file", "1")]) == {
+        ("file", "1"): "/bob/alice/doc.pdf"
+    }

--- a/tests/unit/test_document_path_store.py
+++ b/tests/unit/test_document_path_store.py
@@ -25,19 +25,19 @@ async def store():
 
 
 async def test_get_missing_returns_empty(store):
-    assert await store.get_paths_for_user("alice", [("file", "1")]) == {}
+    assert await store.get_paths_for_user("alice", "file", ["1"]) == {}
 
 
 async def test_empty_docs_short_circuits(store):
-    assert await store.get_paths_for_user("alice", []) == {}
+    assert await store.get_paths_for_user("alice", "file", []) == {}
 
 
 async def test_upsert_then_get(store):
     await store.upsert(
         user_id="alice", doc_id="1", doc_type="file", file_path="/alice/doc.pdf"
     )
-    paths = await store.get_paths_for_user("alice", [("file", "1")])
-    assert paths == {("file", "1"): "/alice/doc.pdf"}
+    paths = await store.get_paths_for_user("alice", "file", ["1"])
+    assert paths == {"1": "/alice/doc.pdf"}
 
 
 async def test_upsert_overwrites_in_place(store):
@@ -47,8 +47,8 @@ async def test_upsert_overwrites_in_place(store):
     await store.upsert(
         user_id="alice", doc_id="1", doc_type="file", file_path="/alice/new.pdf"
     )
-    paths = await store.get_paths_for_user("alice", [("file", "1")])
-    assert paths == {("file", "1"): "/alice/new.pdf"}
+    paths = await store.get_paths_for_user("alice", "file", ["1"])
+    assert paths == {"1": "/alice/new.pdf"}
 
 
 async def test_paths_are_per_user(store):
@@ -59,11 +59,11 @@ async def test_paths_are_per_user(store):
     await store.upsert(
         user_id="bob", doc_id="1", doc_type="file", file_path="/bob/alice/doc.pdf"
     )
-    assert await store.get_paths_for_user("alice", [("file", "1")]) == {
-        ("file", "1"): "/alice/doc.pdf"
+    assert await store.get_paths_for_user("alice", "file", ["1"]) == {
+        "1": "/alice/doc.pdf"
     }
-    assert await store.get_paths_for_user("bob", [("file", "1")]) == {
-        ("file", "1"): "/bob/alice/doc.pdf"
+    assert await store.get_paths_for_user("bob", "file", ["1"]) == {
+        "1": "/bob/alice/doc.pdf"
     }
 
 
@@ -72,9 +72,9 @@ async def test_get_returns_only_requested_subset(store):
         await store.upsert(
             user_id="alice", doc_id=doc_id, doc_type="file", file_path=path
         )
-    # Only the two requested docs come back, keyed by (doc_type, doc_id).
-    got = await store.get_paths_for_user("alice", [("file", "1"), ("file", "3")])
-    assert got == {("file", "1"): "/a/1.pdf", ("file", "3"): "/a/3.pdf"}
+    # Only the two requested docs come back, keyed by doc_id.
+    got = await store.get_paths_for_user("alice", "file", ["1", "3"])
+    assert got == {"1": "/a/1.pdf", "3": "/a/3.pdf"}
 
 
 async def test_get_tolerates_duplicate_and_missing_ids(store):
@@ -82,10 +82,25 @@ async def test_get_tolerates_duplicate_and_missing_ids(store):
         user_id="alice", doc_id="1", doc_type="file", file_path="/a/1.pdf"
     )
     # Duplicate (multiple chunks of one doc) + an id with no row.
-    got = await store.get_paths_for_user(
-        "alice", [("file", "1"), ("file", "1"), ("file", "99")]
+    got = await store.get_paths_for_user("alice", "file", ["1", "1", "99"])
+    assert got == {"1": "/a/1.pdf"}
+
+
+async def test_get_scopes_by_doc_type(store):
+    # A row for a different doc_type whose id collides with a file's id must NOT
+    # be returned when querying files (guards the id-collision case).
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="file", file_path="/a/file.pdf"
     )
-    assert got == {("file", "1"): "/a/1.pdf"}
+    await store.upsert(
+        user_id="alice", doc_id="1", doc_type="note", file_path="/a/note-row"
+    )
+    assert await store.get_paths_for_user("alice", "file", ["1"]) == {
+        "1": "/a/file.pdf"
+    }
+    assert await store.get_paths_for_user("alice", "note", ["1"]) == {
+        "1": "/a/note-row"
+    }
 
 
 async def test_delete_removes_only_that_user_row(store):
@@ -96,8 +111,8 @@ async def test_delete_removes_only_that_user_row(store):
         user_id="bob", doc_id="1", doc_type="file", file_path="/bob/alice/doc.pdf"
     )
     await store.delete(user_id="alice", doc_id="1", doc_type="file")
-    assert await store.get_paths_for_user("alice", [("file", "1")]) == {}
+    assert await store.get_paths_for_user("alice", "file", ["1"]) == {}
     # Bob's row is untouched.
-    assert await store.get_paths_for_user("bob", [("file", "1")]) == {
-        ("file", "1"): "/bob/alice/doc.pdf"
+    assert await store.get_paths_for_user("bob", "file", ["1"]) == {
+        "1": "/bob/alice/doc.pdf"
     }

--- a/tests/unit/vector/test_folder_ancestors.py
+++ b/tests/unit/vector/test_folder_ancestors.py
@@ -1,0 +1,72 @@
+"""Unit tests for folder-ancestor resolution (ADR-033 Phase 3, Deck #740)."""
+
+from __future__ import annotations
+
+import pytest
+
+from nextcloud_mcp_server.vector.folder_ancestors import (
+    ancestor_dir_paths,
+    resolve_folder_ancestors,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _StubWebdav:
+    """Resolves folder paths to fileids from a fixed map; counts calls."""
+
+    def __init__(self, mapping: dict[str, str | None], *, raises: set | None = None):
+        self._mapping = mapping
+        self._raises = raises or set()
+        self.calls: list[str] = []
+
+    async def get_fileid(self, path: str) -> str | None:
+        self.calls.append(path)
+        if path in self._raises:
+            raise RuntimeError("boom")
+        return self._mapping.get(path)
+
+
+class TestAncestorDirPaths:
+    def test_immediate_parent_first_root_excluded(self) -> None:
+        assert ancestor_dir_paths("/A/B/doc.pdf") == ["/A/B", "/A"]
+
+    def test_top_level_file_has_no_ancestors(self) -> None:
+        # Only the root would be an ancestor, and root is excluded.
+        assert ancestor_dir_paths("/doc.pdf") == []
+
+    def test_empty_path(self) -> None:
+        assert ancestor_dir_paths("") == []
+
+
+class TestResolveFolderAncestors:
+    async def test_resolves_each_ancestor_in_order(self) -> None:
+        webdav = _StubWebdav({"/A/B": "200", "/A": "100"})
+        got = await resolve_folder_ancestors(webdav, "/A/B/doc.pdf")
+        # Immediate parent first.
+        assert got == ["200", "100"]
+
+    async def test_unresolved_ancestor_is_skipped(self) -> None:
+        # /A/B has no fileid (None) -> omitted; /A resolves.
+        webdav = _StubWebdav({"/A/B": None, "/A": "100"})
+        got = await resolve_folder_ancestors(webdav, "/A/B/doc.pdf")
+        assert got == ["100"]
+
+    async def test_error_on_one_ancestor_is_best_effort(self) -> None:
+        webdav = _StubWebdav({"/A": "100"}, raises={"/A/B"})
+        got = await resolve_folder_ancestors(webdav, "/A/B/doc.pdf")
+        assert got == ["100"]  # the raising folder is skipped, not fatal
+
+    async def test_empty_path_returns_empty_without_calls(self) -> None:
+        webdav = _StubWebdav({})
+        assert await resolve_folder_ancestors(webdav, "") == []
+        assert webdav.calls == []
+
+    async def test_cache_memoises_repeated_lookups(self) -> None:
+        webdav = _StubWebdav({"/A/B": "200", "/A": "100"})
+        cache: dict[str, str | None] = {}
+        await resolve_folder_ancestors(webdav, "/A/B/x.pdf", cache=cache)
+        await resolve_folder_ancestors(webdav, "/A/B/y.pdf", cache=cache)
+        # Two files under the same folders -> each folder resolved once.
+        assert sorted(webdav.calls) == ["/A", "/A/B"]
+        assert cache == {"/A/B": "200", "/A": "100"}

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -599,3 +599,51 @@ class TestClaimFolderAncestorBackfill:
             "42", "file", "abc", "alice", current_path="/A/doc.pdf", webdav=webdav
         )
         assert _folder_ancestor_payloads(client) == [["100"]]
+
+
+class _CountingWebdav:
+    """Counts get_fileid calls to prove the per-scan cache collapses lookups."""
+
+    def __init__(self, mapping: dict) -> None:
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    async def get_fileid(self, path: str):
+        self.calls.append(path)
+        return self._mapping.get(path)
+
+
+class TestBackfillCacheThreading:
+    async def test_shared_cache_resolves_common_ancestor_once(self, client) -> None:
+        # Two files under the same folder /A, both needing a Phase-3 backfill.
+        # A shared folder_ancestor_cache must resolve /A exactly once.
+        payload = {
+            payload_keys.EMBEDDING_IDENTITY: _MODEL,
+            ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+            "owner_id": "alice",
+        }
+        client.scroll.return_value = ([_point(dict(payload))], None)
+        webdav = _CountingWebdav({"/A": "100"})
+        cache: dict = {}
+
+        await ss.claim_existing_index(
+            "1",
+            "file",
+            "abc",
+            "alice",
+            current_path="/A/one.pdf",
+            webdav=webdav,
+            folder_ancestor_cache=cache,
+        )
+        await ss.claim_existing_index(
+            "2",
+            "file",
+            "abc",
+            "alice",
+            current_path="/A/two.pdf",
+            webdav=webdav,
+            folder_ancestor_cache=cache,
+        )
+        # /A resolved once across the two files, not twice.
+        assert webdav.calls == ["/A"]
+        assert cache == {"/A": "100"}

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -160,6 +160,65 @@ class TestReconcileDocumentPath:
         kwargs = client.set_payload.await_args.kwargs
         assert kwargs["payload"]["title"] == "new.pdf"
 
+    async def test_suppresses_non_owner_divergent_path(self, client) -> None:
+        # ADR-033 Phase 1: a reader (bob) observing the shared file at their own
+        # mount path must NOT overwrite the owner-pinned scalar. This is the
+        # thrash guard — no set_payload is issued.
+        changed = await ss.reconcile_document_path(
+            "42",
+            "file",
+            "/alice/doc.pdf",
+            "/bob/alice/doc.pdf",
+            caller_user_id="bob",
+            owner_id="alice",
+        )
+        assert changed is False
+        client.set_payload.assert_not_called()
+
+    async def test_rewrites_for_owner_rename(self, client) -> None:
+        # The owner renaming their own file is a genuine change -> reconcile.
+        changed = await ss.reconcile_document_path(
+            "42",
+            "file",
+            "/alice/old.pdf",
+            "/alice/new.pdf",
+            caller_user_id="alice",
+            owner_id="alice",
+        )
+        assert changed is True
+        kwargs = client.set_payload.await_args.kwargs
+        assert kwargs["payload"]["file_path"] == "/alice/new.pdf"
+
+    async def test_legacy_point_without_owner_still_reconciles(self, client) -> None:
+        # owner_id unknown (pre-owner_id point) -> fall through to the old
+        # always-reconcile behaviour (single-owner, so no thrash to guard).
+        changed = await ss.reconcile_document_path(
+            "42",
+            "file",
+            "/a/old.pdf",
+            "/a/new.pdf",
+            caller_user_id="bob",
+            owner_id=None,
+        )
+        assert changed is True
+        client.set_payload.assert_awaited_once()
+
+    async def test_backfill_empty_stored_path_regardless_of_caller(
+        self, client
+    ) -> None:
+        # An empty stored path has nothing to thrash: a non-owner may backfill it
+        # (the owner's next scan re-pins it if it diverges).
+        changed = await ss.reconcile_document_path(
+            "42",
+            "file",
+            "",
+            "/bob/alice/doc.pdf",
+            caller_user_id="bob",
+            owner_id="alice",
+        )
+        assert changed is True
+        client.set_payload.assert_awaited_once()
+
 
 class TestClaimExistingIndex:
     async def test_true_and_grants_principal_on_hit(self, client) -> None:

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -514,3 +514,88 @@ class TestReleaseDocumentForUser:
 
         selector = client.delete.await_args.kwargs["points_selector"]
         assert _must_keys(selector) == ["user_id", "doc_id", "doc_type"]
+
+
+class _StubWebdav:
+    """Resolves ancestor folder paths to fileids for the backfill tests."""
+
+    def __init__(self, mapping: dict) -> None:
+        self._mapping = mapping
+
+    async def get_fileid(self, path: str):
+        return self._mapping.get(path)
+
+
+def _folder_ancestor_payloads(client) -> list[list]:
+    """The folder_ancestors values from every set_payload call, in order."""
+    return [
+        call.kwargs["payload"][payload_keys.FOLDER_ANCESTORS]
+        for call in client.set_payload.await_args_list
+        if payload_keys.FOLDER_ANCESTORS in call.kwargs["payload"]
+    ]
+
+
+class TestClaimFolderAncestorBackfill:
+    def _hit(self, **extra) -> dict:
+        payload = {
+            payload_keys.EMBEDDING_IDENTITY: _MODEL,
+            ss.ACL_PRINCIPALS_KEY: ["user:alice"],
+            "file_path": "/A/doc.pdf",
+            "owner_id": "alice",
+        }
+        payload.update(extra)
+        return payload
+
+    async def test_backfills_folder_ancestors_for_owner(self, client) -> None:
+        # Owner (alice) re-scans a pre-Phase-3 doc (no folder_ancestors); the
+        # ancestors are resolved from her canonical path and written once.
+        client.scroll.return_value = ([_point(self._hit())], None)
+        webdav = _StubWebdav({"/A": "100"})
+
+        claimed = await ss.claim_existing_index(
+            "42", "file", "abc", "alice", current_path="/A/doc.pdf", webdav=webdav
+        )
+        assert claimed is True
+        assert _folder_ancestor_payloads(client) == [["100"]]
+
+    async def test_skips_backfill_for_non_owner(self, client) -> None:
+        # A reader (bob) must NOT backfill — his mount prefix would pollute the
+        # canonical, user-agnostic ancestor set.
+        client.scroll.return_value = ([_point(self._hit())], None)
+        webdav = _StubWebdav({"/bob/A": "999"})
+
+        await ss.claim_existing_index(
+            "42", "file", "abc", "bob", current_path="/bob/A/doc.pdf", webdav=webdav
+        )
+        assert _folder_ancestor_payloads(client) == []
+
+    async def test_skips_backfill_when_already_present(self, client) -> None:
+        client.scroll.return_value = (
+            [_point(self._hit(**{payload_keys.FOLDER_ANCESTORS: ["777"]}))],
+            None,
+        )
+        webdav = _StubWebdav({"/A": "100"})
+
+        await ss.claim_existing_index(
+            "42", "file", "abc", "alice", current_path="/A/doc.pdf", webdav=webdav
+        )
+        assert _folder_ancestor_payloads(client) == []
+
+    async def test_no_backfill_without_webdav(self, client) -> None:
+        client.scroll.return_value = ([_point(self._hit())], None)
+        await ss.claim_existing_index(
+            "42", "file", "abc", "alice", current_path="/A/doc.pdf"
+        )
+        assert _folder_ancestor_payloads(client) == []
+
+    async def test_backfills_for_legacy_point_without_owner(self, client) -> None:
+        # owner_id unknown (pre-owner_id point) -> single-owner, safe to backfill.
+        payload = self._hit()
+        del payload["owner_id"]
+        client.scroll.return_value = ([_point(payload)], None)
+        webdav = _StubWebdav({"/A": "100"})
+
+        await ss.claim_existing_index(
+            "42", "file", "abc", "alice", current_path="/A/doc.pdf", webdav=webdav
+        )
+        assert _folder_ancestor_payloads(client) == [["100"]]


### PR DESCRIPTION
## Summary

Fixes the shared-document `file_path` thrash (Deck #737): a file visible to more
than one user is mounted at a different path per user, but the tenant-wide dedup
stores **one point set per `doc_id` with a single scalar `file_path`**, so every
reader's scan rewrote it to their own path — flipping it back and forth once per
user per scan pass. That caused write amplification (a `set_payload` per shared
doc per user every scan) and a **non-deterministic `file_path`** that silently
broke the `path_prefix` search filter.

Implements the full three-phase design in **ADR-033** (new), which also resolves
the loose-prefix bug (#739) and the folder-ancestor filtering approach (#740).

## What changed (by phase)

**Phase 1 — deterministic canonical path (stop the thrash).** Owner-gate
`reconcile_document_path` on the point's `owner_id`: the `set_payload` fires only
for a genuine owner-side rename, an empty stored path, or a legacy point with no
owner. A non-owner reader's divergent path is now a no-op.

**Phase 2 — per-user display paths (relational).** New `document_paths` table
(migration 009; portable Text + epoch types, runs on **both SQLite and
Postgres** via the existing Alembic abstraction). The scanner upserts each
reader's observed path (one bounded relational write replaces the per-chunk
`set_payload`); `verify_search_results` substitutes the querying user's own
path/title onto the returned file results. It is a **derived, non-security
cache** — Qdrant stays the system of record, so a store miss only mis-displays a
path, never a permission or a retrieval result.

**Phase 3 — folder-ancestor scope filter.** New `folder_ancestors` payload key
(KEYWORD-indexed) carrying a file's ancestor folder fileids — user-agnostic,
since a shared folder keeps one canonical fileid for every user who mounts it.
`WebDAVClient.get_fileid` resolves prefixes/ancestors; the search filter ORs
`MatchAny(folder_ancestors, [folder_id])` (a true left-anchored containment,
fixing #739) with the legacy `MatchText(file_path)` fallback so un-backfilled
points keep recall. Backfill is **lazy and owner-scoped** inside
`claim_existing_index` (reuses the already-fetched payload, no extra scroll, no
re-embed, bounded).

Existing collections need **no re-embedding** at any phase; they degrade
gracefully and self-populate as scans run.

## Tests

- Unit: owner-gating, the path store (on real temp-SQLite — also validates
  migration 009), the search-time override, ancestor resolution, filter
  construction, the prefix resolver, `get_fileid` parsing, and the owner-scoped
  backfill. All green; `ruff`/`ruff format`/`ty` clean.
- Integration (`-m integration`): shared-folder end-to-end — a recipient sees
  their own path and folder-scopes by the shared folder's canonical id.

## Follow-ups / notes

- The new KEYWORD index + `MatchAny` selectivity, and the integration lane,
  should be validated against a live Qdrant (login-flow profile) — the local
  unit tier can't exercise the real engine index.
- Prefix→fileid resolution is a synchronous PROPFIND per prefix on the search
  path (currently uncached); a per-user TTL cache like `list_accessible_owners`
  is the obvious follow-up if it shows in latency.
- Unrelated pre-existing flake: `tests/unit/test_config_paths.py` two tempfile
  tests fail only under full-suite ordering (a `gettempdir()` glob picks up
  ephemeral token DBs other tests leak); both pass in isolation and are untouched
  by this branch.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
