### PR TITLE
fix(contacts): stop rebuilding vCards on update

### DIFF
--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -468,6 +468,11 @@ class ContactsClient(BaseNextcloudClient):
         ETag so callers can chain updates without a re-read. ``getetag`` is an
         empty string when the server omitted the header from the PUT response
         (some proxies strip it); chaining then requires a fresh read first.
+
+        Failures before the PUT raise. Failures *after* it do not: once the write
+        has landed, an error building the response projection would misreport a
+        successful update, so ``contact`` degrades to ``{}`` and the raw
+        ``addressdata`` plus the new ETag are still returned.
         """
         await self._ensure_principal_id()
         carddav_path = self._get_carddav_base_path()
@@ -501,13 +506,34 @@ class ContactsClient(BaseNextcloudClient):
             "PUT", url, content=vcard_content, headers=headers
         )
 
+        # Re-parse the card we just wrote rather than issuing a second GET.
+        #
+        # Deliberately fail-open, unlike every other error path in this method:
+        # the PUT has already landed, so raising here would report a *successful*
+        # write as a failure and invite a pointless — possibly destructive —
+        # retry. The contract this method exists to protect ("never silently lose
+        # data") is already satisfied at this point; only the convenience
+        # projection is at risk. The caller still gets the new ETag and the full
+        # ``addressdata``, so nothing is withheld.
+        try:
+            contact_projection = _project_contact(Contact.from_vcard(vcard_content))
+        except Exception:
+            # Broad by intent: pythonvCard4 is third-party and its parse failure
+            # modes aren't enumerable. Whatever it raises, the write stands.
+            logger.exception(
+                "Contact %s was updated successfully but the written vCard could "
+                "not be re-parsed for the response projection; returning the raw "
+                "card and ETag instead",
+                uid,
+            )
+            contact_projection = {}
+
         return {
             "vcard_id": object_name.removesuffix(".vcf"),
             "object_path": url,
             "object_name": object_name,
-            # Re-parse the card we just wrote rather than issuing a second GET.
             "getetag": response.headers.get("etag", ""),
-            "contact": _project_contact(Contact.from_vcard(vcard_content)),
+            "contact": contact_projection,
             "addressdata": vcard_content,
         }
 

--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -137,6 +137,35 @@ def _first_custom(custom: dict[str, str | list[str]], key: str) -> str | None:
     return None
 
 
+def _project_contact(contact: Contact) -> dict[str, Any]:
+    """Project a parsed vCard into the flat dict the server layer maps to a model.
+
+    Single projection point shared by ``list_contacts`` and ``update_contact`` so
+    the read-after-write shape cannot drift from the read shape.
+
+    pythonvCard4's parser has no branch for ORG / TITLE — they fall through into
+    ``contact.custom`` as a list of raw values. PHOTO only gets typed-parsed when
+    the line carries an ``ENCODING=`` parameter; otherwise it lands in ``custom``
+    too. Pull them out here so the read side surfaces what the write side
+    persisted (issue #716 follow-up).
+    """
+    return {
+        "fullname": contact.fn,
+        "nickname": contact.nickname,
+        "birthday": contact.bday.isoformat()
+        if isinstance(contact.bday, date)
+        else contact.bday,
+        "email": contact.email,
+        "tel": contact.tel,
+        "org": _first_custom(contact.custom, "ORG"),
+        "title": _first_custom(contact.custom, "TITLE"),
+        "note": contact.note,
+        "url": contact.url,
+        "categories": contact.categories,
+        "photo": contact.photo_data or _first_custom(contact.custom, "PHOTO"),
+    }
+
+
 def _safe_vcard_value(value: Any) -> Any:
     """Escape newlines in a value so it can't inject additional vCard properties.
 
@@ -425,8 +454,21 @@ class ContactsClient(BaseNextcloudClient):
         uid: str,
         contact_data: dict[str, Any],
         etag: str = "",
-    ):
-        """Update an existing contact while preserving all existing properties."""
+    ) -> dict[str, Any]:
+        """Update an existing contact while preserving all existing properties.
+
+        The existing vCard is **always** fetched and merged into. Previously the
+        fetch was skipped whenever the caller supplied an ``etag``, so the
+        concurrency-correct call silently fell through to a rebuild from the
+        handful of supported keys — destroying PHOTO, ADR, N, X-*, IMPP, GEO and
+        REV. There is no rebuild path any more: if the existing card cannot be
+        read, this raises rather than replacing it with a synthesised one.
+
+        Returns the same shape as one ``list_contacts`` entry, carrying the new
+        ETag so callers can chain updates without a re-read. ``getetag`` is an
+        empty string when the server omitted the header from the PUT response
+        (some proxies strip it); chaining then requires a fresh read first.
+        """
         await self._ensure_principal_id()
         carddav_path = self._get_carddav_base_path()
         # Resolve the real object filename (may differ from ``<uid>.vcf``) so the
@@ -434,32 +476,20 @@ class ContactsClient(BaseNextcloudClient):
         object_name = await self._resolve_object_name(addressbook, uid) or f"{uid}.vcf"
         url = f"{carddav_path}/{addressbook}/{object_name}"
 
-        # Canonicalise aliases up front so both code paths (merge + fallback) agree.
         contact_data = _normalize_contact_data(contact_data)
 
-        # Get raw vCard content to preserve all properties including extended ones
-        raw_vcard_content = ""
+        # Always read the current card: it is the only source of the properties
+        # this method has no vocabulary for. A failure here propagates — a raised
+        # error is recoverable, a silent rebuild is not.
+        raw_vcard_content, current_etag = await self._fetch_raw_vcard(
+            addressbook, object_name
+        )
+        # The caller's etag wins: it is their concurrency assertion, and honouring
+        # the freshly-read one instead would defeat the check they asked for.
         if not etag:
