### PR TITLE
feat(contacts): surface addresses, name parts and X-* extensions

### DIFF
--- a/nextcloud_mcp_server/client/contacts.py
+++ b/nextcloud_mcp_server/client/contacts.py
@@ -182,6 +182,23 @@ def _existing_parameters(line: str) -> str:
     return head[param_start:] if param_start != -1 else ""
 
 
+# Properties pythonvCard4 stashes in ``Contact.custom`` that the projection
+# already surfaces under their own key. Everything else in ``custom`` is a
+# genuine extension (``X-*``) and is passed through. PHOTO is excluded
+# deliberately: it is already returned as ``photo``, and re-emitting a base64
+# image per contact would roughly double every list_contacts response.
+_CUSTOM_KEYS_ALREADY_SURFACED = frozenset({"FN", "N", "ORG", "TITLE", "PHOTO"})
+
+
+def _custom_extras(custom: dict[str, str | list[str]]) -> dict[str, str | list[str]]:
+    """Return the ``X-*`` extensions from ``Contact.custom``, minus duplicates."""
+    return {
+        key: value
+        for key, value in custom.items()
+        if key.upper() not in _CUSTOM_KEYS_ALREADY_SURFACED
+    }
+
+
 def _project_contact(contact: Contact) -> dict[str, Any]:
     """Project a parsed vCard into the flat dict the server layer maps to a model.
 
@@ -208,6 +225,12 @@ def _project_contact(contact: Contact) -> dict[str, Any]:
         "url": contact.url,
         "categories": contact.categories,
         "photo": contact.photo_data or _first_custom(contact.custom, "PHOTO"),
+        # ADR and N are parsed by the library but were never projected, so the
+        # model's ``addresses`` list was declared and permanently empty and
+        # ``given_name``/``family_name`` were never populated.
+        "adr": contact.adr,
+        "n": contact.n,
+        "custom": _custom_extras(contact.custom),
     }
 
 
@@ -663,13 +686,31 @@ class ContactsClient(BaseNextcloudClient):
                 logger.info("Skip missing addressdata")
                 continue
 
+            # Isolate the parse per contact. pythonvCard4 raises on shapes real
+            # servers store — e.g. a vCard 3.0 ``GEO:lat,lon`` (RFC 2426 uses a
+            # comma; the library splits on ";"). Unguarded, one such contact made
+            # the entire addressbook unlistable. Degrade to the raw card instead:
+            # ``addressdata`` still carries everything, so the caller loses the
+            # parsed convenience fields for that one contact, not the listing.
+            try:
+                contact_projection = _project_contact(Contact.from_vcard(addressdata))
+            except Exception:
+                logger.warning(
+                    "Could not parse vCard for %s in addressbook %s; returning it "
+                    "with raw addressdata only",
+                    object_name,
+                    addressbook,
+                    exc_info=True,
+                )
+                contact_projection = {}
+
             contacts.append(
                 {
                     "vcard_id": vcard_id,
                     "object_path": object_path,
                     "object_name": object_name,
                     "getetag": getetag,
-                    "contact": _project_contact(Contact.from_vcard(addressdata)),
+                    "contact": contact_projection,
                     "addressdata": addressdata,
                 }
             )

--- a/nextcloud_mcp_server/models/contacts.py
+++ b/nextcloud_mcp_server/models/contacts.py
@@ -28,6 +28,15 @@ class ContactField(BaseModel):
     preferred: bool = Field(
         default=False, description="Whether this is the preferred field of this type"
     )
+    components: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Structured components, populated for addresses only. The seven ADR "
+            "components in RFC 6350 §6.3.1 order: PO box, extended address, "
+            "street, locality, region, postal code, country. None for every other "
+            "field type."
+        ),
+    )
 
 
 class Contact(BaseModel):

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -65,49 +65,126 @@ def _parse_vcard_fields(
     return fields
 
 
-def _raw_contact_to_model(raw: dict) -> Contact:
-    """Convert a raw contact dict from the contacts client to a Contact model.
+def _parse_address_fields(raw_values: dict | list | None) -> list[ContactField]:
+    """Parse pythonvCard4's ADR shape into ContactField entries.
 
-    Maps fullname, nickname, birthday, email, tel, org, title, note, url,
-    categories, and photo fields. Email/tel values may be plain strings, dicts
-    with ``value``/``type`` keys, or lists of either – see
-    :func:`_parse_vcard_fields`.
+    The library yields ``[{'value': [7 components], 'type': ['HOME', 'PREF']}]``
+    — verified to be a list even for a single ADR. A bare dict is normalised
+    anyway so this stays symmetric with :func:`_parse_vcard_fields`, which
+    handles the same polymorphism for EMAIL/TEL; relying on the list shape alone
+    would fail silently (iterating a dict yields its keys, each skipped by the
+    isinstance check) if the library ever changed.
+
+    ``value`` is joined with ';' for a flat display string while ``components``
+    keeps the structured form, so a consumer isn't forced to re-split it.
     """
