### PR TITLE
fix(contacts): preserve vCard line folding on update

### DIFF
--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -1,7 +1,6 @@
 """CardDAV client for NextCloud contacts operations."""
 
 import logging
-import re
 import xml.etree.ElementTree as ET
 from datetime import date
 from typing import Any
@@ -157,27 +156,30 @@ def _split_property_head(line: str) -> tuple[str, str]:
     return group + sep, name.upper()
 
 
-def _existing_type_param(line: str) -> str | None:
-    """Return the raw ``TYPE=`` parameter value of a logical line, or ``None``.
+def _existing_parameters(line: str) -> str:
+    """Return a logical line's parameter section verbatim, including the leading ``;``.
 
-    Parameter names are case-insensitive (RFC 6350 §3.3) just like property
-    names. A case-sensitive ``";TYPE=" in line`` test would miss
-    ``email;type=work:`` — which, now that property names match
-    case-insensitively, *is* reached by the EMAIL branch and would have its TYPE
-    parameter silently dropped on rewrite.
+    ``EMAIL;PREF=1;TYPE=work:a@b`` -> ``";PREF=1;TYPE=work"``
+    ``item1.EMAIL:a@b``            -> ``""``
 
-    The match is done with a case-insensitive regex rather than
-    ``line.upper().find(...)``: ``str.upper()`` is not length-preserving for all
-    Unicode (``"ß".upper() == "SS"``), so an index taken from the upper-cased copy
-    can be off by one or more in the original. With
-    ``EMAIL;X-LABEL=straße;TYPE=work:...`` that misalignment sliced ``"ork"``
-    instead of ``"work"``. A regex match position always refers to the original
-    string, which sidesteps it entirely.
+    Copying the whole section rather than re-deriving a single ``TYPE=`` value
+    preserves *every* parameter on a rewritten line. The previous approach
+    reconstructed the line as ``EMAIL;TYPE=<value>:``, which silently dropped any
+    other parameter — ``PREF``, ``X-ABLabel``, ``CHARSET`` — and dropped ``TYPE``
+    itself whenever it was not the parameter being matched. Verbatim copying also
+    sidesteps casing entirely: no case-insensitive search, so no dependence on
+    ``str.upper()`` being length-preserving (it isn't — ``"ß".upper() == "SS"``).
+
+    Known limitation, unchanged from the original: the value separator is taken
+    as the first ``:``, so a quoted parameter value containing a colon
+    (``TYPE="a:b"``, legal per RFC 6350 §3.3) would split early. No producer we
+    have seen emits one.
     """
-    match = re.search(r";TYPE=", line, re.IGNORECASE)
-    if match is None:
-        return None
-    return line[match.end() :].split(":")[0]
+    head, separator, _ = line.partition(":")
+    if not separator:
+        return ""
+    param_start = head.find(";")
+    return head[param_start:] if param_start != -1 else ""
 
 
 def _project_contact(contact: Contact) -> dict[str, Any]:
@@ -716,8 +718,8 @@ class ContactsClient(BaseNextcloudClient):
         ``fn:`` comes back as ``FN:``. Property names are case-insensitive per
         RFC 6350 §3.3 so this is semantically identical, but it is a visible
         formatting change and the only place the "preserve exact formatting"
-        intent above does not hold literally. Group prefixes and ``TYPE``
-        parameters are preserved as written.
+        intent above does not hold literally. Group prefixes and the whole
+        parameter section are copied verbatim.
 
         Raises on any merge failure rather than substituting a synthesised card.
         This function previously caught every exception and returned a four-line
@@ -778,13 +780,10 @@ class ContactsClient(BaseNextcloudClient):
                     if isinstance(contact_data["email"], str):
                         email_value = _safe_vcard_value(contact_data["email"])
                         # Try to preserve the original format as much as possible
-                        type_part = _existing_type_param(line)
-                        if type_part is not None:
-                            updated_lines.append(
-                                f"{group_prefix}EMAIL;TYPE={type_part}:{email_value}"
-                            )
-                        else:
-                            updated_lines.append(f"{group_prefix}EMAIL:{email_value}")
+                        params = _existing_parameters(line)
+                        updated_lines.append(
+                            f"{group_prefix}EMAIL{params}:{email_value}"
+                        )
                         updated_properties.add("email")
                     else:
                         # Dict / list inputs aren't translatable to a single
@@ -799,13 +798,8 @@ class ContactsClient(BaseNextcloudClient):
                 if "tel" not in updated_properties:
                     if isinstance(contact_data["tel"], str):
                         tel_value = _safe_vcard_value(contact_data["tel"])
-                        type_part = _existing_type_param(line)
-                        if type_part is not None:
-                            updated_lines.append(
-                                f"{group_prefix}TEL;TYPE={type_part}:{tel_value}"
-                            )
-                        else:
-                            updated_lines.append(f"{group_prefix}TEL:{tel_value}")
+                        params = _existing_parameters(line)
+                        updated_lines.append(f"{group_prefix}TEL{params}:{tel_value}")
                         updated_properties.add("tel")
                     else:
                         # Same reasoning as the EMAIL branch above: don't drop.

--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -156,6 +156,23 @@ def _split_property_head(line: str) -> tuple[str, str]:
     return group + sep, name.upper()
 
 
+def _existing_type_param(line: str) -> str | None:
+    """Return the raw ``TYPE=`` parameter value of a logical line, or ``None``.
+
+    Parameter names are case-insensitive (RFC 6350 §3.3) just like property
+    names, so the lookup runs on an upper-cased copy while the value is sliced
+    from the original to preserve its casing. A case-sensitive ``";TYPE=" in
+    line`` test would miss ``email;type=work:`` — which, now that property names
+    match case-insensitively, *is* reached by the EMAIL branch and would have its
+    TYPE parameter silently dropped on rewrite.
+    """
+    marker = ";TYPE="
+    index = line.upper().find(marker)
+    if index == -1:
+        return None
+    return line[index + len(marker) :].split(":")[0]
+
+
 def _project_contact(contact: Contact) -> dict[str, Any]:
     """Project a parsed vCard into the flat dict the server layer maps to a model.
 
@@ -687,6 +704,14 @@ class ContactsClient(BaseNextcloudClient):
         to update EMAIL/TEL here, or recreate via ``create_contact`` for full
         multi-entry support with TYPE annotations.
 
+        Unrecognised properties are copied through verbatim, but a property this
+        method *rewrites* is re-emitted with its name upper-cased — a lower-cased
+        ``fn:`` comes back as ``FN:``. Property names are case-insensitive per
+        RFC 6350 §3.3 so this is semantically identical, but it is a visible
+        formatting change and the only place the "preserve exact formatting"
+        intent above does not hold literally. Group prefixes and ``TYPE``
+        parameters are preserved as written.
+
         Raises on any merge failure rather than substituting a synthesised card.
         This function previously caught every exception and returned a four-line
         vCard built from ``fn``/``email``/``tel``, which silently destroyed PHOTO,
@@ -746,8 +771,8 @@ class ContactsClient(BaseNextcloudClient):
                     if isinstance(contact_data["email"], str):
                         email_value = _safe_vcard_value(contact_data["email"])
                         # Try to preserve the original format as much as possible
-                        if ";TYPE=" in line:
-                            type_part = line.split(";TYPE=")[1].split(":")[0]
+                        type_part = _existing_type_param(line)
+                        if type_part is not None:
                             updated_lines.append(
                                 f"{group_prefix}EMAIL;TYPE={type_part}:{email_value}"
                             )
@@ -767,8 +792,8 @@ class ContactsClient(BaseNextcloudClient):
                 if "tel" not in updated_properties:
                     if isinstance(contact_data["tel"], str):
                         tel_value = _safe_vcard_value(contact_data["tel"])
-                        if ";TYPE=" in line:
-                            type_part = line.split(";TYPE=")[1].split(":")[0]
+                        type_part = _existing_type_param(line)
+                        if type_part is not None:
                             updated_lines.append(
                                 f"{group_prefix}TEL;TYPE={type_part}:{tel_value}"
                             )

--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -1,6 +1,7 @@
 """CardDAV client for NextCloud contacts operations."""
 
 import logging
+import re
 import xml.etree.ElementTree as ET
 from datetime import date
 from typing import Any
@@ -160,17 +161,23 @@ def _existing_type_param(line: str) -> str | None:
     """Return the raw ``TYPE=`` parameter value of a logical line, or ``None``.
 
     Parameter names are case-insensitive (RFC 6350 §3.3) just like property
-    names, so the lookup runs on an upper-cased copy while the value is sliced
-    from the original to preserve its casing. A case-sensitive ``";TYPE=" in
-    line`` test would miss ``email;type=work:`` — which, now that property names
-    match case-insensitively, *is* reached by the EMAIL branch and would have its
-    TYPE parameter silently dropped on rewrite.
+    names. A case-sensitive ``";TYPE=" in line`` test would miss
+    ``email;type=work:`` — which, now that property names match
+    case-insensitively, *is* reached by the EMAIL branch and would have its TYPE
+    parameter silently dropped on rewrite.
+
+    The match is done with a case-insensitive regex rather than
+    ``line.upper().find(...)``: ``str.upper()`` is not length-preserving for all
+    Unicode (``"ß".upper() == "SS"``), so an index taken from the upper-cased copy
+    can be off by one or more in the original. With
+    ``EMAIL;X-LABEL=straße;TYPE=work:...`` that misalignment sliced ``"ork"``
+    instead of ``"work"``. A regex match position always refers to the original
+    string, which sidesteps it entirely.
     """
-    marker = ";TYPE="
-    index = line.upper().find(marker)
-    if index == -1:
+    match = re.search(r";TYPE=", line, re.IGNORECASE)
+    if match is None:
         return None
-    return line[index + len(marker) :].split(":")[0]
+    return line[match.end() :].split(":")[0]
 
 
 def _project_contact(contact: Contact) -> dict[str, Any]:

--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as ET
 from datetime import date
 from typing import Any
 
-from pythonvCard4.vcard import Contact
+from pythonvCard4.vcard import Contact, fold_line, unfold_lines
 
 from .base import BaseNextcloudClient
 
@@ -135,6 +135,25 @@ def _first_custom(custom: dict[str, str | list[str]], key: str) -> str | None:
     if isinstance(values, str):
         return values or None
     return None
+
+
+def _split_property_head(line: str) -> tuple[str, str]:
+    """Split a logical vCard line into its group prefix and upper-cased name.
+
+    ``FN:Alice``                   -> ``("", "FN")``
+    ``email;TYPE=WORK:a@b``        -> ``("", "EMAIL")``
+    ``item1.URL:https://x``        -> ``("item1.", "URL")``
+
+    Property names are case-insensitive per RFC 6350 §3.3, and Apple-produced
+    cards group related properties (``item1.URL`` + ``item1.X-ABLabel``). Matching
+    on the raw text missed both shapes, so a lower-cased ``fn:`` or a grouped
+    ``item1.EMAIL:`` was treated as unknown — preserved verbatim *and* then
+    duplicated by the add-new loop. The group prefix is returned so a rewritten
+    line can keep it and stay attached to its ``X-ABLabel``.
+    """
+    head = line.split(":", 1)[0].split(";", 1)[0]
+    group, sep, name = head.rpartition(".")
+    return group + sep, name.upper()
 
 
 def _project_contact(contact: Contact) -> dict[str, Any]:
@@ -690,29 +709,36 @@ class ContactsClient(BaseNextcloudClient):
                     _key.upper(),
                 )
         # Instead of using pythonvCard4 which has formatting issues,
