### PR TITLE
fix(calendar): preserve value type and timezone when updating events

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1225,6 +1225,11 @@ class CalendarClient:
         else:
             target_all_day = bool(stored_all_day)
 
+        # ``stored_all_day is None`` means neither DTSTART nor DTEND gave a
+        # definitive type — a VEVENT with no dates at all. There is nothing to
+        # flip *from*, so flip validation is deliberately skipped rather than
+        # guessing; ``bool(None)`` then treats the target as timed, matching the
+        # pre-existing default.
         flipping = stored_all_day is not None and target_all_day != stored_all_day
 
         if flipping:
@@ -1254,6 +1259,13 @@ class CalendarClient:
                 used_timezones,
             )
 
+        if target_all_day:
+            # Apply the same zero-length guard the implicit conversion path uses.
+            # An explicit ``all_day=True`` with start and end resolving to the same
+            # calendar date would otherwise write ``DTEND == DTSTART`` — the very
+            # zero-length DATE range this method rejects elsewhere.
+            self._clamp_all_day_end(component)
+
         return used_timezones
 
     def _write_date_property(
@@ -1280,13 +1292,28 @@ class CalendarClient:
         component[prop] = vDDDTypes(parsed)
 
     @staticmethod
-    def _convert_component_to_all_day(component) -> None:
-        """Re-write stored DTSTART/DTEND as DATE values.
+    def _clamp_all_day_end(component) -> None:
+        """Ensure an all-day ``DTEND`` is at least the day after ``DTSTART``.
 
-        ``DTEND`` is clamped to at least the day after ``DTSTART``: a 09:00-10:00
-        event naively ``.date()``-ed on both ends would yield ``DTEND == DTSTART``,
-        a zero-length DATE range and invalid per RFC 5545.
+        ``DTEND == DTSTART`` is a zero-length DATE range and invalid per RFC 5545.
+        Shared by both routes that can produce one: the implicit timed -> all-day
+        conversion (``.date()`` on a 09:00-10:00 event collapses both ends onto the
+        same day) and an explicit ``all_day=True`` whose supplied start and end
+        resolve to the same calendar date. A no-op unless both are DATE values.
         """
+        start_value = component.get("DTSTART")
+        end_value = component.get("DTEND")
+        if start_value is None or end_value is None:
+            return
+        start_date, end_date = start_value.dt, end_value.dt
+        if isinstance(start_date, dt.datetime) or isinstance(end_date, dt.datetime):
+            return  # not an all-day pair; nothing to clamp
+        if end_date <= start_date:
+            component["DTEND"] = vDDDTypes(start_date + dt.timedelta(days=1))
+
+    @classmethod
+    def _convert_component_to_all_day(cls, component) -> None:
+        """Re-write stored DTSTART/DTEND as DATE values."""
         start_value = component.get("DTSTART")
         if start_value is None:
             return
@@ -1297,11 +1324,14 @@ class CalendarClient:
         component["DTSTART"] = vDDDTypes(start_date)
 
         end_value = component.get("DTEND")
-        if end_value is None:
-            return
-        end_date = end_value.dt
-        end_date = end_date.date() if isinstance(end_date, dt.datetime) else end_date
-        component["DTEND"] = vDDDTypes(max(end_date, start_date + dt.timedelta(days=1)))
+        if end_value is not None:
+            end_date = end_value.dt
+            end_date = (
+                end_date.date() if isinstance(end_date, dt.datetime) else end_date
+            )
+            component["DTEND"] = vDDDTypes(end_date)
+
+        cls._clamp_all_day_end(component)
 
     def _merge_ical_properties(self, raw_ical: str, event_data: dict[str, Any]) -> str:
         """Merge new event data into existing raw iCal while preserving all properties.

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -982,7 +982,21 @@ class CalendarClient:
             return parsed.replace(tzinfo=zi), zi
 
         if inherited_tz:
-            inherited_zi = cls._resolve_timezone(inherited_tz)
+            # Resolve quietly. A stored TZID is not guaranteed to be an IANA name:
+            # icalendar renders a fixed-offset tzinfo as TZID="UTC-04:00" with no
+            # VTIMEZONE, so inheriting one is expected to fail. Routing that
+            # through _resolve_timezone would log "Unknown IANA timezone", which
+            # reads as an error when the floating-time fallback below is the
+            # correct, harmless outcome. An explicit `timezone=` from the caller
+            # still warns — that one really is a mistake worth surfacing.
+            try:
+                inherited_zi = ZoneInfo(inherited_tz)
+            except (ZoneInfoNotFoundError, ValueError):
+                logger.debug(
+                    "Stored TZID %r is not an IANA name; not inheriting it",
+                    inherited_tz,
+                )
+                inherited_zi = None
             if inherited_zi is not None:
                 # Inheriting is the expected behaviour, not a problem — debug, not
                 # warning. Without this, updating the time of a TZID-bound event

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -657,7 +657,7 @@ class CalendarClient:
         await _maybe_await(event.load(only_if_unloaded=True))
 
         # Merge updates into existing iCal data
-        updated_ical = self._merge_ical_properties(event.data, event_data, event_uid)  # type: ignore[arg-type]
+        updated_ical = self._merge_ical_properties(event.data, event_data)  # type: ignore[arg-type]
         event.data = updated_ical  # type: ignore[misc]
 
         await _maybe_await(event.save())
@@ -1164,6 +1164,27 @@ class CalendarClient:
             logger.error("Error parsing iCalendar event: %s", e)
             return None
 
+    @staticmethod
+    def _validate_all_day_flip(
+        target_all_day: bool, has_start: bool, has_end: bool
+    ) -> None:
+        """Reject flips between all-day and timed that can't produce valid iCal.
+
+        Only called when the update actually changes the value type.
+        """
+        if (has_start or has_end) and not (has_start and has_end):
+            raise ValueError(
+                "changing an event between all-day and timed requires both "
+                "start_datetime and end_datetime, so DTSTART and DTEND cannot "
+                "end up with mismatched value types"
+            )
+        if not has_start and not has_end and not target_all_day:
+            raise ValueError(
+                "converting an all-day event to a timed one requires "
+                "start_datetime and end_datetime — there is no defensible "
+                "time-of-day to invent"
+            )
+
     def _apply_date_updates(
         self, component, event_data: dict[str, Any]
     ) -> set[ZoneInfo]:
@@ -1206,24 +1227,13 @@ class CalendarClient:
 
         flipping = stored_all_day is not None and target_all_day != stored_all_day
 
-        if flipping and (has_start or has_end) and not (has_start and has_end):
-            raise ValueError(
-                "changing an event between all-day and timed requires both "
-                "start_datetime and end_datetime, so DTSTART and DTEND cannot "
-                "end up with mismatched value types"
-            )
-
-        if flipping and not has_start and not has_end:
-            if target_all_day:
+        if flipping:
+            self._validate_all_day_flip(target_all_day, has_start, has_end)
+            if not has_start and not has_end:
                 # Timed -> all-day with no new datetimes is well defined: take the
-                # dates off the stored values.
+                # dates off the stored values. (The converse already raised.)
                 self._convert_component_to_all_day(component)
                 return used_timezones
-            raise ValueError(
-                "converting an all-day event to a timed one requires "
-                "start_datetime and end_datetime — there is no defensible "
-                "time-of-day to invent"
-            )
 
         if has_start:
             self._write_date_property(
@@ -1293,10 +1303,12 @@ class CalendarClient:
         end_date = end_date.date() if isinstance(end_date, dt.datetime) else end_date
         component["DTEND"] = vDDDTypes(max(end_date, start_date + dt.timedelta(days=1)))
 
-    def _merge_ical_properties(
-        self, raw_ical: str, event_data: dict[str, Any], event_uid: str
-    ) -> str:
+    def _merge_ical_properties(self, raw_ical: str, event_data: dict[str, Any]) -> str:
         """Merge new event data into existing raw iCal while preserving all properties.
+
+        The event's own ``UID`` is carried through from ``raw_ical`` like any other
+        preserved property, so no ``event_uid`` argument is needed. (One used to be
+        required solely by the removed rebuild fallback.)
 
         Raises on any merge failure rather than substituting a synthesised event.
         This previously caught every exception and fell back to

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -915,21 +915,62 @@ class CalendarClient:
             )
             return None
 
+    @staticmethod
+    def _stored_is_all_day(component, prop: str = "DTSTART") -> bool | None:
+        """Whether ``prop`` on the stored component is a DATE (all-day) value.
+
+        Returns ``None`` when the property is absent, so callers can distinguish
+        "unknown" from "timed" — the update path needs that difference to decide
+        whether to inherit the stored value type or fall back to a default.
+        """
+        value = component.get(prop)
+        if value is None:
+            return None
+        inner = getattr(value, "dt", None)
+        if inner is None:
+            return None
+        return isinstance(inner, dt.date) and not isinstance(inner, dt.datetime)
+
+    @staticmethod
+    def _stored_tzid(component, prop: str = "DTSTART") -> str | None:
+        """Return the TZID parameter on ``prop``, if the stored value carries one.
+
+        ``None`` for all-day, floating and UTC values — none of which should have
+        a zone inherited onto them.
+        """
+        value = component.get(prop)
+        if value is None:
+            return None
+        tzid = getattr(value, "params", {}).get("TZID")
+        return str(tzid) if tzid else None
+
     @classmethod
     def _parse_event_datetime(
-        cls, dt_str: str, tz_name: str | None = None
+        cls,
+        dt_str: str,
+        tz_name: str | None = None,
+        *,
+        inherited_tz: str | None = None,
     ) -> tuple[dt.datetime, ZoneInfo | None]:
         """Parse an ISO datetime string with optional TZID application.
 
         Returns ``(parsed_dt, applied_zoneinfo)`` where ``applied_zoneinfo``
-        is non-None only when ``tz_name`` was applied to a naive input — the
+        is non-None only when a zone was applied to a naive input — the
         caller uses this to know whether to emit a VTIMEZONE component.
+
+        ``tz_name`` is the caller's explicit request; ``inherited_tz`` is the TZID
+        already on the stored property. They are separate parameters on purpose:
+        passing the stored zone as ``tz_name`` would fire the "explicit offset;
+        ignoring timezone" warning spuriously on every offset-bearing update, and
+        would override a caller who deliberately wants floating time. Explicit
+        always wins over inherited.
         """
         parsed = dt.datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
         zi = cls._resolve_timezone(tz_name) if tz_name else None
 
         if parsed.tzinfo is not None:
-            if zi is not None:
+            # Only complain about a zone the caller actually asked for.
+            if tz_name:
                 logger.warning(
                     "Datetime %r has an explicit offset; ignoring timezone=%r",
                     dt_str,
@@ -939,6 +980,19 @@ class CalendarClient:
 
         if zi is not None:
             return parsed.replace(tzinfo=zi), zi
+
+        if inherited_tz:
+            inherited_zi = cls._resolve_timezone(inherited_tz)
+            if inherited_zi is not None:
+                # Inheriting is the expected behaviour, not a problem — debug, not
+                # warning. Without this, updating the time of a TZID-bound event
+                # without re-passing `timezone` silently produced floating time.
+                logger.debug(
+                    "Datetime %r is naive; inheriting stored TZID=%r",
+                    dt_str,
+                    inherited_tz,
+                )
+                return parsed.replace(tzinfo=inherited_zi), inherited_zi
 
         logger.warning(
             "Datetime %r is naive and no timezone was supplied — storing as RFC 5545 floating local time",
@@ -1110,130 +1164,230 @@ class CalendarClient:
             logger.error("Error parsing iCalendar event: %s", e)
             return None
 
+    def _apply_date_updates(
+        self, component, event_data: dict[str, Any]
+    ) -> set[ZoneInfo]:
+        """Write DTSTART/DTEND onto ``component``, preserving its stored shape.
+
+        Returns the set of zones applied, so the caller can emit the matching
+        VTIMEZONE components.
+
+        Two properties of the stored event are inherited when the caller does not
+        override them, because reading them from ``event_data`` alone is what made
+        updates lossy:
+
+        * **Value type.** ``all_day`` was previously read as
+          ``event_data.get("all_day", False)`` independently in each branch, so
+          updating an all-day event's start without re-passing ``all_day=True``
+          rewrote DTSTART as a naive DATE-TIME — RFC 5545 floating time — and could
+          leave DTSTART and DTEND with mismatched value types, which is invalid
+          iCalendar.
+        * **TZID.** Inherited *per property*: DTSTART and DTEND may legally carry
+          different zones, so sharing DTSTART's would silently relocate the end.
+        """
+        tz_name = event_data.get("timezone", "")
+        used_timezones: set[ZoneInfo] = set()
+
+        has_start = "start_datetime" in event_data
+        has_end = "end_datetime" in event_data
+        if not has_start and not has_end and "all_day" not in event_data:
+            return used_timezones
+
+        stored_all_day = self._stored_is_all_day(component, "DTSTART")
+        if stored_all_day is None:
+            stored_all_day = self._stored_is_all_day(component, "DTEND")
+
+        # Computed once. Falling back to the *stored* type is the fix: absent an
+        # explicit `all_day`, the event keeps the shape it already had.
+        if "all_day" in event_data:
+            target_all_day = bool(event_data["all_day"])
+        else:
+            target_all_day = bool(stored_all_day)
+
+        flipping = stored_all_day is not None and target_all_day != stored_all_day
+
+        if flipping and (has_start or has_end) and not (has_start and has_end):
+            raise ValueError(
+                "changing an event between all-day and timed requires both "
+                "start_datetime and end_datetime, so DTSTART and DTEND cannot "
+                "end up with mismatched value types"
+            )
+
+        if flipping and not has_start and not has_end:
+            if target_all_day:
+                # Timed -> all-day with no new datetimes is well defined: take the
+                # dates off the stored values.
+                self._convert_component_to_all_day(component)
+                return used_timezones
+            raise ValueError(
+                "converting an all-day event to a timed one requires "
+                "start_datetime and end_datetime — there is no defensible "
+                "time-of-day to invent"
+            )
+
+        if has_start:
+            self._write_date_property(
+                component,
+                "DTSTART",
+                event_data["start_datetime"],
+                target_all_day,
+                tz_name,
+                used_timezones,
+            )
+        if has_end:
+            self._write_date_property(
+                component,
+                "DTEND",
+                event_data["end_datetime"],
+                target_all_day,
+                tz_name,
+                used_timezones,
+            )
+
+        return used_timezones
+
+    def _write_date_property(
+        self,
+        component,
+        prop: str,
+        value: str,
+        all_day: bool,
+        tz_name: str,
+        used_timezones: set[ZoneInfo],
+    ) -> None:
+        """Write one DATE or DATE-TIME property, inheriting that property's TZID."""
+        if all_day:
+            component[prop] = vDDDTypes(
+                dt.datetime.fromisoformat(value.split("T")[0]).date()
+            )
+            return
+
+        parsed, zi = self._parse_event_datetime(
+            value, tz_name, inherited_tz=self._stored_tzid(component, prop)
+        )
+        if zi is not None:
+            used_timezones.add(zi)
+        component[prop] = vDDDTypes(parsed)
+
+    @staticmethod
+    def _convert_component_to_all_day(component) -> None:
+        """Re-write stored DTSTART/DTEND as DATE values.
+
+        ``DTEND`` is clamped to at least the day after ``DTSTART``: a 09:00-10:00
+        event naively ``.date()``-ed on both ends would yield ``DTEND == DTSTART``,
+        a zero-length DATE range and invalid per RFC 5545.
+        """
+        start_value = component.get("DTSTART")
+        if start_value is None:
+            return
+        start_date = start_value.dt
+        start_date = (
+            start_date.date() if isinstance(start_date, dt.datetime) else start_date
+        )
+        component["DTSTART"] = vDDDTypes(start_date)
+
+        end_value = component.get("DTEND")
+        if end_value is None:
+            return
+        end_date = end_value.dt
+        end_date = end_date.date() if isinstance(end_date, dt.datetime) else end_date
+        component["DTEND"] = vDDDTypes(max(end_date, start_date + dt.timedelta(days=1)))
+
     def _merge_ical_properties(
         self, raw_ical: str, event_data: dict[str, Any], event_uid: str
     ) -> str:
-        """Merge new event data into existing raw iCal while preserving all properties."""
-        try:
-            cal = Calendar.from_ical(raw_ical)
+        """Merge new event data into existing raw iCal while preserving all properties.
 
-            for component in cal.walk():
-                if component.name == "VEVENT":
-                    # Update only provided properties
-                    if "title" in event_data:
-                        component["SUMMARY"] = event_data["title"]
-                    if "description" in event_data:
-                        component["DESCRIPTION"] = event_data["description"]
-                    if "location" in event_data:
-                        component["LOCATION"] = event_data["location"]
-                    if "status" in event_data:
-                        component["STATUS"] = event_data["status"].upper()
-                    if "priority" in event_data:
-                        component["PRIORITY"] = event_data["priority"]
-                    if "privacy" in event_data:
-                        component["CLASS"] = event_data["privacy"].upper()
-                    if "url" in event_data:
-                        component["URL"] = event_data["url"]
+        Raises on any merge failure rather than substituting a synthesised event.
+        This previously caught every exception and fell back to
+        ``_create_ical_event(event_data, ...)``, which rebuilds the event from the
+        *partial update dict* — destroying summary, location, attendees, alarms,
+        RRULE and every custom property the caller did not happen to pass, while
+        reporting success.
+        """
+        cal = Calendar.from_ical(raw_ical)
 
-                    # Handle categories
-                    if "categories" in event_data:
-                        categories_str = event_data["categories"]
-                        if categories_str:
-                            component["CATEGORIES"] = [
-                                c.strip() for c in categories_str.split(",")
-                            ]
-                        elif "CATEGORIES" in component:
-                            del component["CATEGORIES"]
+        for component in cal.walk():
+            if component.name == "VEVENT":
+                # Update only provided properties
+                if "title" in event_data:
+                    component["SUMMARY"] = event_data["title"]
+                if "description" in event_data:
+                    component["DESCRIPTION"] = event_data["description"]
+                if "location" in event_data:
+                    component["LOCATION"] = event_data["location"]
+                if "status" in event_data:
+                    component["STATUS"] = event_data["status"].upper()
+                if "priority" in event_data:
+                    component["PRIORITY"] = event_data["priority"]
+                if "privacy" in event_data:
+                    component["CLASS"] = event_data["privacy"].upper()
+                if "url" in event_data:
+                    component["URL"] = event_data["url"]
 
-                    # Handle recurrence rule
-                    if "recurrence_rule" in event_data:
-                        rrule_str = event_data["recurrence_rule"]
-                        if rrule_str:
-                            component["RRULE"] = vRecur.from_ical(rrule_str)
-                        elif "RRULE" in component:
-                            del component["RRULE"]
-
-                    # Handle attendees
-                    if "attendees" in event_data:
-                        attendees_str = event_data["attendees"]
-                        # Remove all existing attendees first
-                        while "ATTENDEE" in component:
-                            del component["ATTENDEE"]
-                        if attendees_str:
-                            for email in attendees_str.split(","):
-                                if email.strip():
-                                    component.add("attendee", f"mailto:{email.strip()}")
-
-                    # Handle reminder (VALARM)
-                    if "reminder_minutes" in event_data:
-                        component.subcomponents = [
-                            sub
-                            for sub in component.subcomponents
-                            if sub.name != "VALARM"
+                # Handle categories
+                if "categories" in event_data:
+                    categories_str = event_data["categories"]
+                    if categories_str:
+                        component["CATEGORIES"] = [
+                            c.strip() for c in categories_str.split(",")
                         ]
-                        minutes = event_data["reminder_minutes"]
-                        if minutes > 0:
-                            alarm = Alarm()
-                            alarm.add("action", "DISPLAY")
-                            alarm.add("description", "Event reminder")
-                            alarm.add("trigger", dt.timedelta(minutes=-minutes))
-                            component.add_component(alarm)
+                    elif "CATEGORIES" in component:
+                        del component["CATEGORIES"]
 
-                    # Handle dates
-                    tz_name = event_data.get("timezone", "")
-                    used_timezones: set[ZoneInfo] = set()
-                    if "start_datetime" in event_data:
-                        start_str = event_data["start_datetime"]
-                        all_day = event_data.get("all_day", False)
-                        if all_day:
-                            start_date = dt.datetime.fromisoformat(
-                                start_str.split("T")[0]
-                            ).date()
-                            component["DTSTART"] = vDDDTypes(start_date)
-                        else:
-                            start_dt, zi = self._parse_event_datetime(
-                                start_str, tz_name
-                            )
-                            if zi is not None:
-                                used_timezones.add(zi)
-                            component["DTSTART"] = vDDDTypes(start_dt)
+                # Handle recurrence rule
+                if "recurrence_rule" in event_data:
+                    rrule_str = event_data["recurrence_rule"]
+                    if rrule_str:
+                        component["RRULE"] = vRecur.from_ical(rrule_str)
+                    elif "RRULE" in component:
+                        del component["RRULE"]
 
-                    if "end_datetime" in event_data:
-                        end_str = event_data["end_datetime"]
-                        all_day = event_data.get("all_day", False)
-                        if all_day:
-                            end_date = dt.datetime.fromisoformat(
-                                end_str.split("T")[0]
-                            ).date()
-                            component["DTEND"] = vDDDTypes(end_date)
-                        else:
-                            end_dt, zi = self._parse_event_datetime(end_str, tz_name)
-                            if zi is not None:
-                                used_timezones.add(zi)
-                            component["DTEND"] = vDDDTypes(end_dt)
+                # Handle attendees
+                if "attendees" in event_data:
+                    attendees_str = event_data["attendees"]
+                    # Remove all existing attendees first
+                    while "ATTENDEE" in component:
+                        del component["ATTENDEE"]
+                    if attendees_str:
+                        for email in attendees_str.split(","):
+                            if email.strip():
+                                component.add("attendee", f"mailto:{email.strip()}")
 
-                    # Update timestamps
-                    now = dt.datetime.now(dt.UTC)
-                    component["LAST-MODIFIED"] = vDDDTypes(now)
-                    component["DTSTAMP"] = vDDDTypes(now)
+                # Handle reminder (VALARM)
+                if "reminder_minutes" in event_data:
+                    component.subcomponents = [
+                        sub for sub in component.subcomponents if sub.name != "VALARM"
+                    ]
+                    minutes = event_data["reminder_minutes"]
+                    if minutes > 0:
+                        alarm = Alarm()
+                        alarm.add("action", "DISPLAY")
+                        alarm.add("description", "Event reminder")
+                        alarm.add("trigger", dt.timedelta(minutes=-minutes))
+                        component.add_component(alarm)
 
-                    # Ensure VTIMEZONE definitions exist for any TZID we just attached.
-                    existing_tzids = {
-                        str(sub.get("TZID", ""))
-                        for sub in cal.subcomponents
-                        if sub.name == "VTIMEZONE"
-                    }
-                    for zi in used_timezones:
-                        if str(zi) not in existing_tzids:
-                            cal.add_component(Timezone.from_tzinfo(zi))
+                # Handle dates
+                used_timezones = self._apply_date_updates(component, event_data)
 
-                    break
+                # Update timestamps
+                now = dt.datetime.now(dt.UTC)
+                component["LAST-MODIFIED"] = vDDDTypes(now)
+                component["DTSTAMP"] = vDDDTypes(now)
 
-            return cal.to_ical().decode("utf-8")
+                # Ensure VTIMEZONE definitions exist for any TZID we just attached.
+                existing_tzids = {
+                    str(sub.get("TZID", ""))
+                    for sub in cal.subcomponents
+                    if sub.name == "VTIMEZONE"
+                }
+                for zi in used_timezones:
+                    if str(zi) not in existing_tzids:
+                        cal.add_component(Timezone.from_tzinfo(zi))
 
-        except Exception as e:
-            logger.error("Error merging iCal properties: %s", e)
-            return self._create_ical_event(event_data, event_uid)
+                break
+
+        return cal.to_ical().decode("utf-8")
 
     # ============= Helper Methods - Todo iCalendar =============
 

--- a/tests/client/calendar/test_timezone_roundtrip.py
+++ b/tests/client/calendar/test_timezone_roundtrip.py
@@ -15,6 +15,8 @@ pin the post-fix contract so the regression cannot return.
 
 from __future__ import annotations
 
+import datetime
+
 import httpx
 import pytest
 
@@ -416,3 +418,39 @@ def test_merge_preserves_properties_absent_from_event_data(mocker):
     assert component["LOCATION"] == "Room 1"
     assert "RRULE" in component
     assert component["X-CUSTOM-PROP"] == "keep me"
+
+
+def test_explicit_all_day_flip_with_same_date_is_clamped(mocker):
+    """Round-2 finding: the zero-length guard must apply to the explicit path too.
+
+    Passing ``all_day=True`` with a start and end that resolve to the same calendar
+    date would otherwise write ``DTEND == DTSTART`` — the same zero-length DATE
+    range the implicit conversion path already guards against.
+    """
+    vevent = "DTSTART:20260101T090000Z\r\nDTEND:20260101T100000Z\r\n"
+    component = _merge(
+        mocker,
+        vevent,
+        {
+            "all_day": True,
+            "start_datetime": "2026-03-10T09:00:00Z",
+            "end_datetime": "2026-03-10T10:00:00Z",
+        },
+    )
+
+    assert _is_date_only(component["DTSTART"])
+    assert _is_date_only(component["DTEND"])
+    assert component["DTEND"].dt == component["DTSTART"].dt + datetime.timedelta(days=1)
+
+
+def test_all_day_update_with_distinct_dates_is_not_clamped(mocker):
+    """A genuine multi-day all-day range must be left exactly as supplied."""
+    vevent = "DTSTART;VALUE=DATE:20260101\r\nDTEND;VALUE=DATE:20260105\r\n"
+    component = _merge(
+        mocker,
+        vevent,
+        {"start_datetime": "2026-02-01", "end_datetime": "2026-02-05"},
+    )
+
+    assert component["DTSTART"].dt.isoformat() == "2026-02-01"
+    assert component["DTEND"].dt.isoformat() == "2026-02-05"

--- a/tests/client/calendar/test_timezone_roundtrip.py
+++ b/tests/client/calendar/test_timezone_roundtrip.py
@@ -255,7 +255,7 @@ def _merge(mocker, vevent_body: str, event_data: dict, vtimezone: str = ""):
 
     client = _make_client(mocker)
     merged = client._merge_ical_properties(
-        _wrap_vevent(vevent_body, vtimezone), event_data, "test-event"
+        _wrap_vevent(vevent_body, vtimezone), event_data
     )
     cal = Calendar.from_ical(merged)
     return next(c for c in cal.walk() if c.name == "VEVENT")
@@ -386,7 +386,7 @@ def test_flip_with_only_one_datetime_raises(mocker):
     event_data = {"all_day": False, "start_datetime": "2026-01-01T09:00:00Z"}
 
     with pytest.raises(ValueError, match="requires both"):
-        client._merge_ical_properties(raw, event_data, "test-event")
+        client._merge_ical_properties(raw, event_data)
 
 
 def test_flip_to_timed_without_datetimes_raises(mocker):
@@ -397,7 +397,7 @@ def test_flip_to_timed_without_datetimes_raises(mocker):
     event_data = {"all_day": False}
 
     with pytest.raises(ValueError, match="no defensible time-of-day"):
-        client._merge_ical_properties(raw, event_data, "test-event")
+        client._merge_ical_properties(raw, event_data)
 
 
 def test_merge_preserves_properties_absent_from_event_data(mocker):

--- a/tests/client/calendar/test_timezone_roundtrip.py
+++ b/tests/client/calendar/test_timezone_roundtrip.py
@@ -240,3 +240,179 @@ def test_roundtrip_tzid_event_preserves_iana_name(mocker):
     assert parsed is not None
     assert parsed["start_tz"] == "America/New_York"
     assert parsed["start_datetime"] == "2026-05-14T10:00:00-04:00"
+
+
+# ============= Update path: _merge_ical_properties preserves stored shape =============
+#
+# The update path had no unit coverage at all, which is why the value-type and
+# TZID bugs below survived. Assertions are on the parsed value type and params,
+# not on rendered strings.
+
+
+def _merge(mocker, vevent_body: str, event_data: dict, vtimezone: str = ""):
+    """Run _merge_ical_properties over a stored VEVENT and parse the result back."""
+    from icalendar import Calendar
+
+    client = _make_client(mocker)
+    merged = client._merge_ical_properties(
+        _wrap_vevent(vevent_body, vtimezone), event_data, "test-event"
+    )
+    cal = Calendar.from_ical(merged)
+    return next(c for c in cal.walk() if c.name == "VEVENT")
+
+
+def _is_date_only(value) -> bool:
+    import datetime as _dt
+
+    return isinstance(value.dt, _dt.date) and not isinstance(value.dt, _dt.datetime)
+
+
+def test_all_day_event_stays_all_day_when_all_day_not_repassed(mocker):
+    """Headline regression: updating an all-day event's start without re-passing
+    ``all_day=True`` used to rewrite DTSTART as naive floating DATE-TIME."""
+    vevent = "DTSTART;VALUE=DATE:20260101\r\nDTEND;VALUE=DATE:20260102\r\n"
+    component = _merge(mocker, vevent, {"start_datetime": "2026-02-02"})
+
+    assert _is_date_only(component["DTSTART"])
+    assert component["DTSTART"].dt.isoformat() == "2026-02-02"
+    # The untouched end keeps its DATE type too.
+    assert _is_date_only(component["DTEND"])
+
+
+def test_timed_event_stays_timed_when_all_day_not_passed(mocker):
+    vevent = "DTSTART:20260101T090000Z\r\nDTEND:20260101T100000Z\r\n"
+    component = _merge(mocker, vevent, {"start_datetime": "2026-02-02T09:00:00Z"})
+
+    assert not _is_date_only(component["DTSTART"])
+
+
+def test_stored_tzid_is_inherited_when_timezone_not_repassed(mocker):
+    """Updating a TZID-bound event with a naive value used to produce floating time."""
+    vtimezone = (
+        "BEGIN:VTIMEZONE\r\nTZID:America/New_York\r\n"
+        "BEGIN:STANDARD\r\nDTSTART:19701101T020000\r\n"
+        "TZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\n"
+        "END:STANDARD\r\nEND:VTIMEZONE\r\n"
+    )
+    vevent = (
+        "DTSTART;TZID=America/New_York:20260101T090000\r\n"
+        "DTEND;TZID=America/New_York:20260101T100000\r\n"
+    )
+    component = _merge(
+        mocker, vevent, {"start_datetime": "2026-03-10T09:00:00"}, vtimezone
+    )
+
+    assert str(component["DTSTART"].dt.tzinfo) == "America/New_York"
+
+
+def test_explicit_timezone_beats_inherited(mocker):
+    vevent = "DTSTART;TZID=America/New_York:20260101T090000\r\n"
+    component = _merge(
+        mocker,
+        vevent,
+        {"start_datetime": "2026-03-10T09:00:00", "timezone": "Europe/Berlin"},
+    )
+
+    assert str(component["DTSTART"].dt.tzinfo) == "Europe/Berlin"
+
+
+def test_explicit_offset_does_not_inherit_and_does_not_warn(mocker, caplog):
+    """An offset-bearing value must not inherit the stored TZID, and must not log
+    the 'ignoring timezone' warning — the caller never asked for a zone.
+
+    The warning previously fired on *every* offset-bearing update of a TZID-bound
+    event, because the stored zone was about to be passed as ``tz_name``.
+
+    Only the wall-clock is asserted: icalendar renders a fixed-offset tzinfo as
+    ``TZID="UTC-04:00"`` with no matching VTIMEZONE, so the offset is dropped on
+    re-parse. That is pre-existing behaviour shared with the create path
+    (``_create_ical_event``) and out of scope here — see the follow-up card.
+    """
+    import logging
+
+    vevent = "DTSTART;TZID=America/New_York:20260101T090000\r\n"
+    with caplog.at_level(
+        logging.WARNING, logger="nextcloud_mcp_server.client.calendar"
+    ):
+        component = _merge(
+            mocker, vevent, {"start_datetime": "2026-03-10T09:00:00-04:00"}
+        )
+
+    # Wall-clock is the caller's, and America/New_York was NOT inherited onto it.
+    assert component["DTSTART"].dt.replace(tzinfo=None).isoformat() == (
+        "2026-03-10T09:00:00"
+    )
+    assert str(component["DTSTART"].dt.tzinfo) != "America/New_York"
+    assert not any("ignoring timezone" in r.message for r in caplog.records)
+
+
+def test_dtstart_and_dtend_inherit_their_own_zones(mocker):
+    """DTSTART and DTEND may legally carry different TZIDs; sharing DTSTART's
+    would silently relocate the end of a cross-zone event."""
+    vevent = (
+        "DTSTART;TZID=America/New_York:20260101T090000\r\n"
+        "DTEND;TZID=Europe/Berlin:20260101T180000\r\n"
+    )
+    component = _merge(
+        mocker,
+        vevent,
+        {
+            "start_datetime": "2026-03-10T09:00:00",
+            "end_datetime": "2026-03-10T18:00:00",
+        },
+    )
+
+    assert str(component["DTSTART"].dt.tzinfo) == "America/New_York"
+    assert str(component["DTEND"].dt.tzinfo) == "Europe/Berlin"
+
+
+def test_flip_to_all_day_without_datetimes_converts_stored_values(mocker):
+    """Timed -> all-day with no new datetimes is well defined, and DTEND must be
+    clamped so the DATE range isn't zero-length."""
+    vevent = "DTSTART:20260101T090000Z\r\nDTEND:20260101T100000Z\r\n"
+    component = _merge(mocker, vevent, {"all_day": True})
+
+    assert _is_date_only(component["DTSTART"])
+    assert _is_date_only(component["DTEND"])
+    assert component["DTEND"].dt > component["DTSTART"].dt
+
+
+def test_flip_with_only_one_datetime_raises(mocker):
+    """A half-supplied flip would leave DTSTART/DTEND with mismatched value
+    types, which is invalid iCalendar."""
+    vevent = "DTSTART;VALUE=DATE:20260101\r\nDTEND;VALUE=DATE:20260102\r\n"
+    client = _make_client(mocker)
+    raw = _wrap_vevent(vevent)
+    event_data = {"all_day": False, "start_datetime": "2026-01-01T09:00:00Z"}
+
+    with pytest.raises(ValueError, match="requires both"):
+        client._merge_ical_properties(raw, event_data, "test-event")
+
+
+def test_flip_to_timed_without_datetimes_raises(mocker):
+    """There is no defensible time-of-day to invent for an all-day event."""
+    vevent = "DTSTART;VALUE=DATE:20260101\r\nDTEND;VALUE=DATE:20260102\r\n"
+    client = _make_client(mocker)
+    raw = _wrap_vevent(vevent)
+    event_data = {"all_day": False}
+
+    with pytest.raises(ValueError, match="no defensible time-of-day"):
+        client._merge_ical_properties(raw, event_data, "test-event")
+
+
+def test_merge_preserves_properties_absent_from_event_data(mocker):
+    """The removed except-Exception fallback rebuilt the event from the partial
+    update dict, destroying everything the caller didn't pass."""
+    vevent = (
+        "DTSTART:20260101T090000Z\r\n"
+        "DTEND:20260101T100000Z\r\n"
+        "LOCATION:Room 1\r\n"
+        "RRULE:FREQ=WEEKLY;COUNT=5\r\n"
+        "X-CUSTOM-PROP:keep me\r\n"
+    )
+    component = _merge(mocker, vevent, {"title": "Renamed"})
+
+    assert component["SUMMARY"] == "Renamed"
+    assert component["LOCATION"] == "Room 1"
+    assert "RRULE" in component
+    assert component["X-CUSTOM-PROP"] == "keep me"

--- a/tests/client/calendar/test_timezone_roundtrip.py
+++ b/tests/client/calendar/test_timezone_roundtrip.py
@@ -454,3 +454,44 @@ def test_all_day_update_with_distinct_dates_is_not_clamped(mocker):
 
     assert component["DTSTART"].dt.isoformat() == "2026-02-01"
     assert component["DTEND"].dt.isoformat() == "2026-02-05"
+
+
+def test_non_iana_stored_tzid_is_not_inherited_and_does_not_warn(mocker, caplog):
+    """Round-3 finding: a stored TZID need not be an IANA name.
+
+    icalendar renders a fixed-offset tzinfo as ``TZID="UTC-04:00"`` with no
+    VTIMEZONE (the limitation documented on this PR), so inheriting one is
+    *expected* to fail. Routing that through ``_resolve_timezone`` logged
+    "Unknown IANA timezone", which reads as an error when falling back to
+    floating time is the correct outcome.
+    """
+    import logging
+
+    vevent = 'DTSTART;TZID="UTC-04:00":20260101T090000\r\n'
+    with caplog.at_level(
+        logging.WARNING, logger="nextcloud_mcp_server.client.calendar"
+    ):
+        component = _merge(mocker, vevent, {"start_datetime": "2026-03-10T09:00:00"})
+
+    assert component["DTSTART"].dt.replace(tzinfo=None).isoformat() == (
+        "2026-03-10T09:00:00"
+    )
+    assert not any("Unknown IANA timezone" in r.message for r in caplog.records)
+
+
+def test_explicit_unknown_timezone_still_warns(mocker, caplog):
+    """The quiet path is scoped to *inherited* zones — an explicit bad
+    ``timezone=`` from the caller is a real mistake and must still surface."""
+    import logging
+
+    vevent = "DTSTART:20260101T090000Z\r\n"
+    with caplog.at_level(
+        logging.WARNING, logger="nextcloud_mcp_server.client.calendar"
+    ):
+        _merge(
+            mocker,
+            vevent,
+            {"start_datetime": "2026-03-10T09:00:00", "timezone": "Not/AZone"},
+        )
+
+    assert any("Unknown IANA timezone" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

Two bugs in `_merge_ical_properties`, both from reading the caller's partial
update dict instead of the stored event:

**1. All-day events silently became floating date-times.** `all_day` was read as
`event_data.get("all_day", False)` independently in each date branch, and the
stored component's value type was never inspected. `nc_calendar_update_event`
only puts `all_day` into `event_data` when the caller explicitly passes it — so
updating an all-day event's start without re-passing `all_day=True` rewrote
DTSTART as a naive DATE-TIME, and could leave DTSTART as DATE-TIME beside a DATE
DTEND. **That is invalid iCalendar**, verified by round-tripping a stored
`VALUE=DATE` event through the old code.

**2. The stored TZID was never read back.** Updating the time of a
`TZID=America/New_York` event without re-passing `timezone` produced RFC 5545
floating local time instead of the original zone.

## Change

Both are inherited from the stored component when the caller doesn't override
them. Extracted `_apply_date_updates()` (which also relieves the cognitive-
complexity pressure Sonar `S3776` flags on the old 120-line branch pile):

- Target value type computed **once**, with the stored type as fallback.
- TZID inherited **per property** — DTSTART and DTEND may legally carry
  different zones, so sharing DTSTART's would silently relocate the end of a
  cross-zone event.
- `inherited_tz` is a **separate parameter** from `tz_name`, not a reuse of it.
  Passing the stored zone as `tz_name` would fire the "explicit offset; ignoring
  timezone" warning on every offset-bearing update, and would override a caller
  who deliberately wants floating time. Explicit wins; inheriting logs at debug
  because it's the expected behaviour, not a problem.

Flipping between all-day and timed now validates instead of emitting broken
iCalendar. A half-supplied flip raises; all-day → timed with no datetimes raises
(there is no defensible time-of-day to invent); timed → all-day with no datetimes
converts the stored values and **clamps DTEND to at least the day after DTSTART**
— a 09:00–10:00 event naively `.date()`-ed on both ends would be a zero-length
DATE range.

## Also removes a latent data-loss fallback

`_merge_ical_properties` ended in `except Exception` → `_create_ical_event(event_data, ...)`,
which rebuilds the event from the **partial update dict** — destroying summary,
location, attendees, alarms, RRULE and every custom property the caller didn't
pass, while reporting success. It would also have swallowed the new validation
errors and converted them into exactly that silent loss.

## Test coverage

The update path had **no unit coverage at all**, which is why both bugs
survived — `test_timezone_roundtrip.py` covered only create and parse. New tests
assert parsed **value types and TZID params**, not rendered strings:

- an all-day event updated without `all_day` stays `VALUE=DATE`
- a TZID-bound event updated naively keeps its zone; an explicit `timezone` beats
  the inherited one; an explicit offset neither inherits nor logs the spurious
  warning
- DTSTART and DTEND each keep their own zone
- timed → all-day clamps DTEND past DTSTART
- both invalid flips raise (setup hoisted out of `pytest.raises` per Sonar `S5778`)
- a property never present in `event_data` survives the merge — the guard against
  the removed rebuild fallback

Tiers executed locally: unit ✅ 2422 passed. Integration/e2e runs in CI on this PR.

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`,
which does not import the calendar client or models. No cross-service boundary touched.

## Known limitation, deliberately out of scope

icalendar renders a fixed-offset tzinfo as `TZID="UTC-04:00"` with no matching
VTIMEZONE, so an offset passed by the caller is dropped on re-parse (wall-clock
survives). That is **pre-existing** and shared with the create path
(`_create_ical_event`), so fixing only the update path would create an asymmetry.
Noted in the test docstring and tracked as a follow-up rather than left silent.

## Provenance

Reported downstream on `pi0n00r/nextcloud-mcp-server` (all-day update, CalDAV
wall-clock preservation). That fork declares CLA non-participation, so **no fork
code or tests were copied** — both bugs were re-verified against this tree and
the fix and tests written from scratch.

---

_This PR was generated with the help of AI, and reviewed by a Human_
