### PR TITLE
fix(auth): enforce @require_scopes at runtime

### DIFF
--- a/nextcloud_mcp_server/auth/scope_authorization.py
+++ b/nextcloud_mcp_server/auth/scope_authorization.py
@@ -408,15 +408,20 @@ def check_scopes(ctx: Context, *required_scopes: str) -> tuple[bool, set[str]]:
         ```
     """
     token_scopes = get_access_token_scopes(ctx)
+    required_scopes_set = set(required_scopes)
 
-    # No verified token at all → BasicAuth mode, where Nextcloud enforces its
-    # own ACLs. A token that merely carries no scopes is a different case and
-    # must still be checked against the requirement, so key this on the token
-    # rather than on the scope set being empty.
+    # No verified token at all. Under BasicAuth that is expected — Nextcloud
+    # enforces its own ACLs — but under OAuth it means the auth middleware never
+    # populated one, so report nothing granted rather than everything. Same
+    # fail-closed rule as require_scopes: reporting "all granted" here would
+    # reintroduce, for any future caller, exactly the bug this module was fixed
+    # for. (A token that merely carries no scopes is a different case and is
+    # still checked against the requirement below.)
     if get_access_token() is None:
+        if get_settings().enable_login_flow:
+            return False, required_scopes_set
         return True, set()
 
-    required_scopes_set = set(required_scopes)
     missing_scopes = required_scopes_set - token_scopes
 
     return len(missing_scopes) == 0, missing_scopes

--- a/nextcloud_mcp_server/auth/scope_authorization.py
+++ b/nextcloud_mcp_server/auth/scope_authorization.py
@@ -123,13 +123,27 @@ def require_scopes(*required_scopes: str):
                 )
                 return await func(*args, **kwargs)
 
-            # Check if we're in OAuth mode (access token available)
-            access_token: AccessToken | None = getattr(
-                ctx.request_context, "access_token", None
-            )
+            # Resolve the verified token from the SDK auth contextvar. It is
+            # never an attribute of RequestContext — reading it from there
+            # always yielded None, which silently disabled every check below.
+            access_token: AccessToken | None = get_access_token()
 
             if access_token is None:
-                # No OAuth token — BasicAuth mode bypasses scope checks
+                # BasicAuth deployments carry no OAuth token: there are no token
+                # scopes to check, and Nextcloud enforces its own ACLs.
+                # Under OAuth a missing token means the auth middleware never
+                # populated one, so deny instead of granting every scope.
+                if get_settings().enable_login_flow:
+                    logger.warning(
+                        "Access denied to %s: OAuth mode but no verified access "
+                        "token on this request",
+                        func_name,
+                    )
+                    raise InsufficientScopeError(
+                        list(required_scopes),
+                        f"Access denied to {func_name}: no verified access token "
+                        f"on this request.",
+                    )
                 logger.debug(
                     "No access token for %s - allowing (BasicAuth mode)", func_name
                 )
@@ -395,8 +409,11 @@ def check_scopes(ctx: Context, *required_scopes: str) -> tuple[bool, set[str]]:
     """
     token_scopes = get_access_token_scopes(ctx)
 
-    # If no access token, assume BasicAuth mode (all operations allowed)
-    if not token_scopes and getattr(ctx.request_context, "access_token", None) is None:
+    # No verified token at all → BasicAuth mode, where Nextcloud enforces its
+    # own ACLs. A token that merely carries no scopes is a different case and
+    # must still be checked against the requirement, so key this on the token
+    # rather than on the scope set being empty.
+    if get_access_token() is None:
         return True, set()
 
     required_scopes_set = set(required_scopes)

--- a/tests/server/login_flow/test_scope_authorization.py
+++ b/tests/server/login_flow/test_scope_authorization.py
@@ -2,19 +2,41 @@
 
 These tests verify:
 1. Dynamic tool filtering based on user's token scopes (using JWT tokens)
-2. Scope enforcement (403 responses for insufficient scopes)
+2. Scope enforcement on the tools/call path (stored app-password scopes)
 3. Protected Resource Metadata (PRM) endpoint (RFC 9728)
-4. WWW-Authenticate challenge headers
-5. BasicAuth bypass (all tools visible)
+4. BasicAuth bypass (all tools visible)
 
 Note: Tests use JWT OAuth tokens because scopes are embedded in the token payload,
 enabling efficient scope-based tool filtering without additional API calls.
+
+FILTERING VS ENFORCEMENT — these are separate layers and both need coverage.
+``list_tools`` filtering is advisory: it changes what a well-behaved client is
+offered, but a client can still invoke a tool it was never shown. Only
+``@require_scopes`` on the tools/call path actually denies. For a long time
+every test in this file asserted filtering alone and none called a tool, which
+is why a regression that made ``@require_scopes`` a runtime no-op went
+unnoticed. ``test_stored_scopes_enforced_on_tool_call`` closes that gap here;
+tests/unit/test_require_scopes_enforcement.py covers the decorator directly.
+
+Enforcement in login-flow mode keys on the *stored app-password* scopes, not on
+the OAuth token's scopes. Nextcloud app passwords are unscoped — they are
+all-or-nothing against the Nextcloud API — so the per-user scope set stored
+alongside the password is the only thing that can restrict a session, and it
+must hold on the call path.
+
+Not covered here: WWW-Authenticate challenge headers for step-up auth.
 """
 
+import json
 import logging
+import os
 
 import httpx
 import pytest
+from mcp.types import CallToolResult
+
+from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
+from tests.server.login_flow.conftest import LOGIN_FLOW_MCP_BASE_URL
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +129,117 @@ async def test_read_only_token_filters_write_tools(nc_mcp_login_flow_client_read
         "✅ Read-only token properly filters tools: %s read tools visible, write tools hidden",
         len(tool_names),
     )
+
+
+async def _set_stored_scopes(user_id: str, password: str, scopes: list[str]) -> None:
+    """Rewrite the caller's stored app-password scopes via the management API.
+
+    PATCH /api/v1/users/{user_id}/scopes changes only the stored scope set —
+    the app password itself is untouched and stays valid — and invalidates the
+    server's scope cache, so the next tool call sees the new set immediately.
+    That makes it the cheapest way to put a provisioned session into a
+    restricted state without driving a second browser login flow.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.patch(
+            f"{LOGIN_FLOW_MCP_BASE_URL}/api/v1/users/{user_id}/scopes",
+            json={"scopes": scopes},
+            auth=(user_id, password),
+            timeout=30.0,
+        )
+
+    assert response.status_code == 200, (
+        f"Could not set stored scopes for {user_id!r} "
+        f"(HTTP {response.status_code}): {response.text}. "
+        "A 403 'User ID mismatch' means the OIDC sub differs from the Nextcloud "
+        "UID, so the management API and @require_scopes key the app-password "
+        "record differently — that is a real bug, not a test-setup problem."
+    )
+
+
+def _tool_text(result: CallToolResult) -> str:
+    """Flatten a tool result's content blocks into one searchable string."""
+    return " ".join(
+        block.text for block in result.content if getattr(block, "text", None)
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.login_flow
+async def test_stored_scopes_enforced_on_tool_call(nc_mcp_login_flow_client):
+    """A tool call must be DENIED when the stored scopes don't cover it.
+
+    This is the property that actually protects data. Nextcloud app passwords
+    carry no scopes of their own, so once a session holds one it can reach the
+    whole Nextcloud API; the per-user scope set this server stores alongside
+    the password is the only limit, and it is enforced application-side by
+    ``@require_scopes`` on the tools/call path.
+
+    Restricting the stored scopes to notes.read and then calling a write tool
+    exercises exactly that. Asserting the read tool still succeeds afterwards
+    keeps the test honest: it proves the write was refused *for lack of scope*,
+    not because the session broke.
+    """
+    session = nc_mcp_login_flow_client
+
+    status_result = await session.call_tool("nc_auth_check_status", {})
+    status = json.loads(status_result.content[0].text)
+    assert status.get("status") == "provisioned", (
+        f"fixture session is not provisioned: {status}"
+    )
+
+    user_id = status["user_id"]
+    original_scopes = status.get("scopes")
+    password = os.getenv("NEXTCLOUD_PASSWORD")
+    assert password, "NEXTCLOUD_PASSWORD env var not set"
+
+    try:
+        await _set_stored_scopes(user_id, password, ["notes.read"])
+
+        write_result = await session.call_tool(
+            "nc_notes_create_note",
+            {
+                "title": "scope-enforcement-probe",
+                "content": "must never be created",
+                "category": "testing",
+            },
+        )
+        assert write_result.isError, (
+            "nc_notes_create_note succeeded with stored scopes ['notes.read'] — "
+            "@require_scopes is not enforcing on the tools/call path"
+        )
+        message = _tool_text(write_result)
+        assert "notes.write" in message, (
+            f"expected the missing scope to be named in the denial, got: {message}"
+        )
+
+        read_result = await session.call_tool(
+            "nc_notes_search_notes", {"query": "scope-enforcement-probe"}
+        )
+        assert not read_result.isError, (
+            "notes.read was granted but the read tool was refused: "
+            f"{_tool_text(read_result)}"
+        )
+    finally:
+        # Session-scoped fixture: other tests reuse this provisioning, so put
+        # the scope set back. Fall back to the full set rather than [], which
+        # would leave every later test denied. Never raise from here — an
+        # exception in `finally` would replace whatever the test was actually
+        # failing on.
+        try:
+            await _set_stored_scopes(
+                user_id,
+                password,
+                original_scopes
+                if isinstance(original_scopes, list) and original_scopes
+                else sorted(ALL_SUPPORTED_SCOPES),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to restore stored scopes for %s — later login_flow "
+                "tests in this session may see a restricted scope set",
+                user_id,
+            )
 
 
 @pytest.mark.integration

--- a/tests/unit/test_require_scopes_enforcement.py
+++ b/tests/unit/test_require_scopes_enforcement.py
@@ -1,0 +1,149 @@
+"""Regression tests: @require_scopes must actually deny insufficient scopes.
+
+These tests build a **real** ``RequestContext`` and populate the **real** SDK
+auth contextvar the way ``AuthContextMiddleware`` does on an authenticated
+request. That matters: the decorator previously read the token from
+``ctx.request_context.access_token``, an attribute ``RequestContext`` does not
+have, so every call took the "BasicAuth mode — allow" branch and no scope was
+ever enforced. Tests that fabricate the attribute (``SimpleNamespace(
+access_token=...)``) pass against that broken contract, which is why the gap
+survived; assert against the real mechanism instead.
+
+The pre-existing scope tests exercise ``list_tools`` filtering, which is
+advisory only — a client can call ``tools/call`` with a name it was never
+shown. These cover the enforcement path.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+
+from nextcloud_mcp_server.auth.scope_authorization import (
+    InsufficientScopeError,
+    ProvisioningRequiredError,
+    require_scopes,
+)
+
+
+def _make_ctx() -> Context:
+    """A real RequestContext — not a mock shaped like one."""
+    return Context(
+        request_context=RequestContext(
+            request_id="req-test",
+            meta=None,
+            session=None,
+            lifespan_context=None,
+        ),
+        fastmcp=None,
+    )
+
+
+@contextmanager
+def _authenticated_with(scopes: list[str]):
+    """Populate the auth contextvar exactly as AuthContextMiddleware does."""
+    token = AccessToken(
+        token="opaque-token",
+        client_id="test-client",
+        scopes=list(scopes),
+        expires_at=None,
+        resource="alice",
+    )
+    reset = auth_context_var.set(AuthenticatedUser(token))
+    try:
+        yield
+    finally:
+        auth_context_var.reset(reset)
+
+
+@contextmanager
+def _settings(*, login_flow: bool = False, offline_access: bool = False):
+    fake = SimpleNamespace(
+        enable_login_flow=login_flow,
+        enable_offline_access=offline_access,
+    )
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=fake,
+    ):
+        yield
+
+
+@require_scopes("notes.write")
+async def _write_tool(ctx: Context) -> str:  # noqa: ARG001
+    return "executed"
+
+
+@pytest.mark.unit
+async def test_request_context_has_no_access_token_attribute():
+    """Pin the SDK contract that the original bug assumed away.
+
+    If a future refactor reintroduces ``ctx.request_context.access_token`` as
+    the token source, this fails and points at why that is wrong.
+    """
+    req_ctx = RequestContext(
+        request_id="req-test", meta=None, session=None, lifespan_context=None
+    )
+    assert not hasattr(req_ctx, "access_token")
+
+
+@pytest.mark.unit
+async def test_denies_when_token_lacks_required_scope():
+    """The core regression: a token without notes.write must not run the tool."""
+    with _settings(), _authenticated_with(["openid"]):
+        with pytest.raises(InsufficientScopeError) as exc_info:
+            await _write_tool(ctx=_make_ctx())
+
+    assert "notes.write" in exc_info.value.missing_scopes
+
+
+@pytest.mark.unit
+async def test_allows_when_token_carries_required_scope():
+    with _settings(), _authenticated_with(["openid", "notes.write"]):
+        assert await _write_tool(ctx=_make_ctx()) == "executed"
+
+
+@pytest.mark.unit
+async def test_basicauth_mode_without_token_still_allowed():
+    """No OAuth token + no OAuth mode = BasicAuth; Nextcloud enforces its ACLs."""
+    with _settings(login_flow=False):
+        assert await _write_tool(ctx=_make_ctx()) == "executed"
+
+
+@pytest.mark.unit
+async def test_oauth_mode_without_token_fails_closed():
+    """A missing token under OAuth means auth middleware did not run: deny.
+
+    Inferring "BasicAuth" from a missing token is what let the original bug
+    grant every scope silently.
+    """
+    with _settings(login_flow=True):
+        with pytest.raises(InsufficientScopeError):
+            await _write_tool(ctx=_make_ctx())
+
+
+@pytest.mark.unit
+async def test_offline_access_requires_provisioning_for_nextcloud_scopes():
+    """Offline-access mode: a token with no Nextcloud scopes must be told to provision.
+
+    This branch was unreachable while the decorator read the token from
+    ``request_context``, so it ships newly-live with this fix and needs its own
+    coverage. A token holding only OIDC scopes has completed Flow 1 but not the
+    Flow 2 provisioning that grants Nextcloud resource access.
+    """
+    with _settings(offline_access=True), _authenticated_with(["openid"]):
+        with pytest.raises(ProvisioningRequiredError):
+            await _write_tool(ctx=_make_ctx())
+
+
+@pytest.mark.unit
+async def test_offline_access_allows_token_carrying_nextcloud_scopes():
+    """The same mode must let a provisioned (Flow 2) token through."""
+    with _settings(offline_access=True), _authenticated_with(["notes.write"]):
+        assert await _write_tool(ctx=_make_ctx()) == "executed"

--- a/tests/unit/test_require_scopes_enforcement.py
+++ b/tests/unit/test_require_scopes_enforcement.py
@@ -196,3 +196,18 @@ async def test_check_scopes_allows_basicauth_without_token():
 
     assert has_all is True
     assert missing == set()
+
+
+@pytest.mark.unit
+async def test_check_scopes_oauth_mode_without_token_fails_closed():
+    """Mirrors ``test_oauth_mode_without_token_fails_closed`` for check_scopes.
+
+    Without the mode gate this returned "all granted" under OAuth — the same
+    fail-open the decorator was fixed for, left latent for the first caller to
+    wire it up.
+    """
+    with _settings(login_flow=True):
+        has_all, missing = check_scopes(_make_ctx(), "notes.write")
+
+    assert has_all is False
+    assert missing == {"notes.write"}

--- a/tests/unit/test_require_scopes_enforcement.py
+++ b/tests/unit/test_require_scopes_enforcement.py
@@ -28,6 +28,7 @@ from mcp.shared.context import RequestContext
 from nextcloud_mcp_server.auth.scope_authorization import (
     InsufficientScopeError,
     ProvisioningRequiredError,
+    check_scopes,
     require_scopes,
 )
 
@@ -147,3 +148,51 @@ async def test_offline_access_allows_token_carrying_nextcloud_scopes():
     """The same mode must let a provisioned (Flow 2) token through."""
     with _settings(offline_access=True), _authenticated_with(["notes.write"]):
         assert await _write_tool(ctx=_make_ctx()) == "executed"
+
+
+# ---------------------------------------------------------------------------
+# check_scopes — the same latent bug lived here, keyed on an always-None
+# getattr. It has no call sites today, so these are its only guard.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_check_scopes_reports_missing_scope():
+    with _settings(), _authenticated_with(["notes.read"]):
+        has_all, missing = check_scopes(_make_ctx(), "notes.write")
+
+    assert has_all is False
+    assert missing == {"notes.write"}
+
+
+@pytest.mark.unit
+async def test_check_scopes_passes_when_covered():
+    with _settings(), _authenticated_with(["notes.read", "notes.write"]):
+        has_all, missing = check_scopes(_make_ctx(), "notes.write")
+
+    assert has_all is True
+    assert missing == set()
+
+
+@pytest.mark.unit
+async def test_check_scopes_denies_verified_token_carrying_no_scopes():
+    """A verified token with an empty scope set is not BasicAuth.
+
+    The old guard was ``not token_scopes and getattr(...) is None``; because the
+    getattr always returned None it collapsed to "no scopes → allow", waving
+    through a real OAuth token that legitimately carried none.
+    """
+    with _settings(), _authenticated_with([]):
+        has_all, missing = check_scopes(_make_ctx(), "notes.write")
+
+    assert has_all is False
+    assert missing == {"notes.write"}
+
+
+@pytest.mark.unit
+async def test_check_scopes_allows_basicauth_without_token():
+    with _settings():
+        has_all, missing = check_scopes(_make_ctx(), "notes.write")
+
+    assert has_all is True
+    assert missing == set()

--- a/tests/unit/test_scope_authorization_stored.py
+++ b/tests/unit/test_scope_authorization_stored.py
@@ -8,6 +8,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
 from mcp.server.fastmcp import Context
 
 from nextcloud_mcp_server.auth.scope_authorization import (
@@ -97,17 +100,35 @@ async def test_get_stored_scopes_storage_error():
         await _get_stored_scopes("alice")
 
 
-def _make_login_flow_ctx() -> MagicMock:
-    """Build a minimal Context shaped like the Login-Flow-v2 / OAuth case.
+@pytest.fixture(autouse=True)
+def authenticated_request():
+    """Populate the auth contextvar as AuthContextMiddleware does per request.
 
-    request_context.access_token must be non-None to pass the BasicAuth-mode
-    short-circuit in require_scopes; the token's actual scopes don't matter
-    because the Login-Flow-v2 branch checks stored scopes instead.
+    ``require_scopes`` reads the token from this contextvar. Fabricating a
+    ``request_context.access_token`` attribute instead (as these tests once
+    did) asserts a contract that does not exist at runtime — ``RequestContext``
+    has no such field, so the decorator silently allowed every call.
+    The token's own scopes don't matter here: the Login-Flow-v2 branch checks
+    the stored app-password scopes instead.
     """
-    ctx = MagicMock()
-    ctx.request_context = SimpleNamespace(
-        access_token=SimpleNamespace(scopes=[], token="opaque")
+    token = AccessToken(
+        token="opaque",
+        client_id="test-client",
+        scopes=[],
+        expires_at=None,
+        resource="alice",
     )
+    reset = auth_context_var.set(AuthenticatedUser(token))
+    try:
+        yield
+    finally:
+        auth_context_var.reset(reset)
+
+
+def _make_login_flow_ctx() -> MagicMock:
+    """Build a minimal Context shaped like the Login-Flow-v2 / OAuth case."""
+    ctx = MagicMock()
+    ctx.request_context = SimpleNamespace()
     ctx.elicit = AsyncMock(return_value=SimpleNamespace(action="accept", data=None))
     return ctx
 

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -7,14 +7,14 @@ Their purpose is **not** to re-test the path-matching logic (covered in
 tool actually consults ``get_excluded_file_paths`` / ``is_path_excluded``
 at the right point and raises / filters as expected.
 
-The decorators on each tool (``@require_scopes``, ``@instrument_tool``)
-are transparent under our mocked ``Context`` (no ``access_token`` set →
-BasicAuth pass-through path).
+The decorators on each tool (``@require_scopes``, ``@instrument_tool``) are
+made transparent by the ``basicauth_mode`` fixture below, which pins the
+deployment mode so these tests exercise path exclusion rather than auth.
 """
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
@@ -25,6 +25,28 @@ from nextcloud_mcp_server.models.webdav import WriteFileResponse
 from nextcloud_mcp_server.server.webdav import configure_webdav_tools
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def basicauth_mode():
+    """Pin ``require_scopes`` to the BasicAuth pass-through path.
+
+    These tests invoke tool functions directly, with no transport and so no
+    verified token. Under any OAuth-style mode the decorator now (correctly)
+    denies such a call, so the mode has to be explicit — otherwise the result
+    depends on ambient environment: ``enable_login_flow`` is derived from
+    ``MCP_DEPLOYMENT_MODE`` and defaults to **True** when no Nextcloud
+    credentials are set, so these tests passed on a developer machine with
+    ``NEXTCLOUD_USERNAME``/``PASSWORD`` exported and failed in CI without them.
+
+    Patched narrowly on the scope_authorization module so the WebDAV tools'
+    own ``get_settings()`` calls (size caps, exclusion tags) are untouched.
+    """
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=SimpleNamespace(enable_login_flow=False),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -38,11 +38,14 @@ def webdav_tools() -> dict:
 def _mock_ctx(client) -> SimpleNamespace:
     """Build a minimal Context-shaped object for the tool decorators.
 
-    Setting ``request_context.access_token = None`` causes ``require_scopes``
-    to take the BasicAuth pass-through branch (see scope_authorization.py).
+    With no auth contextvar set and OAuth mode off, ``require_scopes`` takes
+    the BasicAuth pass-through branch (see scope_authorization.py). Note the
+    token is read from the SDK ``auth_context`` contextvar, never from
+    ``request_context`` — setting an ``access_token`` attribute here would
+    have no effect on the decorator.
     """
     ctx = SimpleNamespace()
-    ctx.request_context = SimpleNamespace(access_token=None)
+    ctx.request_context = SimpleNamespace()
     ctx._client = client  # only used by tools that fetch via get_client(ctx)
     return ctx
 


### PR DESCRIPTION
## Summary

`@require_scopes` was a **runtime no-op**: it read the access token from `ctx.request_context.access_token`, but `RequestContext` is a dataclass with no such field and nothing ever sets one. The lookup always returned `None`, so every call took the *"BasicAuth mode — allow"* branch and **no scope was ever enforced on the tools/call path**. The stored app-password scope check and the offline-access provisioning gate both sit after that short-circuit, so they were dead too.

Fixed by reading the token from the SDK auth contextvar — matching `get_access_token_scopes`, `provisioning_decorator`, and the `list_tools` filter, all of which already used it correctly. `check_scopes` carried the identical bug and is fixed the same way.

Verified empirically with a real `RequestContext` and a real populated contextvar: before the fix a tool requiring `notes.write` executed with a token carrying only `openid`; after, it is denied.

## Why extensive testing never caught it

Every scope test asserted **`list_tools` filtering**, and none called a tool:

| test file | `list_tools` | `call_tool` |
|---|---:|---:|
| `test_scope_authorization.py` (integration) | 10 | **0** |
| `test_scope_decorator.py` | 0 | 0 |
| `test_scope_authorization_stored.py` | 0 | 0 |

Filtering genuinely works and is well covered — but it is **advisory**: it only changes what a well-behaved client is *offered*, and a client can invoke a tool it was never shown. The two unit tests that *did* assert denial passed because they fabricated the missing attribute (`SimpleNamespace(access_token=...)`), encoding a contract that does not exist at runtime.

## Fail-open → fail-closed

Inferring *"BasicAuth"* from a missing token is what made the failure silent — any break in token propagation degraded to granting every scope. Enforcement now keys on the resolved deployment mode: BasicAuth still passes through (Nextcloud enforces its own ACLs), while OAuth denies when no verified token is present.

## Test coverage

- **`tests/unit/test_require_scopes_enforcement.py`** (new, 7 tests) builds a **real** `RequestContext` and populates the **real** contextvar. Confirmed to **fail against the pre-fix code** (2 failures) and pass after — it genuinely catches the regression rather than agreeing with whatever ships. Includes a guard pinning that `RequestContext` has no `access_token`, so the fabricated-attribute pattern cannot quietly return, plus coverage for the offline-access branch that this fix makes reachable for the first time.
- **`tests/server/login_flow/test_scope_authorization.py`** — new `test_stored_scopes_enforced_on_tool_call` closes the call-path gap in CI. Nextcloud app passwords are unscoped, so the per-user scope set stored alongside the password is the only thing that can restrict a session; the test restricts stored scopes via `PATCH /api/v1/users/{user_id}/scopes`, asserts a write tool is refused **and** that a read tool still succeeds (proving the refusal is for lack of scope, not a broken session), then restores the scope set.
- Updated the two tests that encoded the broken contract to use the real mechanism.

Runs in the existing **`login-flow` CI lane** (`-m login_flow`) — no workflow change needed. This integration test has not been run locally (the stack needs ports held by another worktree), so CI is its first real execution; every other assumption it makes was verified statically.

## Breaking change

Recorded via a `BREAKING CHANGE:` footer, so commitizen bumps the minor version and writes the entry into `CHANGELOG.md` against the released version.

Scope enforcement now actually applies to tool calls. Sessions whose token or stored app-password scopes do not cover a tool were silently allowed and are now denied with `InsufficientScopeError`; under OAuth, a request arriving without a verified token is denied rather than treated as BasicAuth. Deployments relying on the previous permissive behaviour must grant the required scopes via `nc_auth_update_scopes` or `PATCH /api/v1/users/{user_id}/scopes`.

Not a cross-user break — Nextcloud ACLs and the login-flow app-password requirement always still applied. What was lost was the intra-user least-privilege model: a grant of `notes.read` could drive `nc_webdav_delete_resource` or `nc_share_create_public_link`.

## Verification

`ruff` ✅ · `ruff format` ✅ · `ty` ✅ · unit tests ✅ (2427 passed) · secrets scan ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_This PR was generated with the help of AI, and reviewed by a Human_