### PR TITLE
refactor(webdav)!: typed responses for move and copy tools

### DIFF
--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -11,8 +11,10 @@ from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models import (
+    CopyResourceResponse,
     DirectoryListing,
     FileInfo,
+    MoveResourceResponse,
     ReadFileResponse,
     SearchFilesResponse,
     WriteFileResponse,
@@ -24,6 +26,11 @@ from nextcloud_mcp_server.server.tag_exclusion import (
 )
 
 logger = logging.getLogger(__name__)
+
+# move_resource/copy_resource return (rather than raise) on these, since they
+# are conditions a caller reacts to rather than transport failures. They are
+# what makes ``success`` False on the typed response.
+_WEBDAV_CONFLICT_STATUSES = frozenset({404, 409, 412})
 
 
 def configure_webdav_tools(mcp: FastMCP):
@@ -431,7 +438,7 @@ def configure_webdav_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_webdav_move_resource(
         source_path: str, destination_path: str, ctx: Context, overwrite: bool = False
-    ):
+    ) -> MoveResourceResponse:
         """Move or rename a file or directory in NextCloud.
 
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and either
@@ -444,7 +451,11 @@ def configure_webdav_tools(mcp: FastMCP):
             overwrite: Whether to overwrite the destination if it exists (default: False)
 
         Returns:
-            Dict with status_code indicating result (404 if source not found, 412 if destination exists and overwrite is False)
+            ``MoveResourceResponse``/``CopyResourceResponse``. ``success`` is
+            False for the known conflicts — 404 when the source does not
+            exist, 412 when the destination exists and ``overwrite`` is
+            False, 409 for a missing parent — with ``message`` explaining
+            which. Other failures raise.
         """
         client = await get_client(ctx)
 
@@ -460,8 +471,17 @@ def configure_webdav_tools(mcp: FastMCP):
                 "inside a path tagged with an excluded tag"
             )
 
-        return await client.webdav.move_resource(
+        result = await client.webdav.move_resource(
             source_path, destination_path, overwrite
+        )
+        status_code = result.get("status_code")
+        return MoveResourceResponse(
+            success=status_code not in _WEBDAV_CONFLICT_STATUSES,
+            status_code=status_code,
+            message=result.get("message"),
+            source_path=source_path,
+            destination_path=destination_path,
+            overwrite=overwrite,
         )
 
     @mcp.tool(
@@ -475,7 +495,7 @@ def configure_webdav_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_webdav_copy_resource(
         source_path: str, destination_path: str, ctx: Context, overwrite: bool = False
-    ):
+    ) -> CopyResourceResponse:
         """Copy a file or directory in NextCloud.
 
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and either
@@ -488,7 +508,11 @@ def configure_webdav_tools(mcp: FastMCP):
             overwrite: Whether to overwrite the destination if it exists (default: False)
 
         Returns:
-            Dict with status_code indicating result (404 if source not found, 412 if destination exists and overwrite is False)
+            ``MoveResourceResponse``/``CopyResourceResponse``. ``success`` is
+            False for the known conflicts — 404 when the source does not
+            exist, 412 when the destination exists and ``overwrite`` is
+            False, 409 for a missing parent — with ``message`` explaining
+            which. Other failures raise.
         """
         client = await get_client(ctx)
 
@@ -504,8 +528,17 @@ def configure_webdav_tools(mcp: FastMCP):
                 "inside a path tagged with an excluded tag"
             )
 