-        # let's do a simple text-based merge to preserve exact formatting
-
-        # Start with the original vCard
-        lines = raw_vcard.strip().split("\n")
+        # let's do a simple text-based merge to preserve exact formatting.
+        #
+        # Unfold first: RFC 6350 §3.2 continuation lines start with a single
+        # space/tab and belong to the property above them. The previous code
+        # split on "\n" and ``.strip()``ed each physical line, which stripped that
+        # leading space and re-emitted the continuation as a standalone property —
+        # corrupting every long NOTE/ADR and every base64 PHOTO on any update.
+        # ``splitlines()`` also handles CRLF, which ``split("\n")`` left as a
+        # trailing "\r" on every line.
+        lines = unfold_lines(raw_vcard.strip().splitlines())
         updated_lines = []
 
         # Track what we've updated to avoid duplicates
         updated_properties = set()
 
         for line in lines:
-            line = line.strip()
-            if not line:
+            if not line.strip():
                 continue
+
+            group_prefix, property_name = _split_property_head(line)
 
             # Skip the END:VCARD line for now
-            if line == "END:VCARD":
+            if property_name == "END":
                 continue
-
-            property_name = line.split(":")[0].split(";")[0]
 
             # Handle updates for specific properties
             if property_name == "FN" and "fn" in contact_data:
-                updated_lines.append(f"FN:{_safe_vcard_value(contact_data['fn'])}")
+                updated_lines.append(
+                    f"{group_prefix}FN:{_safe_vcard_value(contact_data['fn'])}"
+                )
                 updated_properties.add("fn")
             elif property_name == "EMAIL" and "email" in contact_data:
                 # Replace first email with new one, preserve others
@@ -723,10 +749,10 @@ class ContactsClient(BaseNextcloudClient):
                         if ";TYPE=" in line:
                             type_part = line.split(";TYPE=")[1].split(":")[0]
                             updated_lines.append(
-                                f"EMAIL;TYPE={type_part}:{email_value}"
+                                f"{group_prefix}EMAIL;TYPE={type_part}:{email_value}"
                             )
                         else:
-                            updated_lines.append(f"EMAIL:{email_value}")
+                            updated_lines.append(f"{group_prefix}EMAIL:{email_value}")
                         updated_properties.add("email")
                     else:
                         # Dict / list inputs aren't translatable to a single
@@ -743,9 +769,11 @@ class ContactsClient(BaseNextcloudClient):
                         tel_value = _safe_vcard_value(contact_data["tel"])
                         if ";TYPE=" in line:
                             type_part = line.split(";TYPE=")[1].split(":")[0]