-            try:
-                raw_vcard_content, current_etag = await self._fetch_raw_vcard(
-                    addressbook, object_name
-                )
-                etag = current_etag
-            except Exception:
-                # Fall back to creating new vCard if we can't get existing
-                logger.warning(
-                    "Could not fetch existing vCard for %s, creating new", uid
-                )
-                raw_vcard_content = ""
+            etag = current_etag
 
-        # Create updated vCard preserving existing properties
-        if raw_vcard_content:
-            vcard_content = self._merge_vcard_properties(
-                raw_vcard_content, contact_data, uid
-            )
-        else:
-            # Fallback to creating new vCard if we couldn't get existing
-            vcard_content = _build_contact_from_data(contact_data, uid).to_vcard()
+        vcard_content = self._merge_vcard_properties(raw_vcard_content, contact_data)
 
         headers = {
             "Content-Type": "text/vcard; charset=utf-8",
@@ -467,7 +497,19 @@ class ContactsClient(BaseNextcloudClient):
         if etag:
             headers["If-Match"] = etag
 
-        await self._make_request("PUT", url, content=vcard_content, headers=headers)
+        response = await self._make_request(
+            "PUT", url, content=vcard_content, headers=headers
+        )
+
+        return {
+            "vcard_id": object_name.removesuffix(".vcf"),
+            "object_path": url,
+            "object_name": object_name,
+            # Re-parse the card we just wrote rather than issuing a second GET.
+            "getetag": response.headers.get("etag", ""),
+            "contact": _project_contact(Contact.from_vcard(vcard_content)),
+            "addressdata": vcard_content,
+        }
 
     async def list_contacts(self, *, addressbook: str):
         """List all available contacts for addressbook."""
@@ -550,39 +592,13 @@ class ContactsClient(BaseNextcloudClient):
                 logger.info("Skip missing addressdata")
                 continue
 
-            contact = Contact.from_vcard(addressdata)
-
-            # pythonvCard4's parser has no branch for ORG / TITLE — they fall
-            # through into ``contact.custom`` as a list of raw values. PHOTO
-            # only gets typed-parsed when the line carries an ``ENCODING=``
-            # parameter; otherwise it lands in ``custom`` too. Pull them out
-            # here so the read side surfaces what the write side persisted
-            # (issue #716 follow-up).
-            org_value = _first_custom(contact.custom, "ORG")
-            title_value = _first_custom(contact.custom, "TITLE")
-            photo_value = contact.photo_data or _first_custom(contact.custom, "PHOTO")
-
             contacts.append(
                 {
                     "vcard_id": vcard_id,
                     "object_path": object_path,
                     "object_name": object_name,
                     "getetag": getetag,
-                    "contact": {
-                        "fullname": contact.fn,
-                        "nickname": contact.nickname,
-                        "birthday": contact.bday.isoformat()
-                        if isinstance(contact.bday, date)
-                        else contact.bday,
-                        "email": contact.email,
-                        "tel": contact.tel,
-                        "org": org_value,
-                        "title": title_value,
-                        "note": contact.note,
-                        "url": contact.url,
-                        "categories": contact.categories,
-                        "photo": photo_value,
-                    },
+                    "contact": _project_contact(Contact.from_vcard(addressdata)),
                     "addressdata": addressdata,
                 }
             )
@@ -612,15 +628,25 @@ class ContactsClient(BaseNextcloudClient):
             raise
 
     def _merge_vcard_properties(
-        self, raw_vcard: str, contact_data: dict[str, Any], uid: str
+        self, raw_vcard: str, contact_data: dict[str, Any]
     ) -> str:
         """Merge new contact data into existing raw vCard while preserving all properties.
+
+        The card's own ``UID`` line is carried through from ``raw_vcard`` like any
+        other unrecognised property, so no ``uid`` argument is needed. (One used to
+        be required solely by the removed rebuild fallback.)
 
         Limitation: dict / list-form ``email`` and ``tel`` inputs are not applied
         by this text-merge path. Existing EMAIL/TEL lines are preserved unchanged,
         and no new lines are written for the dict/list inputs. Pass plain strings
         to update EMAIL/TEL here, or recreate via ``create_contact`` for full
         multi-entry support with TYPE annotations.
+
+        Raises on any merge failure rather than substituting a synthesised card.
+        This function previously caught every exception and returned a four-line
+        vCard built from ``fn``/``email``/``tel``, which silently destroyed PHOTO,
+        ADR, N, X-* and every other property while reporting success. A raised
+        error is recoverable; a silent rebuild is not.
         """
         # Surface dict/list email/tel up front rather than silently no-op in the
         # add-new loop below (where the isinstance(value, str) guard skips them).
@@ -637,199 +663,172 @@ class ContactsClient(BaseNextcloudClient):
                     _key.upper(),
                     _key.upper(),
                 )
-        try:
-            # Instead of using pythonvCard4 which has formatting issues,
-            # let's do a simple text-based merge to preserve exact formatting
+        # Instead of using pythonvCard4 which has formatting issues,
+        # let's do a simple text-based merge to preserve exact formatting
 
-            # Start with the original vCard
-            lines = raw_vcard.strip().split("\n")
-            updated_lines = []
+        # Start with the original vCard
+        lines = raw_vcard.strip().split("\n")
+        updated_lines = []
 
-            # Track what we've updated to avoid duplicates
-            updated_properties = set()
+        # Track what we've updated to avoid duplicates
+        updated_properties = set()
 
-            for line in lines:
-                line = line.strip()
-                if not line:
-                    continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
 
-                # Skip the END:VCARD line for now
-                if line == "END:VCARD":
-                    continue
+            # Skip the END:VCARD line for now
+            if line == "END:VCARD":
+                continue
 
