### PR TITLE
fix(deck): preserve order and due date on partial card updates

### DIFF
--- a/nextcloud_mcp_server/client/deck.py
+++ b/nextcloud_mcp_server/client/deck.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from httpx import HTTPStatusError, RequestError
@@ -17,6 +18,35 @@ from nextcloud_mcp_server.models.deck import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_duedate(duedate: Optional[str]) -> Optional[str]:
+    """Convert an offset-aware due date to the UTC ``Z`` form Deck parses reliably.
+
+    Deck's PHP date handling is unreliable with non-UTC offsets, so an
+    offset-aware value is converted to the same instant in UTC. Naive and
+    unparseable strings are passed through untouched — this normalises, it does
+    not validate, and rejecting a format Deck might accept would be worse than
+    forwarding it.
+
+    An empty string maps to ``None`` so "clear the due date" is expressible;
+    previously it went on the wire as ``""``, where Deck's behaviour is undefined.
+
+    ``strftime`` rather than ``isoformat()``: the latter yields ``+00:00`` and
+    keeps microseconds, neither of which is what Deck stores.
+    """
+    if duedate is None:
+        return None
+    if not duedate.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(duedate.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Passing through unparseable duedate %r unchanged", duedate)
+        return duedate
+    if parsed.tzinfo is None:
+        return duedate
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class DeckClient(BaseNextcloudClient):
@@ -266,7 +296,7 @@ class DeckClient(BaseNextcloudClient):
         if description is not None:
             json_data["description"] = description
         if duedate is not None:
-            json_data["duedate"] = duedate
+            json_data["duedate"] = _normalize_duedate(duedate)
         headers = self._get_deck_headers()
         response = await self._make_request(
             "POST",
@@ -275,6 +305,59 @@ class DeckClient(BaseNextcloudClient):
             headers=headers,
         )
         return DeckCard(**response.json())
+
+    @staticmethod
+    def _card_update_payload(
+        current: DeckCard,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        type: Optional[str] = None,
+        owner: Optional[str] = None,
+        order: Optional[int] = None,
+        duedate: Optional[str] = None,
+        archived: Optional[bool] = None,
+        done: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Build the full-replacement body for a card update.
+
+        Deck's card PUT replaces the whole card, so every field the caller did
+        *not* supply has to be carried over from ``current``. ``order``,
+        ``duedate`` and ``archived`` were previously only sent when explicitly
+        passed, so a title-only update reset the card's order to 0 and cleared its
+        due date. ``move_card_to_board`` already sent order and duedate
+        unconditionally — the two payload builders simply disagreed.
+
+        Every fallback tests ``is not None``, never truthiness: ``order=0`` is a
+        legitimate first position and ``archived=False`` is meaningful, so
+        ``order or current.order`` would silently discard both.
+
+        ``done`` is deliberately not carried over. ``move_card_to_board``'s
+        docstring records that the internal route does not accept a ``done``
+        value, so the two routes genuinely differ here; preserving it blind could
+        re-stamp a done timestamp. Left as an explicit omission pending an
+        integration test that shows whether this route clears it.
+        """
+        return {
+            # Title is required by the API
+            "title": title if title is not None else current.title,
+            # Type is required by the API
+            "type": type if type is not None else current.type,
+            # Owner is required by the API (model validator ensures it's a string)
+            "owner": owner if owner is not None else current.owner,
+            # Description must be sent to preserve it (PUT clears omitted fields)
+            "description": description
+            if description is not None
+            else (current.description or ""),
+            "order": order if order is not None else current.order,
+            "duedate": _normalize_duedate(
+                duedate
+                if duedate is not None
+                else (current.duedate.isoformat() if current.duedate else None)
+            ),
+            "archived": archived if archived is not None else current.archived,
+            **({"done": done} if done is not None else {}),
+        }
 
     async def update_card(
         self,
@@ -294,27 +377,17 @@ class DeckClient(BaseNextcloudClient):
         # Fetch current card to preserve values for fields not being updated.
         current_card = await self.get_card(board_id, stack_id, card_id)
 
-        # Build payload with required fields always included
-        json_data = {
-            # Title is required by the API
-            "title": title if title is not None else current_card.title,
-            # Type is required by the API
-            "type": type if type is not None else current_card.type,
-            # Owner is required by the API (model validator ensures it's a string)
-            "owner": owner if owner is not None else current_card.owner,
-            # Description must be sent to preserve it (PUT clears omitted fields)
-            "description": description
-            if description is not None
-            else (current_card.description or ""),
-        }
-        if order is not None:
-            json_data["order"] = order
-        if duedate is not None:
-            json_data["duedate"] = duedate
-        if archived is not None:
-            json_data["archived"] = archived
-        if done is not None:
-            json_data["done"] = done
+        json_data = self._card_update_payload(
+            current_card,
+            title=title,
+            description=description,
+            type=type,
+            owner=owner,
+            order=order,
+            duedate=duedate,
+            archived=archived,
+            done=done,
+        )
         headers = self._get_deck_headers()
         await self._make_request(
             "PUT",
@@ -483,7 +556,9 @@ class DeckClient(BaseNextcloudClient):
             # Sent explicitly as None when absent (update_card omits the key);
             # both are equivalent here — the route reads duedate and there's
             # nothing to clear on a card that never had one.
-            "duedate": current.duedate.isoformat() if current.duedate else None,
+            "duedate": _normalize_duedate(
+                current.duedate.isoformat() if current.duedate else None
+            ),
             # 0 keeps the card live (a positive value would soft-delete it)
             "deletedAt": current.deletedAt or 0,
         }

--- a/tests/client/deck/test_deck_api.py
+++ b/tests/client/deck/test_deck_api.py
@@ -362,7 +362,15 @@ async def test_deck_update_card(mocker):
     put_call = mock_make_request.call_args_list[1]
     assert put_call[0][0] == "PUT"
     assert "/boards/123/stacks/456/cards/789" in put_call[0][1]
-    assert put_call[1]["json"]["title"] == "Updated Card"
+    body = put_call[1]["json"]
+    assert body["title"] == "Updated Card"
+    # Deck's PUT is a full replacement, so the fields the caller did NOT pass
+    # must still be carried over. Asserting only `title` is what let a bug
+    # through where order was reset to 0 and the due date cleared on every
+    # partial update; see test_deck_update_card_payload.py.
+    assert body["order"] == 999  # from the mocked current card
+    assert "duedate" in body
+    assert body["archived"] is False
 
 
 # Label Tests

--- a/tests/client/deck/test_deck_move_card_api.py
+++ b/tests/client/deck/test_deck_move_card_api.py
@@ -77,7 +77,13 @@ async def test_move_card_to_board_sends_id_and_target_stack(mocker):
 
 
 async def test_move_card_to_board_preserves_duedate(mocker):
-    """A due date on the source card is forwarded as an ISO-8601 string."""
+    """A due date on the source card is forwarded, normalised to UTC "Z" form.
+
+    move_card_to_board now shares `_normalize_duedate` with create_card and
+    update_card, so all three put the same representation on the wire. The
+    instant is unchanged — "+00:00" and "Z" are the same time — but the shape is
+    now consistent, which is the point of having one normalisation helper.
+    """
     mock_make_request = mocker.patch.object(
         DeckClient,
         "_make_request",
@@ -100,7 +106,7 @@ async def test_move_card_to_board_preserves_duedate(mocker):
     )
 
     body = mock_make_request.call_args_list[2].kwargs["json"]
-    assert body["duedate"] == "2030-01-02T03:04:05+00:00"
+    assert body["duedate"] == "2030-01-02T03:04:05Z"
 
 
 async def test_move_card_to_board_restores_done_state(mocker):

--- a/tests/client/deck/test_deck_update_card_api.py
+++ b/tests/client/deck/test_deck_update_card_api.py
@@ -11,6 +11,8 @@ Related issues:
 - deck #4106: Provide a working example of API usage to update a cards details
 """
 
+import datetime as dt
+
 import pytest
 
 pytestmark = [pytest.mark.integration]
@@ -117,6 +119,41 @@ class TestDeckClientUpdateCard:
         )
         assert updated.title == "Original Title"
         assert updated.description == "Original description"
+        # Assert the actual instant, not merely that *a* date is set — the old
+        # `is not None` check passed whether or not the offset was mishandled.
+        assert updated.duedate is not None
+        assert updated.duedate.tzinfo is not None
+        assert updated.duedate.astimezone(dt.timezone.utc).replace(
+            tzinfo=None
+        ) == dt.datetime(2025, 12, 31, 23, 59, 59)
+
+    async def test_update_title_preserves_order_and_duedate(
+        self, nc_client, deck_test_card
+    ):
+        """The inverse of the per-field tests: updating one field must not
+        silently reset the others."""
+        await nc_client.deck.update_card(
+            board_id=deck_test_card["board_id"],
+            stack_id=deck_test_card["stack_id"],
+            card_id=deck_test_card["card_id"],
+            order=42,
+            duedate="2030-06-01T12:00:00+00:00",
+        )
+
+        await nc_client.deck.update_card(
+            board_id=deck_test_card["board_id"],
+            stack_id=deck_test_card["stack_id"],
+            card_id=deck_test_card["card_id"],
+            title="Renamed Only",
+        )
+
+        updated = await nc_client.deck.get_card(
+            deck_test_card["board_id"],
+            deck_test_card["stack_id"],
+            deck_test_card["card_id"],
+        )
+        assert updated.title == "Renamed Only"
+        assert updated.order == 42
         assert updated.duedate is not None
 
     async def test_update_archived_only(self, nc_client, deck_test_card):

--- a/tests/client/deck/test_deck_update_card_payload.py
+++ b/tests/client/deck/test_deck_update_card_payload.py
@@ -1,0 +1,153 @@
+"""Unit tests for the body DeckClient.update_card sends.
+
+Deck's card PUT is a full replacement, so every field the caller did not supply
+has to be carried over from the current card. ``order``, ``duedate`` and
+``archived`` were previously only sent when explicitly passed, so a title-only
+update reset the card's order to 0 and cleared its due date.
+
+These assert the request body directly — the existing integration tests only
+checked fields they had just set, which is why the bug survived.
+"""
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.client.deck import DeckClient, _normalize_duedate
+from tests.client.conftest import create_mock_deck_card_response, create_mock_response
+
+pytestmark = pytest.mark.unit
+
+
+def _patch_get_then_put(mocker, **card_fields) -> object:
+    """Stub the GET (current card) then the PUT, returning the mock."""
+    return mocker.patch.object(
+        DeckClient,
+        "_make_request",
+        side_effect=[
+            create_mock_deck_card_response(**card_fields),
+            create_mock_response(status_code=200, json_data={}),
+        ],
+    )
+
+
+def _put_body(mock_make_request) -> dict:
+    """Return the JSON body of the PUT (the second call)."""
+    return mock_make_request.call_args_list[1].kwargs["json"]
+
+
+async def test_title_only_update_preserves_order_and_duedate(mocker):
+    """The headline regression: a title-only update must not reset order or
+    clear the due date."""
+    mock = _patch_get_then_put(
+        mocker, order=7, duedate="2030-06-01T12:00:00+00:00", archived=False
+    )
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, title="Renamed")
+
+    body = _put_body(mock)
+    assert body["title"] == "Renamed"
+    assert body["order"] == 7
+    assert body["duedate"] == "2030-06-01T12:00:00Z"
+    assert body["archived"] is False
+
+
+async def test_explicit_zero_order_is_sent(mocker):
+    """``order=0`` is a legitimate first position.
+
+    Guards against an ``order or current.order`` implementation, which would
+    silently discard it.
+    """
+    mock = _patch_get_then_put(mocker, order=7)
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, order=0)
+
+    assert _put_body(mock)["order"] == 0
+
+
+async def test_explicit_false_archived_is_sent(mocker):
+    """Un-archiving must survive the same falsy-value trap as ``order=0``."""
+    mock = _patch_get_then_put(mocker, archived=True)
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, archived=False)
+
+    assert _put_body(mock)["archived"] is False
+
+
+async def test_card_without_duedate_sends_null(mocker):
+    """The key is present with a null value — the shape move_card_to_board uses —
+    rather than being omitted."""
+    mock = _patch_get_then_put(mocker, duedate=None)
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, title="Renamed")
+
+    body = _put_body(mock)
+    assert "duedate" in body
+    assert body["duedate"] is None
+
+
+async def test_explicit_duedate_is_normalized_to_utc(mocker):
+    mock = _patch_get_then_put(mocker)
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, duedate="2030-06-01T14:00:00-04:00")
+
+    assert _put_body(mock)["duedate"] == "2030-06-01T18:00:00Z"
+
+
+async def test_empty_duedate_clears_it(mocker):
+    """An empty string means "clear the due date"; it previously went on the wire
+    as ``""``, where Deck's behaviour is undefined."""
+    mock = _patch_get_then_put(mocker, duedate="2030-06-01T12:00:00+00:00")
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, duedate="")
+
+    assert _put_body(mock)["duedate"] is None
+
+
+async def test_done_is_only_sent_when_supplied(mocker):
+    """``done`` is deliberately not carried over — the internal move route does
+    not accept it, so the two routes differ and preserving it blind could
+    re-stamp a timestamp."""
+    mock = _patch_get_then_put(mocker)
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.update_card(1, 1, 1, title="Renamed")
+
+    assert "done" not in _put_body(mock)
+
+
+async def test_create_card_normalizes_duedate(mocker):
+    mock_make_request = mocker.patch.object(
+        DeckClient,
+        "_make_request",
+        return_value=create_mock_deck_card_response(),
+    )
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+
+    await client.create_card(1, 1, "New", duedate="2030-06-01T14:00:00-04:00")
+
+    body = mock_make_request.call_args.kwargs["json"]
+    assert body["duedate"] == "2030-06-01T18:00:00Z"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2030-06-01T14:00:00-04:00", "2030-06-01T18:00:00Z"),
+        ("2030-06-01T18:00:00Z", "2030-06-01T18:00:00Z"),  # idempotent
+        ("2030-06-01T18:00:00+00:00", "2030-06-01T18:00:00Z"),
+        ("2030-06-01T18:00:00.123456+00:00", "2030-06-01T18:00:00Z"),  # no micros
+        ("2030-06-01T18:00:00", "2030-06-01T18:00:00"),  # naive stays naive
+        ("2030-06-01", "2030-06-01"),
+        ("not a date", "not a date"),  # passed through, never raises
+        ("", None),
+        (None, None),
+    ],
+)
+def test_normalize_duedate(raw, expected):
+    assert _normalize_duedate(raw) == expected