-    contact_info = raw.get("contact", {})
+    if not raw_values:
+        return []
+    if isinstance(raw_values, dict):
+        raw_values = [raw_values]
 
-    emails = _parse_vcard_fields(contact_info.get("email"), "email")
-    phones = _parse_vcard_fields(contact_info.get("tel"), "phone")
+    fields: list[ContactField] = []
+    for item in raw_values:
+        if not isinstance(item, dict):
+            continue
+        components = item.get("value") or []
+        if isinstance(components, str):
+            components = components.split(";")
+        components = [str(c) for c in components]
+        if not any(c.strip() for c in components):
+            continue
+        raw_types: list[str] = item.get("type") or []
+        preferred = any(t.upper() == "PREF" for t in raw_types)
+        labels = [t.lower() for t in raw_types if t.upper() != "PREF"]
+        fields.append(
+            ContactField(
+                type="address",
+                value=";".join(components),
+                label=", ".join(labels) if labels else None,
+                preferred=preferred,
+                components=components,
+            )
+        )
+    return fields
 
-    # URL is parsed by pythonvCard4 into a plain ``list[str]``. Single-string
-    # inputs surface as such too. Either way wrap each into a ContactField.
-    raw_urls = contact_info.get("url")
+
+def _parse_url_fields(raw_urls: str | list | None) -> list[ContactField]:
+    """Wrap URL values into ContactFields.
+
+    pythonvCard4 parses URL into a plain ``list[str]``; single-string inputs
+    surface as such too.
+    """
     if isinstance(raw_urls, str):
         raw_urls = [raw_urls] if raw_urls else []