-        return await client.webdav.copy_resource(
+        result = await client.webdav.copy_resource(
             source_path, destination_path, overwrite
+        )
+        status_code = result.get("status_code")
+        return CopyResourceResponse(
+            success=status_code not in _WEBDAV_CONFLICT_STATUSES,
+            status_code=status_code,
+            message=result.get("message"),
+            source_path=source_path,
+            destination_path=destination_path,
+            overwrite=overwrite,
         )
 
     @mcp.tool(

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -451,7 +451,7 @@ def configure_webdav_tools(mcp: FastMCP):
             overwrite: Whether to overwrite the destination if it exists (default: False)
 
         Returns:
-            ``MoveResourceResponse``/``CopyResourceResponse``. ``success`` is
+            ``MoveResourceResponse``. ``success`` is
             False for the known conflicts — 404 when the source does not
             exist, 412 when the destination exists and ``overwrite`` is
             False, 409 for a missing parent — with ``message`` explaining
@@ -508,7 +508,7 @@ def configure_webdav_tools(mcp: FastMCP):
             overwrite: Whether to overwrite the destination if it exists (default: False)
 
         Returns:
-            ``MoveResourceResponse``/``CopyResourceResponse``. ``success`` is
+            ``CopyResourceResponse``. ``success`` is
             False for the known conflicts — 404 when the source does not
             exist, 412 when the destination exists and ``overwrite`` is
             False, 409 for a missing parent — with ``message`` explaining

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -770,7 +770,10 @@ async def test_move_copy_return_typed_success(
     getattr(fake_client.webdav, f"{verb}_resource").return_value = {"status_code": 201}
 
     result = await webdav_tools[tool_name].fn(
-        source_path="/a.txt", destination_path="/b.txt", ctx=object(), overwrite=False
+        source_path="/a.txt",
+        destination_path="/b.txt",
+        ctx=_mock_ctx(fake_client),
+        overwrite=False,
     )
 
     assert result.success is True
@@ -799,7 +802,10 @@ async def test_move_copy_report_conflicts_as_unsuccessful(
     }
 
     result = await webdav_tools[tool_name].fn(
-        source_path="/a.txt", destination_path="/b.txt", ctx=object(), overwrite=False
+        source_path="/a.txt",
+        destination_path="/b.txt",
+        ctx=_mock_ctx(fake_client),
+        overwrite=False,
     )
 
     assert result.success is False

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -749,3 +749,59 @@ async def test_write_file_size_gate_disabled_when_max_mb_is_zero(
     await fn(path="/Public/notes.md", content="hi", ctx=_mock_ctx(fake_client))
 
     fake_client.webdav.write_file.assert_awaited_once()
+
+
+# ============= Typed responses for move/copy =============
+#
+# Both tools previously returned the client's raw dict with no return
+# annotation, which the CLAUDE.md response-pattern gate treats as a defect: raw
+# dicts bypass the success/timestamp envelope every other tool provides.
+
+
+@pytest.mark.parametrize(
+    "tool_name,verb",
+    [("nc_webdav_move_resource", "move"), ("nc_webdav_copy_resource", "copy")],
+)
+async def test_move_copy_return_typed_success(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, tool_name, verb
+):
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    getattr(fake_client.webdav, f"{verb}_resource").return_value = {"status_code": 201}
+
+    result = await webdav_tools[tool_name].fn(
+        source_path="/a.txt", destination_path="/b.txt", ctx=object(), overwrite=False
+    )
+
+    assert result.success is True
+    assert result.status_code == 201
+    assert result.source_path == "/a.txt"
+    assert result.destination_path == "/b.txt"
+    assert result.overwrite is False
+
+
+@pytest.mark.parametrize(
+    "tool_name,verb",
+    [("nc_webdav_move_resource", "move"), ("nc_webdav_copy_resource", "copy")],
+)
+@pytest.mark.parametrize("status", [404, 409, 412])
+async def test_move_copy_report_conflicts_as_unsuccessful(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, tool_name, verb, status
+):
+    """The client returns rather than raises on these, so the typed response has
+    to carry the failure — otherwise a 412 would arrive inside a success
+    envelope."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    getattr(fake_client.webdav, f"{verb}_resource").return_value = {
+        "status_code": status,
+        "message": "nope",
+    }
+
+    result = await webdav_tools[tool_name].fn(
+        source_path="/a.txt", destination_path="/b.txt", ctx=object(), overwrite=False
+    )
+
+    assert result.success is False
+    assert result.status_code == status
+    assert result.message == "nope"


### PR DESCRIPTION
## Problem

`nc_webdav_move_resource` and `nc_webdav_copy_resource` returned the client's raw
dict with **no return annotation**. Per `CLAUDE.md`'s MCP response pattern that is
a defect on its own: a raw dict bypasses the `success`/`timestamp` envelope every
other tool provides, so clients can't rely on a consistent contract.

`MoveResourceResponse` and `CopyResourceResponse` were already defined in
`models/webdav.py` and **entirely unused**.

## Change

Mechanical. No behaviour change beyond the response shape.

The client still *returns* rather than raises on the known conflicts — 404
(source missing), 412 (destination exists with `overwrite=False`), 409 (missing
parent) — because those are conditions a caller reacts to, not transport
failures. What changes is that they now arrive with **`success=False`** instead of
a bare status code inside what looked like a success envelope, with the existing
message carried through.

The conflict set is a named constant rather than three literals, so the
"returns rather than raises" contract has one definition:

```python
_WEBDAV_CONFLICT_STATUSES = frozenset({404, 409, 412})
```

## Why this is its own PR

Deliberately separated from the destination-precondition work that follows
(tranche D3). That change has real semantics to argue about — WebDAV `If:`
tagged-lists, `IFile`-only etag conditions, 404-vs-412 on a missing destination.
Reviewing it through a response-shape diff would bury it.

## Breaking change

Recorded via a `BREAKING CHANGE:` footer so commitizen writes it into
`CHANGELOG.md` against the released version:

> `nc_webdav_move_resource` and `nc_webdav_copy_resource` now return
> `MoveResourceResponse` / `CopyResourceResponse` instead of a raw dict.

`status_code` keeps its meaning, so field-level consumers are unaffected; callers
treating the result as a plain mapping must switch to attribute access.

## Test coverage

Parametrised over **both** tools (the symmetry gap `CLAUDE.md` calls out): a
successful move/copy returns `success=True` with the paths and `overwrite` echoed
back, and each of 404 / 409 / 412 comes back `success=False` with the message
preserved. That second one is the point — without it a 412 would keep arriving
inside a success envelope.

Tiers executed locally: unit ✅ 2467 passed. Integration/e2e runs in CI.

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`,
which does not import `models/webdav.py`.

---

_This PR was generated with the help of AI, and reviewed by a Human_