-                            updated_lines.append(f"TEL;TYPE={type_part}:{tel_value}")
+                            updated_lines.append(
+                                f"{group_prefix}TEL;TYPE={type_part}:{tel_value}"
+                            )
                         else:
-                            updated_lines.append(f"TEL:{tel_value}")
+                            updated_lines.append(f"{group_prefix}TEL:{tel_value}")
                         updated_properties.add("tel")
                     else:
                         # Same reasoning as the EMAIL branch above: don't drop.
@@ -754,18 +782,24 @@ class ContactsClient(BaseNextcloudClient):
                     # Keep additional phone numbers unchanged
                     updated_lines.append(line)
             elif property_name == "NOTE" and "note" in contact_data:
-                updated_lines.append(f"NOTE:{_safe_vcard_value(contact_data['note'])}")
+                updated_lines.append(
+                    f"{group_prefix}NOTE:{_safe_vcard_value(contact_data['note'])}"
+                )
                 updated_properties.add("note")
             elif property_name == "NICKNAME" and "nickname" in contact_data:
                 nickname_value = contact_data["nickname"]
                 if isinstance(nickname_value, list):
                     nickname_value = ",".join(nickname_value)
-                updated_lines.append(f"NICKNAME:{_safe_vcard_value(nickname_value)}")
+                updated_lines.append(
+                    f"{group_prefix}NICKNAME:{_safe_vcard_value(nickname_value)}"
+                )
                 updated_properties.add("nickname")
             elif property_name == "BDAY" and "bday" in contact_data:
                 parsed_bday = _parse_bday(contact_data["bday"])
                 if parsed_bday is not None:
-                    updated_lines.append(f"BDAY:{parsed_bday.isoformat()}")
+                    updated_lines.append(
+                        f"{group_prefix}BDAY:{parsed_bday.isoformat()}"
+                    )
                     updated_properties.add("bday")
                 else:
                     # Invalid input — keep the existing BDAY rather than
@@ -776,7 +810,7 @@ class ContactsClient(BaseNextcloudClient):
                 if isinstance(categories_value, list):
                     categories_value = ",".join(categories_value)
                 updated_lines.append(
-                    f"CATEGORIES:{_safe_vcard_value(categories_value)}"
+                    f"{group_prefix}CATEGORIES:{_safe_vcard_value(categories_value)}"
                 )
                 updated_properties.add("categories")
             elif property_name == "ORG" and "org" in contact_data:
@@ -786,11 +820,13 @@ class ContactsClient(BaseNextcloudClient):
                 # ``_build_contact_from_data`` accepts don't get a Python repr.
                 if isinstance(org_value, list):
                     org_value = ";".join(org_value)
