### PR TITLE
refactor(webdav): return typed BaseResponse models from read/write tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,19 +456,40 @@ window (keep it, log on use, remove a version later), not a merge-order note.
 
 ## MCP Response Patterns (CRITICAL)
 
-**Never return raw `List[Dict]` from MCP tools** - FastMCP mangles them into dicts with numeric string keys.
+**Every MCP tool MUST return a Pydantic model that inherits from `BaseResponse`
+(`nextcloud_mcp_server/models/base.py`) — never a raw `dict`, `list`, or
+`List[Dict]`.** Raw `list`/`List[Dict]` returns are mangled by FastMCP into dicts
+with numeric string keys; raw `dict` returns silently bypass the typed schema and
+the `success`/`timestamp` envelope every other tool provides, so clients can't rely
+on a consistent contract. This applies to **all** tools — list/search *and*
+single-resource reads, writes, and status results alike.
+
+**This is a review gate.** A new or modified `@mcp.tool` that returns a bare
+`dict`/`list` — or that lacks a `-> <SomeResponse>` return annotation — is a
+required-changes finding (reviewers, including the Claude review bot, must flag it).
 
 **Correct Pattern**:
-1. Client methods return `List[Dict]` (raw data)
-2. MCP tools convert to Pydantic models and wrap in response object
-3. Response models inherit from `BaseResponse`, include `results` field + metadata
+1. Client methods return raw data (`dict` / `list[dict]`).
+2. MCP tools convert that into a Pydantic model and return it.
+3. The model inherits from `BaseResponse` — list/search tools expose a `results`
+   field + metadata; single-resource tools return a purpose-built model (e.g.
+   `ReadFileResponse`, `WriteFileResponse`, `UpdateNoteResponse`).
+4. The tool's signature carries the `-> <Model>` return annotation.
 
 **Reference implementations**:
-- `nextcloud_mcp_server/models/notes.py:80` - `SearchNotesResponse`
-- `nextcloud_mcp_server/models/webdav.py:113` - `SearchFilesResponse`
+- `nextcloud_mcp_server/models/notes.py` - `SearchNotesResponse`, `UpdateNoteResponse`
+- `nextcloud_mcp_server/models/webdav.py` - `SearchFilesResponse`, `ReadFileResponse`, `WriteFileResponse`
 - `nextcloud_mcp_server/server/{notes,webdav}.py` - Tool examples
 
-**Testing**: Extract `data["results"]` from MCP responses, not `data` directly.
+**Testing**:
+- Through the MCP client the response is JSON — extract the field you need
+  (`data["results"]`, `data["content"]`, ...) from the parsed object, not `data`.
+- Calling a tool's `.fn` directly in a unit test returns the **model instance** —
+  use attribute access (`result.content`), not `result["content"]`.
+
+> Any remaining tools that still return raw dicts are pre-existing debt being
+> migrated to typed `BaseResponse` models (tracked on Deck board 12). New code must
+> not add to that debt.
 
 ## MCP Sampling for RAG (ADR-008)
 

--- a/nextcloud_mcp_server/models/webdav.py
+++ b/nextcloud_mcp_server/models/webdav.py
@@ -72,7 +72,11 @@ class WriteFileResponse(StatusResponse):
     """Response model for writing files."""
 
     path: str = Field(description="File path that was written")
-    size: Optional[int] = Field(None, description="Size of the written file")
+    size: Optional[int] = Field(
+        None,
+        description="Size of the written file in bytes (decoded content, not the "
+        "caller-supplied string length)",
+    )
     created: bool = Field(description="Whether a new file was created (vs overwritten)")
 
 

--- a/nextcloud_mcp_server/models/webdav.py
+++ b/nextcloud_mcp_server/models/webdav.py
@@ -53,9 +53,16 @@ class ReadFileResponse(BaseResponse):
     path: str = Field(description="File path")
     content: str = Field(description="File content (text or base64 for binary)")
     content_type: str = Field(description="MIME content type")