-                property_name = line.split(":")[0].split(";")[0]
+            property_name = line.split(":")[0].split(";")[0]
 
-                # Handle updates for specific properties
-                if property_name == "FN" and "fn" in contact_data:
-                    updated_lines.append(f"FN:{_safe_vcard_value(contact_data['fn'])}")
-                    updated_properties.add("fn")
-                elif property_name == "EMAIL" and "email" in contact_data:
-                    # Replace first email with new one, preserve others
-                    if "email" not in updated_properties:
-                        if isinstance(contact_data["email"], str):
-                            email_value = _safe_vcard_value(contact_data["email"])
-                            # Try to preserve the original format as much as possible
-                            if ";TYPE=" in line:
-                                type_part = line.split(";TYPE=")[1].split(":")[0]
-                                updated_lines.append(
-                                    f"EMAIL;TYPE={type_part}:{email_value}"
-                                )
-                            else:
-                                updated_lines.append(f"EMAIL:{email_value}")
-                            updated_properties.add("email")
+            # Handle updates for specific properties
+            if property_name == "FN" and "fn" in contact_data:
+                updated_lines.append(f"FN:{_safe_vcard_value(contact_data['fn'])}")
+                updated_properties.add("fn")
+            elif property_name == "EMAIL" and "email" in contact_data:
+                # Replace first email with new one, preserve others
+                if "email" not in updated_properties:
+                    if isinstance(contact_data["email"], str):
+                        email_value = _safe_vcard_value(contact_data["email"])
+                        # Try to preserve the original format as much as possible
+                        if ";TYPE=" in line:
+                            type_part = line.split(";TYPE=")[1].split(":")[0]
+                            updated_lines.append(
+                                f"EMAIL;TYPE={type_part}:{email_value}"
+                            )
                         else:
-                            # Dict / list inputs aren't translatable to a single
-                            # text-merge replacement; keep the original line so we
-                            # don't silently drop the contact's email.
-                            updated_lines.append(line)
+                            updated_lines.append(f"EMAIL:{email_value}")
+                        updated_properties.add("email")
                     else:
-                        # Keep additional emails unchanged
+                        # Dict / list inputs aren't translatable to a single
+                        # text-merge replacement; keep the original line so we
+                        # don't silently drop the contact's email.
                         updated_lines.append(line)
-                elif property_name == "TEL" and "tel" in contact_data:
-                    # Similar handling for phone numbers
-                    if "tel" not in updated_properties:
-                        if isinstance(contact_data["tel"], str):
-                            tel_value = _safe_vcard_value(contact_data["tel"])
-                            if ";TYPE=" in line:
-                                type_part = line.split(";TYPE=")[1].split(":")[0]
-                                updated_lines.append(
-                                    f"TEL;TYPE={type_part}:{tel_value}"
-                                )
-                            else:
-                                updated_lines.append(f"TEL:{tel_value}")
-                            updated_properties.add("tel")
+                else:
+                    # Keep additional emails unchanged
+                    updated_lines.append(line)
+            elif property_name == "TEL" and "tel" in contact_data:
+                # Similar handling for phone numbers
+                if "tel" not in updated_properties:
+                    if isinstance(contact_data["tel"], str):
+                        tel_value = _safe_vcard_value(contact_data["tel"])
+                        if ";TYPE=" in line:
+                            type_part = line.split(";TYPE=")[1].split(":")[0]
+                            updated_lines.append(f"TEL;TYPE={type_part}:{tel_value}")
                         else:
-                            # Same reasoning as the EMAIL branch above: don't drop.
-                            updated_lines.append(line)
+                            updated_lines.append(f"TEL:{tel_value}")
+                        updated_properties.add("tel")
                     else:
-                        # Keep additional phone numbers unchanged
+                        # Same reasoning as the EMAIL branch above: don't drop.
                         updated_lines.append(line)