### PR DESCRIPTION
## Problem

Deck's card `PUT` is a **full replacement**, so every field the caller does not
supply has to be carried over from the current card. `title`, `type`, `owner` and
`description` were preserved that way — `order`, `duedate` and `archived` were
only sent when explicitly passed:

```python
if order is not None:
    json_data["order"] = order
if duedate is not None:
    json_data["duedate"] = duedate
```

So `deck_update_card(title=...)` **reset the card's order to 0 and cleared its
due date**. On a board where cards are manually ordered, renaming one card
reshuffles it to the top.

`move_card_to_board` already sent both unconditionally — the two payload builders
simply disagreed. Extracted `_card_update_payload()` so one place decides what a
full replacement contains.

## Falsy values are the trap here

Every fallback tests `is not None`, never truthiness. `order=0` is a legitimate
first position and `archived=False` is meaningful, so the tempting
`order or current.order` would silently discard both. Both have dedicated tests.

## Due date normalisation

New `_normalize_duedate`, used by **create, update and move** so there is a single
normalisation point:

- offset-aware → the UTC `Z` form Deck's PHP date handling parses reliably
- naive and unparseable strings → passed through untouched (this normalises, it
  does not validate; rejecting a format Deck might accept would be worse)
- `strftime`, not `isoformat()` — the latter yields `+00:00` and keeps microseconds