-    size: int = Field(description="File size in bytes")
+    size: int = Field(description="File size in bytes (raw, pre-parse)")
     encoding: Optional[str] = Field(
         None, description="Encoding used (e.g., 'base64' for binary files)"
+    )
+    parsed: bool = Field(
+        default=False,
+        description="Whether content was extracted from a document (PDF, DOCX, ...)",
+    )
+    parsing_metadata: Optional[dict] = Field(
+        None, description="Document-processor metadata when parsed=True"
     )
     etag: Optional[str] = Field(None, description="ETag for versioning")
     last_modified: Optional[str] = Field(None, description="Last modification time")

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -10,7 +10,13 @@ from mcp.types import ToolAnnotations
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
-from nextcloud_mcp_server.models import DirectoryListing, FileInfo, SearchFilesResponse
+from nextcloud_mcp_server.models import (
+    DirectoryListing,
+    FileInfo,
+    ReadFileResponse,
+    SearchFilesResponse,
+    WriteFileResponse,
+)
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 from nextcloud_mcp_server.server.tag_exclusion import (
     get_excluded_file_paths,
@@ -92,7 +98,7 @@ def configure_webdav_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_webdav_read_file(
         path: str, ctx: Context, force_processor: str | None = None
-    ):
+    ) -> ReadFileResponse:
         """Read the content of a file from NextCloud.
 
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and the
@@ -108,15 +114,16 @@ def configure_webdav_tools(mcp: FastMCP):
                 raises ``ToolError`` otherwise. ``None`` = auto-select.
 
         Returns:
-            Dict with path, content, content_type, size, etag, and optional
-            parsing metadata
-            - Text files are decoded to UTF-8
-            - Documents (PDF, DOCX, etc.) are parsed and text is extracted
-            - Other binary files are base64 encoded
+            ``ReadFileResponse`` with ``path``, ``content``, ``content_type``,
+            ``size`` and ``etag``. Depending on the file:
+            - Text files are decoded to UTF-8.
+            - Documents (PDF, DOCX, ...) are parsed to text with
+              ``parsed=True`` and ``parsing_metadata`` set.
+            - Other binary files are base64-encoded with ``encoding="base64"``.
             - ``etag``: pass this back into ``nc_webdav_write_file``'s
-              ``if_match`` when writing this same path later, so a manual
-              edit made elsewhere in the meantime (e.g. in the Nextcloud web
-              UI) is detected as a conflict instead of silently overwritten.
+              ``if_match`` when writing this same path later, so a manual edit
+              made elsewhere in the meantime (e.g. in the Nextcloud web UI) is
+              detected as a conflict instead of silently overwritten.
         """
         client = await get_client(ctx)
 
@@ -187,15 +194,15 @@ def configure_webdav_tools(mcp: FastMCP):
                         progress_callback=ctx.report_progress,
                         processor_name=force_processor,
                     )
-                return {
-                    "path": path,
-                    "content": parsed_text,
-                    "content_type": content_type,
-                    "size": len(content),
-                    "parsed": True,
-                    "parsing_metadata": metadata,
-                    "etag": etag,
-                }
+                return ReadFileResponse(
+                    path=path,
+                    content=parsed_text,
+                    content_type=content_type,
+                    size=len(content),
+                    parsed=True,
+                    parsing_metadata=metadata,
+                    etag=etag,
+                )
             except TimeoutError as e:
                 # Caught before the generic Exception (subclass-first). When the cap
                 # is set this is our anyio.fail_after tripping; when it is None the
@@ -227,26 +234,26 @@ def configure_webdav_tools(mcp: FastMCP):
         if content_type and content_type.startswith("text/"):
             try:
                 decoded_content = content.decode("utf-8")
-                return {
-                    "path": path,
-                    "content": decoded_content,
-                    "content_type": content_type,
-                    "size": len(content),
-                    "etag": etag,
-                }
+                return ReadFileResponse(
+                    path=path,
+                    content=decoded_content,
+                    content_type=content_type,
+                    size=len(content),
+                    etag=etag,
+                )
             except UnicodeDecodeError:
                 pass
 
         # For binary files, return metadata and base64 encoded content
 
-        return {
-            "path": path,
-            "content": base64.b64encode(content).decode("ascii"),
-            "content_type": content_type,
-            "size": len(content),
-            "encoding": "base64",
-            "etag": etag,
-        }
+        return ReadFileResponse(
+            path=path,
+            content=base64.b64encode(content).decode("ascii"),
+            content_type=content_type,
+            size=len(content),
+            encoding="base64",
+            etag=etag,
+        )
 
     @mcp.tool(
         title="Write File",
@@ -267,7 +274,7 @@ def configure_webdav_tools(mcp: FastMCP):
         ctx: Context,
         content_type: str | None = None,
         if_match: str | None = None,
-    ):
+    ) -> WriteFileResponse:
         """Write content to a file in NextCloud.
 
         Writes are **fail-closed**: an existing file is never silently
@@ -297,7 +304,9 @@ def configure_webdav_tools(mcp: FastMCP):
                   file unconditionally (fails if the file does not exist).
 
         Returns:
-            Dict with status_code indicating success
+            ``WriteFileResponse`` with ``path``, ``status_code``, ``size`` and
+            ``created`` (True when a new file was created, i.e. HTTP 201; False
+            when an existing file was overwritten, i.e. HTTP 204).
         """
         client = await get_client(ctx)
 
