### PR TITLE
fix(calendar): structured handling for CalDAV delete refusals

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import inspect
 import logging
+import re
 import uuid
 from typing import Any
 from urllib.parse import unquote, urlsplit, urlunsplit
@@ -670,21 +671,106 @@ class CalendarClient:
             "status_code": 200,
         }
 
-    async def delete_event(self, calendar_name: str, event_uid: str) -> dict[str, Any]:
-        """Delete a calendar event."""
+    @staticmethod
+    def _status_from_dav_error(exc: caldav_error.DAVError) -> int | None:
+        """Best-effort HTTP status from a caldav DAVError, or ``None``.
+
+        caldav offers nothing structured here. ``_post_delete`` raises
+        ``DeleteError(errmsg(r))``, and ``errmsg`` formats
+        ``"<status> <reason>\\n\\n<body>"`` — which lands in the exception's
+        ``url`` slot, because ``DAVError.__init__``'s first positional parameter
+        is ``url``. So the status is the leading integer of ``exc.url``, with
+        ``str(exc)`` as a fallback in case a future caldav populates it properly.
+
+        Returns ``None`` when nothing parses; callers must treat that as an
+        unknown refusal rather than substituting a plausible-looking code.
+        """
+        for candidate in (getattr(exc, "url", None), str(exc)):
+            if not candidate:
+                continue
+            match = re.search(r"\b(\d{3})\b", str(candidate))
+            if match:
+                return int(match.group(1))
+        return None
+
+    async def _delete_dav_object(
+        self,
+        calendar_name: str,
+        uid: str,
+        comp_filter: Any,
+        kind: str,
+    ) -> dict[str, Any]:
+        """Delete one CalDAV object, mapping refusals to a structured result.
+
+        Only ``NotFoundError`` used to be caught, so a 403 (Nextcloud refuses to
+        delete iMIP/scheduled objects) or a 409/412 (a stale entry in the calendar
+        trashbin colliding with the delete) escaped as a raw caldav traceback out
+        of the MCP tool.
+
+        Only ``DeleteError`` is treated as a refusal: it is precisely what
+        ``DAVObject._post_delete`` raises when the server rejects the DELETE.
+        caldav's other error classes are flat siblings under ``DAVError``, not
+        subclasses of it, so ``AuthorizationError`` (expired credential) and
+        ``RateLimitError`` (retryable) keep propagating instead of being flattened
+        into a per-object "the server refused this event" message. Catching the
+        ``DAVError`` base would have masked exactly those.
+        """
         await self._ensure_calendar_home()
         calendar = self._get_calendar(calendar_name)
 
         try:
-            event = await self._async_object_by_uid(
-                calendar, event_uid, cdav.CompFilter("VEVENT")
-            )
-            await _maybe_await(event.delete())
-            logger.debug("Deleted event %s", event_uid)
-            return {"status_code": 204}
+            obj = await self._async_object_by_uid(calendar, uid, comp_filter)
+            await _maybe_await(obj.delete())
+            logger.debug("Deleted %s %s", kind, uid)
+            return {"success": True, "status_code": 204}
         except caldav_error.NotFoundError as e:
-            logger.debug("Event %s not found: %s", event_uid, e)
-            return {"status_code": 404}
+            logger.debug("%s %s not found: %s", kind.capitalize(), uid, e)
+            return {"success": True, "status_code": 404}
+        except caldav_error.DeleteError as e:
+            status = self._status_from_dav_error(e)
+            logger.warning(
+                "Server refused to delete %s %s (status %s)",
+                kind,
+                uid,
+                status if status is not None else "unknown",
+            )
+            return {
+                "success": False,
+                "status_code": status if status is not None else 500,
+                "message": self._delete_refusal_message(status, kind),
+                "reason": str(e),
+            }
+
+    @staticmethod
+    def _delete_refusal_message(status: int | None, kind: str) -> str:
+        """Explain a delete refusal in terms of its likely cause."""
+        if status == 403:
+            return (
+                f"The server refused to delete this {kind}. Nextcloud rejects "
+                "deletion of scheduled (iMIP) objects — if you are an attendee, "
+                "decline the invitation instead; if you are the organizer, cancel "
+                "it so attendees are notified."
+            )
+        if status in (409, 412, 500):
+            return (
+                f"The server refused to delete this {kind}, most likely because a "
+                "previously-deleted object with the same UID is still in the "
+                "calendar trashbin. Empty the trashbin in the Nextcloud Calendar "
+                "UI and retry."
+            )
+        return f"The server refused to delete this {kind}" + (
+            f" (HTTP {status})." if status is not None else "."
+        )
+
+    async def delete_event(self, calendar_name: str, event_uid: str) -> dict[str, Any]:
+        """Delete a calendar event.
+
+        Returns a structured result rather than raising on a server refusal —
+        see :meth:`_delete_dav_object`.
+        """
+        return await self._delete_dav_object(
+            calendar_name, event_uid, cdav.CompFilter("VEVENT"), "event"
+        )
 
     async def get_event(
         self, calendar_name: str, event_uid: str
@@ -851,20 +937,14 @@ class CalendarClient:
             raise
 
     async def delete_todo(self, calendar_name: str, todo_uid: str) -> dict[str, Any]:
-        """Delete a todo/task."""
-        await self._ensure_calendar_home()
-        calendar = self._get_calendar(calendar_name)
+        """Delete a todo/task.
 
-        try:
-            todo = await self._async_object_by_uid(
-                calendar, todo_uid, cdav.CompFilter("VTODO")
-            )
-            await _maybe_await(todo.delete())
-            logger.debug("Deleted todo %s", todo_uid)
-            return {"status_code": 204}
-        except caldav_error.NotFoundError as e:
-            logger.debug("Todo %s not found: %s", todo_uid, e)
-            return {"status_code": 404}
+        Returns a structured result rather than raising on a server refusal —
+        see :meth:`_delete_dav_object`.
+        """
+        return await self._delete_dav_object(
+            calendar_name, todo_uid, cdav.CompFilter("VTODO"), "todo"
+        )
 
     async def search_todos_across_calendars(
         self, filters: dict[str, Any] | None = None

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -10,6 +10,8 @@ from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.calendar import (
     Calendar,
     CalendarEventSummary,
+    DeleteEventResponse,
+    DeleteTodoResponse,
     ListCalendarsResponse,
     ListEventsResponse,
     ListTodosResponse,
@@ -396,10 +398,23 @@ def configure_calendar_tools(mcp: FastMCP):
         calendar_name: str,
         event_uid: str,
         ctx: Context,
-    ):
-        """Delete a calendar event"""
+    ) -> DeleteEventResponse:
+        """Delete a calendar event.
+
+        A missing event is reported as success (status 404) so retries are safe.
+        A server *refusal* — a scheduled/iMIP object, or a stale entry in the
+        calendar trashbin holding the UID — comes back with ``success=False`` and
+        a message explaining the likely cause, rather than raising.
+        """
         client = await get_client(ctx)
-        return await client.calendar.delete_event(calendar_name, event_uid)
+        result = await client.calendar.delete_event(calendar_name, event_uid)
+        return DeleteEventResponse(
+            success=result.get("success", True),
+            status_code=result.get("status_code"),
+            message=result.get("message"),
+            deleted_uid=event_uid,
+            calendar_name=calendar_name,
+        )
 
     @mcp.tool(
         title="Create Meeting",
@@ -739,9 +754,23 @@ def configure_calendar_tools(mcp: FastMCP):
 
             for event in events:
                 try:
-                    await client.calendar.delete_event(
+                    outcome = await client.calendar.delete_event(
                         event.get("calendar_name", calendar_name), event["uid"]
                     )
+                    # A server refusal is now a structured result rather than an
+                    # exception, so it has to be counted explicitly — otherwise it
+                    # would be tallied as a successful delete.
+                    if not outcome.get("success", True):
+                        failed_count += 1
+                        results.append(
+                            {
+                                "uid": event["uid"],
+                                "status": "failed",
+                                "error": outcome.get("message", "delete refused"),
+                                "title": event.get("title", ""),
+                            }
+                        )
+                        continue
                     deleted_count += 1
                     results.append(
                         {
@@ -837,9 +866,30 @@ def configure_calendar_tools(mcp: FastMCP):
                     await client.calendar.create_event(target_calendar, event_data)
 
                     # Delete from source calendar
-                    await client.calendar.delete_event(
+                    outcome = await client.calendar.delete_event(
                         event.get("calendar_name", calendar_name), event["uid"]
                     )
+                    # The copy has already landed in the target. If the source
+                    # delete is refused, the event now exists in *both* calendars,
+                    # so this must be reported as a failure with the duplicate
+                    # named — counting it as "moved" would hide it.
+                    if not outcome.get("success", True):
+                        failed_count += 1
+                        results.append(
+                            {
+                                "uid": event["uid"],
+                                "status": "failed",
+                                "error": (
+                                    "copied to "
+                                    f"{target_calendar} but the source copy could "
+                                    "not be deleted, so the event now exists in "
+                                    "both calendars: "
+                                    f"{outcome.get('message', 'delete refused')}"
+                                ),
+                                "title": event.get("title", ""),
+                            }
+                        )
+                        continue
 
                     moved_count += 1
                     results.append(
@@ -1116,8 +1166,13 @@ def configure_calendar_tools(mcp: FastMCP):
         calendar_name: str,
         todo_uid: str,
         ctx: Context,
-    ):
+    ) -> DeleteTodoResponse:
         """Delete a todo/task from a calendar.
+
+        A missing todo is reported as success (status 404) so retries are safe.
+        A server *refusal* — a scheduled/iMIP object, or a stale entry in the
+        calendar trashbin holding the UID — comes back with ``success=False`` and
+        a message explaining the likely cause, rather than raising.
 
         Args:
             calendar_name: Name of the calendar containing the todo
@@ -1125,10 +1180,17 @@ def configure_calendar_tools(mcp: FastMCP):
             ctx: MCP context
 
         Returns:
-            Dict with deletion status
+            DeleteTodoResponse carrying the status and, on refusal, why.
         """
         client = await get_client(ctx)
-        return await client.calendar.delete_todo(calendar_name, todo_uid)
+        result = await client.calendar.delete_todo(calendar_name, todo_uid)
+        return DeleteTodoResponse(
+            success=result.get("success", True),
+            status_code=result.get("status_code"),
+            message=result.get("message"),
+            deleted_uid=todo_uid,
+            calendar_name=calendar_name,
+        )
 
     @mcp.tool(
         title="Search Todo Tasks",

--- a/tests/client/calendar/test_delete_refusals.py
+++ b/tests/client/calendar/test_delete_refusals.py
@@ -1,0 +1,160 @@
+"""Unit tests for structured CalDAV delete-refusal handling.
+
+``delete_event`` / ``delete_todo`` used to catch only ``NotFoundError``, so a
+server *refusal* — a 403 on a scheduled (iMIP) object, or a 409/412 from a stale
+entry in the calendar trashbin still holding the UID — escaped as a raw caldav
+traceback out of the MCP tool.
+
+The shape being pinned here was verified against the installed caldav:
+``DAVObject._post_delete`` raises ``DeleteError(errmsg(r))`` where ``errmsg``
+formats ``"<status> <reason>\\n\\n<body>"``, and ``DAVError.__init__``'s first
+positional parameter is ``url`` — so the status string lands in ``exc.url``, not
+``exc.reason``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from caldav.lib import error as caldav_error
+
+from nextcloud_mcp_server.client.calendar import CalendarClient
+
+pytestmark = pytest.mark.unit
+
+
+def _client(mocker, *, delete_raises: Exception | None = None) -> CalendarClient:
+    """Build a CalendarClient whose object lookup and delete are stubbed."""
+    client = CalendarClient.__new__(CalendarClient)
+    client._client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    client._principal_resolved = True
+    mocker.patch.object(client, "_ensure_calendar_home", mocker.AsyncMock())
+    mocker.patch.object(
+        client, "_get_calendar", mocker.Mock(return_value=mocker.Mock())
+    )
+
+    obj = mocker.Mock()
+    obj.delete = (
+        mocker.Mock(side_effect=delete_raises) if delete_raises else mocker.Mock()
+    )
+    mocker.patch.object(
+        client, "_async_object_by_uid", mocker.AsyncMock(return_value=obj)
+    )
+    return client
+
+
+def _delete_error(status_line: str) -> caldav_error.DeleteError:
+    """Build a DeleteError exactly as caldav's _post_delete does."""
+    return caldav_error.DeleteError(f"{status_line}\n\n<d:error/>")
+
+
+@pytest.mark.parametrize("method,uid", [("delete_event", "e1"), ("delete_todo", "t1")])
+async def test_successful_delete_reports_204(mocker, method, uid):
+    client = _client(mocker)
+    result = await getattr(client, method)("Personal", uid)
+    assert result == {"success": True, "status_code": 204}
+
+
+@pytest.mark.parametrize("method,uid", [("delete_event", "e1"), ("delete_todo", "t1")])
+async def test_missing_object_stays_idempotent_404(mocker, method, uid):
+    """A missing object is a *success*: retrying a delete must be safe.
+
+    ``NotFoundError`` and ``DeleteError`` are flat siblings under ``DAVError``,
+    so clause ordering is not load-bearing here — but widening the refusal clause
+    to ``DAVError`` would swallow this and report a refusal instead.
+    """
+    client = _client(mocker)
+    mocker.patch.object(
+        client,
+        "_async_object_by_uid",
+        mocker.AsyncMock(side_effect=caldav_error.NotFoundError("nope")),
+    )
+
+    result = await getattr(client, method)("Personal", uid)
+
+    assert result == {"success": True, "status_code": 404}
+
+
+@pytest.mark.parametrize("method,uid", [("delete_event", "e1"), ("delete_todo", "t1")])
+async def test_403_refusal_names_scheduled_objects(mocker, method, uid):
+    client = _client(mocker, delete_raises=_delete_error("403 Forbidden"))
+
+    result = await getattr(client, method)("Personal", uid)
+
+    assert result["success"] is False
+    assert result["status_code"] == 403
+    assert "scheduled" in result["message"]
+    assert "403 Forbidden" in result["reason"]
+
+
+@pytest.mark.parametrize("status", ["409 Conflict", "412 Precondition Failed"])
+async def test_conflict_refusal_names_the_trashbin(mocker, status):
+    client = _client(mocker, delete_raises=_delete_error(status))
+
+    result = await client.delete_event("Personal", "e1")
+
+    assert result["success"] is False
+    assert result["status_code"] == int(status.split()[0])
+    assert "trashbin" in result["message"]
+
+
+async def test_unparseable_refusal_is_not_guessed(mocker):
+    """An unknown refusal must surface as 500, not a plausible-looking code."""
+    client = _client(mocker, delete_raises=caldav_error.DeleteError())
+
+    result = await client.delete_event("Personal", "e1")
+
+    assert result["success"] is False
+    assert result["status_code"] == 500
+    assert "refused" in result["message"]
+
+
+async def test_transport_errors_still_propagate(mocker):
+    """Refusals are handled; connectivity failures are not ours to swallow."""
+    client = _client(mocker, delete_raises=httpx.ConnectError("boom"))
+    pending = client.delete_event("Personal", "e1")
+
+    with pytest.raises(httpx.ConnectError):
+        await pending
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [caldav_error.AuthorizationError(), caldav_error.RateLimitError()],
+    ids=["authorization", "rate_limit"],
+)
+async def test_non_refusal_dav_errors_still_propagate(mocker, exc):
+    """Only DeleteError is a refusal.
+
+    AuthorizationError (expired credential) and RateLimitError (retryable) are
+    siblings under DAVError, not delete rejections. Catching the DAVError base
+    would flatten an auth failure into a per-object "the server refused this
+    event" message and hide a systemic problem — this test is what caught that
+    in the first implementation.
+    """
+    client = _client(mocker)
+    mocker.patch.object(
+        client, "_async_object_by_uid", mocker.AsyncMock(side_effect=exc)
+    )
+    pending = client.delete_event("Personal", "e1")
+
+    with pytest.raises(type(exc)):
+        await pending
+
+
+@pytest.mark.parametrize(
+    "status_line,expected",
+    [
+        ("403 Forbidden", 403),
+        ("409 Conflict", 409),
+        ("412 Precondition Failed", 412),
+        ("500 Internal Server Error", 500),
+    ],
+)
+def test_status_parsing_from_caldav_error(status_line, expected):
+    exc = _delete_error(status_line)
+    assert CalendarClient._status_from_dav_error(exc) == expected
+
+
+def test_status_parsing_returns_none_when_absent():
+    assert CalendarClient._status_from_dav_error(caldav_error.DeleteError()) is None


### PR DESCRIPTION
## Problem

`delete_event` and `delete_todo` caught only `NotFoundError`, so a server
**refusal** escaped as a raw caldav traceback out of the MCP tool:

- **403** — Nextcloud rejects deletion of scheduled (iMIP) objects.
- **409 / 412** — a stale entry in the calendar trashbin still holds the UID.

## Change

Both share `_delete_dav_object`, which maps a refusal to a structured result with
the status, a message naming the likely cause, and the raw reason.
`nc_calendar_delete_event` / `nc_calendar_delete_todo` return the
previously-unused `DeleteEventResponse` / `DeleteTodoResponse`, so a refusal
reports `success=False` rather than hiding a 403 inside a success envelope.

A missing object stays an idempotent **success** (404), so retries remain safe.

### Only `DeleteError` counts as a refusal

Worth calling out, because the obvious `except caldav_error.DAVError` is wrong.
caldav's error classes are **flat siblings** under `DAVError`, not a hierarchy —
verified against the installed version:

```
AuthorizationError  <- ['DAVError', 'Exception']
DeleteError         <- ['DAVError', 'Exception']
RateLimitError      <- ['DAVError', 'Exception']
NotFoundError is DeleteError subclass? False
```

Catching the base would flatten `AuthorizationError` (expired credential) and
`RateLimitError` (retryable) into a per-object *"the server refused this event"*
message, hiding a systemic problem behind a per-item one. My first implementation
did exactly that; the propagation test caught it.

### Status parsing is empirical, not assumed

`DAVObject._post_delete` raises `DeleteError(errmsg(r))`, and `errmsg` formats
`"<status> <reason>\n\n<body>"` — but `DAVError.__init__`'s first positional
parameter is **`url`**, so the status string lands in `exc.url`, not `exc.reason`.
An unparseable refusal reports 500 rather than guessing a plausible-looking code.

### No retry for the trashbin case

Deterministic, not transient — a retry fails identically. The only real recovery
is purging the trashbin entry, which is **irreversible** and could destroy an
unrelated previously-trashed object. That belongs behind an explicit tool, not
inside a delete. Tracked as a follow-up.

## Regression this would otherwise have introduced

`nc_calendar_bulk_operations` relied on the **exception** to increment
`failed_count`. With refusals no longer raising, a refused delete would have been
tallied as `"deleted"`.

The bulk **move** is worse: it copies to the target and then deletes the source,
so a silently-ignored refusal would leave the event in **both** calendars while
reporting a clean move. Both paths now check the outcome explicitly, and the move
names the duplicate in its error so it can be cleaned up.

## Test coverage

New `tests/client/calendar/test_delete_refusals.py` (17 cases), parametrised over
both `delete_event` and `delete_todo`:

- 403 message names scheduled/iMIP objects; 409/412 name the trashbin
- missing object stays an idempotent 404 success
- unparseable refusal reports 500, not a guess
- **`AuthorizationError` and `RateLimitError` still propagate** — the test that
  caught the over-broad handler
- transport errors (`httpx.ConnectError`) still propagate
- direct parsing tests for `_status_from_dav_error`

Existing integration assertions (`delete_result["status_code"] in [200, 204, 404]`)
are unaffected — the success shape is unchanged, `success` is additive.

Tiers executed locally: unit ✅ 2447 passed. Integration/e2e runs in CI.

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`,
which does not import the calendar client or models.

## Provenance

Reported downstream on `pi0n00r/nextcloud-mcp-server` (iMIP VTODO delete rejection,
stale trash collisions). That fork declares CLA non-participation, so **no fork code
or tests were copied** — the behaviour was re-derived from the installed caldav and
the fix written from scratch.

---

_This PR was generated with the help of AI, and reviewed by a Human_