-                updated_lines.append(f"ORG:{_safe_vcard_value(org_value)}")
+                updated_lines.append(
+                    f"{group_prefix}ORG:{_safe_vcard_value(org_value)}"
+                )
                 updated_properties.add("org")
             elif property_name == "TITLE" and "title" in contact_data:
                 updated_lines.append(
-                    f"TITLE:{_safe_vcard_value(contact_data['title'])}"
+                    f"{group_prefix}TITLE:{_safe_vcard_value(contact_data['title'])}"
                 )
                 updated_properties.add("title")
             elif property_name == "URL" and "url" in contact_data:
@@ -802,7 +838,9 @@ class ContactsClient(BaseNextcloudClient):
                     if isinstance(url_value, list):
                         url_value = url_value[0] if url_value else ""
                     if url_value:
-                        updated_lines.append(f"URL:{_safe_vcard_value(url_value)}")
+                        updated_lines.append(
+                            f"{group_prefix}URL:{_safe_vcard_value(url_value)}"
+                        )
                     updated_properties.add("url")
                 else:
                     # Keep additional URLs unchanged
@@ -856,5 +894,13 @@ class ContactsClient(BaseNextcloudClient):
         # Add the END:VCARD line
         updated_lines.append("END:VCARD")
 
-        # Join all lines
-        return "\n".join(updated_lines)
+        # Re-fold on the way out and join with CRLF, so an updated card is framed
+        # exactly like a created one (``Contact.to_vcard()``) instead of the LF
+        # this used to emit. Caveat: ``fold_line`` counts characters, not octets,
+        # so a multibyte line can exceed RFC 6350's 75-octet target — it never
+        # splits a codepoint, Sabre accepts it, and using the library helper keeps
+        # create and update on one folding rule rather than inventing a second.
+        physical_lines: list[str] = []
+        for logical_line in updated_lines:
+            physical_lines.extend(fold_line(logical_line))
+        return "\r\n".join(physical_lines) + "\r\n"

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -788,3 +788,126 @@ class TestUpdatePreservesUnsupportedProperties:
         assert result["object_name"] == "alice.vcf"
         assert result["contact"]["fullname"] == "Alice Updated"
         assert "X-ABLabel:custom-label" in result["addressdata"]