@@ -338,7 +347,14 @@ def configure_webdav_tools(mcp: FastMCP):
         status_code = result.get("status_code")
         if status_code in (412, 423):
             raise ToolError(f"{result['message']} ({path!r})")
-        return result
+        # 201 Created for a new file (create-only / If-None-Match), 204 No
+        # Content when an existing file was overwritten (If-Match).
+        return WriteFileResponse(
+            path=path,
+            status_code=status_code,
+            created=status_code == 201,
+            size=len(content_bytes),
+        )
 
     @mcp.tool(
         title="Create Directory",

--- a/tests/server/test_mcp.py
+++ b/tests/server/test_mcp.py
@@ -428,6 +428,11 @@ async def test_mcp_webdav_workflow(
         assert write_result.isError is False, (
             f"MCP file write failed: {write_result.content}"
         )
+        # WriteFileResponse (BaseResponse) structured fields, not a raw dict.
+        write_data = json.loads(write_result.content[0].text)
+        assert write_data["path"] == test_file_path
+        assert write_data["created"] is True  # new file (create-only default)
+        assert write_data["success"] is True
 
         # 4. Verify file creation via direct WebDAV
         file_listing = await nc_client.webdav.list_directory(test_dir)
@@ -450,6 +455,9 @@ async def test_mcp_webdav_workflow(
         assert read_data["content"] == test_content, "File content mismatch"
         assert read_data["path"] == test_file_path
         assert "text/plain" in read_data["content_type"]
+        # ReadFileResponse (BaseResponse) structured fields.
+        assert read_data["etag"], "read response should carry an etag"
+        assert read_data["success"] is True
 
         # 6. Verify file content via direct WebDAV
         direct_content, direct_content_type, _ = await nc_client.webdav.read_file(

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -114,7 +114,7 @@ async def test_read_file_passes_through_when_not_excluded(
     fn = webdav_tools["nc_webdav_read_file"].fn
     result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
 
-    assert result["content"] == "hello"
+    assert result.content == "hello"
     fake_client.webdav.read_file.assert_awaited_once_with("/Public/notes.md")
 
 
@@ -467,9 +467,9 @@ async def test_read_file_interactive_cap_falls_back_to_base64(
     result = await fn(path="/scan.png", ctx=ctx)
 
     # Graceful base64 fallback, not the parsed-document shape.
-    assert result["encoding"] == "base64"
-    assert result["content"] == base64.b64encode(b"\x89PNG").decode("ascii")
-    assert "parsed" not in result
+    assert result.encoding == "base64"
+    assert result.content == base64.b64encode(b"\x89PNG").decode("ascii")
+    assert result.parsed is False
 
 
 async def test_read_file_no_cap_returns_parsed(
@@ -501,9 +501,9 @@ async def test_read_file_no_cap_returns_parsed(
     fn = webdav_tools["nc_webdav_read_file"].fn
     result = await fn(path="/doc.pdf", ctx=ctx)
 
-    assert result["parsed"] is True
-    assert result["content"] == "parsed text"
-    assert result["parsing_metadata"]["parsing_method"] == "docling"
+    assert result.parsed is True
+    assert result.content == "parsed text"
+    assert result.parsing_metadata["parsing_method"] == "docling"
 
 
 # ── Write conflict handling (etag / lock) and size gate ─────────────────
@@ -521,7 +521,7 @@ async def test_read_file_includes_etag_in_response(
     fn = webdav_tools["nc_webdav_read_file"].fn
     result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
 
-    assert result["etag"] == "abc123"
+    assert result.etag == "abc123"
 
 
 async def test_write_file_passes_if_match_through_to_client(

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -21,6 +21,7 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 
+from nextcloud_mcp_server.models.webdav import WriteFileResponse
 from nextcloud_mcp_server.server.webdav import configure_webdav_tools
 
 pytestmark = pytest.mark.unit
@@ -536,7 +537,7 @@ async def test_write_file_passes_if_match_through_to_client(
     )
 
     fn = webdav_tools["nc_webdav_write_file"].fn
-    await fn(
+    result = await fn(
         path="/Public/notes.md",
         content="hi",
         ctx=_mock_ctx(fake_client),
@@ -546,6 +547,36 @@ async def test_write_file_passes_if_match_through_to_client(
     fake_client.webdav.write_file.assert_awaited_once_with(
         "/Public/notes.md", b"hi", None, if_match="abc123"
     )
+    # A 204 (overwrite of an existing file) is reported as created=False on the
+    # typed WriteFileResponse; size is the decoded byte count.
+    assert isinstance(result, WriteFileResponse)
+    assert result.status_code == 204
+    assert result.created is False
+    assert result.size == 2
+    assert result.success is True
+
+
+async def test_write_file_create_only_success_returns_created(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+):
+    """A create-only write (no if_match) that the server answers 201 is reported
+    as created=True on the WriteFileResponse -- the overwrite path (204) above
+    is created=False."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    fake_client.webdav.write_file = AsyncMock(return_value={"status_code": 201})
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=50.0),
+    )
+
+    fn = webdav_tools["nc_webdav_write_file"].fn
+    result = await fn(path="/Public/new.md", content="hi", ctx=_mock_ctx(fake_client))
+
+    assert isinstance(result, WriteFileResponse)
+    assert result.status_code == 201
+    assert result.created is True
+    assert result.path == "/Public/new.md"
 
 
 async def test_write_file_passes_force_star_through_to_client(


### PR DESCRIPTION
## Summary

Follow-up to #1133. `nc_webdav_read_file` and `nc_webdav_write_file` returned raw
`dict`s while the `ReadFileResponse` / `WriteFileResponse` Pydantic models already
existed but went **unused**. This converts both tools to the typed models and
codifies the rule so it doesn't recur.

- `ReadFileResponse` gains `parsed` / `parsing_metadata`, so all three read
  branches (parsed document, decoded text, base64 binary) map to one model.
- `WriteFileResponse` derives `created` from the HTTP status (**201** create-only
  vs **204** overwrite) and carries `path` + `size`. The fail-closed 412/423 →
  `ToolError` behavior from #1133 is unchanged.
- Both tools now declare their `-> *Response` return annotation.

**CLAUDE.md** — the "MCP Response Patterns" section is tightened to a hard
requirement: **every MCP tool MUST return a `BaseResponse`-derived model** (no raw
`dict`/`list`), stated as a **review gate**.

An audit of all 153 MCP tools found **110 already compliant**. The remaining
raw-dict/list tools (the other WebDAV tools, `tables`, most `calendar`,
`notes.get_attachment`, plus bare-`BaseModel`/`str` returns) are **pre-existing
debt tracked on Deck board 12** — this PR does not silently expand scope to all of
them; new code must not add to the debt.

## Changes
- `nextcloud_mcp_server/models/webdav.py` — `ReadFileResponse` + `parsed`/`parsing_metadata`.
- `nextcloud_mcp_server/server/webdav.py` — `read_file`/`write_file` return typed models + annotations; `Returns:` docstrings updated.
- `CLAUDE.md` — MCP Response Patterns → hard requirement + review gate.
- tests — unit switched to attribute access (`result.content`); `test_mcp.py` asserts structured fields (`created`/`success`/`etag`) through the real MCP client.

## Test plan
- [x] `uv run pytest tests/unit/` — 2419 passed
- [x] `uv run pytest -m smoke` — 7 passed
- [x] Integration (live Nextcloud): `test_mcp` WebDAV workflow, `test_annotations`, WebDAV client ops — passed
- [x] `ruff` / `ruff format` / `ty` / Sonar secrets — clean

## Notes
- **Backward compatible:** response shape is enriched (adds `success`/`timestamp` +
  structured fields) but every existing key (`content`, `path`, `status_code`, …)
  is preserved — callers reading those are unaffected. Not a breaking change.
- **API-surface testing policy:** this changes MCP tool response *shape*; e2e is
  covered by `test_mcp.py`. MCP tool responses are not part of the Pact contract
  boundary (that's `/api/v1` + the gateway OCR consumer), so no contract test
  applies here.

---

_This PR was generated with the help of AI, and reviewed by a Human_