**One deliberate semantic change:** an empty `duedate` now maps to `None`, so
"clear the due date" is expressible. It previously went on the wire as `""`, where
Deck's behaviour is undefined. Flagging it because it *is* a behaviour change for
anyone currently passing `""`.

## `done` is deliberately not carried over

By symmetry it looks like the same bug, but `move_card_to_board`'s docstring
records that the internal route **does not accept a `done` value** — so the two
routes genuinely differ, and preserving it blind could re-stamp a done timestamp.
Left as an explicit omission with a test pinning it, pending an integration test
that shows whether this route clears it. Raising it here rather than guessing.

## Why the existing tests missed this

- `test_deck_update_card` asserted **only** `title` on the PUT body.
- The per-field integration tests (`test_update_duedate_only`,
  `test_update_order_only`) each checked the field they had just set — none
  checked the *inverse*, that other fields survived.
- `test_update_duedate_only` asserted merely `duedate is not None`, which passes
  whether or not the offset was mishandled.

All three are strengthened, plus a new title-only integration round-trip.

## Test coverage

New `tests/client/deck/test_deck_update_card_payload.py` (17 cases) asserting the
request body directly: title-only preserves order/duedate/archived; `order=0` and
`archived=False` survive; a card without a due date sends `"duedate": null` (the
shape `move_card_to_board` uses) rather than omitting the key; explicit due dates
normalise; `done` absent unless supplied; plus a parametrised table for
`_normalize_duedate` including idempotency, microsecond stripping and the
never-raises case.

Tiers executed locally: unit ✅ 2447 passed. Integration/e2e runs in CI.

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`,
which does not import the Deck client.

## Provenance

Reported downstream on `pi0n00r/nextcloud-mcp-server` ("persist due dates and
preserve order"). That fork declares CLA non-participation, so **no fork code or
tests were copied** — the bug was re-verified against this tree and the fix and
tests written from scratch.

---

_This PR was generated with the help of AI, and reviewed by a Human_