+
+
+class TestVcardLineFolding:
+    """RFC 6350 §3.2 line folding must survive the text merge.
+
+    The merge split on ``"\\n"`` and ``.strip()``ed every physical line, so a
+    continuation line (which begins with a single space) lost that space and was
+    re-emitted as a standalone property — corrupting every long NOTE/ADR and every
+    base64 PHOTO on any update. Output was also LF-joined, so a CRLF card silently
+    changed framing on every write.
+    """
+
+    @staticmethod
+    def _merge(raw: str, data: dict) -> str:
+        from nextcloud_mcp_server.client.contacts import ContactsClient
+
+        client = ContactsClient.__new__(ContactsClient)
+        return client._merge_vcard_properties(raw, data)
+
+    @staticmethod
+    def _value_of(vcard: str, prop: str) -> str:
+        """Return the unfolded value of ``prop`` from a serialised vCard."""
+        from pythonvCard4.vcard import unfold_lines
+
+        for line in unfold_lines(vcard.splitlines()):
+            head, _, value = line.partition(":")
+            if head.split(";")[0].upper() == prop:
+                return value
+        raise AssertionError(f"{prop} not found in {vcard!r}")
+
+    def test_folded_note_survives_unrelated_update(self):
+        """A folded NOTE must round-trip to the same logical value."""
+        note = "A" * 60 + "B" * 60 + "C" * 60
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:fold-test\r\n"
+            "FN:Alice\r\n"
+            f"NOTE:{note[:60]}\r\n {note[60:120]}\r\n {note[120:]}\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"fn": "Alice Updated"})
+        assert self._value_of(result, "NOTE") == note
+
+    def test_folded_base64_photo_survives_byte_for_byte(self):
+        """The canonical corruption case: PHOTO is always folded on real cards."""
+        photo = "/9j/4AAQSkZJRgABAQEAYABgAAD" * 8
+        folded = "\r\n ".join(photo[i : i + 60] for i in range(0, len(photo), 60))
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:fold-test\r\n"
+            "FN:Alice\r\n"
+            f"PHOTO;ENCODING=b;TYPE=JPEG:{folded}\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"fn": "Alice Updated"})
+        assert self._value_of(result, "PHOTO") == photo
+
+    def test_output_is_crlf_framed(self):
+        """Update must frame like create (``Contact.to_vcard()``), not LF."""
+        raw = "BEGIN:VCARD\r\nVERSION:3.0\r\nUID:x\r\nFN:Alice\r\nEND:VCARD\r\n"
+        result = self._merge(raw, {"fn": "Alice Updated"})
+        assert result.endswith("END:VCARD\r\n")
+        # No bare LF anywhere: every \n is preceded by \r.
+        assert "\n" in result
+        assert result.replace("\r\n", "").count("\n") == 0
+
+    def test_lf_input_still_parses(self):
+        """Cards from clients that emit bare LF must not break."""
+        raw = "BEGIN:VCARD\nVERSION:3.0\nUID:x\nFN:Alice\nNOTE:hi\nEND:VCARD\n"
+        result = self._merge(raw, {"fn": "Alice Updated"})
+        assert self._value_of(result, "FN") == "Alice Updated"
+        assert self._value_of(result, "NOTE") == "hi"
+
+    def test_long_updated_value_is_refolded(self):
+        """A newly written long value must be folded, and unfold to the input."""
+        long_note = "x" * 300
+        raw = "BEGIN:VCARD\r\nVERSION:3.0\r\nUID:x\r\nFN:Alice\r\nEND:VCARD\r\n"
+        result = self._merge(raw, {"note": long_note})
+        # Folded: at least one continuation line starting with a single space.
+        assert any(line.startswith(" ") for line in result.split("\r\n"))
+        # No physical line exceeds the 75-char target.
+        assert all(len(line) <= 75 for line in result.split("\r\n"))
+        assert self._value_of(result, "NOTE") == long_note
+
+    def test_lowercase_property_is_updated_not_duplicated(self):
+        """Property names are case-insensitive (RFC 6350 §3.3)."""
+        raw = "BEGIN:VCARD\r\nVERSION:3.0\r\nUID:x\r\nfn:Alice\r\nEND:VCARD\r\n"
+        result = self._merge(raw, {"fn": "Alice Updated"})
+        fn_lines = [
+            line
+            for line in result.split("\r\n")
+            if line.split(":")[0].split(";")[0].upper() == "FN"
+        ]
+        assert len(fn_lines) == 1
+        assert self._value_of(result, "FN") == "Alice Updated"
+
+    def test_grouped_property_is_updated_in_place_keeping_its_group(self):
+        """Apple cards group related properties (``item1.URL`` + ``item1.X-ABLabel``).
+
+        The grouped line was previously unmatched, so it was preserved *and* a
+        duplicate ungrouped line was appended. It must be updated in place, and
+        keep its group so the X-ABLabel stays attached.
+        """
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:x\r\n"
+            "FN:Alice\r\n"
+            "item1.URL:https://old.example.com\r\n"
+            "item1.X-ABLabel:homepage\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"url": "https://new.example.com"})
+        url_lines = [
+            line
+            for line in result.split("\r\n")
+            if line.split(":")[0].split(";")[0].rpartition(".")[2].upper() == "URL"
+        ]
+        assert len(url_lines) == 1
+        assert url_lines[0] == "item1.URL:https://new.example.com"
+        assert "item1.X-ABLabel:homepage" in result

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -907,8 +907,10 @@ class TestVcardLineFolding:
         )
         result = self._merge(raw, {"email": "new@example.com", "tel": "555-1111"})
 
-        assert "EMAIL;TYPE=work:new@example.com" in result
-        assert "TEL;TYPE=cell:555-1111" in result
+        # Parameters are copied verbatim, so the original lower-case ``type=``
+        # survives rather than being normalised to ``TYPE=``.
+        assert "EMAIL;type=work:new@example.com" in result
+        assert "TEL;type=cell:555-1111" in result
         assert "old@example.com" not in result
         assert "555-0000" not in result
 
@@ -926,25 +928,27 @@ class TestVcardLineFolding:
 
         assert "EMAIL;TYPE=WORK:new@example.com" in result
 
-    def test_type_param_survives_length_expanding_uppercase(self):
-        """Regression: str.upper() is not length-preserving for all Unicode.
+    def test_all_parameters_survive_rewrite(self):
+        """Every parameter on a rewritten line is preserved, not just TYPE.
 
