### PR TITLE
fix(webdav): detect concurrent edits and locks on write, guard oversized writes

### DIFF
--- a/docs/webdav.md
+++ b/docs/webdav.md
@@ -61,26 +61,45 @@ await nc_webdav_copy_resource("document.txt", "Backup/document.txt")
 await nc_webdav_copy_resource("Projects/ProjectA", "Projects/ProjectA_Backup")
 ```
 
-### Detecting Concurrent Edits and Locks
+### Safe Writes: Concurrent Edits and Locks
 
-`nc_webdav_read_file` returns an `etag` for the file it read. Pass it back
-into `nc_webdav_write_file`'s `if_match` when writing that same path later:
-the write is then conditional and fails with a clear error instead of
-silently overwriting a change made elsewhere in the meantime (e.g. someone
-editing the file directly in the Nextcloud web UI).
+`nc_webdav_write_file` is **fail-closed** — it never silently overwrites an
+existing file. Every write is a conditional PUT; the `if_match` argument
+selects one of three modes:
+
+| `if_match`            | Behaviour |
+|-----------------------|-----------|
+| omitted (`None`)      | **Create-only.** Fails if the path already exists. |
+| an `etag`             | **Safe overwrite.** Fails if the file changed since that etag was read. |
+| `"*"`                 | **Force-overwrite.** Overwrites unconditionally; fails only if the file does not exist. |
+
+To change an existing file, read it first to obtain its `etag`
+(`nc_webdav_read_file` returns one), then pass that `etag` back into the
+write. If the file changed in the meantime (e.g. someone edited it directly
+in the Nextcloud web UI), the write fails instead of clobbering their change.
+`nc_webdav_list_directory` and the search/find tools also return an `etag`
+per file, so you can obtain one without a full read.
 
 ```python
-# Read, capture the etag, and write back conditionally
+# Read, capture the etag, and write back safely
 result = await nc_webdav_read_file("Documents/notes.md")
 await nc_webdav_write_file(
     "Documents/notes.md", result["content"] + "\nMore.", if_match=result["etag"]
 )
 # Raises ToolError if the file changed since the read (etag mismatch, HTTP 412)
 # or if it's locked by another client, e.g. open in the web editor (HTTP 423).
+
+# Create a brand-new file (fails with ToolError if it already exists):
+await nc_webdav_write_file("Documents/new.md", "# New")
+
+# Deliberately replace an existing file wholesale, without reading it first:
+await nc_webdav_write_file("Documents/notes.md", "# Regenerated", if_match="*")
 ```
 
-Omit `if_match` for a fresh file or a deliberate unconditional overwrite —
-this keeps the previous last-write-wins behavior.
+> **Breaking change (0.x):** an `if_match`-less write over an *existing* file
+> now fails with a `ToolError` rather than overwriting it (the previous
+> last-write-wins behaviour). Pass the file's `etag`, or `if_match="*"` to
+> force the overwrite.
 
 ### Write Size Limit
 

--- a/docs/webdav.md
+++ b/docs/webdav.md
@@ -60,3 +60,32 @@ await nc_webdav_copy_resource("document.txt", "Backup/document.txt")
 # Copy a directory
 await nc_webdav_copy_resource("Projects/ProjectA", "Projects/ProjectA_Backup")
 ```
+
+### Detecting Concurrent Edits and Locks
+
+`nc_webdav_read_file` returns an `etag` for the file it read. Pass it back
+into `nc_webdav_write_file`'s `if_match` when writing that same path later:
+the write is then conditional and fails with a clear error instead of
+silently overwriting a change made elsewhere in the meantime (e.g. someone
+editing the file directly in the Nextcloud web UI).
+
+```python
+# Read, capture the etag, and write back conditionally
+result = await nc_webdav_read_file("Documents/notes.md")
+await nc_webdav_write_file(
+    "Documents/notes.md", result["content"] + "\nMore.", if_match=result["etag"]
+)
+# Raises ToolError if the file changed since the read (etag mismatch, HTTP 412)
+# or if it's locked by another client, e.g. open in the web editor (HTTP 423).
+```
+
+Omit `if_match` for a fresh file or a deliberate unconditional overwrite —
+this keeps the previous last-write-wins behavior.
+
+### Write Size Limit
+
+`nc_webdav_write_file` builds its request from a single in-memory MCP tool
+argument — there is no chunked/streaming upload for writes (unlike the
+read/ingest path). A pre-flight size gate rejects content over
+`WEBDAV_WRITE_MAX_MB` (default 50, `0` disables) with a clear error rather
+than risking a timeout or out-of-memory failure on a very large PUT.

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -400,6 +400,7 @@ class WebDAVClient(BaseNextcloudClient):
                 <d:getcontentlength/>
                 <d:getcontenttype/>
                 <d:getlastmodified/>
+                <d:getetag/>
                 <d:resourcetype/>
             </d:prop>
         </d:propfind>"""
@@ -464,6 +465,16 @@ class WebDAVClient(BaseNextcloudClient):
                 modified_elem = prop.find(".//{DAV:}getlastmodified")
                 modified = modified_elem.text if modified_elem is not None else None
 
+                # Strip surrounding quotes to match every other etag path in
+                # this client (a caller feeds this straight into write_file's
+                # if_match, which re-adds the quotes for the If-Match header).
+                etag_elem = prop.find(".//{DAV:}getetag")
+                etag = (
+                    etag_elem.text.strip('"')
+                    if etag_elem is not None and etag_elem.text
+                    else None
+                )
+
                 items.append(
                     {
                         "name": name,
@@ -472,6 +483,7 @@ class WebDAVClient(BaseNextcloudClient):
                         "size": size if not is_directory else None,
                         "content_type": content_type,
                         "last_modified": modified,
+                        "etag": etag,
                     }
                 )
 
@@ -586,22 +598,34 @@ class WebDAVClient(BaseNextcloudClient):
     ) -> Dict[str, Any]:
         """Write content to a file via WebDAV PUT.
 
+        Every PUT is conditional: the write is fail-closed so an existing file
+        is never silently overwritten. Exactly one precondition header is sent,
+        chosen by ``if_match``:
+
+        =================  ====================  ======================================
+        ``if_match``       Header sent           Behaviour (412 = precondition failed)
+        =================  ====================  ======================================
+        ``None`` (default) ``If-None-Match: *``  Create-only. 412 if the path already
+                                                 exists -- read it first to get an etag.
+        an etag, e.g. abc  ``If-Match: "abc"``   Conditional overwrite. 412 if the file
+                                                 changed since that etag (or is gone).
+        ``"*"``            ``If-Match: *``       Force-overwrite an existing file. 412 if
+                                                 it does not exist.
+        =================  ====================  ======================================
+
         Args:
             path: Destination path.
             content: Raw bytes to write.
             content_type: MIME type (guessed from ``path`` if omitted).
-            if_match: ETag previously returned by :meth:`read_file` for this
-                same path. When given, the PUT is conditional (``If-Match``):
-                Nextcloud rejects it with 412 if the file changed since that
-                read instead of silently overwriting the newer content.
-                Omit for the previous unconditional (last-write-wins) PUT.
+            if_match: ``None`` to create a new file (fails if it exists); an
+                etag from :meth:`read_file` to overwrite only if unchanged; or
+                the literal ``"*"`` to force-overwrite an existing file.
 
         Returns:
-            ``{"status_code": ...}`` on success. On a 412 (etag mismatch,
-            i.e. the file was modified since ``if_match`` was read) or a 423
-            (WebDAV lock held by another client, e.g. the file is open in the
-            Nextcloud web editor), returns ``{"status_code": ..., "message":
-            ...}`` instead of raising, matching ``move_resource``/
+            ``{"status_code": ...}`` on success. On a 412 (a precondition above
+            failed) or a 423 (WebDAV lock held by another client, e.g. the file
+            is open in the Nextcloud web editor), returns ``{"status_code": ...,
+            "message": ...}`` instead of raising, matching ``move_resource``/
             ``copy_resource``'s handling of their own known conflict statuses
             -- both are conditions a caller should react to, not a transport
             failure. Any other error status still raises ``HTTPStatusError``.