-    urls = [
+    return [
         ContactField(type="url", value=u)
         for u in (raw_urls or [])
         if isinstance(u, str) and u
     ]
 
-    # CATEGORIES is parsed as ``list[str]``. Accept a comma-separated string
-    # too for forward-compat with library updates that might change shape.
-    raw_categories = contact_info.get("categories") or []
-    if isinstance(raw_categories, str):
-        categories = [c.strip() for c in raw_categories.split(",") if c.strip()]
-    else:
-        categories = [c for c in raw_categories if isinstance(c, str) and c]
 
-    # Nickname goes into custom_fields (no dedicated model field)
+def _parse_categories(raw_categories: str | list | None) -> list[str]:
+    """Normalise CATEGORIES to a list of non-empty strings.
+
+    Parsed as ``list[str]``; a comma-separated string is also accepted for
+    forward-compat with library updates that might change shape.
+    """
+    raw_categories = raw_categories or []
+    if isinstance(raw_categories, str):
+        return [c.strip() for c in raw_categories.split(",") if c.strip()]
+    return [c for c in raw_categories if isinstance(c, str) and c]
+
+
+def _build_custom_fields(contact_info: dict) -> dict[str, Any]:
+    """Merge the nickname and any X-* extensions into one custom-field map.
+
+    The ``nickname`` key is lower-case and extension keys are upper-case
+    property names, so they cannot collide.
+    """
     custom_fields: dict[str, Any] = {}
     nickname = contact_info.get("nickname")
     if nickname:
         custom_fields["nickname"] = nickname
+    custom_fields.update(contact_info.get("custom") or {})
+    return custom_fields
+
+
+def _split_name_parts(raw_n: list | None) -> tuple[str | None, str | None]:
+    """Return ``(family_name, given_name)`` from the N component list.
+
+    N is ``[family, given, additional, prefix, suffix]``; index-guarded since a
+    malformed card can carry fewer components. Empty strings become ``None``.
+    """
+    name_parts = raw_n or []
+    family = name_parts[0] if len(name_parts) > 0 else None
+    given = name_parts[1] if len(name_parts) > 1 else None
+    return (family or None), (given or None)
+
+
+def _raw_contact_to_model(raw: dict) -> Contact:
+    """Convert a raw contact dict from the contacts client to a Contact model.
+
+    Maps fullname, name parts, nickname, birthday, email, tel, address, org,
+    title, note, url, categories, photo and X-* extension fields. Email/tel
+    values may be plain strings, dicts with ``value``/``type`` keys, or lists of
+    either – see :func:`_parse_vcard_fields`.
+    """
+    contact_info = raw.get("contact", {})
+
+    emails = _parse_vcard_fields(contact_info.get("email"), "email")
+    phones = _parse_vcard_fields(contact_info.get("tel"), "phone")
+    urls = _parse_url_fields(contact_info.get("url"))
+    categories = _parse_categories(contact_info.get("categories"))
+    custom_fields = _build_custom_fields(contact_info)
+    family_name, given_name = _split_name_parts(contact_info.get("n"))
 
     return Contact(
         uid=raw["vcard_id"],
         resource_path=raw.get("object_path"),
         fn=contact_info.get("fullname", ""),
         etag=raw.get("getetag"),
+        given_name=given_name,
+        family_name=family_name,
         organization=contact_info.get("org"),
         title=contact_info.get("title"),
         note=contact_info.get("note"),
@@ -117,6 +194,7 @@ def _raw_contact_to_model(raw: dict) -> Contact:
         else contact_info.get("birthday"),
         emails=emails,
         phones=phones,
+        addresses=_parse_address_fields(contact_info.get("adr")),
         urls=urls,
         categories=categories,
         custom_fields=custom_fields,

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -65,6 +65,12 @@ def _parse_vcard_fields(
     return fields
 
 
+# RFC 6350 §6.3.1: PO box, extended address, street, locality, region, postal
+# code, country. Fixed at seven so `ContactField.components` can promise a stable
+# shape regardless of how many parts the producing client emitted.
+_ADR_COMPONENT_COUNT = 7
+
+
 def _parse_address_fields(raw_values: dict | list | None) -> list[ContactField]:
     """Parse pythonvCard4's ADR shape into ContactField entries.
 
@@ -93,6 +99,11 @@ def _parse_address_fields(raw_values: dict | list | None) -> list[ContactField]:
         components = [str(c) for c in components]
         if not any(c.strip() for c in components):
             continue
+        # Pad (or truncate) to exactly the seven RFC 6350 §6.3.1 components, so a
+        # consumer can index `components[6]` for country without length-checking.
+        # Lenient real-world producers emit fewer parts; the model documents seven,
+        # and an unpadded short list would silently break that contract.
+        components = (components + [""] * _ADR_COMPONENT_COUNT)[:_ADR_COMPONENT_COUNT]
         raw_types: list[str] = item.get("type") or []
         preferred = any(t.upper() == "PREF" for t in raw_types)
         labels = [t.lower() for t in raw_types if t.upper() != "PREF"]

--- a/tests/server/test_contacts_mcp.py
+++ b/tests/server/test_contacts_mcp.py
@@ -175,3 +175,93 @@ async def test_mcp_contacts_workflow(
             await nc_client.contacts.delete_addressbook(name=addressbook_name)
         except Exception:
             pass
+
+
+async def test_mcp_contacts_surfaces_structured_fields_and_survives_bad_cards(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """ADR / N / X-* reach the model, and one unparseable card can't kill the list.
+
+    Two contacts are injected by raw CardDAV PUT because ``create_contact`` has no
+    vocabulary for ADR or X-* properties:
+
+    * ``rich`` carries ADR, N and X-* — previously parsed by pythonvCard4 but
+      never projected, so ``addresses`` was declared and permanently empty.
+    * ``geo`` carries a vCard 3.0 ``GEO:lat,lon`` (RFC 2426 uses a comma;
+      pythonvCard4 splits on ";" and raises). Unguarded, this one contact made the
+      whole addressbook unlistable.
+    """
+    addressbook_name = f"mcp-struct-{uuid.uuid4().hex[:8]}"
+    suffix = uuid.uuid4().hex[:8]
+    rich_uid = f"rich-{suffix}"
+    geo_uid = f"geo-{suffix}"
+
+    base = f"/remote.php/dav/addressbooks/users/{nc_client.contacts.username}/{addressbook_name}"
+
+    rich_vcard = (
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        f"UID:{rich_uid}\r\n"
+        "FN:Alice Doe\r\n"
+        "N:Doe;Alice;Q;Dr;Jr\r\n"
+        "ADR;TYPE=HOME:;;1 Main St;Springfield;IL;12345;US\r\n"
+        "X-ABLabel:custom-label\r\n"
+        "END:VCARD\r\n"
+    )
+    # GEO in vCard 3.0 comma form — the shape that used to break the listing.
+    geo_vcard = (
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        f"UID:{geo_uid}\r\n"
+        "FN:Geo Person\r\n"
+        "GEO:37.386013,-122.082932\r\n"
+        "END:VCARD\r\n"
+    )
+
+    try:
+        await nc_client.contacts.create_addressbook(
+            name=addressbook_name, display_name=f"Struct {addressbook_name}"
+        )
+        for uid_, vcard in ((rich_uid, rich_vcard), (geo_uid, geo_vcard)):
+            await nc_client.contacts._make_request(
+                "PUT",
+                f"{base}/{uid_}.vcf",
+                content=vcard,
+                headers={"Content-Type": "text/vcard; charset=utf-8"},
+            )
+
+        list_result = await nc_mcp_client.call_tool(
+            "nc_contacts_list_contacts", {"addressbook": addressbook_name}
+        )
+        assert list_result.isError is False
+        payload = _extract_payload(list_result)
+
+        by_uid = {c["uid"]: c for c in payload["contacts"]}
+        # Both contacts come back — the unparseable one no longer takes the
+        # listing down with it.
+        assert rich_uid in by_uid, "structured contact missing from listing"
+        assert geo_uid in by_uid, "unparseable contact took down the whole listing"
+
+        rich = by_uid[rich_uid]
+        assert rich["given_name"] == "Alice"
+        assert rich["family_name"] == "Doe"
+        assert len(rich["addresses"]) == 1
+        address = rich["addresses"][0]
+        assert address["type"] == "address"
+        assert address["components"] == [
+            "",
+            "",
+            "1 Main St",
+            "Springfield",
+            "IL",
+            "12345",
+            "US",
+        ]
+        assert address["label"] == "home"
+        assert rich["custom_fields"]["X-ABLABEL"] == ["custom-label"]
+
+    finally:
+        try:
+            await nc_client.contacts.delete_addressbook(name=addressbook_name)
+        except Exception:
+            pass

--- a/tests/unit/test_response_models.py
+++ b/tests/unit/test_response_models.py
@@ -847,3 +847,154 @@ def test_table_parses_with_owner_display_name():
     }
     table = Table(**raw)
     assert table.owner_display_name == "Bob the Builder"
+
+
+@pytest.mark.unit
+def test_contact_mapping_surfaces_addresses_name_parts_and_extensions():
+    """ADR / N / X-* are parsed by pythonvCard4 but were never projected.
+
+    ``Contact.addresses`` was declared and permanently empty, and
+    ``given_name``/``family_name`` were never populated, so structured address
+    and name data was invisible to every MCP consumer even though the raw
+    ``addressdata`` carried it.
+    """
+    raw_contact = {
+        "vcard_id": "adr-1",
+        "getetag": '"e"',
+        "contact": {
+            "fullname": "Alice Doe",
+            "n": ["Doe", "Alice", "Q", "Dr", "Jr"],
+            "adr": [
+                {
+                    "value": ["", "", "1 Main St", "Springfield", "IL", "12345", "US"],
+                    "type": ["HOME", "PREF"],
+                },
+                {
+                    "value": [
+                        "",
+                        "Suite 5",
+                        "2 Oak Ave",
+                        "Shelbyville",
+                        "IL",
+                        "54321",
+                        "US",
+                    ],
+                    "type": ["WORK"],
+                },
+            ],
+            "custom": {"X-ABLABEL": ["custom"], "X-SOCIALPROFILE": ["https://t.co/x"]},
+        },
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert contact.given_name == "Alice"
+    assert contact.family_name == "Doe"
+
+    assert len(contact.addresses) == 2
+    home = contact.addresses[0]
+    assert home.type == "address"
+    assert home.components == [
+        "",
+        "",
+        "1 Main St",
+        "Springfield",
+        "IL",
+        "12345",
+        "US",
+    ]
+    assert home.value == ";;1 Main St;Springfield;IL;12345;US"
+    assert home.preferred is True
+    assert home.label == "home"
+
+    work = contact.addresses[1]
+    assert work.preferred is False
+    assert work.label == "work"
+
+    assert contact.custom_fields["X-ABLABEL"] == ["custom"]
+    assert contact.custom_fields["X-SOCIALPROFILE"] == ["https://t.co/x"]
+
+
+@pytest.mark.unit
+def test_contact_mapping_excludes_photo_from_custom_fields():
+    """PHOTO is already surfaced as ``photo``; re-emitting the base64 blob in
+    custom_fields would roughly double every list_contacts response."""
+    raw_contact = {
+        "vcard_id": "photo-1",
+        "getetag": '"e"',
+        "contact": {
+            "fullname": "Alice",
+            "photo": "AAAA",
+            # The client's _custom_extras drops PHOTO before it reaches here.
+            "custom": {"X-KEEP": ["yes"]},
+        },
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert contact.photo == "AAAA"
+    assert "PHOTO" not in contact.custom_fields
+    assert contact.custom_fields["X-KEEP"] == ["yes"]
+
+
+@pytest.mark.unit
+def test_contact_mapping_tolerates_short_and_empty_structured_values():
+    """A malformed card can carry fewer N components or an all-empty ADR."""
+    raw_contact = {
+        "vcard_id": "short-1",
+        "getetag": '"e"',
+        "contact": {
+            "fullname": "Mononym",
+            "n": ["OnlyFamily"],
+            "adr": [
+                {"value": ["", "", "", "", "", "", ""], "type": ["HOME"]},
+                "not-a-dict",
+            ],
+        },
+    }
+
+    contact = _map_contact(raw_contact)
+
+    assert contact.family_name == "OnlyFamily"
+    assert contact.given_name is None
+    # The all-empty ADR and the non-dict entry are both dropped.
+    assert contact.addresses == []
+
+
+@pytest.mark.unit
+def test_contact_mapping_handles_missing_structured_keys():
+    """Contacts projected before this change (or by a degraded parse) carry no
+    ``n``/``adr``/``custom`` keys at all."""
+    contact = _map_contact(
+        {"vcard_id": "bare-1", "getetag": '"e"', "contact": {"fullname": "Alice"}}
+    )
+
+    assert contact.given_name is None
+    assert contact.family_name is None
+    assert contact.addresses == []
+    assert contact.custom_fields == {}
+
+
+@pytest.mark.unit
+def test_contact_mapping_accepts_bare_dict_address():
+    """A single ADR arrives as a list from pythonvCard4, but the parser accepts a
+    bare dict too — staying symmetric with _parse_vcard_fields, which handles the
+    same polymorphism for EMAIL/TEL. Without the normalisation, iterating a dict
+    would yield its keys and silently produce zero addresses.
+    """
+    contact = _map_contact(
+        {
+            "vcard_id": "adr-dict",
+            "getetag": '"e"',
+            "contact": {
+                "fullname": "Alice",
+                "adr": {
+                    "value": ["", "", "1 Main St", "Springfield", "", "", "US"],
+                    "type": ["HOME"],
+                },
+            },
+        }
+    )
+
+    assert len(contact.addresses) == 1
+    assert contact.addresses[0].components[2] == "1 Main St"

--- a/tests/unit/test_response_models.py
+++ b/tests/unit/test_response_models.py
@@ -998,3 +998,47 @@ def test_contact_mapping_accepts_bare_dict_address():
 
     assert len(contact.addresses) == 1
     assert contact.addresses[0].components[2] == "1 Main St"
+
+
+@pytest.mark.unit
+def test_contact_mapping_pads_short_address_to_seven_components():
+    """Lenient producers emit fewer than seven ADR parts.
+
+    ``ContactField.components`` documents the seven RFC 6350 §6.3.1 components in
+    order, so a short list is padded rather than silently breaking that contract
+    for a consumer indexing ``components[6]`` for country.
+    """
+    contact = _map_contact(
+        {
+            "vcard_id": "adr-short",
+            "getetag": '"e"',
+            "contact": {
+                "fullname": "Alice",
+                "adr": [{"value": ["", "", "1 Main St", "Springfield"], "type": []}],
+            },
+        }
+    )
+
+    assert len(contact.addresses[0].components) == 7
+    assert contact.addresses[0].components[2] == "1 Main St"
+    assert contact.addresses[0].components[6] == ""
+    # The flat display value reflects the padded form, consistent with components.
+    assert contact.addresses[0].value == ";;1 Main St;Springfield;;;"
+
+
+@pytest.mark.unit
+def test_contact_mapping_truncates_overlong_address_components():
+    """An over-long ADR is truncated to seven so the promised shape holds."""
+    contact = _map_contact(
+        {
+            "vcard_id": "adr-long",
+            "getetag": '"e"',
+            "contact": {
+                "fullname": "Alice",
+                "adr": [{"value": [str(i) for i in range(10)], "type": []}],
+            },
+        }
+    )
+
+    assert len(contact.addresses[0].components) == 7
+    assert contact.addresses[0].components == ["0", "1", "2", "3", "4", "5", "6"]


### PR DESCRIPTION
> Stacked on #1151 (which is stacked on #1149). Retarget down the chain as each merges.

## Problem

pythonvCard4 **already parses** `ADR`, `N` and `X-*` — the projection simply never
carried them:

- `Contact.addresses` was declared (`models/contacts.py`) and **permanently empty**
- `given_name` / `family_name` were never populated
- `custom_fields` held only `nickname`

So structured address and name data was invisible to every MCP consumer, even
though the raw `addressdata` had it all along.

## Change

- `_project_contact` carries `adr`, `n` and the `X-*` extras.
- `_raw_contact_to_model` maps them; new `_parse_address_fields()` mirrors the
  existing `_parse_vcard_fields()` convention.
- `ContactField` gains an optional `components: list[str] | None` holding the seven
  RFC 6350 §6.3.1 ADR components (PO box, extended, street, locality, region,
  postal code, country) so a consumer isn't forced to re-split the joined value.
  Optional, so it's `None` for every non-address field — backward compatible.
- Properties already surfaced under their own key (`FN`/`N`/`ORG`/`TITLE`/`PHOTO`)
  are excluded from the extras. **PHOTO especially** — it's already returned as
  `photo`, and re-emitting a base64 image per contact would roughly double every
  `list_contacts` response.

## Second bug, found while testing the projection

`list_contacts` parsed each card **unguarded**, so a single contact pythonvCard4
chokes on made the **entire addressbook unlistable**.

A vCard 3.0 `GEO:lat,lon` does exactly that — RFC 2426 separates with a comma,
while the library does `entry['value'].split(';')` and raises `ValueError`.
Nextcloud stores vCard 3.0, so this is reachable with an ordinary contact.

The parse is now isolated per contact and degrades to raw `addressdata` for that
one card, logging a warning. The caller loses the parsed convenience fields for
that contact, not the listing.

## Test coverage

**Unit** (`tests/unit/test_response_models.py`): ADR/N/X-* surfacing including
`components`, `preferred` and `label`; PHOTO excluded from `custom_fields`;
short `N`, all-empty ADR and non-dict ADR entries tolerated; contacts carrying
none of the new keys still map.

**e2e** (`tests/server/test_contacts_mcp.py`): injects two contacts by raw CardDAV
PUT — `create_contact` has no vocabulary for ADR or X-* — one structured and one
with a 3.0-form `GEO`. Asserts **both** come back from `nc_contacts_list_contacts`
and that the structured one exposes `given_name`, `family_name`, `addresses[0].components`
and `custom_fields["X-ABLABEL"]`. That second contact is the regression guard for
the listing-wide failure.

Tiers executed locally: unit ✅ 2436 passed. Integration/e2e runs in CI on this PR.

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`,
which does not import `models/contacts.py`. No cross-service boundary touched.

## Provenance

`pi0n00r/nextcloud-mcp-server` reported a "CardDAV read projection" gap downstream.
That fork declares CLA non-participation, so **no fork code or tests were copied** —
the gap was re-verified here and this implementation written from scratch. The
`GEO` listing bug is ours, found independently.

---

_This PR was generated with the help of AI, and reviewed by a Human_