-        With ``EMAIL;X-LABEL=straße;TYPE=work:...`` the 'ß' expands to 'SS' under
-        upper(), so an index taken from the upper-cased copy pointed one character
-        too far into the original and sliced 'ork' instead of 'work'. The regex
-        match position always refers to the original string.
+        Two bugs converged here. The line was reconstructed as
+        ``EMAIL;TYPE=<value>:``, so any *other* parameter (``PREF``, ``X-LABEL``)
+        was silently dropped. And the TYPE value itself was located by index into
+        ``line.upper()``, which is not length-preserving for all Unicode — the
+        'ß' below expands to 'SS' and shifted the slice to 'ork' instead of
+        'work'. Copying the parameter section verbatim fixes both at once.
         """
         raw = (
             "BEGIN:VCARD\r\n"
             "VERSION:3.0\r\n"
             "UID:x\r\n"
             "FN:Alice\r\n"
-            "EMAIL;X-LABEL=stra\u00dfe;TYPE=work:old@example.com\r\n"
+            "EMAIL;PREF=1;X-LABEL=stra\u00dfe;TYPE=work:old@example.com\r\n"
             "END:VCARD\r\n"
         )
         result = self._merge(raw, {"email": "new@example.com"})
 
-        assert "EMAIL;TYPE=work:new@example.com" in result
+        assert "EMAIL;PREF=1;X-LABEL=stra\u00dfe;TYPE=work:new@example.com" in result
         assert "TYPE=ork" not in result
 
     def test_grouped_and_lowercase_property_combined(self):
@@ -961,7 +965,7 @@ class TestVcardLineFolding:
         )
         result = self._merge(raw, {"email": "new@example.com"})
 
-        assert "item1.EMAIL;TYPE=work:new@example.com" in result
+        assert "item1.EMAIL;type=work:new@example.com" in result
         assert "item1.X-ABLabel:work email" in result
         assert "old@example.com" not in result
 

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -926,6 +926,45 @@ class TestVcardLineFolding:
 
         assert "EMAIL;TYPE=WORK:new@example.com" in result
 
+    def test_type_param_survives_length_expanding_uppercase(self):
+        """Regression: str.upper() is not length-preserving for all Unicode.
+
+        With ``EMAIL;X-LABEL=straße;TYPE=work:...`` the 'ß' expands to 'SS' under
+        upper(), so an index taken from the upper-cased copy pointed one character
+        too far into the original and sliced 'ork' instead of 'work'. The regex
+        match position always refers to the original string.
+        """
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:x\r\n"
+            "FN:Alice\r\n"
+            "EMAIL;X-LABEL=stra\u00dfe;TYPE=work:old@example.com\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"email": "new@example.com"})
+
+        assert "EMAIL;TYPE=work:new@example.com" in result
+        assert "TYPE=ork" not in result
+
+    def test_grouped_and_lowercase_property_combined(self):
+        """The two behaviours are proven independently; this guards their
+        interaction (round-2 reviewer suggestion)."""
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:x\r\n"
+            "FN:Alice\r\n"
+            "item1.email;type=work:old@example.com\r\n"
+            "item1.X-ABLabel:work email\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"email": "new@example.com"})
+
+        assert "item1.EMAIL;TYPE=work:new@example.com" in result
+        assert "item1.X-ABLabel:work email" in result
+        assert "old@example.com" not in result
+
     def test_grouped_property_is_updated_in_place_keeping_its_group(self):
         """Apple cards group related properties (``item1.URL`` + ``item1.X-ABLabel``).
 

--- a/tests/unit/client/test_contacts.py
+++ b/tests/unit/client/test_contacts.py
@@ -886,6 +886,46 @@ class TestVcardLineFolding:
         assert len(fn_lines) == 1
         assert self._value_of(result, "FN") == "Alice Updated"
 