@@ -617,8 +641,15 @@ class WebDAVClient(BaseNextcloudClient):
                 content_type = "application/octet-stream"
 
         headers = {"Content-Type": content_type, "OCS-APIRequest": "true"}
-        if if_match is not None:
-            headers["If-Match"] = f'"{if_match}"'
+        # Always send a precondition so a write can never silently clobber an
+        # existing file. The server (Sabre checkPreconditions) evaluates it
+        # atomically before the PUT, so this is race-free.
+        if if_match is None:
+            headers["If-None-Match"] = "*"  # create-only
+        elif if_match == "*":
+            headers["If-Match"] = "*"  # force-overwrite an existing file
+        else:
+            headers["If-Match"] = f'"{if_match}"'  # overwrite iff unchanged
 
         try:
             response = await self._make_request(
@@ -631,6 +662,32 @@ class WebDAVClient(BaseNextcloudClient):
 
         except HTTPStatusError as e:
             if e.response.status_code == 412:
+                # Which precondition failed depends on which header we sent --
+                # the client knows, so give a cause-specific, actionable message
+                # rather than parsing the server's response body.
+                if if_match is None:
+                    logger.debug(
+                        "Precondition failed writing '%s': file already exists "
+                        "(create-only If-None-Match)",
+                        path,
+                    )
+                    return {
+                        "status_code": 412,
+                        "message": "File already exists — read it first to get its "
+                        "etag and pass if_match to overwrite safely, or pass "
+                        "if_match='*' to overwrite deliberately",
+                    }
+                if if_match == "*":
+                    logger.debug(
+                        "Precondition failed writing '%s': file does not exist "
+                        "(force-overwrite If-Match: *)",
+                        path,
+                    )
+                    return {
+                        "status_code": 412,
+                        "message": "File does not exist — cannot force-overwrite a "
+                        "missing file; omit if_match to create it",
+                    }
                 logger.debug(
                     "Precondition failed writing '%s': file changed since if_match "
                     "etag was read",

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -633,7 +633,8 @@ class WebDAVClient(BaseNextcloudClient):
         write the file back can pass it as ``write_file``'s ``if_match`` and
         detect a concurrent edit (made e.g. directly in the Nextcloud web UI)
         instead of silently overwriting it -- there was previously no way for
-        a caller to even notice that race.
+        a caller to even notice that race. The etag is ``None`` if the server
+        did not return an ``ETag`` header.
         """
         await self._ensure_principal_id()
         webdav_path = self._webdav_path(path)

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -541,8 +541,15 @@ class WebDAVClient(BaseNextcloudClient):
         logger.debug("Streamed '%s' to %s (%s bytes)", path, dest, written)
         return written, content_type
 
-    async def read_file(self, path: str) -> Tuple[bytes, str]:
-        """Read a file's content via WebDAV GET."""
+    async def read_file(self, path: str) -> Tuple[bytes, str, Optional[str]]:
+        """Read a file's content via WebDAV GET.
+
+        Returns the ``ETag`` alongside the content so a caller that intends to
+        write the file back can pass it as ``write_file``'s ``if_match`` and
+        detect a concurrent edit (made e.g. directly in the Nextcloud web UI)
+        instead of silently overwriting it -- there was previously no way for
+        a caller to even notice that race.
+        """
         await self._ensure_principal_id()
         webdav_path = self._webdav_path(path)
 
@@ -556,9 +563,12 @@ class WebDAVClient(BaseNextcloudClient):
             content_type = response.headers.get(
                 "content-type", "application/octet-stream"
             )
+            etag = response.headers.get("etag")
+            if etag is not None:
+                etag = etag.strip('"')
 
             logger.debug("Successfully read file '%s' (%s bytes)", path, len(content))
-            return content, content_type
+            return content, content_type, etag
 
         except HTTPStatusError as e:
             logger.error("HTTP error reading file '%s': %s", path, e)
@@ -568,9 +578,34 @@ class WebDAVClient(BaseNextcloudClient):
             raise e
 
     async def write_file(
-        self, path: str, content: bytes, content_type: Optional[str] = None
+        self,
+        path: str,
+        content: bytes,
+        content_type: Optional[str] = None,
+        if_match: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Write content to a file via WebDAV PUT."""
+        """Write content to a file via WebDAV PUT.
+
+        Args:
+            path: Destination path.
+            content: Raw bytes to write.
+            content_type: MIME type (guessed from ``path`` if omitted).
+            if_match: ETag previously returned by :meth:`read_file` for this
+                same path. When given, the PUT is conditional (``If-Match``):
+                Nextcloud rejects it with 412 if the file changed since that
+                read instead of silently overwriting the newer content.
+                Omit for the previous unconditional (last-write-wins) PUT.
+
+        Returns:
+            ``{"status_code": ...}`` on success. On a 412 (etag mismatch,
+            i.e. the file was modified since ``if_match`` was read) or a 423
+            (WebDAV lock held by another client, e.g. the file is open in the
+            Nextcloud web editor), returns ``{"status_code": ..., "message":
+            ...}`` instead of raising, matching ``move_resource``/
+            ``copy_resource``'s handling of their own known conflict statuses
+            -- both are conditions a caller should react to, not a transport
+            failure. Any other error status still raises ``HTTPStatusError``.
+        """
         await self._ensure_principal_id()
         webdav_path = self._webdav_path(path)
 
@@ -582,6 +617,8 @@ class WebDAVClient(BaseNextcloudClient):
                 content_type = "application/octet-stream"
 
         headers = {"Content-Type": content_type, "OCS-APIRequest": "true"}
+        if if_match is not None:
+            headers["If-Match"] = f'"{if_match}"'
 
         try:
             response = await self._make_request(
@@ -593,6 +630,24 @@ class WebDAVClient(BaseNextcloudClient):
             return {"status_code": response.status_code}
 
         except HTTPStatusError as e:
+            if e.response.status_code == 412:
+                logger.debug(
+                    "Precondition failed writing '%s': file changed since if_match "
+                    "etag was read",
+                    path,
+                )
+                return {
+                    "status_code": 412,
+                    "message": "File was modified since the given etag was read "
+                    "(concurrent edit) — re-read before writing",
+                }
+            if e.response.status_code == 423:
+                logger.debug("Resource locked writing '%s'", path)
+                return {
+                    "status_code": 423,
+                    "message": "File is locked by another client (e.g. open in "
+                    "the Nextcloud web editor) — not retried automatically",
+                }
             logger.error("HTTP error writing file '%s': %s", path, e)
             raise e
         except Exception as e:

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -142,6 +142,79 @@ def _encode_dav_path(path: str) -> str:
     return quote(path, safe="/")
 
 
+def _write_precondition_header(if_match: Optional[str]) -> dict[str, str]:
+    """Pick the single conditional header for a fail-closed PUT.
+
+    A write always carries a precondition so it can never silently clobber an
+    existing file (the server evaluates it atomically before the PUT):
+
+    - ``None``  -> ``If-None-Match: *`` (create-only)
+    - ``"*"``   -> ``If-Match: *`` (force-overwrite an existing file)
+    - an etag   -> ``If-Match: "<etag>"`` (overwrite iff unchanged)
+    """
+    if if_match is None:
+        return {"If-None-Match": "*"}
+    if if_match == "*":
+        return {"If-Match": "*"}
+    return {"If-Match": f'"{if_match}"'}
+
+
+def _write_conflict_result(
+    if_match: Optional[str], status_code: int, path: str
+) -> Optional[Dict[str, Any]]:
+    """Map a known write-conflict status to a structured result, else ``None``.
+
+    412 and 423 are conditions a caller must react to (not transport failures),
+    so :meth:`WebDAVClient.write_file` returns them rather than raising, matching
+    ``move_resource``/``copy_resource``. Which 412 message applies depends on
+    which precondition we sent -- the client knows, so it gives a cause-specific,
+    actionable message instead of parsing the server's response body. Any other
+    status returns ``None`` so the caller re-raises.
+    """
+    if status_code == 412:
+        if if_match is None:
+            logger.debug(
+                "Precondition failed writing '%s': file already exists "
+                "(create-only If-None-Match)",
+                path,
+            )
+            return {
+                "status_code": 412,
+                "message": "File already exists — read it first to get its etag "
+                "and pass if_match to overwrite safely, or pass if_match='*' to "
+                "overwrite deliberately",
+            }
+        if if_match == "*":
+            logger.debug(
+                "Precondition failed writing '%s': file does not exist "
+                "(force-overwrite If-Match: *)",
+                path,
+            )
+            return {
+                "status_code": 412,
+                "message": "File does not exist — cannot force-overwrite a missing "
+                "file; omit if_match to create it",
+            }
+        logger.debug(
+            "Precondition failed writing '%s': file changed since if_match etag "
+            "was read",
+            path,
+        )
+        return {
+            "status_code": 412,
+            "message": "File was modified since the given etag was read "
+            "(concurrent edit) — re-read before writing",
+        }
+    if status_code == 423:
+        logger.debug("Resource locked writing '%s'", path)
+        return {
+            "status_code": 423,
+            "message": "File is locked by another client (e.g. open in the "
+            "Nextcloud web editor) — not retried automatically",
+        }
+    return None
+
+
 class WebDAVClient(BaseNextcloudClient):
     """Client for Nextcloud WebDAV operations."""
 
@@ -644,12 +717,7 @@ class WebDAVClient(BaseNextcloudClient):
         # Always send a precondition so a write can never silently clobber an
         # existing file. The server (Sabre checkPreconditions) evaluates it
         # atomically before the PUT, so this is race-free.
-        if if_match is None:
-            headers["If-None-Match"] = "*"  # create-only
-        elif if_match == "*":
-            headers["If-Match"] = "*"  # force-overwrite an existing file
-        else:
-            headers["If-Match"] = f'"{if_match}"'  # overwrite iff unchanged
+        headers.update(_write_precondition_header(if_match))
 
         try:
             response = await self._make_request(
@@ -661,50 +729,11 @@ class WebDAVClient(BaseNextcloudClient):
             return {"status_code": response.status_code}
 
         except HTTPStatusError as e:
-            if e.response.status_code == 412:
-                # Which precondition failed depends on which header we sent --
-                # the client knows, so give a cause-specific, actionable message
-                # rather than parsing the server's response body.
-                if if_match is None:
-                    logger.debug(
-                        "Precondition failed writing '%s': file already exists "
-                        "(create-only If-None-Match)",
-                        path,
-                    )
-                    return {
-                        "status_code": 412,
-                        "message": "File already exists — read it first to get its "
-                        "etag and pass if_match to overwrite safely, or pass "
-                        "if_match='*' to overwrite deliberately",
-                    }
-                if if_match == "*":
-                    logger.debug(
-                        "Precondition failed writing '%s': file does not exist "
-                        "(force-overwrite If-Match: *)",
-                        path,
-                    )
-                    return {
-                        "status_code": 412,
-                        "message": "File does not exist — cannot force-overwrite a "
-                        "missing file; omit if_match to create it",
-                    }
-                logger.debug(
-                    "Precondition failed writing '%s': file changed since if_match "
-                    "etag was read",
-                    path,
-                )
-                return {
-                    "status_code": 412,
-                    "message": "File was modified since the given etag was read "
-                    "(concurrent edit) — re-read before writing",
-                }
-            if e.response.status_code == 423:
-                logger.debug("Resource locked writing '%s'", path)
-                return {
-                    "status_code": 423,
-                    "message": "File is locked by another client (e.g. open in "
-                    "the Nextcloud web editor) — not retried automatically",
-                }
+            # 412/423 are actionable conflicts the caller must handle -> return
+            # a structured result. Anything else is a genuine transport error.
+            conflict = _write_conflict_result(if_match, e.response.status_code, path)
+            if conflict is not None:
+                return conflict
             logger.error("HTTP error writing file '%s': %s", path, e)
             raise e
         except Exception as e:

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -211,6 +211,12 @@ _DEFAULTS: dict[str, Any] = {
     # "oversize" instead of burning the OCR timeout to 0 chars on a pathological
     # file. 0 disables the guard.
     "document_max_pdf_size_mb": 50.0,
+    # Pre-flight cap (MB) on nc_webdav_write_file's content: a huge PUT built
+    # from a single in-memory MCP tool argument (no chunked/streaming upload
+    # exists for writes, unlike the read-side stream_to_file path) risks
+    # timing out or exhausting memory rather than failing predictably. 0
+    # disables the guard.
+    "webdav_write_max_mb": 50.0,
     # Page ceiling for markdown reconstruction (see document_markdown_max_pages).
     "document_markdown_max_pages": 150,
     # Pages per pypdfium2 extraction window (see document_parse_page_window).
@@ -1151,6 +1157,9 @@ class Settings:
     # being handed to the fast/OCR tiers, where a pathological large file burns
     # the OCR timeout for 0 chars. 0 disables the guard.
     document_max_pdf_size_mb: float = 50.0
+    # Pre-flight cap (MB) on nc_webdav_write_file's content (see _DEFAULTS
+    # for rationale). 0 disables the guard.
+    webdav_write_max_mb: float = 50.0
     # Page ceiling above which the structured tier skips pymupdf4llm.to_markdown
     # and returns the raw text layer instead. 0 disables markdown entirely
     # (every document takes the raw-text path), matching how
@@ -2013,6 +2022,7 @@ def _build_settings() -> Settings:
         "document_parse_timeout_seconds": "DOCUMENT_PARSE_TIMEOUT_SECONDS",
         "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
+        "webdav_write_max_mb": "WEBDAV_WRITE_MAX_MB",
         "document_markdown_max_pages": "DOCUMENT_MARKDOWN_MAX_PAGES",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",

--- a/nextcloud_mcp_server/server/collectives.py
+++ b/nextcloud_mcp_server/server/collectives.py
@@ -123,7 +123,7 @@ def configure_collectives_tools(mcp: FastMCP):
             parts.append(page.fileName)
             webdav_path = "/".join(p.strip("/") for p in parts)
             try:
-                file_bytes, _ = await client.webdav.read_file(webdav_path)
+                file_bytes, _, _ = await client.webdav.read_file(webdav_path)
                 content = file_bytes.decode("utf-8")
             except (HTTPStatusError, OSError, UnicodeDecodeError) as e:
                 logger.warning(

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -251,8 +251,11 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Write File",
         annotations=ToolAnnotations(
-            idempotentHint=True,  # true unconditionally; with if_match a repeat
-            # call after a real conflict returns 412 both times, still idempotent
+            # Not idempotent: the write is fail-closed. A create (no if_match)
+            # succeeds once then returns 412 ("already exists") on repeat, and
+            # an if_match overwrite is invalidated by its own success (the etag
+            # changes) -- mirroring nc_notes_update_note's etag-guarded update.
+            idempotentHint=False,
             openWorldHint=True,
         ),
     )
@@ -267,25 +270,31 @@ def configure_webdav_tools(mcp: FastMCP):
     ):
         """Write content to a file in NextCloud.
 
+        Writes are **fail-closed**: an existing file is never silently
+        overwritten. What happens depends on ``if_match`` (see below).
+
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and the
         target path (or an ancestor folder) carries an excluded system tag;
         when the decoded content exceeds ``WEBDAV_WRITE_MAX_MB``; when the
-        write conflicts with a concurrent edit (412); or when the file is
-        locked by another client (423) -- see ``if_match`` below.
+        write conflicts with a concurrent edit or an existing/missing file
+        (412); or when the file is locked by another client (423) -- see
+        ``if_match`` below.
 
         Args:
             path: Full path where to write the file
             content: File content (text or base64 for binary)
             content_type: MIME type (auto-detected if not provided, use 'type;base64' for binary)
-            if_match: Etag previously returned by ``nc_webdav_read_file`` for
-                this same path. Pass it whenever you read this file earlier
-                in the conversation before writing it back: if the file
-                changed since that read (e.g. someone edited it manually in
-                the Nextcloud web UI), the write is rejected with a
-                ``ToolError`` instead of silently overwriting the newer
-                content -- re-read the file and retry deliberately rather
-                than looping automatically. Omit only for a fresh file, or
-                a deliberate unconditional overwrite.
+            if_match: Controls overwrite safety.
+                - Omit (``None``) to **create a new file**: the write fails
+                  with a ``ToolError`` if the path already exists. To change an
+                  existing file you must first read it with
+                  ``nc_webdav_read_file`` and pass the etag it returned.
+                - Pass that **etag** to overwrite the file only if it has not
+                  changed since you read it; if someone edited it in the
+                  meantime (e.g. in the Nextcloud web UI) the write fails --
+                  re-read and retry deliberately rather than looping.
+                - Pass the literal ``"*"`` to **force-overwrite** an existing
+                  file unconditionally (fails if the file does not exist).
 
         Returns:
             Dict with status_code indicating success

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -108,10 +108,15 @@ def configure_webdav_tools(mcp: FastMCP):
                 raises ``ToolError`` otherwise. ``None`` = auto-select.
 
         Returns:
-            Dict with path, content, content_type, size, and optional parsing metadata
+            Dict with path, content, content_type, size, etag, and optional
+            parsing metadata
             - Text files are decoded to UTF-8
             - Documents (PDF, DOCX, etc.) are parsed and text is extracted
             - Other binary files are base64 encoded
+            - ``etag``: pass this back into ``nc_webdav_write_file``'s
+              ``if_match`` when writing this same path later, so a manual
+              edit made elsewhere in the meantime (e.g. in the Nextcloud web
+              UI) is detected as a conflict instead of silently overwritten.
         """
         client = await get_client(ctx)
 
@@ -120,7 +125,7 @@ def configure_webdav_tools(mcp: FastMCP):
         if is_path_excluded(path, excluded):
             raise ToolError(f"Access denied: {path!r} is tagged with an excluded tag")
 
-        content, content_type = await client.webdav.read_file(path)
+        content, content_type, etag = await client.webdav.read_file(path)
 
         # Imported lazily so server startup never loads the document-parsing
         # stack (document_processors -> pymupdf -> _isolation). That stack is an
@@ -189,6 +194,7 @@ def configure_webdav_tools(mcp: FastMCP):
                     "size": len(content),
                     "parsed": True,
                     "parsing_metadata": metadata,
+                    "etag": etag,
                 }
             except TimeoutError as e:
                 # Caught before the generic Exception (subclass-first). When the cap
@@ -226,6 +232,7 @@ def configure_webdav_tools(mcp: FastMCP):
                     "content": decoded_content,
                     "content_type": content_type,
                     "size": len(content),
+                    "etag": etag,
                 }
             except UnicodeDecodeError:
                 pass
@@ -238,29 +245,47 @@ def configure_webdav_tools(mcp: FastMCP):
             "content_type": content_type,
             "size": len(content),
             "encoding": "base64",
+            "etag": etag,
         }
 
     @mcp.tool(
         title="Write File",
         annotations=ToolAnnotations(
-            idempotentHint=True,  # HTTP PUT without version control is idempotent
+            idempotentHint=True,  # true unconditionally; with if_match a repeat
+            # call after a real conflict returns 412 both times, still idempotent
             openWorldHint=True,
         ),
     )
     @require_scopes("files.write")
     @instrument_tool
     async def nc_webdav_write_file(
-        path: str, content: str, ctx: Context, content_type: str | None = None
+        path: str,
+        content: str,
+        ctx: Context,
+        content_type: str | None = None,
+        if_match: str | None = None,
     ):
         """Write content to a file in NextCloud.
 
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and the
-        target path (or an ancestor folder) carries an excluded system tag.
+        target path (or an ancestor folder) carries an excluded system tag;
+        when the decoded content exceeds ``WEBDAV_WRITE_MAX_MB``; when the
+        write conflicts with a concurrent edit (412); or when the file is
+        locked by another client (423) -- see ``if_match`` below.
 
         Args:
             path: Full path where to write the file
             content: File content (text or base64 for binary)
             content_type: MIME type (auto-detected if not provided, use 'type;base64' for binary)
+            if_match: Etag previously returned by ``nc_webdav_read_file`` for
+                this same path. Pass it whenever you read this file earlier
+                in the conversation before writing it back: if the file
+                changed since that read (e.g. someone edited it manually in
+                the Nextcloud web UI), the write is rejected with a
+                ``ToolError`` instead of silently overwriting the newer
+                content -- re-read the file and retry deliberately rather
+                than looping automatically. Omit only for a fresh file, or
+                a deliberate unconditional overwrite.
 
         Returns:
             Dict with status_code indicating success
@@ -279,7 +304,32 @@ def configure_webdav_tools(mcp: FastMCP):
         else:
             content_bytes = content.encode("utf-8")
 
-        return await client.webdav.write_file(path, content_bytes, content_type)
+        # Pre-flight size gate: a single-shot PUT built from one in-memory MCP
+        # tool argument has no chunked/streaming path, so fail fast with a
+        # clear error rather than risk a timeout or OOM on a huge file.
+        max_mb = get_settings().webdav_write_max_mb
+        if max_mb:
+            size_mb = len(content_bytes) / (1024 * 1024)
+            if size_mb > max_mb:
+                raise ToolError(
+                    f"Refusing to write {path!r}: {size_mb:.1f} MB exceeds the "
+                    f"configured WEBDAV_WRITE_MAX_MB ({max_mb} MB). Write the "
+                    "file directly via the Nextcloud web UI or a synced client "
+                    "instead, or raise WEBDAV_WRITE_MAX_MB if this size is "
+                    "expected."
+                )
+
+        result = await client.webdav.write_file(
+            path, content_bytes, content_type, if_match=if_match
+        )
+        # write_file returns (rather than raises) on 412/423 -- known
+        # conflict statuses the caller must react to, mirroring
+        # move_resource/copy_resource. Raise here so they surface exactly
+        # like any other actionable failure of this tool.
+        status_code = result.get("status_code")
+        if status_code in (412, 423):
+            raise ToolError(f"{result['message']} ({path!r})")
+        return result
 
     @mcp.tool(
         title="Create Directory",

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1335,7 +1335,7 @@ async def _index_document_inner(
                 content_bytes = None
             else:
                 # Buffered fallback (DOCUMENT_STREAM_DOWNLOAD_ENABLED=false).
-                content_bytes, content_type = await nc_client.webdav.read_file(
+                content_bytes, content_type, _ = await nc_client.webdav.read_file(
                     file_path
                 )
                 source = MemoryDocumentSource(

--- a/tests/client/webdav/test_webdav_operations.py
+++ b/tests/client/webdav/test_webdav_operations.py
@@ -70,9 +70,10 @@ async def test_write_read_delete_file(nc_client: NextcloudClient, test_base_path
         logger.info("Wrote file: %s", test_file)
 
         # Read file back
-        content, content_type = await nc_client.webdav.read_file(test_file)
+        content, content_type, etag = await nc_client.webdav.read_file(test_file)
         assert content.decode("utf-8") == test_content
         assert "text/plain" in content_type
+        assert etag
         logger.info("Read file: %s", test_file)
 
         # Verify file appears in directory listing
@@ -228,7 +229,7 @@ async def test_overwrite_existing_file(nc_client: NextcloudClient, test_base_pat
         )
 
         # Verify original content
-        content, _ = await nc_client.webdav.read_file(test_file)
+        content, _, _ = await nc_client.webdav.read_file(test_file)
         assert content.decode("utf-8") == original_content
 
         # Overwrite with new content
@@ -238,7 +239,7 @@ async def test_overwrite_existing_file(nc_client: NextcloudClient, test_base_pat
         assert overwrite_result["status_code"] in [200, 204]  # OK or No Content
 
         # Verify new content
-        content, _ = await nc_client.webdav.read_file(test_file)
+        content, _, _ = await nc_client.webdav.read_file(test_file)
         assert content.decode("utf-8") == new_content
 
         logger.info("Successfully overwrote file: %s", test_file)

--- a/tests/client/webdav/test_webdav_operations.py
+++ b/tests/client/webdav/test_webdav_operations.py
@@ -214,7 +214,9 @@ async def test_create_nested_directories(
 
 
 async def test_overwrite_existing_file(nc_client: NextcloudClient, test_base_path: str):
-    """Test overwriting an existing file."""
+    """Writes are fail-closed: an existing file can only be overwritten with a
+    matching etag (safe) or if_match='*' (force). An etag-less write over an
+    existing file fails; a stale etag fails; the fresh etag succeeds."""
     test_file = f"{test_base_path}/overwrite_test.txt"
     original_content = "Original content"
     new_content = "New content after overwrite"
@@ -223,24 +225,52 @@ async def test_overwrite_existing_file(nc_client: NextcloudClient, test_base_pat
         # Create base directory
         await nc_client.webdav.create_directory(test_base_path)
 
-        # Write original file
+        # Write original file (create-only default; the path does not exist yet)
         await nc_client.webdav.write_file(
             test_file, original_content.encode("utf-8"), content_type="text/plain"
         )
 
-        # Verify original content
+        # Verify original content and capture the etag
+        content, _, original_etag = await nc_client.webdav.read_file(test_file)
+        assert content.decode("utf-8") == original_content
+        assert original_etag
+
+        # An etag-less write over the now-existing file is refused (fail-closed).
+        create_conflict = await nc_client.webdav.write_file(
+            test_file, new_content.encode("utf-8"), content_type="text/plain"
+        )
+        assert create_conflict["status_code"] == 412
+        # Content is untouched.
         content, _, _ = await nc_client.webdav.read_file(test_file)
         assert content.decode("utf-8") == original_content
 
-        # Overwrite with new content
+        # A stale etag is also refused.
+        stale = await nc_client.webdav.write_file(
+            test_file,
+            new_content.encode("utf-8"),
+            content_type="text/plain",
+            if_match="deadbeef-not-the-real-etag",
+        )
+        assert stale["status_code"] == 412
+
+        # The fresh etag succeeds.
         overwrite_result = await nc_client.webdav.write_file(
-            test_file, new_content.encode("utf-8"), content_type="text/plain"
+            test_file,
+            new_content.encode("utf-8"),
+            content_type="text/plain",
+            if_match=original_etag,
         )
         assert overwrite_result["status_code"] in [200, 204]  # OK or No Content
 
         # Verify new content
         content, _, _ = await nc_client.webdav.read_file(test_file)
         assert content.decode("utf-8") == new_content
+
+        # if_match='*' force-overwrites an existing file unconditionally.
+        force_result = await nc_client.webdav.write_file(
+            test_file, b"Forced", content_type="text/plain", if_match="*"
+        )
+        assert force_result["status_code"] in [200, 204]
 
         logger.info("Successfully overwrote file: %s", test_file)
 

--- a/tests/server/login_flow/test_multi_user_permissions.py
+++ b/tests/server/login_flow/test_multi_user_permissions.py
@@ -133,24 +133,30 @@ class TestFilePermissions:
             assert not result.isError
             bob_share_id = json.loads(result.content[0].text)["id"]
 
-            # Charlie can write
+            # Charlie can write. Writes are fail-closed, so overwriting the
+            # existing shared file needs an explicit if_match -- use "*" to
+            # force the overwrite; success proves he has write permission.
             result = await charlie_login_flow_mcp_client.call_tool(
                 "nc_webdav_write_file",
                 arguments={
                     "path": file_path,
                     "content": f"{file_content}\nCharlie added this line.",
+                    "if_match": "*",
                 },
             )
             assert not result.isError, (
                 f"Charlie should be able to write: {result.content}"
             )
 
-            # Bob cannot write
+            # Bob cannot write. Same force-overwrite request, so the failure is
+            # a genuine permission denial (read-only share), not the fail-closed
+            # create-only guard tripping on the existing file.
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_webdav_write_file",
                 arguments={
                     "path": file_path,
                     "content": "Bob tries to overwrite this.",
+                    "if_match": "*",
                 },
             )
             assert result.isError, "Bob should be denied write access (read-only)"

--- a/tests/server/test_annotations.py
+++ b/tests/server/test_annotations.py
@@ -121,11 +121,14 @@ async def test_update_operations_not_idempotent(nc_mcp_client: ClientSession):
             )
 
 
-async def test_webdav_write_is_idempotent(nc_mcp_client: ClientSession):
-    """Verify nc_webdav_write_file is marked as idempotent (ADR-017 decision).
+async def test_webdav_write_is_not_idempotent(nc_mcp_client: ClientSession):
+    """Verify nc_webdav_write_file is marked as non-idempotent.
 
-    WebDAV write uses HTTP PUT without version control, making it idempotent.
-    Writing same content to same path repeatedly produces same end state.
+    The write is fail-closed (every PUT is conditional): a create (no if_match)
+    succeeds once then returns 412 on repeat, and an if_match overwrite is
+    invalidated by its own success (the etag changes) -- so writing the same
+    content to the same path repeatedly does NOT produce the same result,
+    mirroring the etag-guarded nc_notes_update_note.
     """
     tools = await nc_mcp_client.list_tools()
 
@@ -134,8 +137,8 @@ async def test_webdav_write_is_idempotent(nc_mcp_client: ClientSession):
     )
     assert write_tool is not None, "nc_webdav_write_file tool not found"
     assert write_tool.annotations is not None, "write_file missing annotations"
-    assert write_tool.annotations.idempotentHint is True, (
-        "nc_webdav_write_file should be idempotent (HTTP PUT without version control)"
+    assert write_tool.annotations.idempotentHint is not True, (
+        "nc_webdav_write_file should not be idempotent (fail-closed conditional PUT)"
     )
 
 

--- a/tests/server/test_mcp.py
+++ b/tests/server/test_mcp.py
@@ -452,7 +452,7 @@ async def test_mcp_webdav_workflow(
         assert "text/plain" in read_data["content_type"]
 
         # 6. Verify file content via direct WebDAV
-        direct_content, direct_content_type = await nc_client.webdav.read_file(
+        direct_content, direct_content_type, _ = await nc_client.webdav.read_file(
             test_file_path
         )
         assert direct_content.decode("utf-8") == test_content

--- a/tests/unit/client/test_dav_principal_discovery.py
+++ b/tests/unit/client/test_dav_principal_discovery.py
@@ -153,7 +153,7 @@ async def test_webdav_equal_principal_keeps_username_path(mocker):
         side_effect=[_http_response(_principal_body("alice")), file_response]
     )
 
-    content, _ = await client.read_file("notes.txt")
+    content, _, _ = await client.read_file("notes.txt")
 
     assert content == b"hello"
     calls = client._make_request.await_args_list
@@ -169,7 +169,7 @@ async def test_webdav_discovery_failure_falls_back_to_username(mocker):
         side_effect=[_request_error(), file_response]
     )
 
-    content, _ = await client.read_file("notes.txt")
+    content, _, _ = await client.read_file("notes.txt")
 
     assert content == b"fallback"
     calls = client._make_request.await_args_list
@@ -209,7 +209,7 @@ async def test_webdav_principal_href_is_unquoted(mocker):
         ]
     )
 
-    content, _ = await client.read_file("notes.txt")
+    content, _, _ = await client.read_file("notes.txt")
 
     assert content == b"mailbox"
     assert client._principal_id == "alice@example.com"
@@ -234,8 +234,8 @@ async def test_webdav_missing_principal_href_falls_back_without_caching(mocker):
         ]
     )
 
-    first_content, _ = await client.read_file("one.txt")
-    second_content, _ = await client.read_file("two.txt")
+    first_content, _, _ = await client.read_file("one.txt")
+    second_content, _, _ = await client.read_file("two.txt")
 
     assert first_content == b"fallback"
     assert second_content == b"discovered"

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -647,7 +647,7 @@ async def test_read_file_accepts_matching_content_length(mocker):
     mock_response.raise_for_status = mocker.Mock()
     mock_http_client.request = AsyncMock(return_value=mock_response)
 
-    content, content_type = await client.read_file("Documents/report.pdf")
+    content, content_type, _ = await client.read_file("Documents/report.pdf")
     assert content == body
     assert content_type == "application/pdf"
 
@@ -672,7 +672,7 @@ async def test_read_file_accepts_gzip_response_shorter_than_content_length(mocke
     mock_response.raise_for_status = mocker.Mock()
     mock_http_client.request = AsyncMock(return_value=mock_response)
 
-    content, _ = await client.read_file("Documents/index.json")
+    content, _, _ = await client.read_file("Documents/index.json")
     assert content == body
 
 
@@ -689,8 +689,149 @@ async def test_read_file_skips_check_without_content_length(mocker):
     mock_response.raise_for_status = mocker.Mock()
     mock_http_client.request = AsyncMock(return_value=mock_response)
 
-    content, _ = await client.read_file("Documents/stream.txt")
+    content, _, _ = await client.read_file("Documents/stream.txt")
     assert content == body
+
+
+@pytest.mark.unit
+async def test_read_file_returns_etag_stripped_of_quotes(mocker):
+    """The ETag header is surfaced so callers can round-trip it into write_file's
+    if_match and detect a concurrent edit instead of silently overwriting it."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    mock_response = AsyncMock()
+    mock_response.content = b"hello"
+    mock_response.headers = {"content-type": "text/plain", "etag": '"abc123"'}
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    _, _, etag = await client.read_file("Documents/notes.txt")
+    assert etag == "abc123"
+
+
+@pytest.mark.unit
+async def test_read_file_returns_none_etag_when_absent(mocker):
+    """No ETag header (unlikely on Nextcloud, but not every WebDAV server sends
+    one) must not raise -- callers simply can't pass if_match for this read."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    mock_response = AsyncMock()
+    mock_response.content = b"hello"
+    mock_response.headers = {"content-type": "text/plain"}
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    _, _, etag = await client.read_file("Documents/notes.txt")
+    assert etag is None
+
+
+@pytest.mark.unit
+async def test_write_file_sends_if_match_header_when_provided(mocker):
+    """if_match must reach the server as a quoted If-Match header."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+    client._principal_discovered = True
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 204
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    await client.write_file("Documents/notes.txt", b"new", if_match="abc123")
+
+    headers = mock_http_client.request.call_args.kwargs["headers"]
+    assert headers["If-Match"] == '"abc123"'
+
+
+@pytest.mark.unit
+async def test_write_file_omits_if_match_header_by_default(mocker):
+    """Unconditional overwrite (the pre-existing behavior) when if_match is
+    omitted -- no If-Match header sent."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+    client._principal_discovered = True
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 204
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    await client.write_file("Documents/notes.txt", b"new")
+
+    headers = mock_http_client.request.call_args.kwargs["headers"]
+    assert "If-Match" not in headers
+
+
+@pytest.mark.unit
+async def test_write_file_returns_structured_result_on_precondition_failed(mocker):
+    """412 (etag mismatch -- the file changed since if_match was read) is a
+    known conflict status: return a structured dict, don't raise, matching
+    move_resource/copy_resource's handling of their own conflict statuses."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp412 = mocker.Mock(spec=Response)
+    resp412.status_code = 412
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp412)
+        ),
+    )
+
+    result = await client.write_file("Documents/notes.txt", b"new", if_match="stale")
+    assert result["status_code"] == 412
+    assert "message" in result
+
+
+@pytest.mark.unit
+async def test_write_file_returns_structured_result_on_locked(mocker):
+    """423 (WebDAV lock held by another client, e.g. the file is open in the
+    Nextcloud web editor) is a known conflict status: return a structured
+    dict, don't raise -- a caller retrying the same write automatically would
+    otherwise be indistinguishable from any other transport failure."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp423 = mocker.Mock(spec=Response)
+    resp423.status_code = 423
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp423)
+        ),
+    )
+
+    result = await client.write_file("Documents/notes.txt", b"new")
+    assert result["status_code"] == 423
+    assert "message" in result
+
+
+@pytest.mark.unit
+async def test_write_file_still_raises_on_other_http_errors(mocker):
+    """Any status other than 412/423 keeps the pre-existing raise behavior."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp500 = mocker.Mock(spec=Response)
+    resp500.status_code = 500
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp500)
+        ),
+    )
+
+    with pytest.raises(HTTPStatusError):
+        await client.write_file("Documents/notes.txt", b"new")
 
 
 @pytest.mark.unit

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -480,6 +480,53 @@ async def test_list_directory_decodes_non_ascii_names(mocker):
 
 
 @pytest.mark.unit
+async def test_list_directory_requests_and_parses_etag(mocker):
+    """list_directory must request <d:getetag/> and expose each file's etag
+    (quotes stripped) so a caller can obtain one for write_file's if_match
+    without a full read -- parity with the search/find paths."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+
+    xml_content = b"""<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:">
+        <d:response>
+            <d:href>/remote.php/dav/files/testuser/</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:resourcetype><d:collection/></d:resourcetype>
+                </d:prop>
+            </d:propstat>
+        </d:response>
+        <d:response>
+            <d:href>/remote.php/dav/files/testuser/notes.txt</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:displayname>notes.txt</d:displayname>
+                    <d:getcontentlength>10</d:getcontentlength>
+                    <d:getcontenttype>text/plain</d:getcontenttype>
+                    <d:getetag>"abc123"</d:getetag>
+                    <d:resourcetype/>
+                </d:prop>
+            </d:propstat>
+        </d:response>
+    </d:multistatus>"""
+
+    mock_response = AsyncMock()
+    mock_response.content = xml_content
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    items = await client.list_directory("")
+
+    # The PROPFIND body must ask for the etag.
+    sent_body = mock_http_client.request.call_args.kwargs["content"]
+    assert "getetag" in sent_body
+
+    by_name = {item["name"]: item for item in items}
+    assert by_name["notes.txt"]["etag"] == "abc123"
+
+
+@pytest.mark.unit
 def test_parse_search_response_decodes_non_ascii_paths(mocker):
     """_parse_search_response must percent-decode <d:href> for non-ASCII paths (issue #776).
 
@@ -746,9 +793,31 @@ async def test_write_file_sends_if_match_header_when_provided(mocker):
 
 
 @pytest.mark.unit
-async def test_write_file_omits_if_match_header_by_default(mocker):
-    """Unconditional overwrite (the pre-existing behavior) when if_match is
-    omitted -- no If-Match header sent."""
+async def test_write_file_sends_create_only_header_by_default(mocker):
+    """Fail-closed default: with no if_match, a create-only ``If-None-Match: *``
+    is sent so an existing file is never silently overwritten (no unconditional
+    last-write-wins PUT anymore)."""
+    mock_http_client = AsyncMock()
+    client = WebDAVClient(mock_http_client, "testuser")
+    client._principal_discovered = True
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 201
+    mock_response.raise_for_status = mocker.Mock()
+    mock_http_client.request = AsyncMock(return_value=mock_response)
+
+    await client.write_file("Documents/new.txt", b"new")
+
+    headers = mock_http_client.request.call_args.kwargs["headers"]
+    assert headers["If-None-Match"] == "*"
+    assert "If-Match" not in headers
+
+
+@pytest.mark.unit
+async def test_write_file_sends_force_header_for_star(mocker):
+    """if_match='*' is the explicit force-overwrite escape hatch: send a bare
+    (unquoted) ``If-Match: *`` so the PUT overwrites an existing file but still
+    fails if the file does not exist."""
     mock_http_client = AsyncMock()
     client = WebDAVClient(mock_http_client, "testuser")
     client._principal_discovered = True
@@ -758,17 +827,19 @@ async def test_write_file_omits_if_match_header_by_default(mocker):
     mock_response.raise_for_status = mocker.Mock()
     mock_http_client.request = AsyncMock(return_value=mock_response)
 
-    await client.write_file("Documents/notes.txt", b"new")
+    await client.write_file("Documents/notes.txt", b"new", if_match="*")
 
     headers = mock_http_client.request.call_args.kwargs["headers"]
-    assert "If-Match" not in headers
+    assert headers["If-Match"] == "*"
+    assert "If-None-Match" not in headers
 
 
 @pytest.mark.unit
-async def test_write_file_returns_structured_result_on_precondition_failed(mocker):
-    """412 (etag mismatch -- the file changed since if_match was read) is a
-    known conflict status: return a structured dict, don't raise, matching
-    move_resource/copy_resource's handling of their own conflict statuses."""
+async def test_write_file_returns_structured_result_on_stale_etag(mocker):
+    """412 from an If-Match etag (the file changed since if_match was read) is a
+    known conflict status: return a structured 'concurrent edit' dict, don't
+    raise, matching move_resource/copy_resource's handling of their own
+    conflict statuses."""
     from httpx import HTTPStatusError, Response
 
     client = WebDAVClient(AsyncMock(), "testuser")
@@ -785,7 +856,53 @@ async def test_write_file_returns_structured_result_on_precondition_failed(mocke
 
     result = await client.write_file("Documents/notes.txt", b"new", if_match="stale")
     assert result["status_code"] == 412
-    assert "message" in result
+    assert "modified" in result["message"]
+
+
+@pytest.mark.unit
+async def test_write_file_returns_already_exists_on_create_conflict(mocker):
+    """412 from the create-only default (If-None-Match: *) means the path
+    already exists -- surface a distinct, actionable 'read it first' message."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp412 = mocker.Mock(spec=Response)
+    resp412.status_code = 412
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp412)
+        ),
+    )
+
+    result = await client.write_file("Documents/notes.txt", b"new")
+    assert result["status_code"] == 412
+    assert "already exists" in result["message"]
+
+
+@pytest.mark.unit
+async def test_write_file_returns_missing_on_force_overwrite_of_absent_file(mocker):
+    """412 from a force-overwrite (If-Match: *) means the file does not exist --
+    surface a distinct message rather than the generic conflict text."""
+    from httpx import HTTPStatusError, Response
+
+    client = WebDAVClient(AsyncMock(), "testuser")
+    mocker.patch.object(client, "_ensure_principal_id", AsyncMock())
+    resp412 = mocker.Mock(spec=Response)
+    resp412.status_code = 412
+    mocker.patch.object(
+        client,
+        "_make_request",
+        AsyncMock(
+            side_effect=HTTPStatusError("x", request=mocker.Mock(), response=resp412)
+        ),
+    )
+
+    result = await client.write_file("Documents/notes.txt", b"new", if_match="*")
+    assert result["status_code"] == 412
+    assert "does not exist" in result["message"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -259,6 +259,31 @@ async def test_list_directory_filters_excluded_children(
     assert [f.path for f in result.files] == ["/Public/visible.md"]
 
 
+async def test_list_directory_surfaces_etag_on_fileinfo(
+    webdav_tools, fake_client, patch_get_client, patch_excluded
+):
+    """The etag the client parses from PROPFIND must reach the MCP tool's
+    FileInfo, so a caller can obtain one for write_file's if_match from a
+    listing (wire-through of the client dict into FileInfo(**result))."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.list_directory = AsyncMock(
+        return_value=[
+            {
+                "path": "/Public/notes.md",
+                "name": "notes.md",
+                "is_directory": False,
+                "etag": "abc123",
+            },
+        ]
+    )
+
+    fn = webdav_tools["nc_webdav_list_directory"].fn
+    result = await fn(path="/Public", ctx=_mock_ctx(fake_client))
+
+    assert result.files[0].etag == "abc123"
+
+
 async def test_list_directory_raises_when_listed_path_itself_excluded(
     webdav_tools, fake_client, patch_get_client, patch_excluded
 ):

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -571,8 +571,9 @@ async def test_write_file_raises_toolerror_when_file_already_exists(
     )
 
     fn = webdav_tools["nc_webdav_write_file"].fn
+    ctx = _mock_ctx(fake_client)
     with pytest.raises(ToolError, match="already exists"):
-        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+        await fn(path="/Public/notes.md", content="hi", ctx=ctx)
 
 
 async def test_write_file_raises_toolerror_on_precondition_failed(
@@ -595,11 +596,12 @@ async def test_write_file_raises_toolerror_on_precondition_failed(
     )
 
     fn = webdav_tools["nc_webdav_write_file"].fn
+    ctx = _mock_ctx(fake_client)
     with pytest.raises(ToolError, match="modified since"):
         await fn(
             path="/Public/notes.md",
             content="hi",
-            ctx=_mock_ctx(fake_client),
+            ctx=ctx,
             if_match="stale",
         )
 
@@ -623,8 +625,9 @@ async def test_write_file_raises_toolerror_on_locked(
     )
 
     fn = webdav_tools["nc_webdav_write_file"].fn
+    ctx = _mock_ctx(fake_client)
     with pytest.raises(ToolError, match="locked"):
-        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+        await fn(path="/Public/notes.md", content="hi", ctx=ctx)
 
 
 async def test_write_file_raises_toolerror_when_content_exceeds_configured_max_size(
@@ -641,8 +644,9 @@ async def test_write_file_raises_toolerror_when_content_exceeds_configured_max_s
     )
 
     fn = webdav_tools["nc_webdav_write_file"].fn
+    ctx = _mock_ctx(fake_client)
     with pytest.raises(ToolError, match="WEBDAV_WRITE_MAX_MB"):
-        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+        await fn(path="/Public/notes.md", content="hi", ctx=ctx)
 
     fake_client.webdav.write_file.assert_not_called()
 

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -107,7 +107,9 @@ async def test_read_file_passes_through_when_not_excluded(
 ):
     patch_get_client(fake_client)
     patch_excluded({"Secret.txt"})
-    fake_client.webdav.read_file = AsyncMock(return_value=(b"hello", "text/plain"))
+    fake_client.webdav.read_file = AsyncMock(
+        return_value=(b"hello", "text/plain", "abc123")
+    )
 
     fn = webdav_tools["nc_webdav_read_file"].fn
     result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
@@ -413,7 +415,9 @@ async def test_read_file_interactive_cap_falls_back_to_base64(
     client's own timeout (ADR-032)."""
     patch_get_client(fake_client)
     patch_excluded(set())
-    fake_client.webdav.read_file = AsyncMock(return_value=(b"\x89PNG", "image/png"))
+    fake_client.webdav.read_file = AsyncMock(
+        return_value=(b"\x89PNG", "image/png", None)
+    )
 
     mocker.patch(
         "nextcloud_mcp_server.server.webdav.get_settings",
@@ -451,7 +455,7 @@ async def test_read_file_no_cap_returns_parsed(
     patch_get_client(fake_client)
     patch_excluded(set())
     fake_client.webdav.read_file = AsyncMock(
-        return_value=(b"%PDF-1.7", "application/pdf")
+        return_value=(b"%PDF-1.7", "application/pdf", "etag-1")
     )
 
     mocker.patch(
@@ -475,3 +479,136 @@ async def test_read_file_no_cap_returns_parsed(
     assert result["parsed"] is True
     assert result["content"] == "parsed text"
     assert result["parsing_metadata"]["parsing_method"] == "docling"
+
+
+# ── Write conflict handling (etag / lock) and size gate ─────────────────
+
+
+async def test_read_file_includes_etag_in_response(
+    webdav_tools, fake_client, patch_get_client, patch_excluded
+):
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.read_file = AsyncMock(
+        return_value=(b"hello", "text/plain", "abc123")
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
+
+    assert result["etag"] == "abc123"
+
+
+async def test_write_file_passes_if_match_through_to_client(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(return_value={"status_code": 204})
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    await fn(
+        path="/Public/notes.md",
+        content="hi",
+        ctx=_mock_ctx(fake_client),
+        if_match="abc123",
+    )
+
+    fake_client.webdav.write_file.assert_awaited_once_with(
+        "/Public/notes.md", b"hi", None, if_match="abc123"
+    )
+
+
+async def test_write_file_raises_toolerror_on_precondition_failed(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """A 412 from the client (concurrent edit since if_match was read) must
+    surface as a clear, actionable ToolError -- not a silently-returned dict
+    a caller might not check, and not a raw transport exception."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(
+        return_value={
+            "status_code": 412,
+            "message": "File was modified since the given etag was read",
+        }
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    with pytest.raises(ToolError, match="modified since"):
+        await fn(
+            path="/Public/notes.md",
+            content="hi",
+            ctx=_mock_ctx(fake_client),
+            if_match="stale",
+        )
+
+
+async def test_write_file_raises_toolerror_on_locked(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """A 423 (locked, e.g. open in the Nextcloud web editor) must surface as a
+    ToolError so the caller stops and reports it rather than retrying."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(
+        return_value={
+            "status_code": 423,
+            "message": "File is locked by another client",
+        }
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    with pytest.raises(ToolError, match="locked"):
+        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+
+
+async def test_write_file_raises_toolerror_when_content_exceeds_configured_max_size(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """A pre-flight size gate fails fast with a clear error instead of
+    attempting a single-shot PUT that risks a timeout or OOM."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(return_value={"status_code": 204})
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=0.000001),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    with pytest.raises(ToolError, match="WEBDAV_WRITE_MAX_MB"):
+        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+
+    fake_client.webdav.write_file.assert_not_called()
+
+
+async def test_write_file_size_gate_disabled_when_max_mb_is_zero(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """0 (falsy) disables the guard entirely, matching document_max_pdf_size_mb's
+    existing "0 disables" convention."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(return_value={"status_code": 204})
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+
+    fake_client.webdav.write_file.assert_awaited_once()

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -523,6 +523,58 @@ async def test_write_file_passes_if_match_through_to_client(
     )
 
 
+async def test_write_file_passes_force_star_through_to_client(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """if_match='*' (explicit force-overwrite) reaches the client unchanged so
+    it becomes a bare If-Match: * PUT."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(return_value={"status_code": 204})
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    await fn(
+        path="/Public/notes.md",
+        content="hi",
+        ctx=_mock_ctx(fake_client),
+        if_match="*",
+    )
+
+    fake_client.webdav.write_file.assert_awaited_once_with(
+        "/Public/notes.md", b"hi", None, if_match="*"
+    )
+
+
+async def test_write_file_raises_toolerror_when_file_already_exists(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """The fail-closed default: an if_match-less write over an existing file
+    (client returns the 'already exists' 412) surfaces as an actionable
+    ToolError telling the caller to read first or pass if_match='*'."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(
+        return_value={
+            "status_code": 412,
+            "message": "File already exists — read it first to get its etag and "
+            "pass if_match to overwrite safely, or pass if_match='*' to "
+            "overwrite deliberately",
+        }
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    with pytest.raises(ToolError, match="already exists"):
+        await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
+
+
 async def test_write_file_raises_toolerror_on_precondition_failed(
     webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
 ):

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -68,7 +68,7 @@ def _nc_client() -> MagicMock:
     # MagicMock (typed Any) keeps the pre-commit ty-check happy where the real
     # signature wants a NextcloudClient -- matching the other processor tests.
     nc = MagicMock()
-    nc.webdav.read_file = AsyncMock(return_value=(b"%PDF-1.4", "application/pdf"))
+    nc.webdav.read_file = AsyncMock(return_value=(b"%PDF-1.4", "application/pdf", None))
     return nc
 
 


### PR DESCRIPTION
## Summary

Found while testing the interactive webdav tools: `nc_webdav_write_file` gave no way to notice that a file changed since it was last read, or that it's locked by another client, and a single-shot PUT had no size guard.

- `read_file` now returns the response `ETag` alongside content/content_type; `nc_webdav_read_file` surfaces it in its result dict.
- `write_file` takes an optional `if_match`, sending a conditional `If-Match` PUT when provided (omit for the previous unconditional last-write-wins behavior).
- `412` (etag mismatch — concurrent edit) and `423` (locked, e.g. open in the Nextcloud web editor) now return a structured `{"status_code": ..., "message": ...}` instead of raising generically — mirroring how `move_resource`/`copy_resource` already handle their own known conflict statuses. The MCP tool (`nc_webdav_write_file`) turns these into a clear `ToolError` so a caller stops and reports instead of silently overwriting or retrying blindly.
- New `WEBDAV_WRITE_MAX_MB` setting (default 50, `0` disables) — a pre-flight size gate on `nc_webdav_write_file`'s content, since a write built from a single in-memory MCP tool argument has no chunked/streaming path (unlike the read/ingest side's `stream_to_file`). Fails fast with a clear message instead of risking a timeout or OOM on a very large PUT.
- `docs/webdav.md`: new section with a read → capture etag → conditional write example, and documents the size limit.

Only 4 real (non-test) call sites of `read_file` existed in the codebase (`server/webdav.py`, `vector/processor.py`, `server/collectives.py`), all updated for the new 3-tuple return. `ReadFileResponse`'s `etag`/`last_modified` fields already existed in `models/webdav.py` but were never populated — this wires up `etag` (left `last_modified` alone, not needed to close this gap).

Not in scope here: true chunked/TUS upload for writes (would need a multi-call protocol, bigger lift) — the size gate is the pragmatic fail-fast fix for now.

## Test plan
- [x] `uv run pytest -m unit` — 2586 passed (added etag/if_match/412/423/size-gate unit tests at both the client and MCP-tool layers; updated existing tests for the new `read_file` 3-tuple return)
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run ty check -- nextcloud_mcp_server`
- [x] Integration tests (`tests/client/webdav/test_webdav_operations.py`, `tests/server/test_mcp.py`) updated for the new tuple but not run here (need a live Nextcloud Docker instance)