-                elif property_name == "NOTE" and "note" in contact_data:
-                    updated_lines.append(
-                        f"NOTE:{_safe_vcard_value(contact_data['note'])}"
+                else:
+                    # Keep additional phone numbers unchanged
+                    updated_lines.append(line)
+            elif property_name == "NOTE" and "note" in contact_data:
+                updated_lines.append(f"NOTE:{_safe_vcard_value(contact_data['note'])}")
+                updated_properties.add("note")
+            elif property_name == "NICKNAME" and "nickname" in contact_data:
+                nickname_value = contact_data["nickname"]
+                if isinstance(nickname_value, list):
+                    nickname_value = ",".join(nickname_value)
+                updated_lines.append(f"NICKNAME:{_safe_vcard_value(nickname_value)}")
+                updated_properties.add("nickname")
+            elif property_name == "BDAY" and "bday" in contact_data:
+                parsed_bday = _parse_bday(contact_data["bday"])
+                if parsed_bday is not None:
+                    updated_lines.append(f"BDAY:{parsed_bday.isoformat()}")
+                    updated_properties.add("bday")
+                else:
+                    # Invalid input — keep the existing BDAY rather than
+                    # writing a malformed line or silently dropping it.
+                    updated_lines.append(line)
+            elif property_name == "CATEGORIES" and "categories" in contact_data:
+                categories_value = contact_data["categories"]
+                if isinstance(categories_value, list):
+                    categories_value = ",".join(categories_value)
+                updated_lines.append(
+                    f"CATEGORIES:{_safe_vcard_value(categories_value)}"
+                )
+                updated_properties.add("categories")
+            elif property_name == "ORG" and "org" in contact_data:
+                org_value = contact_data["org"]
+                # ORG is structured (Company;Department;…) per RFC 6350 §6.6.4;
+                # join list components with ';' so callers using the same shape
+                # ``_build_contact_from_data`` accepts don't get a Python repr.
+                if isinstance(org_value, list):
+                    org_value = ";".join(org_value)
+                updated_lines.append(f"ORG:{_safe_vcard_value(org_value)}")
+                updated_properties.add("org")
+            elif property_name == "TITLE" and "title" in contact_data:
+                updated_lines.append(
+                    f"TITLE:{_safe_vcard_value(contact_data['title'])}"
+                )
+                updated_properties.add("title")
+            elif property_name == "URL" and "url" in contact_data:
+                if "url" not in updated_properties:
+                    url_value = contact_data["url"]
+                    # Only the first URL from a list is written; multi-URL
+                    # contacts are rare and this text merge doesn't attempt
+                    # position-stable mapping to existing URL lines.
+                    if isinstance(url_value, list):
+                        url_value = url_value[0] if url_value else ""
+                    if url_value:
+                        updated_lines.append(f"URL:{_safe_vcard_value(url_value)}")
+                    updated_properties.add("url")
+                else:
+                    # Keep additional URLs unchanged
+                    updated_lines.append(line)
+            else:
+                # Keep all other properties unchanged (preserves all extended/custom fields)
+                updated_lines.append(line)
+
+        # Add any new properties that weren't in the original vCard
+        for key, value in contact_data.items():
+            if key not in updated_properties:
+                if key == "fn":
+                    updated_lines.append(f"FN:{_safe_vcard_value(value)}")
+                elif key == "email" and isinstance(value, str):
+                    updated_lines.append(f"EMAIL:{_safe_vcard_value(value)}")
+                elif key == "tel" and isinstance(value, str):
+                    updated_lines.append(f"TEL:{_safe_vcard_value(value)}")
+                elif key == "note":
+                    updated_lines.append(f"NOTE:{_safe_vcard_value(value)}")
+                elif key == "nickname":
+                    nickname_value = (
+                        value if isinstance(value, str) else ",".join(value)
                     )
-                    updated_properties.add("note")
-                elif property_name == "NICKNAME" and "nickname" in contact_data:
-                    nickname_value = contact_data["nickname"]
-                    if isinstance(nickname_value, list):
-                        nickname_value = ",".join(nickname_value)
                     updated_lines.append(
                         f"NICKNAME:{_safe_vcard_value(nickname_value)}"
                     )
-                    updated_properties.add("nickname")
-                elif property_name == "BDAY" and "bday" in contact_data:
-                    parsed_bday = _parse_bday(contact_data["bday"])
+                elif key == "bday":
+                    parsed_bday = _parse_bday(value)
                     if parsed_bday is not None:
                         updated_lines.append(f"BDAY:{parsed_bday.isoformat()}")
-                        updated_properties.add("bday")
-                    else:
-                        # Invalid input — keep the existing BDAY rather than
-                        # writing a malformed line or silently dropping it.
-                        updated_lines.append(line)
-                elif property_name == "CATEGORIES" and "categories" in contact_data:
-                    categories_value = contact_data["categories"]
-                    if isinstance(categories_value, list):
-                        categories_value = ",".join(categories_value)
+                elif key == "categories":
+                    categories_value = (
+                        value if isinstance(value, str) else ",".join(value)
+                    )
                     updated_lines.append(
                         f"CATEGORIES:{_safe_vcard_value(categories_value)}"
                     )
-                    updated_properties.add("categories")
-                elif property_name == "ORG" and "org" in contact_data:
-                    org_value = contact_data["org"]
-                    # ORG is structured (Company;Department;…) per RFC 6350 §6.6.4;
-                    # join list components with ';' so callers using the same shape
-                    # ``_build_contact_from_data`` accepts don't get a Python repr.
-                    if isinstance(org_value, list):
-                        org_value = ";".join(org_value)
+                elif key == "org":
+                    # See ORG note in update-existing branch above.
+                    org_value = ";".join(value) if isinstance(value, list) else value
                     updated_lines.append(f"ORG:{_safe_vcard_value(org_value)}")
-                    updated_properties.add("org")
-                elif property_name == "TITLE" and "title" in contact_data:
-                    updated_lines.append(
-                        f"TITLE:{_safe_vcard_value(contact_data['title'])}"
-                    )
-                    updated_properties.add("title")
-                elif property_name == "URL" and "url" in contact_data:
-                    if "url" not in updated_properties:
-                        url_value = contact_data["url"]
-                        # Only the first URL from a list is written; multi-URL
-                        # contacts are rare and this text merge doesn't attempt
-                        # position-stable mapping to existing URL lines.
-                        if isinstance(url_value, list):
-                            url_value = url_value[0] if url_value else ""
-                        if url_value:
-                            updated_lines.append(f"URL:{_safe_vcard_value(url_value)}")
-                        updated_properties.add("url")
-                    else:
-                        # Keep additional URLs unchanged
-                        updated_lines.append(line)
-                else:
-                    # Keep all other properties unchanged (preserves all extended/custom fields)
-                    updated_lines.append(line)
+                elif key == "title":
+                    updated_lines.append(f"TITLE:{_safe_vcard_value(value)}")
+                elif key == "url":
+                    # Only the first URL is written on add-new; see note in the
+                    # update-existing branch above.
+                    url_value = value[0] if isinstance(value, list) and value else value
+                    if url_value:
+                        updated_lines.append(f"URL:{_safe_vcard_value(url_value)}")
 
-            # Add any new properties that weren't in the original vCard
-            for key, value in contact_data.items():
-                if key not in updated_properties:
-                    if key == "fn":
-                        updated_lines.append(f"FN:{_safe_vcard_value(value)}")
-                    elif key == "email" and isinstance(value, str):
-                        updated_lines.append(f"EMAIL:{_safe_vcard_value(value)}")
-                    elif key == "tel" and isinstance(value, str):
-                        updated_lines.append(f"TEL:{_safe_vcard_value(value)}")
-                    elif key == "note":
-                        updated_lines.append(f"NOTE:{_safe_vcard_value(value)}")
-                    elif key == "nickname":
-                        nickname_value = (
-                            value if isinstance(value, str) else ",".join(value)
-                        )
-                        updated_lines.append(
-                            f"NICKNAME:{_safe_vcard_value(nickname_value)}"
-                        )
-                    elif key == "bday":
-                        parsed_bday = _parse_bday(value)
-                        if parsed_bday is not None:
-                            updated_lines.append(f"BDAY:{parsed_bday.isoformat()}")
-                    elif key == "categories":
-                        categories_value = (
-                            value if isinstance(value, str) else ",".join(value)
-                        )
-                        updated_lines.append(
-                            f"CATEGORIES:{_safe_vcard_value(categories_value)}"
-                        )
-                    elif key == "org":
-                        # See ORG note in update-existing branch above.
-                        org_value = (
-                            ";".join(value) if isinstance(value, list) else value
-                        )
-                        updated_lines.append(f"ORG:{_safe_vcard_value(org_value)}")
-                    elif key == "title":
-                        updated_lines.append(f"TITLE:{_safe_vcard_value(value)}")
-                    elif key == "url":
-                        # Only the first URL is written on add-new; see note in the
-                        # update-existing branch above.
-                        url_value = (
-                            value[0] if isinstance(value, list) and value else value
-                        )
-                        if url_value:
-                            updated_lines.append(f"URL:{_safe_vcard_value(url_value)}")
+        # Add the END:VCARD line
+        updated_lines.append("END:VCARD")
 
-            # Add the END:VCARD line
-            updated_lines.append("END:VCARD")
-
-            # Join all lines
-            return "\n".join(updated_lines)
-
-        except Exception as e:
-            logger.error("Error merging vCard properties: %s", e)
-            # Fallback to creating basic vCard matching Nextcloud format
-            basic_vcard = f"""BEGIN:VCARD
-VERSION:3.0
-UID:{uid}
-FN:{contact_data.get("fn", "Unknown")}"""
-
-            if "email" in contact_data:
-                basic_vcard += f"\nEMAIL:{contact_data['email']}"
-            if "tel" in contact_data:
-                basic_vcard += f"\nTEL:{contact_data['tel']}"
-
-            basic_vcard += "\nEND:VCARD"
-            return basic_vcard
+        # Join all lines
+        return "\n".join(updated_lines)

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -2,7 +2,9 @@ import logging
 from datetime import date
 from typing import Any
 
+from httpx import HTTPStatusError
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -13,6 +15,7 @@ from nextcloud_mcp_server.models.contacts import (
     ContactField,
     ListAddressBooksResponse,
     ListContactsResponse,
+    UpdateContactResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 
@@ -351,7 +354,7 @@ def configure_contacts_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_contacts_update_contact(
         ctx: Context, *, addressbook: str, uid: str, contact_data: dict, etag: str = ""
-    ):
+    ) -> UpdateContactResponse:
         """Update an existing contact while preserving all existing properties.
 
         Args:
@@ -383,9 +386,28 @@ def configure_contacts_tools(mcp: FastMCP):
                   on update; multi-URL contacts should use create_contact.
 
                 Example: ``{"fn": "Jane Doe", "email": "jane.doe@example.com"}``.
-            etag: Optional ETag for optimistic concurrency control.
+            etag: Optional ETag for optimistic concurrency control. Pass the
+                value from a previous read or update; the update is rejected if
+                the contact changed since.
+
+        Returns:
+            The updated contact and its new ETag, so updates can be chained
+            without an intervening read.
         """
         client = await get_client(ctx)
-        return await client.contacts.update_contact(
-            addressbook=addressbook, uid=uid, contact_data=contact_data, etag=etag
+        try:
+            raw = await client.contacts.update_contact(
+                addressbook=addressbook, uid=uid, contact_data=contact_data, etag=etag
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 412:
+                raise ToolError(
+                    f"Contact {uid!r} changed since etag {etag!r} was read. "
+                    "Re-read it and retry the update."
+                ) from e
+            raise
+
+        return UpdateContactResponse(
+            contact=_raw_contact_to_model(raw),
+            addressbook=addressbook,
         )

--- a/tests/server/test_contacts_mcp.py
+++ b/tests/server/test_contacts_mcp.py
@@ -96,12 +96,55 @@ async def test_mcp_contacts_workflow(
             },
         )
         assert update_result.isError is False
+        # The tool now returns a typed UpdateContactResponse carrying the new etag.
+        update_payload = _extract_payload(update_result)
+        assert update_payload["success"] is True
+        assert update_payload["addressbook"] == addressbook_name
+        assert update_payload["contact"]["uid"] == contact_uid
+        chained_etag = update_payload["contact"]["etag"]
+        assert chained_etag
+
         contacts = await nc_client.contacts.list_contacts(addressbook=addressbook_name)
         updated = next(c for c in contacts if c["vcard_id"] == contact_uid)
         updated_vcard = updated.get("addressdata", "")
         assert "mcp-test.example.com" in updated_vcard
         # Prior properties must not have been clobbered by the merge.
         assert "ORG:MCP Test Corp" in updated_vcard
+
+        # 4c. Chain a second update using the etag the previous one returned —
+        # no intervening read. Supplying an etag used to skip the existing-vCard
+        # fetch entirely and rebuild the card from the supplied keys, destroying
+        # every property not passed in. Guard that the merge still runs.
+        chained_result = await nc_mcp_client.call_tool(
+            "nc_contacts_update_contact",
+            {
+                "addressbook": addressbook_name,
+                "uid": contact_uid,
+                "contact_data": {"note": "Updated with etag"},
+                "etag": chained_etag,
+            },
+        )
+        assert chained_result.isError is False
+        contacts = await nc_client.contacts.list_contacts(addressbook=addressbook_name)
+        chained_vcard = next(c for c in contacts if c["vcard_id"] == contact_uid).get(
+            "addressdata", ""
+        )
+        assert "NOTE:Updated with etag" in chained_vcard
+        # Properties absent from contact_data must survive the etag path.
+        assert "ORG:MCP Test Corp" in chained_vcard
+        assert "mcp-test.example.com" in chained_vcard
+
+        # 4d. A stale etag must be rejected, not silently applied.
+        stale_result = await nc_mcp_client.call_tool(
+            "nc_contacts_update_contact",
+            {
+                "addressbook": addressbook_name,
+                "uid": contact_uid,
+                "contact_data": {"note": "Should not land"},
+                "etag": chained_etag,
+            },
+        )
+        assert stale_result.isError is True
 
         # 5. Delete contact via MCP
         logger.info("Deleting contact %s via MCP", contact_uid)

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -20,6 +20,43 @@ from nextcloud_mcp_server.client.contacts import (
 pytestmark = pytest.mark.unit
 
 
+def _update_client(
+    mocker, *, object_name: str | None, raw_vcard: str, etag: str = '"srv"'
+):
+    """Build a ContactsClient wired for ``update_contact`` with no HTTP.
+
+    ``_resolve_object_name`` and ``_fetch_raw_vcard`` are patched; ``_make_request``
+    returns a response whose ``etag`` header is a real string so the returned
+    projection is realistic.
+    """
+    client = ContactsClient.__new__(ContactsClient)
+    client.username = "testuser"
+    client._principal_discovered = True
+    mocker.patch.object(
+        client, "_resolve_object_name", mocker.AsyncMock(return_value=object_name)
+    )
+    mocker.patch.object(
+        client, "_fetch_raw_vcard", mocker.AsyncMock(return_value=(raw_vcard, etag))
+    )
+    response = mocker.Mock()
+    response.headers = {"etag": '"new-etag"'}
+    mocker.patch.object(
+        client, "_make_request", mocker.AsyncMock(return_value=response)
+    )
+    return client
+
+
+def _put_call(client) -> tuple[str, str]:
+    """Return the (method, url) of the client's single ``_make_request`` call."""
+    args = client._make_request.await_args.args
+    return args[0], args[1]
+
+
+def _put_body(client) -> str:
+    """Return the vCard text sent in the PUT."""
+    return client._make_request.await_args.kwargs["content"]
+
+
 def _vcard(**kwargs) -> str:
     """Build a vCard from ``contact_data`` with a fixed uid, return the serialised text.
 
@@ -302,50 +339,40 @@ class TestObjectNameResolution:
         """Regression for #874: update must PUT to ``.../default`` not
         ``.../default.vcf`` (parallels the delete coverage).
         """
-        client = ContactsClient.__new__(ContactsClient)
-        client.username = "testuser"
-        client._principal_discovered = True
-        mocker.patch.object(
-            client, "_resolve_object_name", mocker.AsyncMock(return_value="default")
+        client = _update_client(
+            mocker,
+            object_name="default",
+            raw_vcard="BEGIN:VCARD\nVERSION:3.0\nUID:default\nFN:No Ext\nEND:VCARD\n",
         )
-        mocker.patch.object(
-            client,
-            "_fetch_raw_vcard",
-            mocker.AsyncMock(
-                return_value=(
-                    "BEGIN:VCARD\nVERSION:3.0\nUID:default\nFN:No Ext\nEND:VCARD\n",
-                    '"etag"',
-                )
-            ),
-        )
-        make_request = mocker.patch.object(client, "_make_request", mocker.AsyncMock())
         await client.update_contact(
             addressbook="contacts", uid="default", contact_data={"fn": "Updated"}
         )
-        method, url = make_request.await_args.args[0], make_request.await_args.args[1]
+        method, url = _put_call(client)
         assert method == "PUT"
         assert url == "/remote.php/dav/addressbooks/users/testuser/contacts/default"
 
     async def test_update_falls_back_to_vcf_when_unresolved(self, mocker):
         """When resolution finds nothing, update falls back to ``<uid>.vcf`` so
-        the caller still gets a clean 404 from the PUT (mirrors delete).
+        the caller still gets a clean 404 from the fetch or the PUT (mirrors
+        delete).
+
+        Previously this test asserted that supplying an etag *skipped* the
+        existing-vCard fetch — i.e. it encoded the data-loss bug. The fetch is
+        now unconditional, so the fallback path is asserted on the GET target.
         """
-        client = ContactsClient.__new__(ContactsClient)
-        client.username = "testuser"
-        client._principal_discovered = True
-        mocker.patch.object(
-            client, "_resolve_object_name", mocker.AsyncMock(return_value=None)
+        client = _update_client(
+            mocker,
+            object_name=None,
+            raw_vcard="BEGIN:VCARD\nVERSION:3.0\nUID:ghost\nFN:Ghost\nEND:VCARD\n",
         )
-        make_request = mocker.patch.object(client, "_make_request", mocker.AsyncMock())
-        # Supplying an etag skips the existing-vCard fetch; update builds a fresh
-        # vCard and PUTs it to the fallback path.
         await client.update_contact(
             addressbook="contacts",
             uid="ghost",
-            contact_data={"fn": "Ghost"},
+            contact_data={"fn": "Ghost Updated"},
             etag='"x"',
         )
-        method, url = make_request.await_args.args[0], make_request.await_args.args[1]
+        client._fetch_raw_vcard.assert_awaited_once_with("contacts", "ghost.vcf")
+        method, url = _put_call(client)
         assert method == "PUT"
         assert url == "/remote.php/dav/addressbooks/users/testuser/contacts/ghost.vcf"
 
@@ -413,7 +440,7 @@ class TestMergeVcardProperties:
         from nextcloud_mcp_server.client.contacts import ContactsClient
 
         client = ContactsClient.__new__(ContactsClient)  # no HTTP / no __init__
-        return client._merge_vcard_properties(raw, data, uid="merge-test")
+        return client._merge_vcard_properties(raw, data)
 
     def test_nickname_overwrites_existing_line(self):
         """Existing NICKNAME must be replaced with the new value, not preserved."""
@@ -583,3 +610,154 @@ class TestMergeVcardProperties:
             result = self._merge(existing, {"email": "alice@work.com"})
         assert "EMAIL:alice@work.com" in result
         assert not any("dict/list shape" in r.message for r in caplog.records)
+
+
+class TestUpdatePreservesUnsupportedProperties:
+    """Regression guard for the update-path data loss.
+
+    ``update_contact`` used to fetch the existing vCard **only when the caller
+    omitted an etag**. Supplying one — the concurrency-correct call — fell
+    through to ``_build_contact_from_data(...).to_vcard()``, rebuilding the card
+    from the ~10 supported keys and silently destroying every other property.
+    """
+
+    # A card carrying exactly the properties the rebuild path had no vocabulary
+    # for, so their survival proves the merge ran.
+    RICH_VCARD = (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:alice\n"
+        "FN:Alice Original\n"
+        "N:Doe;Alice;;;\n"
+        "ADR;TYPE=HOME:;;1 Main St;Springfield;;12345;US\n"
+        "PHOTO;ENCODING=b;TYPE=JPEG:/9j/4AAQSkZJRgABAQ==\n"
+        "X-ABLabel:custom-label\n"
+        "REV:20240101T000000Z\n"
+        "END:VCARD\n"
+    )
+
+    async def test_etag_supplied_still_merges_into_existing_card(self, mocker):
+        """The headline regression: an etag must not bypass the fetch."""
+        client = _update_client(
+            mocker, object_name="alice.vcf", raw_vcard=self.RICH_VCARD
+        )
+
+        await client.update_contact(
+            addressbook="contacts",
+            uid="alice",
+            contact_data={"fn": "Alice Updated"},
+            etag='"caller-etag"',
+        )
+
+        # The fetch is the whole point — it was skipped before.
+        client._fetch_raw_vcard.assert_awaited_once_with("contacts", "alice.vcf")
+
+        body = _put_body(client)
+        assert "N:Doe;Alice;;;" in body
+        assert "ADR;TYPE=HOME:;;1 Main St;Springfield;;12345;US" in body
+        assert "PHOTO;ENCODING=b;TYPE=JPEG:/9j/4AAQSkZJRgABAQ==" in body
+        assert "X-ABLabel:custom-label" in body
+        assert "REV:20240101T000000Z" in body
+        # ...and the requested change actually landed.
+        assert "FN:Alice Updated" in body
+        assert "FN:Alice Original" not in body
+
+    async def test_caller_etag_wins_over_fetched_etag(self, mocker):
+        """The caller's etag is their concurrency assertion — honouring the
+        freshly-read one instead would defeat the check they asked for."""
+        client = _update_client(
+            mocker,
+            object_name="alice.vcf",
+            raw_vcard=self.RICH_VCARD,
+            etag='"server-etag"',
+        )
+
+        await client.update_contact(
+            addressbook="contacts",
+            uid="alice",
+            contact_data={"fn": "Alice Updated"},
+            etag='"caller-etag"',
+        )
+
+        headers = client._make_request.await_args.kwargs["headers"]
+        assert headers["If-Match"] == '"caller-etag"'
+
+    async def test_fetched_etag_used_when_caller_omits_one(self, mocker):
+        client = _update_client(
+            mocker,
+            object_name="alice.vcf",
+            raw_vcard=self.RICH_VCARD,
+            etag='"server-etag"',
+        )
+
+        await client.update_contact(
+            addressbook="contacts", uid="alice", contact_data={"fn": "Alice Updated"}
+        )
+
+        headers = client._make_request.await_args.kwargs["headers"]
+        assert headers["If-Match"] == '"server-etag"'
+
+    async def test_fetch_failure_raises_and_writes_nothing(self, mocker):
+        """Fail closed: a fetch failure must not fall back to a destructive
+        rebuild-and-replace."""
+        client = ContactsClient.__new__(ContactsClient)
+        client.username = "testuser"
+        client._principal_discovered = True
+        mocker.patch.object(
+            client,
+            "_resolve_object_name",
+            mocker.AsyncMock(return_value="alice.vcf"),
+        )
+        mocker.patch.object(
+            client,
+            "_fetch_raw_vcard",
+            mocker.AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        make_request = mocker.patch.object(client, "_make_request", mocker.AsyncMock())
+        update = client.update_contact(
+            addressbook="contacts", uid="alice", contact_data={"fn": "Alice"}
+        )
+
+        with pytest.raises(RuntimeError):
+            await update
+
+        make_request.assert_not_awaited()
+
+    async def test_merge_failure_propagates_instead_of_rebuilding(self, mocker):
+        """``_merge_vcard_properties`` used to catch everything and return a
+        four-line card; a merge failure must now surface."""
+        client = _update_client(
+            mocker, object_name="alice.vcf", raw_vcard=self.RICH_VCARD
+        )
+        mocker.patch.object(
+            client,
+            "_merge_vcard_properties",
+            mocker.Mock(side_effect=ValueError("merge blew up")),
+        )
+        update = client.update_contact(
+            addressbook="contacts", uid="alice", contact_data={"fn": "Alice"}
+        )
+
+        with pytest.raises(ValueError, match="merge blew up"):
+            await update
+
+        client._make_request.assert_not_awaited()
+
+    async def test_returns_projection_with_new_etag(self, mocker):
+        """The result carries the new ETag so updates can be chained without a
+        re-read."""
+        client = _update_client(
+            mocker, object_name="alice.vcf", raw_vcard=self.RICH_VCARD
+        )
+
+        result = await client.update_contact(
+            addressbook="contacts",
+            uid="alice",
+            contact_data={"fn": "Alice Updated"},
+        )
+
+        assert result["getetag"] == '"new-etag"'
+        assert result["vcard_id"] == "alice"
+        assert result["object_name"] == "alice.vcf"
+        assert result["contact"]["fullname"] == "Alice Updated"
+        assert "X-ABLabel:custom-label" in result["addressdata"]

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -743,6 +743,33 @@ class TestUpdatePreservesUnsupportedProperties:
 
         client._make_request.assert_not_awaited()
 
+    async def test_reparse_failure_after_write_does_not_report_failure(self, mocker):
+        """The PUT has already landed, so a projection error must not surface as a
+        failed update — that would invite a pointless, possibly destructive retry.
+
+        This is the one deliberate fail-open path in update_contact; everything
+        before the PUT fails closed.
+        """
+        client = _update_client(
+            mocker, object_name="alice.vcf", raw_vcard=self.RICH_VCARD
+        )
+        mocker.patch(
+            "nextcloud_mcp_server.client.contacts.Contact.from_vcard",
+            side_effect=ValueError("unparseable"),
+        )
+
+        result = await client.update_contact(
+            addressbook="contacts",
+            uid="alice",
+            contact_data={"fn": "Alice Updated"},
+        )
+
+        # The write stands and nothing is withheld from the caller.
+        client._make_request.assert_awaited_once()
+        assert result["getetag"] == '"new-etag"'
+        assert "FN:Alice Updated" in result["addressdata"]
+        assert result["contact"] == {}
+
     async def test_returns_projection_with_new_etag(self, mocker):
         """The result carries the new ETag so updates can be chained without a
         re-read."""


### PR DESCRIPTION
## Problem

`update_contact` fetched the existing vCard **only when the caller omitted `etag`**.
Supplying one — the concurrency-correct call — fell through to
`_build_contact_from_data(...).to_vcard()`, rebuilding the card from the ten
supported keys and silently destroying `PHOTO`, `ADR`, `N`, `X-*`, `IMPP`, `GEO`
and `REV`. The etag path was the *safe-looking* one, which is what made this easy
to miss.

`_merge_vcard_properties` had the same shape one level down: a bare
`except Exception` that returned a four-line vCard built from `fn`/`email`/`tel`,
so any merge error replaced the whole contact and still reported success.

Neither was reported by a user — both surfaced while verifying downstream fork bug
reports against this tree.

## Change

- The existing card is **always** fetched and **always** merged into.
- Both rebuild fallbacks are removed. A fetch or merge failure now raises rather
  than replacing the card with a synthesised one. A raised error is recoverable; a
  silent rebuild is not, since the data is gone and the ETag has already moved on.
- The caller's etag still wins for `If-Match` — it is their concurrency assertion,
  and honouring the freshly-read one instead would defeat the check they asked for.
- `_project_contact()` extracted as the single projection point shared by
  `list_contacts` and `update_contact`, so read-after-write cannot drift from read.
- `nc_contacts_update_contact` returns the previously-unused
  `UpdateContactResponse` instead of bare `None` (also a `CLAUDE.md` response-pattern
  gate violation on its own), carrying the new ETag so updates can be chained
  without an intervening read. A stale etag maps to a `ToolError`.

## Breaking change

Recorded via a `BREAKING CHANGE:` footer, so commitizen writes it into
`CHANGELOG.md` against the released version:

- `nc_contacts_update_contact` returns `UpdateContactResponse`, not `None`.
- It no longer rebuilds the vCard when the existing card cannot be fetched — it
  raises. A caller that relied on update creating a missing contact must call
  `nc_contacts_create_contact`.

## Test coverage

`tests/unit/client/test_contacts.py::test_update_falls_back_to_vcf_when_unresolved`
**asserted the buggy behaviour** ("supplying an etag skips the existing-vCard
fetch"), so it is rewritten rather than worked around.

New `TestUpdatePreservesUnsupportedProperties` proves `PHOTO`/`ADR`/`X-ABLabel`/`N`/`REV`
survive an etag-supplied update, that a fetch failure raises **without issuing a
PUT** (fail closed), and that a merge failure propagates instead of rebuilding.

Tiers actually executed:

- unit — ✅ 2428 passed
- smoke — ✅ 7 passed
- e2e (`tests/server/test_contacts_mcp.py`, live docker stack) — ✅ 1 passed.
  Extended to chain a second update using the ETag the first returned (no
  intervening read) and to assert a stale etag is rejected.
- **contract (Pact) — not applicable.** `tests/contract/test_mcp_provider_verification.py`
  verifies only the `/api/v1/*` surface consumed by the astrolabe app; the API
  package does not import `models/contacts.py`, and this PR touches no
  cross-service boundary. Stated explicitly rather than left silent, per `CLAUDE.md`.

## Provenance

Downstream fork `pi0n00r/nextcloud-mcp-server` reported adjacent symptoms (contact
URL preservation, CardDAV read projection). That fork declares CLA
non-participation, so **no fork code or tests were copied** — the bugs were
re-verified against this tree and the fix and tests written from scratch. Credited
as reporter, not author.

---

_This PR was generated with the help of AI, and reviewed by a Human_