+    def test_lowercase_type_param_is_preserved_on_rewrite(self):
+        """Regression for the case-insensitivity half-fix.
+
+        Once ``_split_property_head`` matched property names case-insensitively,
+        a ``email;type=work:`` line started being picked up by the EMAIL update
+        branch — but the ``TYPE=`` lookup was still a case-sensitive substring
+        test, so the parameter was silently dropped on rewrite. Before the
+        name-matching change the line wasn't matched at all and the parameter
+        survived by accident, so this was a real regression.
+        """
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:x\r\n"
+            "FN:Alice\r\n"
+            "email;type=work:old@example.com\r\n"
+            "tel;type=cell:555-0000\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"email": "new@example.com", "tel": "555-1111"})
+
+        assert "EMAIL;TYPE=work:new@example.com" in result
+        assert "TEL;TYPE=cell:555-1111" in result
+        assert "old@example.com" not in result
+        assert "555-0000" not in result
+
+    def test_uppercase_type_param_still_preserved(self):
+        """The pre-existing uppercase path must keep working."""
+        raw = (
+            "BEGIN:VCARD\r\n"
+            "VERSION:3.0\r\n"
+            "UID:x\r\n"
+            "FN:Alice\r\n"
+            "EMAIL;TYPE=WORK:old@example.com\r\n"
+            "END:VCARD\r\n"
+        )
+        result = self._merge(raw, {"email": "new@example.com"})
+
+        assert "EMAIL;TYPE=WORK:new@example.com" in result
+
     def test_grouped_property_is_updated_in_place_keeping_its_group(self):
         """Apple cards group related properties (``item1.URL`` + ``item1.X-ABLabel``).
 


### PR DESCRIPTION
> Stacked on #1149 — base is `fix/contacts-vcard-rebuild-data-loss`, so this diff shows only the folding work. Retarget to `master` once #1149 merges.

## Problem

`_merge_vcard_properties` split the card on `"\n"` and `.strip()`ed every physical
line. RFC 6350 §3.2 continuation lines begin with a single space and belong to the
property above them — stripping that space re-emitted each continuation as a
**standalone property**, corrupting every long `NOTE`/`ADR` and every base64
`PHOTO` on any update. Real Nextcloud cards carrying a photo are always folded, so
this fired routinely rather than in some edge case.

Output was LF-joined, so a CRLF card silently changed framing on every write and
stopped matching what `Contact.to_vcard()` emits on create.

Separately, property-name matching was raw text: a lower-cased `fn:` or an
Apple-style `item1.EMAIL:` was treated as unknown — preserved verbatim **and** then
duplicated by the add-new loop.

## Change

- Unfold with `unfold_lines` before merging, re-fold with `fold_line` on the way
  out — both already in `pythonvCard4.vcard` and already used by
  `Contact.from_vcard`, so no second hand-rolled folding rule.
- `splitlines()` replaces `split("\n")`, so CRLF input no longer leaves a trailing
  `\r` on every line. Output is CRLF-framed to match the create path.
- New `_split_property_head()` upper-cases the property name (case-insensitive per
  RFC 6350 §3.3) and separates any group prefix. Rewritten lines **keep** their
  group, so a grouped property stays attached to its `X-ABLabel` instead of being
  orphaned.

### Documented caveat

`fold_line` counts characters, not octets, so a multibyte line can exceed RFC
6350's 75-octet target. It never splits a codepoint, Sabre accepts it, and using
the library helper keeps create and update on one rule rather than inventing a
second. Noted in a comment at the call site.

## Test coverage

Assertions are on **round-tripped values, not line shapes** — the point is that
the logical value survives, not that the bytes fold identically:

- a folded `NOTE` and a folded base64 `PHOTO` come back byte-identical
- output is CRLF-framed and ends `END:VCARD\r\n`
- bare-LF input still parses
- a long *new* value is re-folded and no physical line exceeds 75 chars
- lower-cased `fn:` updates once, not duplicated
- `item1.URL:` updates in place, keeps its group, and `item1.X-ABLabel` survives

Tiers executed locally: unit ✅ 2435 passed. **Integration/e2e runs in CI** on this
PR rather than locally.

**Contract (Pact): not applicable** — `tests/contract/test_mcp_provider_verification.py`
covers only the `/api/v1/*` surface, which does not import `models/contacts.py`.
No cross-service boundary is touched. Stated explicitly rather than left silent,
per `CLAUDE.md`.

## Provenance

No downstream-fork code or tests were copied. `pi0n00r/nextcloud-mcp-server`
declares CLA non-participation; its reports were used as bug reports only, and this
fix and its tests were written from scratch.

---

_This PR was generated with the help of AI, and reviewed by a Human_
