### PR TITLE
feat(webdav): read documents as text/markdown, not base64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -377,15 +377,18 @@ jobs:
           up-flags: "--build"
         env:
           TOKEN_ENCRYPTION_KEY: ${{ env.TOKEN_ENCRYPTION_KEY }}
-          # Master switch: without it initialize_document_processors() no-ops and
-          # docling never registers on the webdav read_file path.
-          ENABLE_DOCUMENT_PROCESSING: "true"
           # Enable the docling backend in the single-user mcp service and point it
           # at the docling-serve container on the compose network.
           ENABLE_DOCLING: "true"
           DOCLING_API_URL: "http://docling:5001"
           # CPU OCR is slow; give the sync convert call generous headroom.
           DOCLING_TIMEOUT: "300"
+          # Docling serves PDFs as the OCR provider, so the OCR tier has to be on
+          # for a scanned PDF to reach it (there is no per-call processor override
+          # any more -- Deck #894).
+          DOCUMENT_OCR_ENABLED: "true"
+          DOCUMENT_OCR_PROVIDER: "docling"
+          DOCUMENT_OCR_TIMEOUT_SECONDS: "300"
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -450,7 +450,12 @@ jobs:
           NEXTCLOUD_USERNAME: "admin"
           NEXTCLOUD_PASSWORD: "admin"
           # Selects the skipif-gated assertions in tests/integration/test_docling_api.py.
+          # These must mirror what the compose step gave the MCP service: the
+          # skipifs read this process's environment, not the container's, so a
+          # value set only on compose leaves the test silently skipped.
           ENABLE_DOCLING: "true"
+          DOCUMENT_OCR_ENABLED: "true"
+          DOCUMENT_OCR_PROVIDER: "docling"
         run: |
           uv run pytest -v \
             --log-cli-level=WARN \

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,5 +25,5 @@ services:
       - OPENAI_GENERATION_MODEL=${OPENAI_GENERATION_MODEL:-openai/gpt-4o-mini}
       # Faster sync for CI
       - VECTOR_SYNC_SCAN_INTERVAL=${VECTOR_SYNC_SCAN_INTERVAL:-5}
-      # Enable document processing for PDF parsing
-      - ENABLE_DOCUMENT_PROCESSING=true
+      # PDF parsing needs no flag: the built-in tiers are always available and
+      # parsing on read is the caller's per-call choice (Deck #894).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,15 +184,18 @@ services:
 
       # Docling OCR-strong parsing backend (docling-serve HTTP API, ADR-031).
       # Off by default so the normal single-user lane is unchanged. The CI
-      # "docling" lane starts the `docling` profile and sets
-      # ENABLE_DOCUMENT_PROCESSING=true + ENABLE_DOCLING=true +
+      # "docling" lane starts the `docling` profile and sets ENABLE_DOCLING=true +
       # DOCLING_API_URL=http://docling:5001 to exercise the gated
       # tests/integration/test_docling_api.py suite. DOCLING_TIMEOUT is bumped in
-      # CI because CPU OCR is slow. ENABLE_DOCUMENT_PROCESSING is the master
-      # switch: initialize_document_processors() no-ops without it, so docling
-      # never registers on the webdav read_file path if it is unset.
-      - ENABLE_DOCUMENT_PROCESSING=${ENABLE_DOCUMENT_PROCESSING:-false}
+      # CI because CPU OCR is slow. Note docling serves PDFs as an OCR provider
+      # (DOCUMENT_OCR_PROVIDER=docling), never as a tier of its own; this
+      # standalone processor handles images.
       - ENABLE_DOCLING=${ENABLE_DOCLING:-false}
+      # OCR tier (opt-in). The docling lane turns it on with provider=docling so a
+      # scanned PDF escalates fast -> ocr and comes back as docling markdown.
+      - DOCUMENT_OCR_ENABLED=${DOCUMENT_OCR_ENABLED:-false}
+      - DOCUMENT_OCR_PROVIDER=${DOCUMENT_OCR_PROVIDER:-auto}
+      - DOCUMENT_OCR_TIMEOUT_SECONDS=${DOCUMENT_OCR_TIMEOUT_SECONDS:-180}
       - DOCLING_API_URL=${DOCLING_API_URL:-}
       - DOCLING_TIMEOUT=${DOCLING_TIMEOUT:-120}
       # Opt-in VLM pipeline (ADR-032): point docling-serve at its VLM presets
@@ -203,8 +206,8 @@ services:
       - DOCLING_PIPELINE=${DOCLING_PIPELINE:-standard}
       - DOCLING_VLM_PRESET=${DOCLING_VLM_PRESET:-}
       # Opt-in cap on the synchronous nc_webdav_read_file parse; empty = disabled.
-      # A client-friendly bound (e.g. 45-60) makes a slow VLM/OCR read fall back to
-      # base64 fast instead of blocking past the MCP client's own timeout.
+      # A client-friendly bound (e.g. 45-60) makes a slow VLM/OCR read return the
+      # raw file fast instead of blocking past the MCP client's own timeout.
       - DOCUMENT_READ_TIMEOUT_SECONDS=${DOCUMENT_READ_TIMEOUT_SECONDS:-}
     profiles:
       - single-user

--- a/docs/ADR-025-dynaconf-configuration-management.md
+++ b/docs/ADR-025-dynaconf-configuration-management.md
@@ -159,9 +159,7 @@ document_chunk_size = 2048
 document_chunk_overlap = 200
 
 # === Document Processing ===
-enable_document_processing = false
 document_processor = "unstructured"
-enable_pymupdf = true
 pymupdf_extract_images = true
 enable_unstructured = false
 unstructured_api_url = "http://unstructured:8000"

--- a/docs/ADR-031-docling-document-parsing-backend.md
+++ b/docs/ADR-031-docling-document-parsing-backend.md
@@ -44,8 +44,8 @@ multipart) is the client; `GET /health` is the probe.
    (`supported_mime_types` = images only, `tier="fast"`) is registered at
    **priority 20** (above `unstructured`'s 10) in `initialize_document_processors()`
    when `ENABLE_DOCLING=true` **and** `DOCLING_API_URL` is set. Images therefore
-   always route to docling when enabled. Gated only by `ENABLE_DOCUMENT_PROCESSING`
-   + `ENABLE_DOCLING` (the image/`find_processor` path has no OCR gate).
+   always route to docling when enabled. Gated only by `ENABLE_DOCLING` +
+   `DOCLING_API_URL` (the image/`find_processor` path has no OCR gate).
 
 2. **Scanned PDFs → docling (automatic, opt-in).** A `_DoclingServeBackend`
    (`_OcrBackend`) is added to `ocr.py` and selected by
@@ -55,14 +55,18 @@ multipart) is the client; `GET /health` is the probe.
    per-page `page_boundaries` by grouping `DoclingDocument.texts[].prov[].page_no`,
    falling back to a single whole-text page when provenance is absent.
 
-3. **Text-layer PDFs → docling (on demand).** `nc_webdav_read_file` gains a
-   `force_processor` argument threaded through `parse_document(processor_name=...)`
-   to the registry's forced path. `force_processor="docling"` re-parses any file
-   with docling even when it has a usable text layer — for tables/figures the text
-   layer misses. `DoclingProcessor.process()` handles PDFs (deriving
-   `from_formats` from the MIME type) even though PDFs are excluded from its
-   `supported_mime_types` (the forced path ignores `supports()`). An unknown/
-   unconfigured processor name raises a `ToolError` with the available names.
+3. ~~**Text-layer PDFs → docling (on demand).**~~ **Superseded in 0.151.0 (Deck
+   #894).** This touchpoint was a `force_processor` argument on
+   `nc_webdav_read_file`, threaded to the registry's forced path so
+   `force_processor="docling"` re-parsed any file with docling. It was removed:
+   it asked the caller (an LLM) to name an extraction engine it had no basis to
+   choose, and the forced path bypassed both tiering and the pre-parse size
+   guard. The two needs it served are now met without it — a text layer that
+   misses tables is handled locally by `parse_document="markdown"` (the
+   `structured`/pymupdf4llm tier), and a genuinely scanned PDF reaches docling
+   through touchpoint 2, where docling belongs as an OCR *provider*.
+   `DoclingProcessor` still handles PDFs internally (deriving `from_formats` from
+   the MIME type), but nothing routes one to it any more.
 
 ### Key design points
 

--- a/docs/ADR-032-docling-vlm-pipeline.md
+++ b/docs/ADR-032-docling-vlm-pipeline.md
@@ -81,9 +81,11 @@ independent** timeout.
   a tool call. **This is the right home for VLM at any volume** — raise
   `DOCUMENT_OCR_TIMEOUT_SECONDS` here freely.
 - **Interactive read (on-demand, synchronous).** `nc_webdav_read_file` parses inline
-  (`await parse_document(...)`), so an image (auto-routed to `DoclingProcessor`) or a
-  `force_processor="docling"` PDF makes a **blocking** POST to docling-serve for up to
+  (`await parse_document_source(...)`), so an image (auto-routed to
+  `DoclingProcessor`) makes a **blocking** POST to docling-serve for up to
   **`DOCLING_TIMEOUT`**. Under VLM (~90–200s/page) this call blocks for minutes.
+  (The `force_processor="docling"` PDF route this section also described was
+  removed in 0.151.0 — see ADR-031 touchpoint 3 and Deck #894.)
 
 **Explicit callout (the operative constraint):** raising `DOCLING_TIMEOUT` for VLM
 directly increases how long `nc_webdav_read_file` blocks, and MCP clients typically

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -690,7 +690,13 @@ DOCUMENT_MAX_PDF_SIZE_MB=50           # Pre-parse size cap; 0 disables (default:
 DOCUMENT_PARSE_PAGE_WINDOW=100        # Pages per extraction window; 0 disables (default: 100)
 DOCUMENT_PARSE_PROCESS_SLOTS=2        # Concurrent isolated parse subprocesses (default: 2)
 DOCUMENT_MARKDOWN_MAX_PAGES=150       # Structured-tier markdown page ceiling; 0 disables markdown (default: 150)
+PYMUPDF_EXTRACT_IMAGES=true           # Extract embedded images during markdown reconstruction (default: true)
+PYMUPDF_IMAGE_DIR=                    # Where extracted images are written; empty = system temp dir
 ```
+
+`PYMUPDF_*` tune the built-in `structured` tier, which is always available — there
+is no enable flag for it. Image extraction only happens on the markdown path, so
+a document past `DOCUMENT_MARKDOWN_MAX_PAGES` writes no images regardless.
 
 `DOCUMENT_PARSE_PROCESS_SLOTS` bounds how many isolated parse subprocesses run at
 once. Without it anyio defaults to an `os.cpu_count()`-wide pool, which is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -640,34 +640,42 @@ CHUNKING_CONFIG_VERSION=1             # Chunker config generation; bump on any c
 
 > **Note:** The `VECTOR_SYNC_*` tuning parameters keep their names as they're implementation details. Only the user-facing feature flag was renamed to `ENABLE_SEMANTIC_SEARCH`.
 
-#### Enabling document parsing — `ENABLE_DOCUMENT_PROCESSING` (master switch)
+#### Reading documents — a per-call decision, not a server switch
 
-`ENABLE_DOCUMENT_PROCESSING` is the master switch for the parsing subsystem and
-is **off by default**. Set it *before* configuring `unstructured`, the OCR tier,
-or docling below — otherwise those processors are never registered and parsing
-silently no-ops (a common first-run trip-up):
+**There is no master switch.** Whether to extract text from a document is decided
+by the caller, per read, through `nc_webdav_read_file`'s `parse_document`
+argument — the server cannot know whether an agent wants a PDF's text or its
+bytes. (`ENABLE_DOCUMENT_PROCESSING` was removed in **0.151.0**; it is ignored if
+still set.)
 
-```dotenv
-ENABLE_DOCUMENT_PROCESSING=true       # register optional processors + on-demand parsing (default: false)
-```
+| `parse_document` | What you get |
+|---|---|
+| `"auto"` (default) | The document's text via the tiered pipeline: `fast` (text layer) → `structured` or `ocr` when the classifier says the text layer is unusable. |
+| `"markdown"` | Reconstructed structure (headings, tables) via the `structured` tier, bounded by `DOCUMENT_MARKDOWN_MAX_PAGES`. |
+| `"raw"` | No parse: text files decoded, anything else base64. |
 
-What it controls:
+The built-in PDF tiers (`pypdfium2_fast` → `fast`, `pymupdf` → `structured`, and
+the `ocr` tier) are always available. The optional processors — `unstructured`,
+`tesseract`, `custom`, **docling** — are each registered from their own
+`ENABLE_*` flag at startup; configuring none of them means the parse stack is not
+even imported.
 
-- **Registers the optional processors** — `unstructured`, `tesseract`, `custom`,
-  and **docling** — into the shared registry at startup
-  (`initialize_document_processors()`). The built-in PDF tiers
-  (`pypdfium2_fast` → `fast`, `pymupdf` → `structured`, and the `ocr` tier) are
-  always registered independently of this flag.
-- **Gates on-demand parsing in `nc_webdav_read_file`.** With it **off** the tool
-  returns the raw file (base64) and a `force_processor=…` argument is rejected as
-  an unknown processor (the parse registry is empty). With it **on**, the tool
-  parses the file inline and honours `force_processor`.
+Every read reports what it actually produced, so a degraded extraction is never
+presented as the whole document:
 
-Consequently the docling **image** and **force-PDF** touchpoints (which flow
-through the registry / `nc_webdav_read_file`) require this flag; the automatic
-**scanned-PDF OCR** touchpoint rides the always-registered `ocr` tier, so it needs
-only `DOCUMENT_OCR_ENABLED` + `DOCUMENT_OCR_PROVIDER` (see the recipe table under
-_Docling_ below).
+- `parse_status` — `parsed` / `failed` / `skipped` / `not_applicable`
+- `parse_tier`, `parse_processor` — which tier produced the content
+- `content_format` — `markdown`, `text` or `base64`
+- `parse_notes` — plain statements when something degraded: OCR not enabled,
+  markdown structure not reconstructed (with the page count and the ceiling), the
+  size cap, a failed or timed-out parse.
+
+What still bounds an interactive read: `DOCUMENT_MAX_PDF_SIZE_MB` (parse cap; the
+download is aborted at twice that), `DOCUMENT_READ_TIMEOUT_SECONDS` (wall-clock
+cap on the synchronous parse), `DOCUMENT_OCR_ENABLED` (the expensive tier stays
+opt-in) and `DOCUMENT_MARKDOWN_MAX_PAGES=0` (disables markdown outright). The
+document is streamed to a spool file and parsed from there, so a large read does
+not scale the server's memory.
 
 #### Document parsing robustness (PDF)
 
@@ -840,37 +848,38 @@ an explicit self-hosted URL):
 
 | Use case | Minimal env |
 |---|---|
-| Images auto-route to docling | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
-| Force docling on a text-layer PDF (`force_processor="docling"`) | `ENABLE_DOCUMENT_PROCESSING=true` + `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
+| Images auto-route to docling | `ENABLE_DOCLING=true` + `DOCLING_API_URL` |
 | Scanned / no-text-layer PDFs auto-OCR via docling | `DOCUMENT_OCR_ENABLED=true` + `DOCUMENT_OCR_PROVIDER=docling` + `DOCLING_API_URL` |
 | **VLM** for bulk PDF indexing (async, recommended) | scanned-PDF row + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`) + raise `DOCUMENT_OCR_TIMEOUT_SECONDS` (e.g. 600–900) |
-| **VLM** for interactive image/force reads | image/force row + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`); expect long blocking — see the VLM note below |
+| **VLM** for interactive image reads | image row + `DOCLING_PIPELINE=vlm` (+ `DOCLING_VLM_PRESET`); expect long blocking — see the VLM note below |
 
-The scanned-PDF row deliberately omits `ENABLE_DOCLING`/`ENABLE_DOCUMENT_PROCESSING`:
-that path rides the always-registered `ocr` tier during **indexing** (so it also
-needs `ENABLE_SEMANTIC_SEARCH=true`), not the on-demand registry. The image and
-force-PDF rows need the `ENABLE_DOCUMENT_PROCESSING` master switch (see above).
+The scanned-PDF row omits `ENABLE_DOCLING`: that path rides the
+always-registered `ocr` tier rather than the standalone image processor. When it
+runs during **indexing** it also needs `ENABLE_SEMANTIC_SEARCH=true`; on an
+interactive `nc_webdav_read_file` it needs nothing further.
 
-Docling plugs in at three points:
+Docling plugs in at two points — it is an **OCR provider**, never a tier of its
+own, so a PDF reaches it through the OCR tier and nowhere else:
 
 - **Images (automatic).** With `ENABLE_DOCLING=true` + `DOCLING_API_URL` set,
   image files (`image/jpeg`, `image/png`, `image/tiff`, `image/bmp`, `image/gif`,
   `image/webp`) always route to docling — it registers at a higher priority than
   `unstructured`. `DOCLING_DO_OCR` toggles OCR on this image path only (the scanned-PDF
-  OCR backend always OCRs). Requires
-  `ENABLE_DOCUMENT_PROCESSING=true`. If `DOCLING_API_URL` is unset the processor is
+  OCR backend always OCRs). If `DOCLING_API_URL` is unset the processor is
   not registered, so a bare `ENABLE_DOCLING` never shadows other image processors
   with a dead endpoint.
 - **Scanned PDFs (automatic).** Set `DOCUMENT_OCR_ENABLED=true` +
   `DOCUMENT_OCR_PROVIDER=docling`. PDFs whose text layer the tier-0 classifier
   finds missing/unusable escalate to the OCR tier and are transcribed by docling.
   Born-digital (text-layer) PDFs still use the cheap local `fast`/`structured`
-  tiers — docling is only paid for genuine scans.
-- **Text-layer PDFs (on demand).** Pass `force_processor="docling"` to the
-  `nc_webdav_read_file` MCP tool to re-parse *any* file with docling even when it
-  already has a text layer — useful when that layer misses tables/figures or is
-  incomplete. Docling returns markdown, preserving table structure. An unknown or
-  unconfigured processor name returns a clear tool error.
+  tiers — docling is only paid for genuine scans. This applies to both indexing
+  and an interactive `nc_webdav_read_file`.
+
+  For a text-layer PDF whose layer misses tables or figures, ask the read for
+  `parse_document="markdown"`: the `structured` tier (pymupdf4llm) reconstructs
+  table structure locally, without a docling round-trip. (Before 0.151.0 this was
+  `force_processor="docling"`, which asked the caller to name an extraction
+  engine it had no basis to choose.)
 
 Office formats (DOCX/PPTX/XLSX) deliberately stay with `unstructured` — docling
 is scoped to the image/scan/handwriting use case here. OCR language codes are
@@ -902,7 +911,7 @@ matters — and the two touchpoints have independent timeouts:**
   the `ingest-ocr` queue) and written to the search index. That path uses
   **`DOCUMENT_OCR_TIMEOUT_SECONDS`** and never blocks a tool call — raise it freely
   (e.g. 600–900s) for VLM.
-- **Interactive reads (`nc_webdav_read_file` on images / `force_processor="docling"`):**
+- **Interactive reads (`nc_webdav_read_file` on images):**
   these parse **synchronously** and block for up to **`DOCLING_TIMEOUT`**. Raising
   `DOCLING_TIMEOUT` for VLM directly lengthens that block, and MCP clients usually
   enforce a much shorter per-tool timeout (~30–60s) — so the client typically kills

--- a/docs/webdav.md
+++ b/docs/webdav.md
@@ -5,7 +5,7 @@
 | Tool | Description |
 |------|-------------|
 | `nc_webdav_list_directory` | List files and directories in any NextCloud path |
-| `nc_webdav_read_file` | Read file content (text files decoded, binary as base64) |
+| `nc_webdav_read_file` | Read file content (documents extracted to text/markdown, text decoded, other binary as base64) |
 | `nc_webdav_write_file` | Create or update files in NextCloud |
 | `nc_webdav_create_directory` | Create new directories |
 | `nc_webdav_delete_resource` | Delete files or directories |
@@ -32,6 +32,19 @@ await nc_webdav_list_directory("Documents/Projects")
 
 # Read a text file
 content = await nc_webdav_read_file("Documents/readme.txt")
+
+# Read a document: extracted text by default, no base64
+result = await nc_webdav_read_file("Documents/report.pdf")
+result.content          # the document's text
+result.parse_tier       # "fast" | "structured" | "ocr" -- what produced it
+result.content_format   # "text" | "markdown" | "base64"
+result.parse_notes      # non-empty => say what degraded; this is not the whole document
+
+# Ask for structure (headings, tables) instead of a flat text layer
+await nc_webdav_read_file("Documents/report.pdf", parse_document="markdown")
+
+# Or take the file itself, unparsed
+await nc_webdav_read_file("Documents/report.pdf", parse_document="raw")
 
 # Create a new directory
 await nc_webdav_create_directory("NewProject/docs")

--- a/env.sample
+++ b/env.sample
@@ -206,10 +206,13 @@ NEXTCLOUD_PASSWORD=
 #WEBHOOK_SECRET=
 
 # ===== DOCUMENT PROCESSING =====
-# Extract text from PDFs, images, DOCX, etc. for semantic search
-# Disabled by default
+# Extract text from PDFs, images, DOCX, etc. for semantic search and for reads.
 #
-#ENABLE_DOCUMENT_PROCESSING=false
+# There is no master switch (ENABLE_DOCUMENT_PROCESSING was removed in 0.151.0):
+# PDF extraction is built in, each optional processor below is gated by its own
+# ENABLE_* flag, and whether a read parses a document is the caller's per-call
+# choice -- nc_webdav_read_file's parse_document="auto"|"markdown"|"raw".
+#
 #DOCUMENT_PROCESSOR=unstructured
 #
 # Unstructured.io Processor (recommended):
@@ -235,10 +238,11 @@ NEXTCLOUD_PASSWORD=
 #
 # Docling (docling-serve, strong OCR for photographed/scanned/handwritten text):
 # - Images always route to docling when enabled (priority over unstructured).
-# - Force docling on a text-layer PDF (tables / partial text) per call via the
-#   nc_webdav_read_file `force_processor="docling"` argument.
-# - Route scanned/no-text-layer PDFs to docling automatically by additionally
-#   setting DOCUMENT_OCR_ENABLED=true and DOCUMENT_OCR_PROVIDER=docling.
+# - For PDFs docling is an OCR *provider*, not a tier of its own: set
+#   DOCUMENT_OCR_ENABLED=true and DOCUMENT_OCR_PROVIDER=docling, and
+#   scanned/no-text-layer PDFs are transcribed by docling automatically.
+# - For a text-layer PDF whose tables the layer misses, ask the read for
+#   parse_document="markdown" (local pymupdf4llm) rather than a docling round-trip.
 # OCR language codes are engine-dependent (docling default EasyOCR uses en,de;
 # a Tesseract-backed instance wants eng,deu).
 #ENABLE_DOCLING=false

--- a/env.sample.oauth-multi-user
+++ b/env.sample.oauth-multi-user
@@ -71,8 +71,9 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 #BEDROCK_EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
 
 # ===== OPTIONAL: DOCUMENT PROCESSING =====
-# Extract text from PDFs, images, DOCX for semantic search
-#ENABLE_DOCUMENT_PROCESSING=true
+# PDF text extraction is built in and needs no flag; reading a document as text
+# is a per-call choice (nc_webdav_read_file's parse_document argument). These
+# add formats the built-in tiers do not cover, e.g. DOCX and images.
 #ENABLE_UNSTRUCTURED=true
 #UNSTRUCTURED_API_URL=http://unstructured:8000
 

--- a/env.sample.single-user
+++ b/env.sample.single-user
@@ -28,8 +28,9 @@ MCP_DEPLOYMENT_MODE=single_user_basic
 #OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
 # ===== OPTIONAL: DOCUMENT PROCESSING =====
-# Extract text from PDFs, images, DOCX for semantic search
-#ENABLE_DOCUMENT_PROCESSING=true
+# PDF text extraction is built in and needs no flag; reading a document as text
+# is a per-call choice (nc_webdav_read_file's parse_document argument). These
+# add formats the built-in tiers do not cover, e.g. DOCX and images.
 #ENABLE_UNSTRUCTURED=true
 #UNSTRUCTURED_API_URL=http://unstructured:8000
 

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -157,19 +157,22 @@ HTTPXClientInstrumentor().instrument()
 def initialize_document_processors():
     """Initialize and register document processors based on configuration.
 
-    This function reads the environment configuration and registers available
-    processors (Unstructured, Tesseract, Custom HTTP, Docling) with the global
-    registry.
+    This function reads the environment configuration and registers the available
+    OPTIONAL processors (Unstructured, Tesseract, Custom HTTP, Docling) with the
+    global registry, each gated by its own ``ENABLE_*`` flag. The built-in PDF
+    tiers (pypdfium2 / pymupdf / OCR) self-register on first import of
+    ``document_processors`` and need nothing here.
     """
     config = get_document_processor_config()
 
-    if not config["enabled"]:
-        logger.info("Document processing disabled")
+    if not config["processors"]:
+        logger.info("No optional document processors configured")
         return
 
     # Imported lazily so the API startup path never loads the ingest document
-    # stack (document_processors -> pymupdf -> _isolation) unless document
-    # processing is actually enabled -- see #877 / the API-vs-ingest split.
+    # stack (document_processors -> pymupdf -> _isolation) unless an optional
+    # processor actually has to be registered -- see #877 / the API-vs-ingest
+    # split. Nothing to register means nothing to import.
     from nextcloud_mcp_server.document_processors import get_registry  # noqa: PLC0415
 
     registry = get_registry()
@@ -214,26 +217,9 @@ def initialize_document_processors():
         except Exception as e:
             logger.warning("Failed to register Tesseract processor: %s", e)
 
-    # Register PyMuPDF processor (high priority, local, no API required)
-    if "pymupdf" in config["processors"]:
-        pymupdf_config = config["processors"]["pymupdf"]
-        try:
-            from nextcloud_mcp_server.document_processors.pymupdf import (  # noqa: PLC0415
-                PyMuPDFProcessor,
-            )
-
-            processor = PyMuPDFProcessor(
-                extract_images=pymupdf_config.get("extract_images", True),
-                image_dir=pymupdf_config.get("image_dir"),
-            )
-            registry.register(processor, priority=15)  # Higher than unstructured
-            logger.info(
-                "Registered PyMuPDF processor: extract_images=%s",
-                pymupdf_config.get("extract_images", True),
-            )
-            registered_count += 1
-        except Exception as e:
-            logger.warning("Failed to register PyMuPDF processor: %s", e)
+    # PyMuPDF is NOT registered here: it is the built-in ``structured`` tier and
+    # registers itself (from Settings.pymupdf_*) when document_processors is
+    # first imported, which is on the first parse rather than at startup (#877).
 
     # Register custom processor
     if "custom" in config["processors"]:
@@ -287,12 +273,16 @@ def initialize_document_processors():
 
     if registered_count > 0:
         logger.info(
-            "Document processing initialized with %s processor(s): %s",
+            "Document processing initialized with %s optional processor(s); "
+            "registry now holds: %s",
             registered_count,
             ", ".join(registry.list_processors()),
         )
     else:
-        logger.warning("Document processing enabled but no processors registered")
+        logger.warning(
+            "Optional document processors were configured but none could be "
+            "registered; only the built-in tiers are available"
+        )
 
 
 def validate_pkce_support(discovery: dict, discovery_url: str) -> None:

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -572,7 +572,7 @@ class WebDAVClient(BaseNextcloudClient):
 
     async def stream_to_file(
         self, path: str, dest: Path, *, max_bytes: int | None = None
-    ) -> Tuple[int, str]:
+    ) -> Tuple[int, str, Optional[str]]:
         """Stream a WebDAV GET straight to ``dest``, never holding the whole body.
 
         :meth:`read_file` buffers the entire response (``response.content``), so
@@ -586,8 +586,11 @@ class WebDAVClient(BaseNextcloudClient):
         the server advertised at scan time, whereas this acts on what actually
         arrives.
 
-        Returns ``(bytes_written, content_type)``. Raises
-        :class:`OversizeDownload` if ``max_bytes`` is exceeded, or
+        Returns ``(bytes_written, content_type, etag)`` -- the same triple
+        :meth:`read_file` returns, so a caller that streams a document can still
+        hand the etag back as ``write_file``'s ``if_match`` (or report it) without
+        a second request. The etag is ``None`` if the server sent no ``ETag``.
+        Raises :class:`OversizeDownload` if ``max_bytes`` is exceeded, or
         :class:`httpx.RemoteProtocolError` on a short read (#965).
         """
         await self._ensure_principal_id()
@@ -601,6 +604,9 @@ class WebDAVClient(BaseNextcloudClient):
                 content_type = response.headers.get(
                     "content-type", "application/octet-stream"
                 )
+                etag = response.headers.get("etag")
+                if etag is not None:
+                    etag = etag.strip('"')
                 # anyio's async file wrapper, not pathlib.Path.open: the writes
                 # run on a worker thread, so streaming a multi-hundred-MB
                 # document does not block the event loop (and with it every other
@@ -624,7 +630,7 @@ class WebDAVClient(BaseNextcloudClient):
             raise
 
         logger.debug("Streamed '%s' to %s (%s bytes)", path, dest, written)
-        return written, content_type
+        return written, content_type, etag
 
     async def read_file(self, path: str) -> Tuple[bytes, str, Optional[str]]:
         """Read a file's content via WebDAV GET.

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -289,8 +289,8 @@ _DEFAULTS: dict[str, Any] = {
     "log_format": "text",
     "log_level": "INFO",
     "log_include_trace_context": True,
-    # Document processing
-    "enable_document_processing": False,
+    # Document processing (no master switch: each optional processor has its own
+    # ENABLE_* flag, and parsing on read is the caller's per-call decision)
     "document_processor": "unstructured",
     "enable_unstructured": False,
     "unstructured_api_url": "http://unstructured:8000",
@@ -301,7 +301,8 @@ _DEFAULTS: dict[str, Any] = {
     "enable_tesseract": False,
     "tesseract_cmd": None,
     "tesseract_lang": "eng",
-    "enable_pymupdf": True,
+    # pymupdf is the built-in "structured" tier and is always available -- there
+    # is no enable flag for it, only these two knobs.
     "pymupdf_extract_images": True,
     "pymupdf_image_dir": None,
     "enable_custom_processor": False,
@@ -772,10 +773,16 @@ def setup_logging():
 def get_document_processor_config() -> dict[str, Any]:
     """Get document processor configuration from dynaconf.
 
+    Each optional processor is gated by its own ``ENABLE_*`` flag. There is no
+    master switch: parsing a document on read is a per-call decision made by the
+    caller (``nc_webdav_read_file``'s ``parse_document`` argument), not an
+    instance-wide setting. The built-in PDF tiers (pypdfium2 / pymupdf / OCR)
+    self-register when ``document_processors`` is first imported and never appear
+    here.
+
     Returns:
         Dict with processor configs:
         {
-            "enabled": bool,
             "default_processor": str,
             "processors": {
                 "unstructured": {...},
@@ -785,7 +792,6 @@ def get_document_processor_config() -> dict[str, Any]:
         }
     """
     config: dict[str, Any] = {
-        "enabled": _dynaconf.get("ENABLE_DOCUMENT_PROCESSING"),
         "default_processor": _dynaconf.get("DOCUMENT_PROCESSOR"),
         "processors": {},
     }
@@ -810,14 +816,12 @@ def get_document_processor_config() -> dict[str, Any]:
             "lang": _dynaconf.get("TESSERACT_LANG"),
         }
 
-    # PyMuPDF configuration (local PDF processing)
-    if _dynaconf.get("ENABLE_PYMUPDF"):  # Enabled by default
-        config["processors"]["pymupdf"] = {
-            "extract_images": _dynaconf.get("PYMUPDF_EXTRACT_IMAGES"),
-            "image_dir": _dynaconf.get(
-                "PYMUPDF_IMAGE_DIR"
-            ),  # None = use temp directory
-        }
+    # NB: pymupdf is deliberately absent. It is the built-in ``structured`` tier,
+    # registered when ``document_processors`` is first imported (lazily, on the
+    # first parse) and tuned from ``Settings.pymupdf_*``. Listing it here would
+    # make ``processors`` non-empty on every deployment, which is what tells app
+    # startup whether it has anything to register -- and so whether it must
+    # import the parse stack at all (#877).
 
     # Custom processor (via HTTP API)
     if _dynaconf.get("ENABLE_CUSTOM_PROCESSOR"):
@@ -839,8 +843,9 @@ def get_document_processor_config() -> dict[str, Any]:
     # Docling configuration (docling-serve HTTP API). Registered only when a URL is
     # set, so a bare ENABLE_DOCLING doesn't shadow other image processors with a
     # dead endpoint (mirrors the custom_url guard above). The standalone processor
-    # auto-serves images; PDFs go through the OCR backend (provider=docling) or an
-    # explicit per-call force_processor override.
+    # auto-serves images; PDFs go through the OCR backend
+    # (DOCUMENT_OCR_PROVIDER=docling) -- docling is an OCR provider, not a tier of
+    # its own.
     if _dynaconf.get("ENABLE_DOCLING"):
         docling_url = _dynaconf.get("DOCLING_API_URL")
         if docling_url:
@@ -1185,6 +1190,12 @@ class Settings:
     # 2-core pod, and it keeps markdown for the small/prose documents that
     # actually benefit from table reconstruction.
     document_markdown_max_pages: int = 150
+    # Structured-tier (pymupdf) image extraction. Read where that tier registers
+    # itself rather than at app startup: it is a built-in tier, not an optional
+    # processor, so nothing about it may pull the parse stack onto the API
+    # startup path (#877).
+    pymupdf_extract_images: bool = True
+    pymupdf_image_dir: str | None = None
     # RLIMIT_AS in the parse subprocess (below the pod limit). Applied once per
     # worker for its lifetime, so changing it needs a pod restart.
     document_parse_mem_limit_mb: int = 1536
@@ -2024,6 +2035,8 @@ def _build_settings() -> Settings:
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
         "webdav_write_max_mb": "WEBDAV_WRITE_MAX_MB",
         "document_markdown_max_pages": "DOCUMENT_MARKDOWN_MAX_PAGES",
+        "pymupdf_extract_images": "PYMUPDF_EXTRACT_IMAGES",
+        "pymupdf_image_dir": "PYMUPDF_IMAGE_DIR",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
         "document_parse_process_slots": "DOCUMENT_PARSE_PROCESS_SLOTS",

--- a/nextcloud_mcp_server/document_processors/__init__.py
+++ b/nextcloud_mcp_server/document_processors/__init__.py
@@ -1,5 +1,7 @@
 """Document processing plugins for extracting text from various file formats."""
 
+from nextcloud_mcp_server.config import get_settings
+
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 from .ocr import OcrProcessor
 from .pymupdf import PyMuPDFProcessor
@@ -13,9 +15,19 @@ from .registry import ProcessorRegistry, get_registry
 # …), and sync/batch mode are all chosen from settings. It is reached only when
 # ``document_ocr_enabled`` is set. OCR gets the lowest priority so it's never the
 # non-tiered default for PDFs.
+#
+# This module is imported lazily (first parse), never at app startup, so reading
+# settings here does not drag the parse stack onto the startup path (#877).
+_settings = get_settings()
 _registry = get_registry()
 _registry.register(Pypdfium2FastProcessor(), priority=20)
-_registry.register(PyMuPDFProcessor(), priority=10)
+_registry.register(
+    PyMuPDFProcessor(
+        extract_images=_settings.pymupdf_extract_images,
+        image_dir=_settings.pymupdf_image_dir,
+    ),
+    priority=10,
+)
 _registry.register(
     OcrProcessor(
         name="ocr",

--- a/nextcloud_mcp_server/document_processors/docling_serve.py
+++ b/nextcloud_mcp_server/document_processors/docling_serve.py
@@ -243,13 +243,13 @@ class DoclingProcessor(DocumentProcessor):
             self.ocr_lang,
             do_ocr,
         )
-        # DoclingProcessor is the INTERACTIVE path (nc_webdav_read_file on images /
-        # force_processor="docling"). Under VLM a convert is slow (~30-150s/page) and
-        # blocks the tool call for up to DOCLING_TIMEOUT, which can exceed an MCP
-        # client's own timeout. Don't inflate DOCLING_TIMEOUT to "fix" this: for bulk
-        # VLM use the async ingest path (DOCUMENT_OCR_PROVIDER=docling, its own
-        # DOCUMENT_OCR_TIMEOUT_SECONDS), and set DOCUMENT_READ_TIMEOUT_SECONDS for a
-        # graceful base64 fallback on interactive reads (ADR-032).
+        # DoclingProcessor is the INTERACTIVE path (nc_webdav_read_file on images).
+        # Under VLM a convert is slow (~30-150s/page) and blocks the tool call for
+        # up to DOCLING_TIMEOUT, which can exceed an MCP client's own timeout. Don't
+        # inflate DOCLING_TIMEOUT to "fix" this: for bulk VLM use the async ingest
+        # path (DOCUMENT_OCR_PROVIDER=docling, its own DOCUMENT_OCR_TIMEOUT_SECONDS),
+        # and set DOCUMENT_READ_TIMEOUT_SECONDS so an interactive read degrades to
+        # the raw file with an explicit note instead (ADR-032).
         if pipeline == "vlm":
             logger.warning(
                 "DOCLING_PIPELINE=vlm makes nc_webdav_read_file a slow synchronous "
@@ -296,6 +296,8 @@ class DoclingProcessor(DocumentProcessor):
                 "parsing_method": "docling",
                 "docling_pipeline": self.pipeline,
                 "text_length": len(text),
+                # ``to_formats=["md"]`` above: docling always returns markdown.
+                "parse_mode": "markdown",
             },
             processor=self.name,
         )

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -756,6 +756,8 @@ class OcrProcessor(DocumentProcessor):
                 "page_count": len(boundaries),
                 "page_boundaries": boundaries,
                 "file_size": len(content),
+                # Every OCR backend returns GitHub-flavoured markdown per page.
+                "parse_mode": "markdown",
                 # Only when the backend returned layout geometry (surya); absent for
                 # markdown-only backends so generate_highlights uses pymupdf.
                 **({OCR_BLOCK_SPANS_KEY: block_spans} if block_spans else {}),
@@ -938,6 +940,7 @@ class OcrProcessor(DocumentProcessor):
                 "page_count": len(boundaries),
                 "page_boundaries": boundaries,
                 "file_size": len(content),
+                "parse_mode": "markdown",
                 **({OCR_BLOCK_SPANS_KEY: block_spans} if block_spans else {}),
             },
             processor=self.name,

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -26,6 +26,37 @@ from .source import DocumentSource, MemoryDocumentSource, resolve_path
 logger = logging.getLogger(__name__)
 
 
+def _record_parse_mode(
+    metadata: dict[str, Any], page_count: int, settings: Any
+) -> None:
+    """Stamp what this parse actually produced, and why, on ``metadata``.
+
+    Recomputes the worker's decision here rather than having it report a mode
+    back: a Counter incremented in the subprocess would never reach this
+    process's registry. Uses ``page_count`` from the metadata read -- the same
+    authoritative value the worker's own ``doc.page_count`` gate saw -- rather
+    than ``len(page_chunks)``, which would silently mislabel the metric if
+    pymupdf4llm ever stopped emitting exactly one chunk per page. Shares the
+    worker's predicate (``uses_markdown``) so the label cannot drift from the
+    actual decision.
+
+    Note the gated path also writes no images, so ``has_images`` is False for a
+    large PDF even with extract_images=True -- markdown reconstruction is what
+    emits them.
+    """
+    markdown = uses_markdown(page_count, settings.document_markdown_max_pages)
+    mode = "markdown" if markdown else "text_only"
+    metadata["parse_mode"] = mode
+    record_document_parse_mode(mode)
+    if not markdown:
+        # Why the structure is missing, decided where the predicate is already
+        # evaluated so an interactive caller can be told plainly (0 = markdown
+        # switched off entirely; otherwise the page ceiling).
+        metadata["markdown_skipped_reason"] = (
+            "disabled" if settings.document_markdown_max_pages <= 0 else "page_ceiling"
+        )
+
+
 class PyMuPDFProcessor(DocumentProcessor):
     """Document processor using PyMuPDF library for PDF processing.
 
@@ -273,22 +304,7 @@ class PyMuPDFProcessor(DocumentProcessor):
             # Note the gated path also writes no images, so ``has_images`` is
             # False for a large PDF even with extract_images=True -- markdown
             # reconstruction is what emits them.
-            mode = (
-                "markdown"
-                if uses_markdown(page_count, settings.document_markdown_max_pages)
-                else "text_only"
-            )
-            metadata["parse_mode"] = mode
-            record_document_parse_mode(mode)
-            if mode == "text_only":
-                # Why the structure is missing, decided where the predicate is
-                # already evaluated so an interactive caller can be told plainly
-                # (0 = markdown switched off entirely; otherwise the ceiling).
-                metadata["markdown_skipped_reason"] = (
-                    "disabled"
-                    if settings.document_markdown_max_pages <= 0
-                    else "page_ceiling"
-                )
+            _record_parse_mode(metadata, page_count, settings)
 
             if progress_callback:
                 await progress_callback(90, 100, "Building result")

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -280,6 +280,15 @@ class PyMuPDFProcessor(DocumentProcessor):
             )
             metadata["parse_mode"] = mode
             record_document_parse_mode(mode)
+            if mode == "text_only":
+                # Why the structure is missing, decided where the predicate is
+                # already evaluated so an interactive caller can be told plainly
+                # (0 = markdown switched off entirely; otherwise the ceiling).
+                metadata["markdown_skipped_reason"] = (
+                    "disabled"
+                    if settings.document_markdown_max_pages <= 0
+                    else "page_ceiling"
+                )
 
             if progress_callback:
                 await progress_callback(90, 100, "Building result")

--- a/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
+++ b/nextcloud_mcp_server/document_processors/pypdfium2_fast.py
@@ -119,6 +119,10 @@ def _extract(
     metadata: dict[str, Any] = {
         "page_count": len(page_texts),
         "page_boundaries": page_boundaries,
+        # This tier is a text-layer extractor by design: no headings, no tables.
+        # Stated here so every processor reports its output shape the same way
+        # and a caller never has to infer markdown-ness from the processor name.
+        "parse_mode": "text_only",
     }
     title = doc_meta.get("Title")
     if title:

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 from nextcloud_mcp_server.config import get_settings
@@ -27,6 +28,34 @@ from .source import DocumentSource
 logger = logging.getLogger(__name__)
 
 PDF_MIME_TYPE = "application/pdf"
+
+
+@dataclass
+class _LadderState:
+    """What the PDF ladder knows between rungs.
+
+    ``from_tier`` is the tier whose output produced the current classification --
+    used as the ``from_tier`` of a subsequent OCR hop so a fast->structured->ocr
+    cascade is attributed correctly (that hop is from ``structured``, not a second
+    ``fast`` escalation). ``structured_failed`` marks a document whose structured
+    parse FAILED: it is terminal, so the OCR gate must not treat it as a fallback.
+    """
+
+    result: ProcessingResult
+    classification: DocClassification | None
+    from_tier: str = "fast"
+    structured_failed: bool = False
+
+    def advance_to_structured(
+        self,
+        result: ProcessingResult,
+        classify: Callable[[ProcessingResult, bool], DocClassification | None],
+    ) -> None:
+        """Adopt a successful structured parse and re-classify from it."""
+        self.result = result
+        self.from_tier = "structured"
+        # record=False: the document was already counted at the fast tier.
+        self.classification = classify(result, False)
 
 
 class ProcessorRegistry:
@@ -317,25 +346,12 @@ class ProcessorRegistry:
         by the bytes- and source-backed adapters above; the size guard has already
         been applied by the caller (it needs the size, which each holds differently).
 
-        ``options["prefer_markdown"]`` additionally promotes a good text-layer PDF
-        to the ``structured`` tier so the caller gets markdown rather than a flat
-        text layer -- see the promotion block below for the ceiling that bounds it.
+        The three rungs above ``fast`` are one method each -- they share only the
+        :class:`_LadderState` they hand along, and each is a separate decision:
+        recover a bad text layer, honour a markdown request, or pay for OCR.
         """
         if settings.document_tier1_engine == "pymupdf":
-            processor = self._pdf_processor_for_tier("structured")
-            if processor is None:
-                # The rollback was set to opt OUT of pypdfium2, so falling back
-                # to it (the highest-priority PDF processor) silently would
-                # defeat that intent -- warn loudly.
-                processor = self.find_processor(content_type)
-                if processor is None:
-                    raise ProcessorError("No PDF processor registered")
-                logger.warning(
-                    "document_tier1_engine=pymupdf but no 'structured' processor "
-                    "is registered; falling back to '%s'",
-                    processor.name,
-                )
-            return await run(processor, False)
+            return await self._run_rollback_engine(content_type, run)
 
         fast = self._pdf_processor_for_tier("fast")
         if fast is None:
@@ -351,198 +367,251 @@ class ProcessorRegistry:
         # when OCR + detect_scanned are enabled, so its cost is paid by
         # OCR-opted-in tenants only. Shared with the external per-tier path via
         # _classify_result.
-        classification = classify(result, True)
+        state = _LadderState(result=result, classification=classify(result, True))
 
-        # The tier whose output produced the current ``classification`` -- used as
-        # ``from_tier`` for a subsequent OCR hop so a fast->structured->ocr cascade
-        # is attributed correctly (the OCR hop is from ``structured``, not a second
-        # ``fast`` escalation).
-        from_tier = "fast"
-        # Set when the structured tier ran but failed to parse. The document is then
-        # terminal -- the external path does not escalate a parse FAILURE either --
-        # so the OCR gate below must not treat it as a fallback.
-        structured_failed = False
+        await self._escalate_structured(state, filename, run, classify)
+        await self._promote_markdown(state, options, filename, settings, run, classify)
+        return await self._escalate_ocr(state, filename, settings, run)
 
-        # Escalate a poor fast extraction up the ladder (fast -> structured -> ocr),
-        # mirroring the external per-tier path so both modes behave identically. A
-        # glyph-corrupt layer (the extractor leaked raw glyph codes -- the
-        # broken-/ToUnicode case) OR a low-quality-but-non-empty layer first tries
-        # the structured (pymupdf) tier: free, in-cluster, and able to recover both.
-        # Only a scanned / no-text-layer doc (total_chars == 0) skips structured --
-        # a text extractor cannot conjure text from a pure raster -- and drops
-        # straight to OCR via the gate below. Structured is therefore NOT gated on
-        # document_ocr_enabled. Its output is re-classified (record=False -- the doc
-        # was already counted at the fast tier) so a doc that is ALSO partly scanned
-        # still reaches the OCR gate.
-        if (
-            classification is not None
-            and classification.page_count > 0
-            and (
-                classification.recommended_tier == "structured"
-                or (
-                    classification.recommended_tier == "ocr"
-                    and classification.total_chars > 0
-                )
-            )
-        ):
-            structured = self._pdf_processor_for_tier("structured")
-            if structured is None:
-                # Structured isn't registered: mirror the external
-                # next_available_tier, which skips the missing rung and lands on
-                # OCR. Leave the recommendation unchanged so the OCR gate below
-                # picks it up (incl. a glyph-corrupt "structured" recommendation).
-                logger.debug(
-                    "No structured processor registered; %s falls through to the "
-                    "OCR gate (recommended_tier=%s)",
-                    filename or "<bytes>",
-                    classification.recommended_tier,
-                )
-            else:
-                reason = (
-                    "corrupt_glyphs"
-                    if classification.recommended_tier == "structured"
-                    else "low_confidence"
-                )
-                record_document_escalation("fast", "structured", reason)
-                logger.info(
-                    "Escalating %s fast->structured (reason=%s)",
-                    filename or "<bytes>",
-                    reason,
-                )
-                structured_result = await run(structured, True)
-                if structured_result.success:
-                    result = structured_result
-                    from_tier = "structured"
-                    classification = classify(result, False)
-                else:
-                    structured_failed = True
-                    logger.warning(
-                        "structured escalation did not succeed for %s (%s); keeping "
-                        "the tier-1 result (OCR not attempted)",
-                        filename or "<bytes>",
-                        structured_result.metadata.get("parse_failed_reason", "error"),
-                    )
-
-        # Caller asked for markdown (an interactive read, not ingest). The fast
-        # tier only ever returns the flat text layer, so promote to the structured
-        # engine -- pymupdf4llm is what reconstructs headings/tables. Bounded by
-        # the same page ceiling the structured tier applies internally
-        # (document_markdown_max_pages): above it that tier returns raw text
-        # anyway, so paying for a superlinear re-parse would buy nothing. A doc
-        # with no text layer at all is left to the OCR gate below, which produces
-        # markdown of its own -- a text extractor cannot conjure text from raster.
-        if (
-            (options or {}).get("prefer_markdown")
-            and from_tier == "fast"
-            and result.success
-            and not (classification is not None and classification.total_chars == 0)
-        ):
-            structured = self._pdf_processor_for_tier("structured")
-            page_count = int(result.metadata.get("page_count", 0) or 0)
-            max_pages = settings.document_markdown_max_pages
-            if structured is None:
-                result.metadata["markdown_skipped_reason"] = "not_registered"
-            elif max_pages <= 0:
-                result.metadata["markdown_skipped_reason"] = "disabled"
-            elif page_count > max_pages:
-                result.metadata["markdown_skipped_reason"] = "page_ceiling"
-            else:
-                record_document_escalation("fast", "structured", "markdown_requested")
-                logger.info(
-                    "Escalating %s fast->structured (reason=markdown_requested)",
-                    filename or "<bytes>",
-                )
-                markdown_result = await run(structured, True)
-                if markdown_result.success:
-                    result = markdown_result
-                    from_tier = "structured"
-                    classification = classify(result, False)
-                else:
-                    # Keep the fast text rather than failing the read, and say why
-                    # the markdown the caller asked for is not there.
-                    result.metadata["markdown_skipped_reason"] = "parse_failed"
-                    logger.warning(
-                        "markdown promotion did not succeed for %s (%s); keeping the "
-                        "tier-1 text",
-                        filename or "<bytes>",
-                        markdown_result.metadata.get("parse_failed_reason", "error"),
-                    )
-
-        # NOTE: the suppressed-escalation metric (document_escalation_suppressed_total,
-        # the "what-if OCR" signal; Deck #324) is intentionally NOT emitted on this
-        # inline/memory path -- it is instrumented only on the per-tier external
-        # path (vector/processor._parse_pdf_tier via evaluate_escalation). When OCR
-        # is off here the would-be escalation is simply not taken (the gate below);
-        # operators reading the suppressed counter are on the procrastinate fleet.
-        #
-        # Escalate to the OCR tier when enabled and a provider is registered. Fires
-        # for a scanned / no-text-layer doc (recommended "ocr"), and also for an
-        # unresolved "structured" recommendation -- a glyph-corrupt doc whose
-        # structured rung wasn't registered -- so the inline path falls through to
-        # OCR exactly like the external next_available_tier. ``structured_failed``
-        # excludes a doc whose structured parse FAILED (terminal, like the external
-        # path). Note: a fast FAILURE (result.success False, no classification) is
-        # NOT escalated; a PDF pypdfium2 can't open is a hard failure (OCR reads the
-        # same bytes and would usually fail too). The page_count guard skips a
-        # zero-page (empty/corrupt) PDF, which OCR can't help either.
-        #
-        # Whenever the classifier wants OCR but it does not run, the reason is
-        # recorded on the result metadata (``ocr_escalation_skipped``) so an
-        # interactive caller can be told plainly that the text it is holding is
-        # what a text extractor could recover, rather than silently receiving a
-        # near-empty parse. Ingest ignores these keys.
-        ocr_wanted = (
-            classification is not None
-            and not structured_failed
-            and classification.recommended_tier in ("ocr", "structured")
-            and classification.page_count > 0
-        )
-        if ocr_wanted and classification is not None:
-            reason = self._escalation_reason(classification)
-            result.metadata["ocr_recommended_reason"] = reason
-            if not settings.document_ocr_enabled:
-                result.metadata["ocr_escalation_skipped"] = "disabled"
-                return result
-
-            # Inline (memory pool) path: no queues to hop, so resolve the OCR tier
-            # via the same availability walk the queue path uses.
-            ocr_tier = self.next_available_tier(from_tier, settings, minimum="ocr")
-            ocr = self._pdf_processor_for_tier(ocr_tier) if ocr_tier else None
-            # `ocr is not None` already implies `ocr_tier is not None` at runtime,
-            # but the type checker can't infer that across the conditional above,
-            # so the explicit guard narrows `ocr_tier` to `str` for the
-            # record_document_escalation(from_tier, ocr_tier, reason) call below.
-            if ocr is None or ocr_tier is None:
-                result.metadata["ocr_escalation_skipped"] = "not_registered"
-                return result
-
-            record_document_escalation(from_tier, ocr_tier, reason)
-            logger.info(
-                "Escalating %s %s->%s (reason=%s)",
-                filename or "<bytes>",
-                from_tier,
-                ocr_tier,
-                reason,
-            )
-            ocr_result = await run(ocr, True)
-            # OCR is an enhancement, not a gate: if it can't run (no backend
-            # configured / API down) or returns nothing, keep the tier-1
-            # result rather than failing the document. Otherwise an operator
-            # who enables OCR without credentials would make scanned docs fail
-            # entirely -- strictly worse than off.
-            if ocr_result.success:
-                return ocr_result
-            result.metadata["ocr_escalation_failed"] = ocr_result.metadata.get(
-                "parse_failed_reason", "error"
-            )
+    async def _run_rollback_engine(
+        self,
+        content_type: str,
+        run: Callable[[DocumentProcessor, bool], Awaitable[ProcessingResult]],
+    ) -> ProcessingResult:
+        """``document_tier1_engine=pymupdf``: pin the structured engine, no ladder."""
+        processor = self._pdf_processor_for_tier("structured")
+        if processor is None:
+            # The rollback was set to opt OUT of pypdfium2, so falling back
+            # to it (the highest-priority PDF processor) silently would
+            # defeat that intent -- warn loudly.
+            processor = self.find_processor(content_type)
+            if processor is None:
+                raise ProcessorError("No PDF processor registered")
             logger.warning(
-                "OCR escalation to %s did not succeed for %s (%s); keeping the "
-                "tier-1 result",
-                ocr_tier,
-                filename or "<bytes>",
-                ocr_result.metadata.get("parse_failed_reason", "error"),
+                "document_tier1_engine=pymupdf but no 'structured' processor "
+                "is registered; falling back to '%s'",
+                processor.name,
             )
+        return await run(processor, False)
 
+    async def _escalate_structured(
+        self,
+        state: "_LadderState",
+        filename: str | None,
+        run: Callable[[DocumentProcessor, bool], Awaitable[ProcessingResult]],
+        classify: Callable[[ProcessingResult, bool], DocClassification | None],
+    ) -> None:
+        """Recover a poor fast extraction at the structured tier.
+
+        Mirrors the external per-tier path so both modes behave identically. A
+        glyph-corrupt layer (the extractor leaked raw glyph codes -- the
+        broken-/ToUnicode case) OR a low-quality-but-non-empty layer first tries
+        the structured (pymupdf) tier: free, in-cluster, and able to recover both.
+        Only a scanned / no-text-layer doc (total_chars == 0) skips structured --
+        a text extractor cannot conjure text from a pure raster -- and drops
+        straight to the OCR gate. Structured is therefore NOT gated on
+        document_ocr_enabled. Its output is re-classified (record=False -- the doc
+        was already counted at the fast tier) so a doc that is ALSO partly scanned
+        still reaches the OCR gate.
+        """
+        classification = state.classification
+        if classification is None or classification.page_count <= 0:
+            return
+        if not (
+            classification.recommended_tier == "structured"
+            or (
+                classification.recommended_tier == "ocr"
+                and classification.total_chars > 0
+            )
+        ):
+            return
+
+        structured = self._pdf_processor_for_tier("structured")
+        if structured is None:
+            # Structured isn't registered: mirror the external
+            # next_available_tier, which skips the missing rung and lands on
+            # OCR. Leave the recommendation unchanged so the OCR gate picks it
+            # up (incl. a glyph-corrupt "structured" recommendation).
+            logger.debug(
+                "No structured processor registered; %s falls through to the "
+                "OCR gate (recommended_tier=%s)",
+                filename or "<bytes>",
+                classification.recommended_tier,
+            )
+            return
+
+        reason = (
+            "corrupt_glyphs"
+            if classification.recommended_tier == "structured"
+            else "low_confidence"
+        )
+        record_document_escalation("fast", "structured", reason)
+        logger.info(
+            "Escalating %s fast->structured (reason=%s)",
+            filename or "<bytes>",
+            reason,
+        )
+        structured_result = await run(structured, True)
+        if structured_result.success:
+            state.advance_to_structured(structured_result, classify)
+            return
+
+        state.structured_failed = True
+        logger.warning(
+            "structured escalation did not succeed for %s (%s); keeping "
+            "the tier-1 result (OCR not attempted)",
+            filename or "<bytes>",
+            structured_result.metadata.get("parse_failed_reason", "error"),
+        )
+
+    async def _promote_markdown(
+        self,
+        state: "_LadderState",
+        options: dict[str, Any] | None,
+        filename: str | None,
+        settings: Any,
+        run: Callable[[DocumentProcessor, bool], Awaitable[ProcessingResult]],
+        classify: Callable[[ProcessingResult, bool], DocClassification | None],
+    ) -> None:
+        """Honour ``options["prefer_markdown"]`` (an interactive read, not ingest).
+
+        The fast tier only ever returns the flat text layer, so promote to the
+        structured engine -- pymupdf4llm is what reconstructs headings/tables.
+        Bounded by the same page ceiling that tier applies internally
+        (document_markdown_max_pages): above it the tier returns raw text anyway,
+        so paying for a superlinear re-parse would buy nothing. A doc with no text
+        layer at all is left to the OCR gate, which produces markdown of its own --
+        a text extractor cannot conjure text from raster.
+
+        Every path that does not produce markdown records WHY, so the caller can be
+        told rather than left to infer it from the absence of headings.
+        """
+        classification = state.classification
+        if not (options or {}).get("prefer_markdown"):
+            return
+        if state.from_tier != "fast" or not state.result.success:
+            return
+        if classification is not None and classification.total_chars == 0:
+            return
+
+        structured = self._pdf_processor_for_tier("structured")
+        max_pages = settings.document_markdown_max_pages
+        page_count = int(state.result.metadata.get("page_count", 0) or 0)
+        if structured is None:
+            state.result.metadata["markdown_skipped_reason"] = "not_registered"
+            return
+        if max_pages <= 0:
+            state.result.metadata["markdown_skipped_reason"] = "disabled"
+            return
+        if page_count > max_pages:
+            state.result.metadata["markdown_skipped_reason"] = "page_ceiling"
+            return
+
+        record_document_escalation("fast", "structured", "markdown_requested")
+        logger.info(
+            "Escalating %s fast->structured (reason=markdown_requested)",
+            filename or "<bytes>",
+        )
+        markdown_result = await run(structured, True)
+        if markdown_result.success:
+            state.advance_to_structured(markdown_result, classify)
+            return
+
+        # Keep the fast text rather than failing the read, and say why the
+        # markdown the caller asked for is not there.
+        state.result.metadata["markdown_skipped_reason"] = "parse_failed"
+        logger.warning(
+            "markdown promotion did not succeed for %s (%s); keeping the tier-1 text",
+            filename or "<bytes>",
+            markdown_result.metadata.get("parse_failed_reason", "error"),
+        )
+
+    async def _escalate_ocr(
+        self,
+        state: "_LadderState",
+        filename: str | None,
+        settings: Any,
+        run: Callable[[DocumentProcessor, bool], Awaitable[ProcessingResult]],
+    ) -> ProcessingResult:
+        """Pay for OCR when the classifier says a text extractor cannot do better.
+
+        Fires for a scanned / no-text-layer doc (recommended "ocr"), and also for
+        an unresolved "structured" recommendation -- a glyph-corrupt doc whose
+        structured rung wasn't registered -- so the inline path falls through to
+        OCR exactly like the external next_available_tier. ``structured_failed``
+        excludes a doc whose structured parse FAILED (terminal, like the external
+        path). A fast FAILURE (result.success False, no classification) is NOT
+        escalated: a PDF pypdfium2 can't open is a hard failure (OCR reads the same
+        bytes and would usually fail too). The page_count guard skips a zero-page
+        (empty/corrupt) PDF, which OCR can't help either.
+
+        Whenever the classifier wants OCR but it does not run, the reason is
+        recorded on the result metadata (``ocr_escalation_skipped``) so an
+        interactive caller can be told plainly that the text it is holding is what
+        a text extractor could recover, rather than silently receiving a near-empty
+        parse. Ingest ignores these keys.
+
+        NOTE: the suppressed-escalation metric (document_escalation_suppressed_total,
+        the "what-if OCR" signal; Deck #324) is intentionally NOT emitted on this
+        inline/memory path -- it is instrumented only on the per-tier external path
+        (vector/processor._parse_pdf_tier via evaluate_escalation). When OCR is off
+        here the would-be escalation is simply not taken; operators reading the
+        suppressed counter are on the procrastinate fleet.
+        """
+        result = state.result
+        classification = state.classification
+        if (
+            classification is None
+            or state.structured_failed
+            or classification.recommended_tier not in ("ocr", "structured")
+            or classification.page_count <= 0
+        ):
+            return result
+
+        reason = self._escalation_reason(classification)
+        result.metadata["ocr_recommended_reason"] = reason
+        if not settings.document_ocr_enabled:
+            result.metadata["ocr_escalation_skipped"] = "disabled"
+            return result
+
+        # Inline (memory pool) path: no queues to hop, so resolve the OCR tier
+        # via the same availability walk the queue path uses.
+        ocr_tier = self.next_available_tier(state.from_tier, settings, minimum="ocr")
+        ocr = self._pdf_processor_for_tier(ocr_tier) if ocr_tier else None
+        # `ocr is not None` already implies `ocr_tier is not None` at runtime,
+        # but the type checker can't infer that across the conditional above,
+        # so the explicit guard narrows `ocr_tier` to `str` for the
+        # record_document_escalation(from_tier, ocr_tier, reason) call below.
+        if ocr is None or ocr_tier is None:
+            result.metadata["ocr_escalation_skipped"] = "not_registered"
+            return result
+
+        record_document_escalation(state.from_tier, ocr_tier, reason)
+        logger.info(
+            "Escalating %s %s->%s (reason=%s)",
+            filename or "<bytes>",
+            state.from_tier,
+            ocr_tier,
+            reason,
+        )
+        ocr_result = await run(ocr, True)
+        # OCR is an enhancement, not a gate: if it can't run (no backend
+        # configured / API down) or returns nothing, keep the tier-1 result
+        # rather than failing the document. Otherwise an operator who enables OCR
+        # without credentials would make scanned docs fail entirely -- strictly
+        # worse than off.
+        if ocr_result.success:
+            return ocr_result
+        result.metadata["ocr_escalation_failed"] = ocr_result.metadata.get(
+            "parse_failed_reason", "error"
+        )
+        logger.warning(
+            "OCR escalation to %s did not succeed for %s (%s); keeping the "
+            "tier-1 result",
+            ocr_tier,
+            filename or "<bytes>",
+            ocr_result.metadata.get("parse_failed_reason", "error"),
+        )
         return result
 
     def oversize_result_for_size(

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -203,12 +203,11 @@ class ProcessorRegistry:
             Callable[[float, float | None, str | None], Awaitable[None]] | None
         ),
     ) -> ProcessingResult:
-        """Tiered PDF pipeline.
+        """Tiered PDF pipeline, bytes-backed.
 
-        pypdfium2 ``fast`` extracts first; classification is then derived from
-        that text (no PDF re-open), and a scanned/no-text-layer doc escalates to
-        the ``ocr`` tier when enabled. ``document_tier1_engine="pymupdf"`` is a
-        deprecated rollback that pins the structured engine instead.
+        Adapter over :meth:`_run_pdf_ladder`: the ladder's decisions are identical
+        either way, only *how* a tier is run and classified differs. See
+        :meth:`_process_pdf_source` for the file-backed twin.
         """
         settings = get_settings()
 
@@ -216,6 +215,112 @@ class ProcessorRegistry:
         if oversize is not None:
             return oversize
 
+        async def run(
+            processor: DocumentProcessor, escalated: bool
+        ) -> ProcessingResult:
+            return await self._run_processor(
+                processor,
+                content,
+                content_type,
+                filename,
+                options,
+                progress_callback,
+                escalated=escalated,
+            )
+
+        def classify(
+            result: ProcessingResult, record: bool
+        ) -> DocClassification | None:
+            return self._classify_result(
+                result, content, settings, record=record, filename=filename
+            )
+
+        return await self._run_pdf_ladder(
+            content_type, filename, options, settings, run, classify
+        )
+
+    async def _process_pdf_source(
+        self,
+        source: DocumentSource,
+        options: dict[str, Any] | None,
+        progress_callback: (
+            Callable[[float, float | None, str | None], Awaitable[None]] | None
+        ),
+    ) -> ProcessingResult:
+        """Tiered PDF pipeline against a file-backed source.
+
+        The path-backed twin of :meth:`_process_pdf`. Every tier opens the spool
+        file directly and scan detection classifies from that path, so a document
+        streamed to disk is never materialised into memory to run the ladder --
+        which is what lets the interactive read tool (and any other in-process
+        caller) parse a large PDF in a pod sized for the API role.
+        """
+        settings = get_settings()
+
+        # The size the guard needs is already known from the download; rejecting
+        # here costs no read at all.
+        oversize = self.oversize_result_for_size(source.size, source.filename, settings)
+        if oversize is not None:
+            return oversize
+
+        async def run(
+            processor: DocumentProcessor, escalated: bool
+        ) -> ProcessingResult:
+            return await self._run_processor_source(
+                processor, source, options, progress_callback, escalated=escalated
+            )
+
+        def classify(
+            result: ProcessingResult, record: bool
+        ) -> DocClassification | None:
+            # ``content`` is unused when a source is given -- scan detection reads
+            # the path instead of the bytes.
+            return self._classify_result(
+                result,
+                b"",
+                settings,
+                record=record,
+                filename=source.filename,
+                source=source,
+            )
+
+        return await self._run_pdf_ladder(
+            source.content_type, source.filename, options, settings, run, classify
+        )
+
+    @staticmethod
+    def _escalation_reason(classification: DocClassification) -> str:
+        """Why the classifier wants to leave the current tier."""
+        if classification.recommended_tier == "structured":
+            return "corrupt_glyphs"
+        if classification.total_chars == 0:
+            return "empty_text"
+        return "low_confidence"
+
+    async def _run_pdf_ladder(
+        self,
+        content_type: str,
+        filename: str | None,
+        options: dict[str, Any] | None,
+        settings: Any,
+        run: Callable[[DocumentProcessor, bool], Awaitable[ProcessingResult]],
+        classify: Callable[[ProcessingResult, bool], DocClassification | None],
+    ) -> ProcessingResult:
+        """Tiered PDF pipeline, independent of how the document is held.
+
+        pypdfium2 ``fast`` extracts first; classification is then derived from
+        that text (no PDF re-open), and a scanned/no-text-layer doc escalates to
+        the ``ocr`` tier when enabled. ``document_tier1_engine="pymupdf"`` is a
+        deprecated rollback that pins the structured engine instead.
+
+        ``run(processor, escalated)`` and ``classify(result, record)`` are supplied
+        by the bytes- and source-backed adapters above; the size guard has already
+        been applied by the caller (it needs the size, which each holds differently).
+
+        ``options["prefer_markdown"]`` additionally promotes a good text-layer PDF
+        to the ``structured`` tier so the caller gets markdown rather than a flat
+        text layer -- see the promotion block below for the ceiling that bounds it.
+        """
         if settings.document_tier1_engine == "pymupdf":
             processor = self._pdf_processor_for_tier("structured")
             if processor is None:
@@ -230,31 +335,23 @@ class ProcessorRegistry:
                     "is registered; falling back to '%s'",
                     processor.name,
                 )
-            return await self._run_processor(
-                processor, content, content_type, filename, options, progress_callback
-            )
+            return await run(processor, False)
 
         fast = self._pdf_processor_for_tier("fast")
         if fast is None:
             processor = self.find_processor(content_type)
             if processor is None:
                 raise ProcessorError("No PDF processor registered")
-            return await self._run_processor(
-                processor, content, content_type, filename, options, progress_callback
-            )
+            return await run(processor, False)
 
-        result = await self._run_processor(
-            fast, content, content_type, filename, options, progress_callback
-        )
+        result = await run(fast, False)
 
         # Tier-0 classification from the extraction (cheap: text-only, no PDF
         # re-open). Scan detection (image analysis, re-opens the PDF) runs only
         # when OCR + detect_scanned are enabled, so its cost is paid by
         # OCR-opted-in tenants only. Shared with the external per-tier path via
         # _classify_result.
-        classification = self._classify_result(
-            result, content, settings, record=True, filename=filename
-        )
+        classification = classify(result, True)
 
         # The tier whose output produced the current ``classification`` -- used as
         # ``from_tier`` for a subsequent OCR hop so a fast->structured->ocr cascade
@@ -312,21 +409,11 @@ class ProcessorRegistry:
                     filename or "<bytes>",
                     reason,
                 )
-                structured_result = await self._run_processor(
-                    structured,
-                    content,
-                    content_type,
-                    filename,
-                    options,
-                    progress_callback,
-                    escalated=True,
-                )
+                structured_result = await run(structured, True)
                 if structured_result.success:
                     result = structured_result
                     from_tier = "structured"
-                    classification = self._classify_result(
-                        result, content, settings, record=False, filename=filename
-                    )
+                    classification = classify(result, False)
                 else:
                     structured_failed = True
                     logger.warning(
@@ -334,6 +421,51 @@ class ProcessorRegistry:
                         "the tier-1 result (OCR not attempted)",
                         filename or "<bytes>",
                         structured_result.metadata.get("parse_failed_reason", "error"),
+                    )
+
+        # Caller asked for markdown (an interactive read, not ingest). The fast
+        # tier only ever returns the flat text layer, so promote to the structured
+        # engine -- pymupdf4llm is what reconstructs headings/tables. Bounded by
+        # the same page ceiling the structured tier applies internally
+        # (document_markdown_max_pages): above it that tier returns raw text
+        # anyway, so paying for a superlinear re-parse would buy nothing. A doc
+        # with no text layer at all is left to the OCR gate below, which produces
+        # markdown of its own -- a text extractor cannot conjure text from raster.
+        if (
+            (options or {}).get("prefer_markdown")
+            and from_tier == "fast"
+            and result.success
+            and not (classification is not None and classification.total_chars == 0)
+        ):
+            structured = self._pdf_processor_for_tier("structured")
+            page_count = int(result.metadata.get("page_count", 0) or 0)
+            max_pages = settings.document_markdown_max_pages
+            if structured is None:
+                result.metadata["markdown_skipped_reason"] = "not_registered"
+            elif max_pages <= 0:
+                result.metadata["markdown_skipped_reason"] = "disabled"
+            elif page_count > max_pages:
+                result.metadata["markdown_skipped_reason"] = "page_ceiling"
+            else:
+                record_document_escalation("fast", "structured", "markdown_requested")
+                logger.info(
+                    "Escalating %s fast->structured (reason=markdown_requested)",
+                    filename or "<bytes>",
+                )
+                markdown_result = await run(structured, True)
+                if markdown_result.success:
+                    result = markdown_result
+                    from_tier = "structured"
+                    classification = classify(result, False)
+                else:
+                    # Keep the fast text rather than failing the read, and say why
+                    # the markdown the caller asked for is not there.
+                    result.metadata["markdown_skipped_reason"] = "parse_failed"
+                    logger.warning(
+                        "markdown promotion did not succeed for %s (%s); keeping the "
+                        "tier-1 text",
+                        filename or "<bytes>",
+                        markdown_result.metadata.get("parse_failed_reason", "error"),
                     )
 
         # NOTE: the suppressed-escalation metric (document_escalation_suppressed_total,
@@ -353,13 +485,25 @@ class ProcessorRegistry:
         # NOT escalated; a PDF pypdfium2 can't open is a hard failure (OCR reads the
         # same bytes and would usually fail too). The page_count guard skips a
         # zero-page (empty/corrupt) PDF, which OCR can't help either.
-        if (
+        #
+        # Whenever the classifier wants OCR but it does not run, the reason is
+        # recorded on the result metadata (``ocr_escalation_skipped``) so an
+        # interactive caller can be told plainly that the text it is holding is
+        # what a text extractor could recover, rather than silently receiving a
+        # near-empty parse. Ingest ignores these keys.
+        ocr_wanted = (
             classification is not None
             and not structured_failed
             and classification.recommended_tier in ("ocr", "structured")
             and classification.page_count > 0
-            and settings.document_ocr_enabled
-        ):
+        )
+        if ocr_wanted and classification is not None:
+            reason = self._escalation_reason(classification)
+            result.metadata["ocr_recommended_reason"] = reason
+            if not settings.document_ocr_enabled:
+                result.metadata["ocr_escalation_skipped"] = "disabled"
+                return result
+
             # Inline (memory pool) path: no queues to hop, so resolve the OCR tier
             # via the same availability walk the queue path uses.
             ocr_tier = self.next_available_tier(from_tier, settings, minimum="ocr")
@@ -368,45 +512,36 @@ class ProcessorRegistry:
             # but the type checker can't infer that across the conditional above,
             # so the explicit guard narrows `ocr_tier` to `str` for the
             # record_document_escalation(from_tier, ocr_tier, reason) call below.
-            if ocr is not None and ocr_tier is not None:
-                reason = (
-                    "corrupt_glyphs"
-                    if classification.recommended_tier == "structured"
-                    else "empty_text"
-                    if classification.total_chars == 0
-                    else "low_confidence"
-                )
-                record_document_escalation(from_tier, ocr_tier, reason)
-                logger.info(
-                    "Escalating %s %s->%s (reason=%s)",
-                    filename or "<bytes>",
-                    from_tier,
-                    ocr_tier,
-                    reason,
-                )
-                ocr_result = await self._run_processor(
-                    ocr,
-                    content,
-                    content_type,
-                    filename,
-                    options,
-                    progress_callback,
-                    escalated=True,
-                )
-                # OCR is an enhancement, not a gate: if it can't run (no backend
-                # configured / API down) or returns nothing, keep the tier-1
-                # result rather than failing the document. Otherwise an operator
-                # who enables OCR without credentials would make scanned docs fail
-                # entirely -- strictly worse than off.
-                if ocr_result.success:
-                    return ocr_result
-                logger.warning(
-                    "OCR escalation to %s did not succeed for %s (%s); keeping the "
-                    "tier-1 result",
-                    ocr_tier,
-                    filename or "<bytes>",
-                    ocr_result.metadata.get("parse_failed_reason", "error"),
-                )
+            if ocr is None or ocr_tier is None:
+                result.metadata["ocr_escalation_skipped"] = "not_registered"
+                return result
+
+            record_document_escalation(from_tier, ocr_tier, reason)
+            logger.info(
+                "Escalating %s %s->%s (reason=%s)",
+                filename or "<bytes>",
+                from_tier,
+                ocr_tier,
+                reason,
+            )
+            ocr_result = await run(ocr, True)
+            # OCR is an enhancement, not a gate: if it can't run (no backend
+            # configured / API down) or returns nothing, keep the tier-1
+            # result rather than failing the document. Otherwise an operator
+            # who enables OCR without credentials would make scanned docs fail
+            # entirely -- strictly worse than off.
+            if ocr_result.success:
+                return ocr_result
+            result.metadata["ocr_escalation_failed"] = ocr_result.metadata.get(
+                "parse_failed_reason", "error"
+            )
+            logger.warning(
+                "OCR escalation to %s did not succeed for %s (%s); keeping the "
+                "tier-1 result",
+                ocr_tier,
+                filename or "<bytes>",
+                ocr_result.metadata.get("parse_failed_reason", "error"),
+            )
 
         return result
 
@@ -606,33 +741,19 @@ class ProcessorRegistry:
             Callable[[float, float | None, str | None], Awaitable[None]] | None
         ) = None,
     ) -> ProcessingResult:
-        """Inline (non-tiered) processing of a file-backed source.
+        """Inline tiered processing of a file-backed source.
 
-        Non-PDFs are handed the source directly. Note that only the two PDF
-        engines override ``process_source`` today, so any other processor still
-        materialises the document via the base-class default -- off the event
-        loop through ``run_sync``, so it no longer blocks, but the memory is
-        still proportional to document size until that processor grows a
-        path-based override.
-
-        PDFs run the inline tiered pipeline, which is bytes-based, so they are
-        materialised here -- see the note below.
+        PDFs run the inline tiered pipeline against the file itself
+        (:meth:`_process_pdf_source`), so the document is never materialised to
+        drive the ladder. Non-PDFs are handed the source directly. Note that only
+        the two PDF engines override ``process_source`` today, so any other
+        processor still materialises the document via the base-class default --
+        off the event loop through ``run_sync``, so it no longer blocks, but the
+        memory is still proportional to document size until that processor grows
+        a path-based override.
         """
         if source.content_type.split(";")[0].strip().lower() == PDF_MIME_TYPE:
-            # TODO: give _process_pdf a source-based twin. The inline pipeline is
-            # the escalation-disabled path (in-process/memory pool), not the
-            # per-tier worker fleet that production runs, so the memory win lands
-            # where it matters first; this keeps behaviour identical meanwhile.
-            from anyio.to_thread import run_sync  # noqa: PLC0415
-
-            content = await run_sync(source.read_bytes)
-            return await self._process_pdf(
-                content,
-                source.content_type,
-                source.filename,
-                options,
-                progress_callback,
-            )
+            return await self._process_pdf_source(source, options, progress_callback)
 
         processor = self.find_processor(source.content_type)
         if not processor:

--- a/nextcloud_mcp_server/document_processors/source.py
+++ b/nextcloud_mcp_server/document_processors/source.py
@@ -96,6 +96,12 @@ class SpooledDocumentSource:
     content_type: str
     filename: str | None = None
     _size: int | None = None
+    #: The origin's ``ETag`` for the bytes that were spooled, when the transport
+    #: reported one. Carried here so a caller that streamed the document (rather
+    #: than buffering it via ``read_file``, which returns the etag directly) can
+    #: still identify the exact version it parsed -- e.g. to hand back as an
+    #: ``If-Match`` precondition for a later write.
+    etag: str | None = None
 
     @property
     def size(self) -> int:

--- a/nextcloud_mcp_server/document_processors/unstructured.py
+++ b/nextcloud_mcp_server/document_processors/unstructured.py
@@ -203,6 +203,8 @@ class UnstructuredProcessor(DocumentProcessor):
                     "element_types": element_types,
                     "strategy": strategy,
                     "languages": languages,
+                    # Elements are joined as plain paragraphs, not markdown.
+                    "parse_mode": "text_only",
                 }
 
                 logger.debug(

--- a/nextcloud_mcp_server/models/webdav.py
+++ b/nextcloud_mcp_server/models/webdav.py
@@ -1,11 +1,17 @@
 """Pydantic models for WebDAV responses."""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
 from .base import BaseResponse, StatusResponse
+
+#: Outcome of a document parse, and the shape of what came back. Defined here
+#: (the response contract) so the tool, the parser and the model cannot drift
+#: into three slightly different vocabularies.
+ParseStatus = Literal["parsed", "failed", "skipped", "not_applicable"]
+ContentFormat = Literal["text", "markdown", "base64"]
 
 
 class FileInfo(BaseModel):
@@ -59,10 +65,49 @@ class ReadFileResponse(BaseResponse):
     )
     parsed: bool = Field(
         default=False,
-        description="Whether content was extracted from a document (PDF, DOCX, ...)",
+        description=(
+            "Whether text was successfully extracted from a document "
+            "(PDF, DOCX, ...). Equivalent to parse_status == 'parsed'."
+        ),
+    )
+    parse_status: ParseStatus = Field(
+        default="not_applicable",
+        description=(
+            "Outcome of the document parse: 'parsed' (content is extracted text), "
+            "'failed' (a parse was attempted and did not produce text -- see "
+            "parse_notes), 'skipped' (the caller asked for the raw file), or "
+            "'not_applicable' (nothing here needed parsing, e.g. a text file or a "
+            "type no processor handles)."
+        ),
+    )
+    parse_tier: Optional[str] = Field(
+        None,
+        description=(
+            "Extraction tier that produced the content: 'fast' (plain text layer), "
+            "'structured' (markdown reconstruction) or 'ocr'."
+        ),
+    )
+    parse_processor: Optional[str] = Field(
+        None, description="Name of the processor that produced the content"
+    )
+    content_format: ContentFormat = Field(
+        default="text",
+        description=(
+            "What `content` actually is: markdown with headings/tables, plain "
+            "text, or base64-encoded bytes."
+        ),
+    )
+    parse_notes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Plain statements about anything that degraded this read -- OCR "
+            "unavailable, markdown structure not reconstructed, size cap hit, "
+            "parse failed. When non-empty, report them; the content is not the "
+            "whole document."
+        ),
     )
     parsing_metadata: Optional[dict] = Field(
-        None, description="Document-processor metadata when parsed=True"
+        None, description="Raw document-processor metadata when a parse ran"
     )
     etag: Optional[str] = Field(None, description="ETag for versioning")
     last_modified: Optional[str] = Field(None, description="Last modification time")

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -142,9 +142,11 @@ def configure_sharing_tools(mcp: FastMCP):
     ) -> PublicDownloadLinkResponse:
         """Create a short-lived, read-only public download link for a file.
 
-        Use this for binary files (especially images) instead of reading them
-        inline: ``nc_webdav_read_file`` returns base64, which can exceed the MCP
-        client response budget and get truncated, leaving the file undecodable.
+        Use this for binary files (especially images) the client needs as bytes
+        rather than as text: ``nc_webdav_read_file`` base64s anything it cannot
+        extract text from, which can exceed the MCP client response budget and get
+        truncated, leaving the file undecodable. (For documents -- PDF, DOCX --
+        prefer reading them: that tool returns their text or markdown.)
         A public link keeps the MCP response small and lets the client download
         the exact original bytes from ``download_url``.
 

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -59,11 +59,18 @@ async def _raw_response(
 ) -> ReadFileResponse:
     """Return the file itself: decoded text, or base64 bytes.
 
-    Reads back from the spool rather than a buffer held across the parse, and
-    stops at :data:`RAW_CONTENT_MAX_BYTES` so the "we could not parse it"
-    fallback cannot itself blow up the response. The read runs on a worker
-    thread: it is a synchronous disk read that would otherwise stall every other
-    request on this event loop.
+    Reads back from the spool rather than from a download buffer held across the
+    parse -- that buffer is what used to make peak memory scale with document
+    size -- and stops at :data:`RAW_CONTENT_MAX_BYTES` so the "we could not parse
+    it" fallback cannot itself blow up the response.
+
+    Peak here is bounded accordingly: on the only path that reaches this with a
+    parse behind it (a FAILED parse), the failed result carries no text, so what
+    is resident is one capped read. A successful parse returns its text directly
+    and never calls this.
+
+    The read runs on a worker thread: it is a synchronous disk read that would
+    otherwise stall every other request on this event loop.
     """
     size = source.size
     content_type = source.content_type

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -343,7 +343,11 @@ def configure_webdav_tools(mcp: FastMCP):
                             ],
                         )
 
-                    summary = document_parser.summarize_parse(result, settings)
+                    summary = document_parser.summarize_parse(
+                        result,
+                        settings,
+                        markdown_requested=(parse_document == "markdown"),
+                    )
                     if summary.status == "failed":
                         # An unsuccessful parse is never reported as content: hand
                         # back the raw file with the reason attached.

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -1,8 +1,10 @@
 import base64
 import contextlib
 import logging
+from typing import TYPE_CHECKING, Literal
 
 import anyio
+from anyio.to_thread import run_sync
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
@@ -19,11 +21,15 @@ from nextcloud_mcp_server.models import (
     SearchFilesResponse,
     WriteFileResponse,
 )
+from nextcloud_mcp_server.models.webdav import ParseStatus
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 from nextcloud_mcp_server.server.tag_exclusion import (
     get_excluded_file_paths,
     is_path_excluded,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle / lazy-import guard
+    from nextcloud_mcp_server.document_processors.source import DocumentSource
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +37,98 @@ logger = logging.getLogger(__name__)
 # are conditions a caller reacts to rather than transport failures. They are
 # what makes ``success`` False on the typed response.
 _WEBDAV_CONFLICT_STATUSES = frozenset({404, 409, 412})
+
+#: Ceiling on the bytes an unparsed file may contribute to one MCP response.
+#: Base64 inflates by ~4/3 and the whole thing lands in a model's context, so a
+#: large binary is not merely expensive to return -- it is unusable once it
+#: arrives. Past this the response carries the file's metadata and says why the
+#: content is absent. A constant rather than a setting: the useful bound is the
+#: client's context, not anything an operator knows better.
+RAW_CONTENT_MAX_BYTES = 5 * 1024 * 1024
+
+
+async def _raw_response(
+    source: "DocumentSource",
+    path: str,
+    parse_status: ParseStatus,
+    notes: list[str],
+    *,
+    parse_tier: str | None = None,
+    parse_processor: str | None = None,
+    parsing_metadata: dict | None = None,
+) -> ReadFileResponse:
+    """Return the file itself: decoded text, or base64 bytes.
+
+    Reads back from the spool rather than a buffer held across the parse, and
+    stops at :data:`RAW_CONTENT_MAX_BYTES` so the "we could not parse it"
+    fallback cannot itself blow up the response. The read runs on a worker
+    thread: it is a synchronous disk read that would otherwise stall every other
+    request on this event loop.
+    """
+    size = source.size
+    content_type = source.content_type
+    # Genuinely optional: only a streamed (spooled) source carries the origin's
+    # etag; an in-memory one has no transport response to have read it from.
+    etag = getattr(source, "etag", None)
+
+    def _read_capped() -> bytes | None:
+        if size > RAW_CONTENT_MAX_BYTES:
+            return None
+        with source.open() as fh:
+            return fh.read()
+
+    content = await run_sync(_read_capped)
+
+    if content is None:
+        return ReadFileResponse(
+            path=path,
+            content="",
+            content_type=content_type,
+            size=size,
+            parse_status=parse_status,
+            parse_tier=parse_tier,
+            parse_processor=parse_processor,
+            parse_notes=[
+                *notes,
+                f"The file itself ({size / (1024 * 1024):.1f} MB) is too large to "
+                f"return inline; download it from Nextcloud directly.",
+            ],
+            parsing_metadata=parsing_metadata,
+            etag=etag,
+        )
+
+    if content_type.startswith("text/"):
+        try:
+            return ReadFileResponse(
+                path=path,
+                content=content.decode("utf-8"),
+                content_type=content_type,
+                size=size,
+                parse_status=parse_status,
+                parse_tier=parse_tier,
+                parse_processor=parse_processor,
+                parse_notes=notes,
+                parsing_metadata=parsing_metadata,
+                etag=etag,
+            )
+        except UnicodeDecodeError:
+            # Mislabelled text/*: fall through and hand back the bytes.
+            pass
+
+    return ReadFileResponse(
+        path=path,
+        content=base64.b64encode(content).decode("ascii"),
+        content_type=content_type,
+        size=size,
+        encoding="base64",
+        content_format="base64",
+        parse_status=parse_status,
+        parse_tier=parse_tier,
+        parse_processor=parse_processor,
+        parse_notes=notes,
+        parsing_metadata=parsing_metadata,
+        etag=etag,
+    )
 
 
 def configure_webdav_tools(mcp: FastMCP):
@@ -104,7 +202,9 @@ def configure_webdav_tools(mcp: FastMCP):
     @require_scopes("files.read")
     @instrument_tool
     async def nc_webdav_read_file(
-        path: str, ctx: Context, force_processor: str | None = None
+        path: str,
+        ctx: Context,
+        parse_document: Literal["auto", "markdown", "raw"] = "auto",
     ) -> ReadFileResponse:
         """Read the content of a file from NextCloud.
 
@@ -113,20 +213,34 @@ def configure_webdav_tools(mcp: FastMCP):
 
         Args:
             path: Full path to the file to read
-            force_processor: Force a specific document processor by name instead of
-                auto-selecting. Set to ``"docling"`` to parse the file with a
-                docling-serve instance even when it is a PDF that already has a text
-                layer -- useful when the text layer misses tables/figures or is
-                incomplete. Requires that processor to be enabled/registered;
-                raises ``ToolError`` otherwise. ``None`` = auto-select.
+            parse_document: How to handle a document (PDF, DOCX, image, ...):
+
+                - ``"auto"`` (default): extract its text. Cheapest route that
+                  works -- a PDF with a good text layer is read directly, and a
+                  scanned one escalates to OCR when the server has OCR enabled.
+                - ``"markdown"``: additionally reconstruct structure (headings,
+                  tables) rather than returning a flat text layer. Costs a
+                  second, slower parse and is bounded by a page ceiling; when it
+                  cannot be honoured the response says so instead of pretending.
+                - ``"raw"``: do not parse. Text files are decoded, anything else
+                  comes back base64-encoded.
+
+                Files no processor handles (plain text, JSON, archives) are
+                unaffected by this argument.
 
         Returns:
-            ``ReadFileResponse`` with ``path``, ``content``, ``content_type``,
-            ``size`` and ``etag``. Depending on the file:
-            - Text files are decoded to UTF-8.
-            - Documents (PDF, DOCX, ...) are parsed to text with
-              ``parsed=True`` and ``parsing_metadata`` set.
-            - Other binary files are base64-encoded with ``encoding="base64"``.
+            ``ReadFileResponse``. Alongside ``path``/``content``/``content_type``/
+            ``size``/``etag`` it always describes what you are actually holding:
+
+            - ``parse_status``: ``parsed`` / ``failed`` / ``skipped`` /
+              ``not_applicable``.
+            - ``content_format``: ``markdown``, ``text`` or ``base64``.
+            - ``parse_tier`` / ``parse_processor``: which extraction tier
+              produced the content (``fast``, ``structured``, ``ocr``).
+            - ``parse_notes``: **if this is non-empty, tell the user what
+              degraded** (OCR unavailable, structure not reconstructed, size cap,
+              parse failure) rather than presenting the content as the complete
+              document.
             - ``etag``: pass this back into ``nc_webdav_write_file``'s
               ``if_match`` when writing this same path later, so a manual edit
               made elsewhere in the meantime (e.g. in the Nextcloud web UI) is
@@ -139,128 +253,137 @@ def configure_webdav_tools(mcp: FastMCP):
         if is_path_excluded(path, excluded):
             raise ToolError(f"Access denied: {path!r} is tagged with an excluded tag")
 
-        content, content_type, etag = await client.webdav.read_file(path)
-
         # Imported lazily so server startup never loads the document-parsing
         # stack (document_processors -> pymupdf -> _isolation). That stack is an
         # ingest-layer concern and, before this, broke Windows startup via a
         # Unix-only ``import resource`` (#877). It is only needed when a file is
         # actually read and parsed.
-        from nextcloud_mcp_server.document_processors import (  # noqa: PLC0415
-            get_registry,
+        #
+        # Imported as a MODULE, not by name: this tool has a parameter called
+        # ``parse_document``, and ``from ... import parse_document`` would rebind
+        # it and silently discard the caller's choice.
+        from nextcloud_mcp_server.client.webdav import OversizeDownload  # noqa: PLC0415
+        from nextcloud_mcp_server.utils import document_parser  # noqa: PLC0415
+        from nextcloud_mcp_server.vector.spool import (  # noqa: PLC0415
+            download_ceiling,
+            spooled_document,
         )
-        from nextcloud_mcp_server.utils.document_parser import (  # noqa: PLC0415
-            is_parseable_document,
-            parse_document,
-        )
 
-        # force_processor is client/LLM-controlled: validate it against the
-        # registered-processor allowlist (a dict-key lookup, never interpolated
-        # into a URL/path) and surface a clear error with the available names
-        # rather than the opaque base64 fallback parse_document would otherwise
-        # return for an unknown/unconfigured processor.
-        if force_processor is not None:
-            registry = get_registry()
-            if registry.get_processor(force_processor) is None:
-                available = ", ".join(registry.list_processors()) or "none"
-                raise ToolError(
-                    f"Unknown document processor {force_processor!r}. Ensure document "
-                    f"processing is enabled (ENABLE_DOCUMENT_PROCESSING) and the "
-                    f"processor is configured (e.g. ENABLE_DOCLING + DOCLING_API_URL "
-                    f"for 'docling'). Available: {available}"
-                )
+        settings = get_settings()
+        ceiling = download_ceiling(settings)
 
-        # Parse when the type is auto-parseable OR the caller forced a processor.
-        # is_parseable_document() also checks that document processing is enabled.
-        if force_processor is not None or is_parseable_document(content_type):
-            # Optional interactive cap (ADR-032): bound the SYNCHRONOUS parse so a
-            # slow VLM/OCR convert returns base64 quickly instead of blocking past
-            # the MCP client's own timeout. Read lazily so test/env overrides apply.
-            # Disabled (None) -> nullcontext, i.e. unchanged behavior. Only wraps this
-            # interactive tool; the async ingest/worker path is never bounded here.
-            read_cap = get_settings().document_read_timeout_seconds
-            cap_ctx = (
-                anyio.fail_after(read_cap)
-                if read_cap is not None
-                else contextlib.nullcontext()
-            )
-            try:
-                logger.info(
-                    "Parsing document %r of type %r%s",
-                    path,
-                    content_type,
-                    f" with forced processor {force_processor!r}"
-                    if force_processor
-                    else "",
-                )
-                with cap_ctx:
-                    parsed_text, metadata = await parse_document(
-                        content,
-                        content_type,
-                        filename=path,
-                        progress_callback=ctx.report_progress,
-                        processor_name=force_processor,
+        # Stream the document to a spool file instead of buffering the whole
+        # response: this tool runs in the API role, which is not sized to hold a
+        # multi-hundred-MB document in memory, and the tiered pipeline parses
+        # straight from the path (page-windowed) once it is there. The ceiling is
+        # the same one ingest streams under, so a runaway transfer is aborted
+        # rather than filling the disk. The block owns the spool file: everything
+        # that touches the document must happen inside it.
+        try:
+            async with spooled_document(
+                client,
+                path,
+                spool_dir=settings.document_spool_dir,
+                max_bytes=ceiling,
+            ) as source:
+                content_type = source.content_type
+                etag = source.etag
+
+                if parse_document != "raw" and document_parser.is_parseable_document(
+                    content_type
+                ):
+                    # Optional interactive cap (ADR-032): bound the SYNCHRONOUS
+                    # parse so a slow VLM/OCR convert returns the raw file quickly
+                    # instead of blocking past the MCP client's own timeout.
+                    # Disabled (None) -> nullcontext. Only wraps this interactive
+                    # tool; the async ingest/worker path is never bounded here.
+                    read_cap = settings.document_read_timeout_seconds
+                    cap_ctx = (
+                        anyio.fail_after(read_cap)
+                        if read_cap is not None
+                        else contextlib.nullcontext()
                     )
-                return ReadFileResponse(
-                    path=path,
-                    content=parsed_text,
-                    content_type=content_type,
-                    size=len(content),
-                    parsed=True,
-                    parsing_metadata=metadata,
-                    etag=etag,
-                )
-            except TimeoutError as e:
-                # Caught before the generic Exception (subclass-first). When the cap
-                # is set this is our anyio.fail_after tripping; when it is None the
-                # TimeoutError bubbled from a backend's own anyio timeout (e.g. the
-                # Mistral OCR path) -- either way base64 is the right fallback.
-                if read_cap is not None:
-                    logger.warning(
-                        "Parsing document %r exceeded the interactive read cap "
-                        "(%ss), falling back to base64",
-                        path,
-                        read_cap,
+                    try:
+                        logger.info(
+                            "Parsing document %r of type %r (mode=%s)",
+                            path,
+                            content_type,
+                            parse_document,
+                        )
+                        with cap_ctx:
+                            result = await document_parser.parse_document_source(
+                                source,
+                                prefer_markdown=(parse_document == "markdown"),
+                                progress_callback=ctx.report_progress,
+                            )
+                    except TimeoutError as e:
+                        # Caught before the generic Exception (subclass-first). When
+                        # the cap is set this is our anyio.fail_after tripping; when
+                        # it is None the TimeoutError bubbled from a backend's own
+                        # anyio timeout (e.g. the Mistral OCR path).
+                        note = (
+                            f"Parsing was aborted after {read_cap}s "
+                            f"(DOCUMENT_READ_TIMEOUT_SECONDS); the raw file is "
+                            f"returned instead."
+                            if read_cap is not None
+                            else f"Parsing timed out ({e}); the raw file is returned "
+                            f"instead."
+                        )
+                        logger.warning("Parsing document %r timed out: %s", path, e)
+                        return await _raw_response(source, path, "failed", [note])
+                    except Exception as e:
+                        logger.warning("Failed to parse document %r: %s", path, e)
+                        return await _raw_response(
+                            source,
+                            path,
+                            "failed",
+                            [
+                                f"Parsing failed ({type(e).__name__}: {e}); the raw "
+                                f"file is returned instead."
+                            ],
+                        )
+
+                    summary = document_parser.summarize_parse(result, settings)
+                    if summary.status == "failed":
+                        # An unsuccessful parse is never reported as content: hand
+                        # back the raw file with the reason attached.
+                        return await _raw_response(
+                            source,
+                            path,
+                            "failed",
+                            summary.notes,
+                            parse_tier=summary.tier,
+                            parse_processor=summary.processor,
+                            parsing_metadata=result.metadata,
+                        )
+                    return ReadFileResponse(
+                        path=path,
+                        content=result.text,
+                        content_type=content_type,
+                        size=source.size,
+                        parsed=True,
+                        parse_status="parsed",
+                        parse_tier=summary.tier,
+                        parse_processor=summary.processor,
+                        content_format=summary.content_format,
+                        parse_notes=summary.notes,
+                        parsing_metadata=result.metadata,
+                        etag=etag,
                     )
-                else:
-                    logger.warning(
-                        "Failed to parse document %r, falling back to base64: %s",
-                        path,
-                        e,
-                    )
-                # Fall through to base64 encoding on timeout
-            except Exception as e:
-                logger.warning(
-                    "Failed to parse document %r, falling back to base64: %s",
-                    path,
-                    e,
+
+                status: ParseStatus = (
+                    "skipped" if parse_document == "raw" else "not_applicable"
                 )
-                # Fall through to base64 encoding on parse failure
-
-        # For text files, decode content for easier viewing
-        if content_type and content_type.startswith("text/"):
-            try:
-                decoded_content = content.decode("utf-8")
-                return ReadFileResponse(
-                    path=path,
-                    content=decoded_content,
-                    content_type=content_type,
-                    size=len(content),
-                    etag=etag,
-                )
-            except UnicodeDecodeError:
-                pass
-
-        # For binary files, return metadata and base64 encoded content
-
-        return ReadFileResponse(
-            path=path,
-            content=base64.b64encode(content).decode("ascii"),
-            content_type=content_type,
-            size=len(content),
-            encoding="base64",
-            etag=etag,
-        )
+                return await _raw_response(source, path, status, [])
+        except OversizeDownload as e:
+            # The transfer was aborted mid-flight, so there is no file left to
+            # describe -- not even its content type. Say that plainly rather than
+            # returning an empty response that reads like an empty document.
+            raise ToolError(
+                f"{path!r} was not downloaded: it exceeds the {ceiling} byte "
+                f"transfer ceiling for a single read (twice "
+                f"DOCUMENT_MAX_PDF_SIZE_MB). {e}"
+            ) from e
 
     @mcp.tool(
         title="Write File",

--- a/nextcloud_mcp_server/utils/document_parser.py
+++ b/nextcloud_mcp_server/utils/document_parser.py
@@ -1,112 +1,206 @@
-"""Document parsing utilities using pluggable processor registry."""
+"""Document parsing utilities using the pluggable processor registry.
 
-import base64
+Two jobs live here:
+
+* :func:`parse_document_source` runs the tiered pipeline against a document that
+  is already on disk, and
+* :func:`summarize_parse` turns the resulting :class:`ProcessingResult` into the
+  handful of plain statements a caller needs to describe what it actually got.
+
+The second exists because a parse can degrade in half a dozen ways that all look
+identical from the outside -- a scanned PDF on a tenant without OCR, a
+600-page document past the markdown ceiling, an oversize file the guard
+rejected, a timeout -- and returning text without saying which of those happened
+is how a caller ends up presenting a partial extraction as the whole document.
+Every one of those statements is written here, once, so the wording cannot drift
+between call sites.
+"""
+
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Optional
 
-from nextcloud_mcp_server.config import get_document_processor_config
 from nextcloud_mcp_server.document_processors import (
+    ProcessingResult,
     ProcessorError,
     get_registry,
 )
+from nextcloud_mcp_server.document_processors.source import DocumentSource
+from nextcloud_mcp_server.models.webdav import ContentFormat, ParseStatus
 
 logger = logging.getLogger(__name__)
 
 
 def is_parseable_document(content_type: Optional[str]) -> bool:
-    """Check if a document type can be parsed by any registered processor.
+    """Whether any registered processor can extract text from this type.
 
-    Args:
-        content_type: The MIME type of the document
-
-    Returns:
-        True if any processor can handle this type, False otherwise
+    There is no instance-wide "document processing" switch: whether to parse a
+    document on read is the caller's decision (``nc_webdav_read_file``'s
+    ``parse_document`` argument). This answers only "is there a processor for
+    this MIME type", which the caller cannot know.
     """
     if not content_type:
         return False
 
-    config = get_document_processor_config()
-    if not config["enabled"]:
-        return False
-
     registry = get_registry()
-    processor = registry.find_processor(content_type)
-    return processor is not None
+    return registry.find_processor(content_type) is not None
 
 
-async def parse_document(
-    content: bytes,
-    content_type: Optional[str],
-    filename: Optional[str] = None,
+async def parse_document_source(
+    source: DocumentSource,
+    *,
+    prefer_markdown: bool = False,
     progress_callback: Optional[
         Callable[[float, Optional[float], Optional[str]], Awaitable[None]]
     ] = None,
-    processor_name: Optional[str] = None,
-) -> Tuple[str, dict]:
-    """Parse a document using registered processors.
+) -> ProcessingResult:
+    """Run the tiered pipeline against a document that is already on disk.
 
-    This function uses the processor registry to find an appropriate
-    processor for the given document type and extract text from it.
+    Source-based on purpose: the interactive read path streams the document to a
+    spool file rather than buffering it, so peak memory stays at one chunk no
+    matter how large the document is. Handing the *source* down (rather than its
+    bytes) is what keeps that true through the parse -- both PDF engines open the
+    path natively.
 
-    Args:
-        content: The document content as bytes
-        content_type: The MIME type of the document
-        filename: Optional filename to help with format detection
-        progress_callback: Optional async callback for progress updates during long operations
-        processor_name: Force a specific registered processor by name (e.g.
-            "docling"), bypassing MIME/tier auto-selection. Use to parse a
-            text-layer PDF with docling (tables / partial text). ``None`` =
-            auto-select.
+    ``prefer_markdown`` asks the pipeline for reconstructed structure rather than
+    a flat text layer; it is bounded by ``document_markdown_max_pages`` and is
+    recorded on the result when it could not be honoured.
 
-    Returns:
-        Tuple of (parsed_text, metadata) where:
-        - parsed_text: The extracted text content
-        - metadata: Additional metadata about the parsing
-
-    Raises:
-        ValueError: If the document type is not supported
-        Exception: If parsing fails
+    Never raises for a processor-level failure: a failed parse comes back as a
+    ``ProcessingResult`` with ``success=False`` and a ``parse_failed_reason``, so
+    the caller can say what went wrong instead of guessing from an exception.
     """
-    if not content_type:
-        raise ValueError("Content type is required for document parsing")
-
-    config = get_document_processor_config()
-    if not config["enabled"]:
-        raise ValueError("Document processing is disabled")
-
     registry = get_registry()
+    options = {"prefer_markdown": True} if prefer_markdown else None
 
     logger.debug(
         "Parsing document of type '%s'%s",
-        content_type,
-        f" with forced processor '{processor_name}'" if processor_name else "",
+        source.content_type,
+        " (markdown requested)" if prefer_markdown else "",
     )
 
     try:
-        # Process using registry (auto-selects by MIME, or forces processor_name)
-        result = await registry.process(
-            content=content,
-            content_type=content_type,
-            filename=filename,
-            processor_name=processor_name,
-            progress_callback=progress_callback,
+        result = await registry.process_source(
+            source, options=options, progress_callback=progress_callback
         )
-
-        logger.info(
-            "Successfully parsed document with '%s' processor", result.processor
-        )
-
-        return result.text, result.metadata
-
     except ProcessorError as e:
-        logger.error("Document processing failed: %s", e)
-        # Fallback to base64 with error metadata
-        parsed_text = f"Document could not be parsed. Base64 content: {base64.b64encode(content).decode('ascii')[:200]}..."
-        metadata = {
-            "mime_type": content_type,
-            "text_length": len(parsed_text),
-            "parsing_method": "fallback_base64",
-            "error": str(e),
-        }
-        return parsed_text, metadata
+        logger.warning("Document processing failed: %s", e)
+        return ProcessingResult(
+            text="",
+            metadata={"parse_failed_reason": "error"},
+            processor="unknown",
+            success=False,
+            error=str(e),
+        )
+
+    logger.info(
+        "Parsed document with '%s' processor (success=%s)",
+        result.processor,
+        result.success,
+    )
+    return result
+
+
+@dataclass
+class ParseSummary:
+    """What a parse actually produced, in terms a caller can report verbatim."""
+
+    status: ParseStatus
+    tier: str | None = None
+    processor: str | None = None
+    content_format: ContentFormat = "text"
+    notes: list[str] = field(default_factory=list)
+
+
+def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
+    """Describe a :class:`ProcessingResult` honestly.
+
+    Pure: no I/O, no globals beyond the ``settings`` handed in, so every
+    degradation path is unit-testable without a running pipeline.
+    """
+    metadata = result.metadata or {}
+    tier = metadata.get("pipeline_tier")
+    notes: list[str] = []
+
+    if not result.success:
+        # A failed parse is never dressed up as content. The tier/processor are
+        # still reported so the caller can see what was attempted.
+        reason = metadata.get("parse_failed_reason", "error")
+        if result.processor == "size_guard" or reason == "oversize":
+            notes.append(
+                f"The document was not parsed: it exceeds the "
+                f"{settings.document_max_pdf_size_mb:g} MB parse cap "
+                f"(DOCUMENT_MAX_PDF_SIZE_MB)."
+            )
+        else:
+            where = f" in the '{tier}' tier" if tier else ""
+            notes.append(f"Parsing failed ({reason}){where}; no text was extracted.")
+        return ParseSummary(
+            status="failed",
+            tier=tier,
+            processor=result.processor,
+            content_format="text",
+            notes=notes,
+        )
+
+    content_format: ContentFormat = (
+        "markdown" if metadata.get("parse_mode") == "markdown" else "text"
+    )
+
+    skipped = metadata.get("markdown_skipped_reason")
+    if skipped == "page_ceiling":
+        pages = metadata.get("page_count")
+        notes.append(
+            f"Markdown structure was not reconstructed: this document has "
+            f"{pages} pages, above DOCUMENT_MARKDOWN_MAX_PAGES="
+            f"{settings.document_markdown_max_pages}. The raw per-page text layer "
+            f"is returned instead."
+        )
+    elif skipped == "disabled":
+        notes.append(
+            "Markdown reconstruction is switched off on this server "
+            "(DOCUMENT_MARKDOWN_MAX_PAGES=0); the raw text layer is returned."
+        )
+    elif skipped == "not_registered":
+        notes.append(
+            "No structured-parse engine is available on this server, so the raw "
+            "text layer is returned without markdown structure."
+        )
+    elif skipped == "parse_failed":
+        notes.append(
+            "Markdown reconstruction was attempted and failed; the raw text layer "
+            "is returned instead."
+        )
+
+    ocr_skipped = metadata.get("ocr_escalation_skipped")
+    if ocr_skipped == "disabled":
+        notes.append(
+            "This document has little or no usable text layer and OCR is not "
+            "enabled on this server (DOCUMENT_OCR_ENABLED), so the text below is "
+            "only what a text extractor could recover -- it may be incomplete or "
+            "empty."
+        )
+    elif ocr_skipped == "not_registered":
+        notes.append(
+            "This document needs OCR, but no OCR backend is configured on this "
+            "server (DOCUMENT_OCR_PROVIDER); the text below may be incomplete or "
+            "empty."
+        )
+    elif metadata.get("ocr_escalation_failed"):
+        notes.append(
+            f"OCR was attempted and did not succeed "
+            f"({metadata['ocr_escalation_failed']}); the text below is what a text "
+            f"extractor could recover."
+        )
+
+    if not result.text:
+        notes.append("The parse succeeded but extracted 0 characters of text.")
+
+    return ParseSummary(
+        status="parsed",
+        tier=tier,
+        processor=result.processor,
+        content_format=content_format,
+        notes=notes,
+    )

--- a/nextcloud_mcp_server/utils/document_parser.py
+++ b/nextcloud_mcp_server/utils/document_parser.py
@@ -113,87 +113,100 @@ class ParseSummary:
     notes: list[str] = field(default_factory=list)
 
 
-def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
-    """Describe a :class:`ProcessingResult` honestly.
-
-    Pure: no I/O, no globals beyond the ``settings`` handed in, so every
-    degradation path is unit-testable without a running pipeline.
-    """
-    metadata = result.metadata or {}
-    tier = metadata.get("pipeline_tier")
-    notes: list[str] = []
-
-    if not result.success:
-        # A failed parse is never dressed up as content. The tier/processor are
-        # still reported so the caller can see what was attempted.
-        reason = metadata.get("parse_failed_reason", "error")
-        if result.processor == "size_guard" or reason == "oversize":
-            notes.append(
-                f"The document was not parsed: it exceeds the "
-                f"{settings.document_max_pdf_size_mb:g} MB parse cap "
-                f"(DOCUMENT_MAX_PDF_SIZE_MB)."
-            )
-        else:
-            where = f" in the '{tier}' tier" if tier else ""
-            notes.append(f"Parsing failed ({reason}){where}; no text was extracted.")
-        return ParseSummary(
-            status="failed",
-            tier=tier,
-            processor=result.processor,
-            content_format="text",
-            notes=notes,
+def _failure_note(result: ProcessingResult, tier: str | None, settings: Any) -> str:
+    """Why a parse that did not succeed produced no text."""
+    reason = (result.metadata or {}).get("parse_failed_reason", "error")
+    if result.processor == "size_guard" or reason == "oversize":
+        return (
+            f"The document was not parsed: it exceeds the "
+            f"{settings.document_max_pdf_size_mb:g} MB parse cap "
+            f"(DOCUMENT_MAX_PDF_SIZE_MB)."
         )
+    where = f" in the '{tier}' tier" if tier else ""
+    return f"Parsing failed ({reason}){where}; no text was extracted."
 
-    content_format: ContentFormat = (
-        "markdown" if metadata.get("parse_mode") == "markdown" else "text"
-    )
 
-    skipped = metadata.get("markdown_skipped_reason")
-    if skipped == "page_ceiling":
-        pages = metadata.get("page_count")
-        notes.append(
+def _markdown_note(metadata: dict, settings: Any) -> str | None:
+    """Why the markdown the caller asked for is not in the content."""
+    reason = metadata.get("markdown_skipped_reason")
+    if reason == "page_ceiling":
+        return (
             f"Markdown structure was not reconstructed: this document has "
-            f"{pages} pages, above DOCUMENT_MARKDOWN_MAX_PAGES="
-            f"{settings.document_markdown_max_pages}. The raw per-page text layer "
-            f"is returned instead."
+            f"{metadata.get('page_count')} pages, above "
+            f"DOCUMENT_MARKDOWN_MAX_PAGES={settings.document_markdown_max_pages}. "
+            f"The raw per-page text layer is returned instead."
         )
-    elif skipped == "disabled":
-        notes.append(
+    if reason == "disabled":
+        return (
             "Markdown reconstruction is switched off on this server "
             "(DOCUMENT_MARKDOWN_MAX_PAGES=0); the raw text layer is returned."
         )
-    elif skipped == "not_registered":
-        notes.append(
+    if reason == "not_registered":
+        return (
             "No structured-parse engine is available on this server, so the raw "
             "text layer is returned without markdown structure."
         )
-    elif skipped == "parse_failed":
-        notes.append(
+    if reason == "parse_failed":
+        return (
             "Markdown reconstruction was attempted and failed; the raw text layer "
             "is returned instead."
         )
+    return None
 
-    ocr_skipped = metadata.get("ocr_escalation_skipped")
-    if ocr_skipped == "disabled":
-        notes.append(
+
+def _ocr_note(metadata: dict) -> str | None:
+    """Why a document the classifier wanted OCR'd was not OCR'd (or failed)."""
+    skipped = metadata.get("ocr_escalation_skipped")
+    if skipped == "disabled":
+        return (
             "This document has little or no usable text layer and OCR is not "
             "enabled on this server (DOCUMENT_OCR_ENABLED), so the text below is "
             "only what a text extractor could recover -- it may be incomplete or "
             "empty."
         )
-    elif ocr_skipped == "not_registered":
-        notes.append(
+    if skipped == "not_registered":
+        return (
             "This document needs OCR, but no OCR backend is configured on this "
             "server (DOCUMENT_OCR_PROVIDER); the text below may be incomplete or "
             "empty."
         )
-    elif metadata.get("ocr_escalation_failed"):
-        notes.append(
-            f"OCR was attempted and did not succeed "
-            f"({metadata['ocr_escalation_failed']}); the text below is what a text "
-            f"extractor could recover."
+    failed = metadata.get("ocr_escalation_failed")
+    if failed:
+        return (
+            f"OCR was attempted and did not succeed ({failed}); the text below is "
+            f"what a text extractor could recover."
+        )
+    return None
+
+
+def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
+    """Describe a :class:`ProcessingResult` honestly.
+
+    Pure: no I/O, no globals beyond the ``settings`` handed in, so every
+    degradation path is unit-testable without a running pipeline. The note
+    wording lives in the three ``_*_note`` helpers above -- one per thing that
+    can degrade -- so a caller never has to infer the difference between "OCR is
+    off here" and "OCR ran and failed".
+    """
+    metadata = result.metadata or {}
+    tier = metadata.get("pipeline_tier")
+
+    if not result.success:
+        # A failed parse is never dressed up as content. The tier/processor are
+        # still reported so the caller can see what was attempted.
+        return ParseSummary(
+            status="failed",
+            tier=tier,
+            processor=result.processor,
+            content_format="text",
+            notes=[_failure_note(result, tier, settings)],
         )
 
+    notes = [
+        note
+        for note in (_markdown_note(metadata, settings), _ocr_note(metadata))
+        if note is not None
+    ]
     if not result.text:
         notes.append("The parse succeeded but extracted 0 characters of text.")
 
@@ -201,6 +214,8 @@ def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
         status="parsed",
         tier=tier,
         processor=result.processor,
-        content_format=content_format,
+        content_format=(
+            "markdown" if metadata.get("parse_mode") == "markdown" else "text"
+        ),
         notes=notes,
     )

--- a/nextcloud_mcp_server/utils/document_parser.py
+++ b/nextcloud_mcp_server/utils/document_parser.py
@@ -126,8 +126,21 @@ def _failure_note(result: ProcessingResult, tier: str | None, settings: Any) -> 
     return f"Parsing failed ({reason}){where}; no text was extracted."
 
 
-def _markdown_note(metadata: dict, settings: Any) -> str | None:
-    """Why the markdown the caller asked for is not in the content."""
+def _markdown_note(
+    metadata: dict, settings: Any, *, markdown_requested: bool
+) -> str | None:
+    """Why the markdown the caller asked for is not in the content.
+
+    Only ever fires when the caller actually asked for markdown.
+    ``markdown_skipped_reason`` records a fact about the parse -- structure was
+    not reconstructed -- and the structured tier stamps it whenever it runs past
+    the page ceiling, INCLUDING when it was reached to recover a glyph-corrupt
+    text layer in ``auto`` mode. Surfacing it there would report a
+    non-degradation as one: a caller that asked for text got exactly the text it
+    asked for, and ``content_format`` already says it is not markdown.
+    """
+    if not markdown_requested:
+        return None
     reason = metadata.get("markdown_skipped_reason")
     if reason == "page_ceiling":
         return (
@@ -179,7 +192,9 @@ def _ocr_note(metadata: dict) -> str | None:
     return None
 
 
-def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
+def summarize_parse(
+    result: ProcessingResult, settings: Any, *, markdown_requested: bool = False
+) -> ParseSummary:
     """Describe a :class:`ProcessingResult` honestly.
 
     Pure: no I/O, no globals beyond the ``settings`` handed in, so every
@@ -187,6 +202,11 @@ def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
     wording lives in the three ``_*_note`` helpers above -- one per thing that
     can degrade -- so a caller never has to infer the difference between "OCR is
     off here" and "OCR ran and failed".
+
+    ``markdown_requested`` is what the CALLER asked for, which the result alone
+    cannot tell you: the structured tier is also reached to recover a corrupt
+    text layer, and its "no markdown here" bookkeeping must not be reported as a
+    degradation to someone who only ever asked for text.
     """
     metadata = result.metadata or {}
     tier = metadata.get("pipeline_tier")
@@ -204,7 +224,10 @@ def summarize_parse(result: ProcessingResult, settings: Any) -> ParseSummary:
 
     notes = [
         note
-        for note in (_markdown_note(metadata, settings), _ocr_note(metadata))
+        for note in (
+            _markdown_note(metadata, settings, markdown_requested=markdown_requested),
+            _ocr_note(metadata),
+        )
         if note is not None
     ]
     if not result.text:

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -83,7 +83,7 @@ from nextcloud_mcp_server.vector.sharing_state import (
     file_title_from_path,
     release_document_for_user,
 )
-from nextcloud_mcp_server.vector.spool import spooled_document
+from nextcloud_mcp_server.vector.spool import download_ceiling, spooled_document
 
 logger = logging.getLogger(__name__)
 
@@ -333,20 +333,6 @@ def should_use_page_aware(
         page_boundaries: The extractor's page-boundary list (or ``None``).
     """
     return page_aware_enabled and doc_type == "file" and bool(page_boundaries)
-
-
-def _download_ceiling(settings: Any) -> int | None:
-    """Hard byte ceiling for a streamed download, or ``None`` when uncapped.
-
-    The pre-flight gate acts on the size the server advertised at scan time;
-    this acts on what actually arrives, so it still holds when Content-Length is
-    absent or wrong. Sized generously above the parse cap -- its job is to stop
-    a runaway transfer filling the spool volume, not to duplicate the cap.
-    """
-    max_pdf_mb = settings.document_max_pdf_size_mb
-    if not max_pdf_mb or max_pdf_mb <= 0:
-        return None
-    return int(max_pdf_mb * 1024 * 1024 * 2)
 
 
 def preflight_oversize_result(
@@ -1328,7 +1314,7 @@ async def _index_document_inner(
                         nc_client,
                         file_path,
                         spool_dir=settings.document_spool_dir,
-                        max_bytes=_download_ceiling(settings),
+                        max_bytes=download_ceiling(settings),
                     )
                 )
                 content_type = source.content_type

--- a/nextcloud_mcp_server/vector/spool.py
+++ b/nextcloud_mcp_server/vector/spool.py
@@ -46,7 +46,7 @@ async def spooled_document(
     time, whereas this acts on what actually arrives.
     """
     with spool_target(spool_dir) as target:
-        written, content_type = await nc_client.webdav.stream_to_file(
+        written, content_type, etag = await nc_client.webdav.stream_to_file(
             file_path, target, max_bytes=max_bytes
         )
         logger.debug(
@@ -57,4 +57,23 @@ async def spooled_document(
             content_type=content_type,
             filename=file_path,
             _size=written,
+            etag=etag,
         )
+
+
+def download_ceiling(settings: Any) -> int | None:
+    """Hard byte ceiling for a streamed download, or ``None`` when uncapped.
+
+    The pre-flight gate acts on the size the server advertised at scan time;
+    this acts on what actually arrives, so it still holds when Content-Length is
+    absent or wrong. Sized generously above the parse cap -- its job is to stop
+    a runaway transfer filling the spool volume, not to duplicate the cap.
+
+    Lives here rather than in ``vector.processor`` so an interactive caller (the
+    ``nc_webdav_read_file`` tool) can spool a document under the same ceiling
+    without importing the ingest/procrastinate stack.
+    """
+    max_pdf_mb = settings.document_max_pdf_size_mb
+    if not max_pdf_mb or max_pdf_mb <= 0:
+        return None
+    return int(max_pdf_mb * 1024 * 1024 * 2)

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -93,7 +93,9 @@ log_level = "INFO"
 log_include_trace_context = true
 
 # --- Document processing ---
-enable_document_processing = false
+# No master switch: PDF extraction is built in, each optional processor below has
+# its own enable flag, and whether a read parses a document is the caller's
+# per-call choice (nc_webdav_read_file's parse_document argument).
 document_processor = "unstructured"
 enable_unstructured = false
 unstructured_api_url = "http://unstructured:8000"
@@ -104,7 +106,8 @@ progress_interval = 10
 enable_tesseract = false
 tesseract_cmd = "@none"
 tesseract_lang = "eng"
-enable_pymupdf = true
+# pymupdf is the built-in "structured" tier and is always available; these two
+# knobs tune it.
 pymupdf_extract_images = true
 pymupdf_image_dir = "@none"
 enable_custom_processor = false

--- a/tests/integration/client/test_document_processing_progress.py
+++ b/tests/integration/client/test_document_processing_progress.py
@@ -72,9 +72,14 @@ class TestDocumentProcessingProgress:
     ):
         """Test that reading a document via WebDAV MCP tool sends progress notifications."""
 
-        # Skip if document processing is not enabled
-        if os.getenv("ENABLE_DOCUMENT_PROCESSING", "false").lower() != "true":
-            pytest.skip("Document processing not enabled")
+        # An image needs an image-capable processor. The built-in tiers are
+        # PDF-only, so without one of these the read returns the file unparsed and
+        # there is no progress to report.
+        if not any(
+            os.getenv(flag, "false").lower() == "true"
+            for flag in ("ENABLE_DOCLING", "ENABLE_UNSTRUCTURED", "ENABLE_TESSERACT")
+        ):
+            pytest.skip("No image-capable document processor is configured")
 
         # Create a test image file in Nextcloud via WebDAV
         from PIL import Image

--- a/tests/integration/test_docling_api.py
+++ b/tests/integration/test_docling_api.py
@@ -36,6 +36,13 @@ _DOCLING_ENABLED = os.getenv("ENABLE_DOCLING", "false").lower() == "true"
 # has no such engine, so the VLM test is opt-in: it runs only when the operator
 # has deployed the MCP service with DOCLING_PIPELINE=vlm against such an instance.
 _DOCLING_VLM = _DOCLING_ENABLED and os.getenv("DOCLING_PIPELINE", "").lower() == "vlm"
+# Docling reaches PDFs only as the OCR provider (Deck #894 removed the per-call
+# processor override), which needs the OCR tier switched on as well.
+_DOCLING_OCR = (
+    _DOCLING_ENABLED
+    and os.getenv("DOCUMENT_OCR_ENABLED", "false").lower() == "true"
+    and os.getenv("DOCUMENT_OCR_PROVIDER", "").lower() == "docling"
+)
 
 
 @pytest.fixture
@@ -75,6 +82,28 @@ def create_text_pdf(text: str) -> bytes:
     buffer = BytesIO()
     c = canvas.Canvas(buffer, pagesize=letter)
     c.drawString(100, 750, text)
+    c.save()
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def create_scanned_pdf(text: str) -> bytes:
+    """A PDF whose only content is a raster image -- no text layer at all.
+
+    This is what makes the tier-0 classifier recommend OCR: a text extractor has
+    nothing to extract, which is exactly the "scanned document" case.
+    """
+    from reportlab.lib.utils import ImageReader  # noqa: PLC0415
+
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=letter)
+    c.drawImage(
+        ImageReader(BytesIO(create_text_image(text))),
+        60,
+        520,
+        width=480,
+        height=128,
+    )
     c.save()
     buffer.seek(0)
     return buffer.getvalue()
@@ -145,55 +174,37 @@ async def test_docling_vlm_image_parsing(
             pass
 
 
-@pytest.mark.skipif(not _DOCLING_ENABLED, reason="Docling is not enabled")
-async def test_docling_force_on_text_layer_pdf(
+@pytest.mark.skipif(
+    not _DOCLING_OCR,
+    reason="Docling OCR provider is not configured (DOCUMENT_OCR_PROVIDER=docling)",
+)
+async def test_docling_ocr_tier_reads_a_scanned_pdf(
     nc_client: NextcloudClient, test_base_path: str, nc_mcp_client: ClientSession
 ):
-    """force_processor="docling" re-parses a PDF that already has a text layer
-    (the override for tables / incomplete text)."""
-    test_file = f"{test_base_path}/docling_force.pdf"
-    test_text = "This text-layer PDF is force-parsed with docling"
+    """A scanned PDF escalates fast -> ocr and docling returns its text.
+
+    Docling is an OCR *provider*, not a tier of its own: since Deck #894 there is
+    no per-call processor override, so this is the route by which a PDF reaches
+    docling at all. The PDF has no text layer, so the tier-0 classifier is what
+    triggers the escalation.
+    """
+    test_file = f"{test_base_path}/docling_scanned.pdf"
+    marker = "DoclingScannedHello"
     try:
         await nc_client.webdav.write_file(
-            test_file, create_text_pdf(test_text), content_type="application/pdf"
+            test_file, create_scanned_pdf(marker), content_type="application/pdf"
         )
         mcp_result = await nc_mcp_client.call_tool(
-            "nc_webdav_read_file",
-            arguments={"path": test_file, "force_processor": "docling"},
+            "nc_webdav_read_file", arguments={"path": test_file}
         )
         result = _read_result(mcp_result)
 
         assert result.get("parsed") is True
-        assert result["parsing_metadata"]["parsing_method"] == "docling"
+        assert result["parse_tier"] == "ocr"
+        # OCR output is markdown whatever the backend, and the read says so.
+        assert result["content_format"] == "markdown"
+        # OCR is imperfect; assert on a distinctive substring rather than equality.
         assert "docling" in result["content"].lower()
-    finally:
-        try:
-            await nc_client.webdav.delete_resource(test_file)
-        except Exception:
-            pass
-
-
-@pytest.mark.skipif(not _DOCLING_ENABLED, reason="Docling is not enabled")
-async def test_docling_unknown_force_processor_errors(
-    nc_client: NextcloudClient, test_base_path: str, nc_mcp_client: ClientSession
-):
-    """An unknown forced processor name is a clear tool error, not a base64 dump."""
-    test_file = f"{test_base_path}/docling_bad_force.pdf"
-    try:
-        await nc_client.webdav.write_file(
-            test_file, create_text_pdf("hello"), content_type="application/pdf"
-        )
-        # The MCP client surfaces a tool failure as an ``isError`` result, not a
-        # raised exception (matches the repo convention, e.g. _search_helpers.py),
-        # so assert on the result rather than pytest.raises.
-        mcp_result = await nc_mcp_client.call_tool(
-            "nc_webdav_read_file",
-            arguments={"path": test_file, "force_processor": "does-not-exist"},
-        )
-        assert mcp_result.isError
-        content = mcp_result.content[0]
-        error_text = str(getattr(content, "text", content))
-        assert "does-not-exist" in error_text
     finally:
         try:
             await nc_client.webdav.delete_resource(test_file)

--- a/tests/integration/test_webdav_document_read.py
+++ b/tests/integration/test_webdav_document_read.py
@@ -1,0 +1,124 @@
+"""End-to-end coverage of reading a document through nc_webdav_read_file (Deck #894).
+
+Runs against the single-user MCP service (port 8000) with the built-in PDF tiers
+-- no optional processor, no OCR backend, nothing enabled beyond a default
+deployment. That is the point: an agent reading a PDF gets its text out of the
+box, and the response says which tier produced it.
+"""
+
+import json
+import logging
+import uuid
+from io import BytesIO
+
+import pytest
+from mcp.client.session import ClientSession
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+from nextcloud_mcp_server.client import NextcloudClient
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.integration
+
+MARKER = "ParseDocumentIntegrationMarker"
+
+
+@pytest.fixture
+async def test_base_path(nc_client: NextcloudClient):
+    test_dir = f"mcp_test_doc_read_{uuid.uuid4().hex[:8]}"
+    await nc_client.webdav.create_directory(test_dir)
+    yield test_dir
+    try:
+        await nc_client.webdav.delete_resource(test_dir)
+    except Exception:
+        pass  # Ignore cleanup errors
+
+
+@pytest.fixture
+async def text_layer_pdf(nc_client: NextcloudClient, test_base_path: str):
+    """A born-digital single-page PDF uploaded to Nextcloud."""
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=letter)
+    c.drawString(100, 750, MARKER)
+    c.save()
+
+    path = f"{test_base_path}/document.pdf"
+    await nc_client.webdav.write_file(
+        path, buffer.getvalue(), content_type="application/pdf"
+    )
+    return path
+
+
+def _read_result(mcp_result) -> dict:
+    content = mcp_result.content[0]
+    text = content.text if hasattr(content, "text") else str(content)
+    return json.loads(text)
+
+
+async def _read(nc_mcp_client: ClientSession, path: str, **arguments) -> dict:
+    return _read_result(
+        await nc_mcp_client.call_tool(
+            "nc_webdav_read_file", arguments={"path": path, **arguments}
+        )
+    )
+
+
+async def test_pdf_reads_as_text_by_default(
+    nc_mcp_client: ClientSession, text_layer_pdf: str
+):
+    """The default is text, not base64 -- the whole point of the card."""
+    result = await _read(nc_mcp_client, text_layer_pdf)
+
+    assert result["parsed"] is True
+    assert result["parse_status"] == "parsed"
+    assert result["parse_tier"] == "fast"
+    assert result["content_format"] == "text"
+    assert result.get("encoding") is None
+    assert MARKER in result["content"]
+    # A clean parse has nothing to disclose.
+    assert result["parse_notes"] == []
+    # The etag survives the streamed download, so the caller can still write back
+    # with an If-Match precondition.
+    assert result["etag"]
+
+
+async def test_markdown_mode_reconstructs_structure(
+    nc_mcp_client: ClientSession, text_layer_pdf: str
+):
+    """Asking for markdown promotes the read to the structured tier."""
+    result = await _read(nc_mcp_client, text_layer_pdf, parse_document="markdown")
+
+    assert result["parse_status"] == "parsed"
+    assert result["parse_tier"] == "structured"
+    assert result["content_format"] == "markdown"
+    assert MARKER in result["content"]
+
+
+async def test_raw_mode_returns_the_bytes(
+    nc_mcp_client: ClientSession, text_layer_pdf: str
+):
+    """The raw path stays reachable for a caller that wants the file itself."""
+    result = await _read(nc_mcp_client, text_layer_pdf, parse_document="raw")
+
+    assert result["parsed"] is False
+    assert result["parse_status"] == "skipped"
+    assert result["encoding"] == "base64"
+    assert result["content_format"] == "base64"
+    assert result["parse_notes"] == []
+
+
+async def test_text_file_is_untouched_by_the_parse_argument(
+    nc_client: NextcloudClient, nc_mcp_client: ClientSession, test_base_path: str
+):
+    """A plain text file needs no processor and is reported as such."""
+    path = f"{test_base_path}/notes.txt"
+    await nc_client.webdav.write_file(path, b"hello world", content_type="text/plain")
+
+    result = await _read(nc_mcp_client, path)
+
+    assert result["content"] == "hello world"
+    assert result["parse_status"] == "not_applicable"
+    assert result["parsed"] is False
+    assert result["parse_notes"] == []

--- a/tests/integration/test_webdav_document_read.py
+++ b/tests/integration/test_webdav_document_read.py
@@ -36,12 +36,31 @@ async def test_base_path(nc_client: NextcloudClient):
         pass  # Ignore cleanup errors
 
 
+#: Ordinary prose, on purpose. The tier-0 classifier scores the extracted text
+#: layer, and a page holding one short unspaced token reads as low-quality: it
+#: escalates fast->structured (verified — a single ``drawString(MARKER)`` page
+#: lands on the structured tier and comes back as markdown). That would make this
+#: file a test of classifier heuristics rather than of the read path, and would
+#: let the markdown test below pass without markdown ever being requested. Keep
+#: the body realistic if you touch it.
+_BODY = [
+    "This document exists so an integration test can read a real PDF back",
+    "through the MCP tool and check that its text comes out as text rather",
+    "than as base64, which is what this tool used to return for any document.",
+    "The wording is deliberately ordinary: several lines of normal words give",
+    "the tier-0 classifier a text layer it can be confident about, so the read",
+    "stops at the cheap fast tier instead of escalating to recover it.",
+]
+
+
 @pytest.fixture
 async def text_layer_pdf(nc_client: NextcloudClient, test_base_path: str):
-    """A born-digital single-page PDF uploaded to Nextcloud."""
+    """A born-digital single-page PDF with a healthy text layer."""
     buffer = BytesIO()
     c = canvas.Canvas(buffer, pagesize=letter)
-    c.drawString(100, 750, MARKER)
+    c.drawString(72, 750, f"Quarterly Report {MARKER}")
+    for offset, line in enumerate(_BODY, start=1):
+        c.drawString(72, 750 - offset * 20, line)
     c.save()
 
     path = f"{test_base_path}/document.pdf"

--- a/tests/unit/client/test_webdav_stream_to_file.py
+++ b/tests/unit/client/test_webdav_stream_to_file.py
@@ -116,13 +116,32 @@ async def test_streams_body_to_disk(tmp_path):
     body = b"%PDF-1.7" + b"x" * 500
     dest = tmp_path / "out.pdf"
 
-    written, content_type = await _client(
-        body, {"content-length": str(len(body)), "content-type": "application/pdf"}
+    written, content_type, etag = await _client(
+        body,
+        {
+            "content-length": str(len(body)),
+            "content-type": "application/pdf",
+            "etag": '"abc123"',
+        },
     ).stream_to_file("/f.pdf", dest)
 
     assert written == len(body)
     assert content_type == "application/pdf"
     assert dest.read_bytes() == body
+    # Same triple read_file returns, quotes stripped: a caller that streams a
+    # document can still hand the etag back as an If-Match precondition.
+    assert etag == "abc123"
+
+
+async def test_streamed_etag_is_none_when_absent(tmp_path):
+    body = b"%PDF-1.7"
+    dest = tmp_path / "out.pdf"
+
+    _, _, etag = await _client(body, {"content-length": str(len(body))}).stream_to_file(
+        "/f.pdf", dest
+    )
+
+    assert etag is None
 
 
 async def test_short_read_raises_and_removes_partial_file(tmp_path):
@@ -143,7 +162,7 @@ async def test_streaming_compressed_response_skips_the_length_check(tmp_path):
     packed = gzip.compress(raw)
     dest = tmp_path / "out.pdf"
 
-    written, _ = await _client(
+    written, _, _ = await _client(
         packed, {"content-length": str(len(packed)), "content-encoding": "gzip"}
     ).stream_to_file("/f.pdf", dest)
 
@@ -185,7 +204,7 @@ async def test_exactly_at_the_limit_is_allowed(tmp_path):
     body = b"x" * 100
     dest = tmp_path / "out.pdf"
 
-    written, _ = await _client(body, {"content-length": "100"}).stream_to_file(
+    written, _, _ = await _client(body, {"content-length": "100"}).stream_to_file(
         "/f.pdf", dest, max_bytes=100
     )
 
@@ -236,7 +255,7 @@ async def test_stream_retries_on_429_then_succeeds(tmp_path, mocker):
     mocker.patch("nextcloud_mcp_server.client.base.anyio.sleep", new=mocker.AsyncMock())
     dest = tmp_path / "out.pdf"
 
-    written, _ = await client.stream_to_file("/f.pdf", dest)
+    written, _, _ = await client.stream_to_file("/f.pdf", dest)
 
     assert len(calls) == 2, "should have retried once after the 429"
     assert written == len(body)

--- a/tests/unit/test_docling_processor.py
+++ b/tests/unit/test_docling_processor.py
@@ -14,6 +14,7 @@ from nextcloud_mcp_server.document_processors.docling_serve import (
     docling_pages,
 )
 from nextcloud_mcp_server.document_processors.registry import ProcessorRegistry
+from nextcloud_mcp_server.document_processors.source import MemoryDocumentSource
 
 pytestmark = pytest.mark.unit
 
@@ -230,8 +231,9 @@ async def test_convert_file_non_json_body_raises(mocker, monkeypatch):
 def test_supported_mime_types_images_only():
     proc = DoclingProcessor("https://docling:5001")
     assert "image/png" in proc.supported_mime_types
-    # PDFs are deliberately excluded from auto-selection (handled by the OCR
-    # backend or an explicit force_processor), so it never hijacks PDF tiering.
+    # PDFs are deliberately excluded from auto-selection -- docling serves PDFs
+    # as an OCR provider (DOCUMENT_OCR_PROVIDER=docling), never as a tier of its
+    # own, so it can't hijack PDF tiering.
     assert "application/pdf" not in proc.supported_mime_types
     assert proc.name == "docling"
     assert proc.tier == "fast"
@@ -378,32 +380,24 @@ def test_docling_wins_image_routing_but_not_pdf():
         assert picked is None or picked.name != "docling"
 
 
-def test_docling_force_selectable_by_name():
-    registry = ProcessorRegistry()
-    registry.register(DoclingProcessor("https://docling:5001"), priority=20)
-    # get_processor("docling") is what the forced-processor path resolves; it must
-    # be found even for a PDF (supports() is bypassed on the forced path).
-    assert registry.get_processor("docling") is not None
-
-
-async def test_parse_document_threads_processor_name(monkeypatch):
-    """parse_document forwards processor_name to registry.process -- the wire that
-    lets nc_webdav_read_file(force_processor="docling") reach the forced path."""
+async def test_parse_document_source_threads_prefer_markdown(monkeypatch):
+    """parse_document_source forwards the markdown request to the registry -- the
+    wire that lets nc_webdav_read_file(parse_document="markdown") reach the
+    structured tier."""
     from nextcloud_mcp_server.utils import document_parser
 
     captured: dict = {}
 
-    async def _fake_process(**kwargs):
-        captured.update(kwargs)
-        return ProcessingResult(text="ok", metadata={}, processor="docling")
+    async def _fake_process_source(source, options=None, progress_callback=None):
+        captured["options"] = options
+        return ProcessingResult(text="ok", metadata={}, processor="pymupdf")
 
     monkeypatch.setattr(
-        document_parser, "get_document_processor_config", lambda: {"enabled": True}
+        document_parser.get_registry(), "process_source", _fake_process_source
     )
-    monkeypatch.setattr(document_parser.get_registry(), "process", _fake_process)
 
-    text, meta = await document_parser.parse_document(
-        b"x", "application/pdf", "f.pdf", processor_name="docling"
-    )
-    assert captured["processor_name"] == "docling"
-    assert text == "ok"
+    source = MemoryDocumentSource(b"x", "application/pdf", "f.pdf")
+    result = await document_parser.parse_document_source(source, prefer_markdown=True)
+
+    assert captured["options"] == {"prefer_markdown": True}
+    assert result.text == "ok"

--- a/tests/unit/test_document_parse_summary.py
+++ b/tests/unit/test_document_parse_summary.py
@@ -1,0 +1,176 @@
+"""What a read tells the caller about a parse that degraded (Deck #894).
+
+``summarize_parse`` is the one place the wording of every degradation lives, so
+these tests pin the *statements* -- not just the flags. The failure they guard
+against is a read that returns three pages of a 400-page scan and says nothing.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nextcloud_mcp_server.document_processors.base import ProcessingResult
+from nextcloud_mcp_server.utils.document_parser import summarize_parse
+
+pytestmark = pytest.mark.unit
+
+
+def _settings(**overrides) -> SimpleNamespace:
+    values = {"document_max_pdf_size_mb": 50.0, "document_markdown_max_pages": 150}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _result(text="text", metadata=None, processor="pypdfium2_fast", success=True):
+    return ProcessingResult(
+        text=text,
+        metadata=metadata or {},
+        processor=processor,
+        success=success,
+    )
+
+
+def test_clean_fast_parse_says_nothing():
+    summary = summarize_parse(
+        _result(metadata={"pipeline_tier": "fast", "parse_mode": "text_only"}),
+        _settings(),
+    )
+
+    assert summary.status == "parsed"
+    assert summary.tier == "fast"
+    assert summary.processor == "pypdfium2_fast"
+    assert summary.content_format == "text"
+    assert summary.notes == []
+
+
+def test_markdown_parse_is_labelled_markdown():
+    summary = summarize_parse(
+        _result(
+            text="# Title",
+            metadata={"pipeline_tier": "structured", "parse_mode": "markdown"},
+            processor="pymupdf",
+        ),
+        _settings(),
+    )
+
+    assert summary.content_format == "markdown"
+    assert summary.tier == "structured"
+    assert summary.notes == []
+
+
+def test_page_ceiling_names_the_document_and_the_limit():
+    summary = summarize_parse(
+        _result(
+            metadata={
+                "pipeline_tier": "fast",
+                "parse_mode": "text_only",
+                "markdown_skipped_reason": "page_ceiling",
+                "page_count": 412,
+            }
+        ),
+        _settings(),
+    )
+
+    assert summary.content_format == "text"
+    assert "412 pages" in summary.notes[0]
+    assert "DOCUMENT_MARKDOWN_MAX_PAGES=150" in summary.notes[0]
+
+
+def test_markdown_disabled_is_distinguished_from_the_ceiling():
+    summary = summarize_parse(
+        _result(
+            metadata={"parse_mode": "text_only", "markdown_skipped_reason": "disabled"}
+        ),
+        _settings(document_markdown_max_pages=0),
+    )
+
+    assert "DOCUMENT_MARKDOWN_MAX_PAGES=0" in summary.notes[0]
+
+
+def test_markdown_promotion_failure_is_stated():
+    summary = summarize_parse(
+        _result(
+            metadata={
+                "parse_mode": "text_only",
+                "markdown_skipped_reason": "parse_failed",
+            }
+        ),
+        _settings(),
+    )
+
+    assert "attempted and failed" in summary.notes[0]
+
+
+def test_ocr_disabled_is_stated_not_implied():
+    """The scanned-PDF-on-a-tenant-without-OCR case: near-empty text that would
+    otherwise read as 'this document is nearly blank'."""
+    summary = summarize_parse(
+        _result(
+            text="",
+            metadata={
+                "pipeline_tier": "fast",
+                "ocr_escalation_skipped": "disabled",
+                "ocr_recommended_reason": "empty_text",
+            },
+        ),
+        _settings(),
+    )
+
+    assert summary.status == "parsed"
+    joined = " ".join(summary.notes)
+    assert "DOCUMENT_OCR_ENABLED" in joined
+    assert "0 characters" in joined
+
+
+def test_ocr_backend_missing_is_distinguished_from_ocr_off():
+    summary = summarize_parse(
+        _result(metadata={"ocr_escalation_skipped": "not_registered"}),
+        _settings(),
+    )
+
+    assert "DOCUMENT_OCR_PROVIDER" in summary.notes[0]
+
+
+def test_failed_ocr_attempt_is_reported():
+    summary = summarize_parse(
+        _result(metadata={"pipeline_tier": "fast", "ocr_escalation_failed": "timeout"}),
+        _settings(),
+    )
+
+    assert "timeout" in summary.notes[0]
+
+
+def test_failed_parse_is_never_dressed_up_as_content():
+    summary = summarize_parse(
+        _result(
+            text="",
+            metadata={"pipeline_tier": "structured", "parse_failed_reason": "oom"},
+            processor="pymupdf",
+            success=False,
+        ),
+        _settings(),
+    )
+
+    assert summary.status == "failed"
+    assert summary.tier == "structured"
+    assert summary.processor == "pymupdf"
+    assert "oom" in summary.notes[0]
+    assert "'structured' tier" in summary.notes[0]
+
+
+def test_oversize_names_the_cap_and_has_no_tier():
+    """The size guard rejects before any tier runs, so there is no tier to name."""
+    summary = summarize_parse(
+        _result(
+            text="",
+            metadata={"parse_failed_reason": "oversize"},
+            processor="size_guard",
+            success=False,
+        ),
+        _settings(),
+    )
+
+    assert summary.status == "failed"
+    assert summary.tier is None
+    assert "50 MB parse cap" in summary.notes[0]
+    assert "DOCUMENT_MAX_PDF_SIZE_MB" in summary.notes[0]

--- a/tests/unit/test_document_parse_summary.py
+++ b/tests/unit/test_document_parse_summary.py
@@ -69,6 +69,7 @@ def test_page_ceiling_names_the_document_and_the_limit():
             }
         ),
         _settings(),
+        markdown_requested=True,
     )
 
     assert summary.content_format == "text"
@@ -82,6 +83,7 @@ def test_markdown_disabled_is_distinguished_from_the_ceiling():
             metadata={"parse_mode": "text_only", "markdown_skipped_reason": "disabled"}
         ),
         _settings(document_markdown_max_pages=0),
+        markdown_requested=True,
     )
 
     assert "DOCUMENT_MARKDOWN_MAX_PAGES=0" in summary.notes[0]
@@ -96,6 +98,7 @@ def test_markdown_promotion_failure_is_stated():
             }
         ),
         _settings(),
+        markdown_requested=True,
     )
 
     assert "attempted and failed" in summary.notes[0]
@@ -174,3 +177,45 @@ def test_oversize_names_the_cap_and_has_no_tier():
     assert summary.tier is None
     assert "50 MB parse cap" in summary.notes[0]
     assert "DOCUMENT_MAX_PDF_SIZE_MB" in summary.notes[0]
+
+
+def test_markdown_bookkeeping_is_not_reported_to_a_caller_who_wanted_text():
+    """The structured tier is also reached to recover a corrupt text layer, and it
+    stamps ``markdown_skipped_reason`` whenever it runs past the page ceiling. A
+    caller that asked for text ("auto") got exactly what it asked for -- reporting
+    that as a degradation would be a false alarm, and would invite a pointless
+    re-request for markdown that hits the same ceiling."""
+    summary = summarize_parse(
+        _result(
+            metadata={
+                "pipeline_tier": "structured",
+                "parse_mode": "text_only",
+                "markdown_skipped_reason": "page_ceiling",
+                "page_count": 300,
+            },
+            processor="pymupdf",
+        ),
+        _settings(),
+    )
+
+    assert summary.status == "parsed"
+    assert summary.content_format == "text"
+    assert summary.notes == []
+
+
+def test_real_degradations_still_reported_to_a_text_caller():
+    """Guard against over-correcting: silencing the markdown note must not silence
+    the OCR one, which matters regardless of what the caller asked for."""
+    summary = summarize_parse(
+        _result(
+            metadata={
+                "pipeline_tier": "structured",
+                "markdown_skipped_reason": "page_ceiling",
+                "ocr_escalation_skipped": "disabled",
+            }
+        ),
+        _settings(),
+    )
+
+    assert len(summary.notes) == 1
+    assert "DOCUMENT_OCR_ENABLED" in summary.notes[0]

--- a/tests/unit/test_document_processor_config.py
+++ b/tests/unit/test_document_processor_config.py
@@ -12,22 +12,19 @@ pytestmark = pytest.mark.unit
 class TestDocumentProcessorConfig:
     """Test document processor configuration system."""
 
-    def test_config_disabled_by_default(self):
-        """Test that document processing is disabled by default."""
-        os.environ.pop("ENABLE_DOCUMENT_PROCESSING", None)
+    def test_no_optional_processors_by_default(self):
+        """Nothing optional is configured out of the box.
+
+        There is no master switch any more (Deck #894): whether to parse a
+        document on read is the caller's per-call decision, and each optional
+        processor is gated only by its own ENABLE_* flag. An empty ``processors``
+        dict is what tells app startup it has nothing to register -- and so
+        nothing to import (#877).
+        """
         _reload_config()
         config = get_document_processor_config()
-        assert config["enabled"] is False
-
-    def test_config_enabled(self):
-        """Test enabling document processing."""
-        os.environ["ENABLE_DOCUMENT_PROCESSING"] = "true"
-        try:
-            _reload_config()
-            config = get_document_processor_config()
-            assert config["enabled"] is True
-        finally:
-            os.environ.pop("ENABLE_DOCUMENT_PROCESSING", None)
+        assert config["processors"] == {}
+        assert "enabled" not in config
 
     def test_unstructured_processor_config(self):
         """Test Unstructured processor configuration."""
@@ -169,18 +166,15 @@ class TestDocumentProcessorConfig:
 
     def test_multiple_processors(self):
         """Test configuration with multiple processors enabled."""
-        os.environ["ENABLE_DOCUMENT_PROCESSING"] = "true"
         os.environ["ENABLE_UNSTRUCTURED"] = "true"
         os.environ["ENABLE_TESSERACT"] = "true"
 
         try:
             _reload_config()
             config = get_document_processor_config()
-            assert config["enabled"] is True
             assert "unstructured" in config["processors"]
             assert "tesseract" in config["processors"]
         finally:
-            os.environ.pop("ENABLE_DOCUMENT_PROCESSING", None)
             os.environ.pop("ENABLE_UNSTRUCTURED", None)
             os.environ.pop("ENABLE_TESSERACT", None)
 

--- a/tests/unit/test_pdf_ladder_source.py
+++ b/tests/unit/test_pdf_ladder_source.py
@@ -21,6 +21,7 @@ from nextcloud_mcp_server.document_processors.source import (
     MemoryDocumentSource,
     SpooledDocumentSource,
 )
+from nextcloud_mcp_server.utils.document_parser import summarize_parse
 
 pytestmark = pytest.mark.unit
 
@@ -151,6 +152,42 @@ async def test_oversize_is_rejected_from_the_size_without_reading_the_file(
     assert result.success is False
     assert result.processor == "size_guard"
     assert result.metadata["parse_failed_reason"] == "oversize"
+
+
+async def test_auto_mode_escalation_past_the_ceiling_reports_nothing_to_the_caller(
+    spooled, settings
+):
+    """A read that never asked for markdown must not be told it was denied any.
+
+    The structured tier is reached two ways: to honour a markdown request, and --
+    as here -- to recover a text layer the classifier distrusts. It stamps
+    ``markdown_skipped_reason`` whenever it runs past the page ceiling either way,
+    so the *fact* is recorded; what must not happen is surfacing it as a
+    degradation to a caller who asked for text and got text.
+
+    Drives the real pymupdf tier: ``min_text_quality=1.1`` is unsatisfiable, so
+    every page reads as low-confidence and the ladder escalates fast->structured
+    with non-empty text, exactly as a glyph-corrupt document would.
+    """
+    stub = settings(document_markdown_max_pages=1, document_ocr_min_text_quality=1.1)
+
+    result = await get_registry().process_source(spooled(_digital_pdf(pages=3)))
+
+    # Escalated for recovery, not for markdown, and past the ceiling.
+    assert result.metadata["pipeline_tier"] == "structured"
+    assert result.metadata["parse_mode"] == "text_only"
+    assert result.metadata["markdown_skipped_reason"] == "page_ceiling"
+
+    # parse_document="auto" -> the caller hears nothing about markdown. (It does
+    # hear that OCR was unavailable: the same distrusted text layer is a real
+    # degradation of what it DID ask for, so that note must survive.)
+    auto = summarize_parse(result, stub)
+    assert not any("markdown" in note.lower() for note in auto.notes)
+    assert any("DOCUMENT_OCR_ENABLED" in note for note in auto.notes)
+
+    # parse_document="markdown" -> the same result does explain itself.
+    requested = summarize_parse(result, stub, markdown_requested=True)
+    assert any("DOCUMENT_MARKDOWN_MAX_PAGES" in note for note in requested.notes)
 
 
 async def test_in_memory_source_still_works(settings):

--- a/tests/unit/test_pdf_ladder_source.py
+++ b/tests/unit/test_pdf_ladder_source.py
@@ -1,0 +1,165 @@
+"""The file-backed PDF ladder, against real PDFs (Deck #894).
+
+``nc_webdav_read_file`` streams a document to a spool file and parses it from
+there, because the API role is not sized to hold a large document in memory.
+These tests drive that path end to end with the real built-in tiers -- pypdfium2
+(fast) and pymupdf4llm in its isolation subprocess (structured) -- so what they
+pin is behaviour, not mocks:
+
+* the source-backed ladder produces the same result as the bytes-backed one, and
+* ``prefer_markdown`` reaches the structured tier, but never past the page
+  ceiling -- and says so when it stops.
+"""
+
+from types import SimpleNamespace
+
+import pymupdf
+import pytest
+
+from nextcloud_mcp_server.document_processors import get_registry
+from nextcloud_mcp_server.document_processors.source import (
+    MemoryDocumentSource,
+    SpooledDocumentSource,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _digital_pdf(pages: int = 1, body: str = "Ladder source test page") -> bytes:
+    """A born-digital PDF: real text layer, no raster."""
+    doc = pymupdf.open()
+    for n in range(pages):
+        page = doc.new_page()
+        page.insert_text((72, 720), f"{body} {n + 1}")
+    return doc.tobytes()
+
+
+@pytest.fixture
+def spooled(tmp_path):
+    """Write bytes to a spool file and hand back a file-backed source."""
+
+    def _make(content: bytes, name: str = "doc.pdf") -> SpooledDocumentSource:
+        target = tmp_path / name
+        target.write_bytes(content)
+        return SpooledDocumentSource(
+            spool_path=target,
+            content_type="application/pdf",
+            filename=name,
+            _size=len(content),
+        )
+
+    return _make
+
+
+@pytest.fixture
+def settings(mocker):
+    """Registry settings, defaulted to a stock deployment."""
+
+    def _install(**overrides):
+        values = {
+            "document_classify_enabled": True,
+            "document_tier1_engine": "pypdfium2",
+            "document_ocr_enabled": False,
+            "document_ocr_detect_scanned": True,
+            "document_ocr_min_text_quality": 0.5,
+            "document_ocr_page_fraction": 0.5,
+            "document_ocr_min_page_chars": 16,
+            "document_glyph_corruption_ratio": 0.02,
+            "document_max_pdf_size_mb": 50.0,
+            "document_markdown_max_pages": 150,
+            "document_pdf_graphics_limit": 1000,
+            "document_parse_timeout_seconds": 120.0,
+            "document_parse_mem_limit_mb": 1536,
+            "document_parse_page_window": 100,
+            "document_parse_process_slots": 2,
+        }
+        values.update(overrides)
+        stub = SimpleNamespace(**values)
+        for module in (
+            "nextcloud_mcp_server.document_processors.registry",
+            "nextcloud_mcp_server.document_processors.pymupdf",
+            "nextcloud_mcp_server.document_processors.pypdfium2_fast",
+        ):
+            mocker.patch(f"{module}.get_settings", return_value=stub)
+        return stub
+
+    return _install
+
+
+async def test_source_path_matches_the_bytes_path(spooled, settings):
+    """Opening by path must not change what the ladder produces."""
+    settings()
+    content = _digital_pdf()
+    registry = get_registry()
+
+    from_bytes = await registry.process(content, "application/pdf", "doc.pdf")
+    from_source = await registry.process_source(spooled(content))
+
+    assert from_source.success is True
+    assert from_source.text.strip() == from_bytes.text.strip()
+    assert from_source.metadata["pipeline_tier"] == from_bytes.metadata["pipeline_tier"]
+
+
+async def test_default_read_stops_at_the_fast_tier(spooled, settings):
+    """A good text layer needs nothing more, and is labelled plain text."""
+    settings()
+
+    result = await get_registry().process_source(spooled(_digital_pdf()))
+
+    assert result.success is True
+    assert result.metadata["pipeline_tier"] == "fast"
+    assert result.metadata["parse_mode"] == "text_only"
+    assert "Ladder source test page" in result.text
+
+
+async def test_prefer_markdown_promotes_to_the_structured_tier(spooled, settings):
+    settings()
+
+    result = await get_registry().process_source(
+        spooled(_digital_pdf()), options={"prefer_markdown": True}
+    )
+
+    assert result.success is True
+    assert result.metadata["pipeline_tier"] == "structured"
+    assert result.metadata["parse_mode"] == "markdown"
+    assert "Ladder source test page" in result.text
+
+
+async def test_prefer_markdown_stops_at_the_page_ceiling_and_says_so(spooled, settings):
+    """Past the ceiling the structured tier would return raw text anyway, so the
+    promotion is skipped -- and the reason is recorded rather than implied."""
+    settings(document_markdown_max_pages=1)
+
+    result = await get_registry().process_source(
+        spooled(_digital_pdf(pages=3)), options={"prefer_markdown": True}
+    )
+
+    assert result.success is True
+    assert result.metadata["pipeline_tier"] == "fast"
+    assert result.metadata["markdown_skipped_reason"] == "page_ceiling"
+    assert result.metadata["page_count"] == 3
+
+
+async def test_oversize_is_rejected_from_the_size_without_reading_the_file(
+    spooled, settings
+):
+    """The guard runs off ``source.size``, so an over-cap document is never read."""
+    settings(document_max_pdf_size_mb=0.000001)
+
+    result = await get_registry().process_source(spooled(_digital_pdf()))
+
+    assert result.success is False
+    assert result.processor == "size_guard"
+    assert result.metadata["parse_failed_reason"] == "oversize"
+
+
+async def test_in_memory_source_still_works(settings):
+    """Notes/deck attachments stay in memory; they must not regress to disk."""
+    settings()
+
+    result = await get_registry().process_source(
+        MemoryDocumentSource(_digital_pdf(), "application/pdf", "doc.pdf")
+    )
+
+    assert result.success is True
+    assert result.metadata["pipeline_tier"] == "fast"

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -658,6 +658,39 @@ async def test_read_file_reports_markdown_page_ceiling(
     assert "DOCUMENT_MARKDOWN_MAX_PAGES=150" in note
 
 
+async def test_read_file_auto_mode_says_nothing_about_markdown(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """The same metadata as the test above, but the caller asked for text.
+
+    The structured tier stamps ``markdown_skipped_reason`` whenever it runs past
+    the ceiling -- including when it was reached to recover a corrupt text layer
+    in auto mode. Reporting that would be a false alarm, and would invite a
+    pointless re-request for markdown that hits the identical ceiling.
+    """
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(
+        _result(
+            metadata={
+                "pipeline_tier": "structured",
+                "parse_mode": "text_only",
+                "markdown_skipped_reason": "page_ceiling",
+                "page_count": 412,
+            },
+            processor="pymupdf",
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/big.pdf", ctx=_read_ctx(fake_client))
+
+    assert result.parse_status == "parsed"
+    assert result.content_format == "text"
+    assert result.parse_notes == []
+
+
 async def test_read_file_reports_ocr_unavailable(
     webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
 ):

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -770,8 +770,9 @@ async def test_read_file_rejects_a_download_past_the_transfer_ceiling(
     )
 
     fn = webdav_tools["nc_webdav_read_file"].fn
+    ctx = _read_ctx(fake_client)
     with pytest.raises(ToolError, match="transfer ceiling"):
-        await fn(path="/enormous.pdf", ctx=_read_ctx(fake_client))
+        await fn(path="/enormous.pdf", ctx=ctx)
 
 
 async def test_read_file_schema_replaces_force_processor(webdav_tools):

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -112,6 +112,74 @@ def fake_client():
     return client
 
 
+def _spool(client, body: bytes, content_type: str, etag: str | None = None):
+    """Make ``client.webdav.stream_to_file`` deliver ``body``.
+
+    ``nc_webdav_read_file`` streams the document to a spool file rather than
+    buffering it, so the fake has to write to the destination the tool chose and
+    return the transport triple.
+    """
+
+    async def _stream_to_file(path, dest, *, max_bytes=None):
+        await anyio.lowlevel.checkpoint()
+        dest.write_bytes(body)
+        return len(body), content_type, etag
+
+    client.webdav.stream_to_file = AsyncMock(side_effect=_stream_to_file)
+
+
+def _settings(**overrides) -> SimpleNamespace:
+    """Settings the read path touches, with production defaults."""
+    values = {
+        "document_read_timeout_seconds": None,
+        "document_spool_dir": None,
+        "document_max_pdf_size_mb": 50.0,
+        "document_markdown_max_pages": 150,
+        "webdav_write_max_mb": 50.0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _result(
+    text="parsed text", metadata=None, processor="pypdfium2_fast", success=True
+):
+    from nextcloud_mcp_server.document_processors import ProcessingResult
+
+    return ProcessingResult(
+        text=text,
+        metadata=metadata if metadata is not None else {},
+        processor=processor,
+        success=success,
+    )
+
+
+@pytest.fixture
+def parsing(mocker):
+    """Drive the read tool's parse branch with a canned ProcessingResult.
+
+    Returns the ``parse_document_source`` mock so a test can assert on how the
+    pipeline was invoked (e.g. that ``prefer_markdown`` was threaded through).
+    """
+
+    def _install(result=None, *, parseable=True, side_effect=None, settings=None):
+        mocker.patch(
+            "nextcloud_mcp_server.server.webdav.get_settings",
+            return_value=settings or _settings(),
+        )
+        mocker.patch(
+            "nextcloud_mcp_server.utils.document_parser.is_parseable_document",
+            return_value=parseable,
+        )
+        return mocker.patch(
+            "nextcloud_mcp_server.utils.document_parser.parse_document_source",
+            side_effect=side_effect,
+            return_value=result,
+        )
+
+    return _install
+
+
 # ── Read / mutate guards ────────────────────────────────────────────────
 
 
@@ -125,23 +193,23 @@ async def test_read_file_raises_when_path_excluded(
     with pytest.raises(ToolError, match="excluded tag"):
         await fn(path="/Secret.txt", ctx=_mock_ctx(fake_client))
 
-    fake_client.webdav.read_file.assert_not_called()
+    fake_client.webdav.stream_to_file.assert_not_called()
 
 
 async def test_read_file_passes_through_when_not_excluded(
-    webdav_tools, fake_client, patch_get_client, patch_excluded
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
 ):
     patch_get_client(fake_client)
     patch_excluded({"Secret.txt"})
-    fake_client.webdav.read_file = AsyncMock(
-        return_value=(b"hello", "text/plain", "abc123")
-    )
+    parsing(parseable=False)
+    _spool(fake_client, b"hello", "text/plain", "abc123")
 
     fn = webdav_tools["nc_webdav_read_file"].fn
     result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
 
     assert result.content == "hello"
-    fake_client.webdav.read_file.assert_awaited_once_with("/Public/notes.md")
+    assert result.parse_status == "not_applicable"
+    assert fake_client.webdav.stream_to_file.await_args.args[0] == "/Public/notes.md"
 
 
 async def test_write_file_raises_when_path_excluded(
@@ -455,97 +523,298 @@ async def test_list_favorites_raises_when_scope_excluded(
     fake_client.webdav.list_favorites.assert_not_called()
 
 
-# ── Interactive read-parse cap (ADR-032) ────────────────────────────────
+# ── Document reads: parse_document + honest degradation (Deck #894) ─────
 
 
-async def test_read_file_interactive_cap_falls_back_to_base64(
-    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+def _read_ctx(fake_client) -> SimpleNamespace:
+    ctx = _mock_ctx(fake_client)
+    ctx.report_progress = AsyncMock()
+    return ctx
+
+
+async def test_read_file_interactive_cap_returns_the_raw_file(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
 ):
     """With DOCUMENT_READ_TIMEOUT_SECONDS set, a slow synchronous parse is aborted
-    at the cap and the tool returns base64 fast instead of blocking past the MCP
-    client's own timeout (ADR-032)."""
+    at the cap and the tool returns the file fast instead of blocking past the MCP
+    client's own timeout (ADR-032) -- saying so, rather than silently."""
     patch_get_client(fake_client)
     patch_excluded(set())
-    fake_client.webdav.read_file = AsyncMock(
-        return_value=(b"\x89PNG", "image/png", None)
-    )
-
-    mocker.patch(
-        "nextcloud_mcp_server.server.webdav.get_settings",
-        return_value=SimpleNamespace(document_read_timeout_seconds=0.05),
-    )
-    mocker.patch(
-        "nextcloud_mcp_server.utils.document_parser.is_parseable_document",
-        return_value=True,
-    )
+    _spool(fake_client, b"\x89PNG", "image/png")
 
     async def slow_parse(*_a, **_k):
         await anyio.sleep(5)  # far beyond the 0.05s cap; fail_after cancels it
 
-    mocker.patch(
-        "nextcloud_mcp_server.utils.document_parser.parse_document",
+    parsing(
         side_effect=slow_parse,
+        settings=_settings(document_read_timeout_seconds=0.05),
     )
 
-    ctx = _mock_ctx(fake_client)
-    ctx.report_progress = AsyncMock()
     fn = webdav_tools["nc_webdav_read_file"].fn
-    result = await fn(path="/scan.png", ctx=ctx)
+    result = await fn(path="/scan.png", ctx=_read_ctx(fake_client))
 
-    # Graceful base64 fallback, not the parsed-document shape.
     assert result.encoding == "base64"
     assert result.content == base64.b64encode(b"\x89PNG").decode("ascii")
     assert result.parsed is False
+    assert result.parse_status == "failed"
+    assert any("DOCUMENT_READ_TIMEOUT_SECONDS" in n for n in result.parse_notes)
 
 
-async def test_read_file_no_cap_returns_parsed(
-    webdav_tools, fake_client, patch_get_client, patch_excluded, mocker
+async def test_read_file_defaults_to_parsing(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
 ):
-    """With the cap disabled (None, the default), a normal parse is returned
-    unchanged -- the nullcontext path adds no behavior."""
+    """The default reads a document as text; the caller does not have to ask."""
     patch_get_client(fake_client)
     patch_excluded(set())
-    fake_client.webdav.read_file = AsyncMock(
-        return_value=(b"%PDF-1.7", "application/pdf", "etag-1")
+    _spool(fake_client, b"%PDF-1.7", "application/pdf", "etag-1")
+    parse = parsing(
+        _result(metadata={"pipeline_tier": "fast", "parse_mode": "text_only"})
     )
 
-    mocker.patch(
-        "nextcloud_mcp_server.server.webdav.get_settings",
-        return_value=SimpleNamespace(document_read_timeout_seconds=None),
-    )
-    mocker.patch(
-        "nextcloud_mcp_server.utils.document_parser.is_parseable_document",
-        return_value=True,
-    )
-    mocker.patch(
-        "nextcloud_mcp_server.utils.document_parser.parse_document",
-        return_value=("parsed text", {"parsing_method": "docling"}),
-    )
-
-    ctx = _mock_ctx(fake_client)
-    ctx.report_progress = AsyncMock()
     fn = webdav_tools["nc_webdav_read_file"].fn
-    result = await fn(path="/doc.pdf", ctx=ctx)
+    result = await fn(path="/doc.pdf", ctx=_read_ctx(fake_client))
 
+    parse.assert_awaited_once()
     assert result.parsed is True
+    assert result.parse_status == "parsed"
     assert result.content == "parsed text"
-    assert result.parsing_metadata["parsing_method"] == "docling"
+    assert result.parse_tier == "fast"
+    assert result.parse_processor == "pypdfium2_fast"
+    assert result.content_format == "text"
+    assert result.parse_notes == []
+    assert result.etag == "etag-1"
+
+
+async def test_read_file_raw_skips_the_parse_entirely(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """``parse_document="raw"`` must reach the bytes without touching the
+    pipeline -- and must not be shadowed by the same-named lazy import."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parse = parsing(_result())
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/doc.pdf", ctx=_read_ctx(fake_client), parse_document="raw")
+
+    parse.assert_not_called()
+    assert result.parse_status == "skipped"
+    assert result.parsed is False
+    assert result.encoding == "base64"
+    assert result.content_format == "base64"
+
+
+async def test_read_file_markdown_asks_the_pipeline_for_structure(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parse = parsing(
+        _result(
+            text="# Heading",
+            metadata={"pipeline_tier": "structured", "parse_mode": "markdown"},
+            processor="pymupdf",
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(
+        path="/doc.pdf", ctx=_read_ctx(fake_client), parse_document="markdown"
+    )
+
+    assert parse.await_args.kwargs["prefer_markdown"] is True
+    assert result.content_format == "markdown"
+    assert result.parse_tier == "structured"
+
+
+async def test_read_file_reports_markdown_page_ceiling(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """A document past the ceiling gets text, and is told it got text."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(
+        _result(
+            metadata={
+                "pipeline_tier": "fast",
+                "parse_mode": "text_only",
+                "markdown_skipped_reason": "page_ceiling",
+                "page_count": 412,
+            }
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(
+        path="/big.pdf", ctx=_read_ctx(fake_client), parse_document="markdown"
+    )
+
+    assert result.content_format == "text"
+    note = " ".join(result.parse_notes)
+    assert "412 pages" in note
+    assert "DOCUMENT_MARKDOWN_MAX_PAGES=150" in note
+
+
+async def test_read_file_reports_ocr_unavailable(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """A scan read on a tenant without OCR must not look like an empty document."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(
+        _result(
+            text="",
+            metadata={
+                "pipeline_tier": "fast",
+                "parse_mode": "text_only",
+                "ocr_escalation_skipped": "disabled",
+                "ocr_recommended_reason": "empty_text",
+            },
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/scan.pdf", ctx=_read_ctx(fake_client))
+
+    assert result.parse_status == "parsed"
+    note = " ".join(result.parse_notes)
+    assert "DOCUMENT_OCR_ENABLED" in note
+    assert "0 characters" in note
+
+
+async def test_read_file_failed_parse_is_not_reported_as_parsed(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """Regression: a failed parse used to return empty content with parsed=True."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(
+        _result(
+            text="",
+            metadata={"pipeline_tier": "structured", "parse_failed_reason": "timeout"},
+            processor="pymupdf",
+            success=False,
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/doc.pdf", ctx=_read_ctx(fake_client))
+
+    assert result.parsed is False
+    assert result.parse_status == "failed"
+    assert result.parse_tier == "structured"
+    assert any("timeout" in n for n in result.parse_notes)
+    # The file itself is still available to the caller.
+    assert result.encoding == "base64"
+
+
+async def test_read_file_reports_the_size_cap(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(
+        _result(
+            text="",
+            metadata={"parse_failed_reason": "oversize"},
+            processor="size_guard",
+            success=False,
+        )
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/huge.pdf", ctx=_read_ctx(fake_client))
+
+    assert result.parse_status == "failed"
+    assert result.parse_tier is None
+    assert any("DOCUMENT_MAX_PDF_SIZE_MB" in n for n in result.parse_notes)
+
+
+async def test_read_file_will_not_inline_a_huge_unparsed_file(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing, mocker
+):
+    """Base64 of a large binary is unusable by the time it reaches a model, so the
+    read reports the file rather than burying the response in it."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    parsing(parseable=False)
+    mocker.patch("nextcloud_mcp_server.server.webdav.RAW_CONTENT_MAX_BYTES", 16)
+    _spool(fake_client, b"x" * 64, "application/zip")
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    result = await fn(path="/big.zip", ctx=_read_ctx(fake_client))
+
+    assert result.content == ""
+    assert result.size == 64
+    assert any("too large to return inline" in n for n in result.parse_notes)
+
+
+async def test_read_file_rejects_a_download_past_the_transfer_ceiling(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """An aborted transfer leaves nothing to describe, so it is an error rather
+    than an empty response that reads like an empty document."""
+    from nextcloud_mcp_server.client.webdav import OversizeDownload
+
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    parsing(parseable=False)
+    fake_client.webdav.stream_to_file = AsyncMock(
+        side_effect=OversizeDownload("aborted after 104857601")
+    )
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    with pytest.raises(ToolError, match="transfer ceiling"):
+        await fn(path="/enormous.pdf", ctx=_read_ctx(fake_client))
+
+
+async def test_read_file_schema_replaces_force_processor(webdav_tools):
+    """The breaking change, in machine-checkable form (Deck #894)."""
+    properties = webdav_tools["nc_webdav_read_file"].parameters["properties"]
+
+    assert "parse_document" in properties
+    assert "force_processor" not in properties
+
+
+async def test_read_file_streams_instead_of_buffering(
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
+):
+    """The API role cannot hold a large document in memory, so the read must go
+    through the streaming spool -- never the buffered ``read_file``."""
+    patch_get_client(fake_client)
+    patch_excluded(set())
+    _spool(fake_client, b"%PDF-1.7", "application/pdf")
+    parsing(_result(metadata={"pipeline_tier": "fast"}))
+
+    fn = webdav_tools["nc_webdav_read_file"].fn
+    await fn(path="/doc.pdf", ctx=_read_ctx(fake_client))
+
+    fake_client.webdav.read_file.assert_not_called()
+    # Bounded by the same ceiling ingest streams under (2x the parse cap).
+    assert fake_client.webdav.stream_to_file.await_args.kwargs["max_bytes"] == int(
+        50.0 * 1024 * 1024 * 2
+    )
 
 
 # ── Write conflict handling (etag / lock) and size gate ─────────────────
 
 
 async def test_read_file_includes_etag_in_response(
-    webdav_tools, fake_client, patch_get_client, patch_excluded
+    webdav_tools, fake_client, patch_get_client, patch_excluded, parsing
 ):
     patch_get_client(fake_client)
     patch_excluded(set())
-    fake_client.webdav.read_file = AsyncMock(
-        return_value=(b"hello", "text/plain", "abc123")
-    )
+    parsing(parseable=False)
+    _spool(fake_client, b"hello", "text/plain", "abc123")
 
     fn = webdav_tools["nc_webdav_read_file"].fn
-    result = await fn(path="/Public/notes.md", ctx=_mock_ctx(fake_client))
+    result = await fn(path="/Public/notes.md", ctx=_read_ctx(fake_client))
 
     assert result.etag == "abc123"
 

--- a/tests/unit/vector/test_spooled_document.py
+++ b/tests/unit/vector/test_spooled_document.py
@@ -20,7 +20,9 @@ pytestmark = pytest.mark.unit
 
 
 def _nc_client(
-    body: bytes = b"%PDF-1.7 spooled", content_type: str = "application/pdf"
+    body: bytes = b"%PDF-1.7 spooled",
+    content_type: str = "application/pdf",
+    etag: str | None = "spooled-etag",
 ):
     """A client whose stream_to_file writes ``body`` to the destination."""
     nc = MagicMock()
@@ -30,7 +32,7 @@ def _nc_client(
         # rather than leaving a bare `async def` with no await in it.
         await anyio.lowlevel.checkpoint()
         dest.write_bytes(body)
-        return len(body), content_type
+        return len(body), content_type, etag
 
     nc.webdav.stream_to_file = AsyncMock(side_effect=_stream_to_file)
     return nc
@@ -46,6 +48,9 @@ async def test_yields_a_source_backed_by_the_spool_file(tmp_path):
         assert source.size == len(body)
         assert source.content_type == "application/pdf"
         assert source.filename == "/f.pdf"
+        # Carried from the transport so a caller that streamed the document can
+        # still identify the exact version it parsed.
+        assert source.etag == "spooled-etag"
 
 
 async def test_spool_is_removed_on_success(tmp_path):


### PR DESCRIPTION
## Context

`nc_webdav_read_file` returned ~92,590 characters of base64 for a 69 KB PDF — useless to a text model, and not a content block a multimodal one can use either. Reading a document is the main thing an agent wants from a file.

Two causes, both removed:

- **`ENABLE_DOCUMENT_PROCESSING` defaulted to false**, so the tool's existing auto-parse was off out of the box. The flag gated only the interactive tool and optional-processor registration — ingest parsed regardless — and whether to extract text from a document is the *caller's* decision, not an instance-wide setting.
- **`force_processor`** asked the caller (an LLM) to name an extraction tier it had no basis to choose, and its forced path bypassed both tiering and the pre-parse size guard.

## What replaces them

`parse_document` names the **output** the caller wants, never a tier:

| value | behaviour |
|---|---|
| `"auto"` (default) | tiered pipeline: `fast` → `structured`/`ocr` when the tier-0 classifier finds the text layer unusable |
| `"markdown"` | promote to the `structured` tier for headings/tables, bounded by `DOCUMENT_MARKDOWN_MAX_PAGES` |
| `"raw"` | the file itself: text decoded, anything else base64 |

### Streamed, not buffered

The read now streams the document to a spool file and parses it from there, the way the procrastinate workers do — the API role is not sized to hold a multi-hundred-MB document in memory. That required giving the inline PDF ladder a file-backed twin (`_process_pdf_source`), which was an outstanding `TODO` in the registry: `process_source` previously materialised **every** PDF to drive the bytes-based ladder, so the streaming win stopped at the download. `stream_to_file` now returns the etag alongside the body, so a streamed read still supports an `If-Match` write-back.

### Honest degradation

Every read reports what it actually produced — `parse_status`, `parse_tier`, `parse_processor`, `content_format`, and `parse_notes` carrying plain statements when something degraded: OCR not enabled, markdown structure not reconstructed (with the page count and the ceiling), the size cap, a failed or timed-out parse. The pipeline records the facts those statements are built from (`ocr_escalation_skipped`, `markdown_skipped_reason`, `parse_mode` at every processor) rather than having the tool re-derive them — `_isolation.py` explicitly warns that duplicating the ceiling comparison lets the label drift.

Two silent failures fixed on the way: a parse with `success=False` returned empty content with `parsed=True` and no explanation, and `ProcessorError` produced a truncated base64 blob shaped like content.

### Docling

Unaffected as a capability. Docling serves PDFs as an **OCR provider** (`DOCUMENT_OCR_PROVIDER=docling` → `_DoclingServeBackend`), which is where `force_processor="docling"` was a second, tier-bypassing route into the same backend. The docling CI lane now sets `DOCUMENT_OCR_ENABLED=true` + `DOCUMENT_OCR_PROVIDER=docling` and asserts a scanned PDF comes back as OCR-tier markdown, preserving end-to-end PDF coverage.

## Breaking changes — shipping in 0.151.0

Per CLAUDE.md this is gated on the version, not on merge order. The `BREAKING CHANGE:` footer names all three:

- `nc_webdav_read_file` no longer accepts `force_processor` (replaced by `parse_document`). A client still sending it gets a clean FastMCP argument-validation error — intended and discoverable.
- `ENABLE_DOCUMENT_PROCESSING` is removed; it is ignored if still set. `PyMuPDF` moved from "optional processor registered at startup" to the built-in `structured` tier that registers itself, tuned by `PYMUPDF_EXTRACT_IMAGES` / `PYMUPDF_IMAGE_DIR` (now `Settings` fields). This preserves the #877 invariant: with no optional processor configured, the parse stack is never imported on the API startup path.
- `utils.document_parser.parse_document(bytes, ...) -> (text, metadata)` → `parse_document_source(source, ...) -> ProcessingResult`; `WebDavClient.stream_to_file` returns `(written, content_type, etag)`.

## Test coverage

- **Unit (2484 passing).** New `tests/unit/test_pdf_ladder_source.py` drives the file-backed ladder against **real** PDFs through the real tiers (pypdfium2 + pymupdf4llm in its isolation subprocess): source and bytes paths agree, `prefer_markdown` reaches the structured tier, the page ceiling stops it and records why, the size guard rejects from `source.size` without reading the file. New `tests/unit/test_document_parse_summary.py` pins the wording of every degradation statement. `test_webdav_tools_exclusion.py` covers each `parse_document` mode, the streaming assertion (`read_file` must not be called), both new bounds, and a schema test asserting `parse_document` in / `force_processor` out — the machine-checkable form of the breaking change.
- **Integration.** New `tests/integration/test_webdav_document_read.py` uploads a generated PDF and reads it back through the MCP tool in all three modes. **Not executed locally** — ports 8000/8080 were occupied by another stack on this machine, so it has only been verified in CI. Please confirm it goes green here.
- **Contract (Pact).** This change introduces **no new or changed cross-service boundary**. `nc_webdav_read_file` talks to Nextcloud WebDAV (not a pacted boundary) and to the in-process registry. The only cross-service calls reachable through it are the gateway OCR endpoints — already pacted, with neither request nor response shape changed here — and docling-serve's `/v1/convert/file`, which is unpacted today (pre-existing gap, third-party upstream, same rationale as ADR-031). `uv run pytest -m contract tests/contract/` is unchanged by this PR.

## Notes for review

- `server/collectives.py` is unaffected: it calls `webdav.read_file` directly and decodes UTF-8 itself.
- There is now no operator off-switch for parsing — that is the point of the change. The remaining bounds are `DOCUMENT_MAX_PDF_SIZE_MB` (and twice that as the transfer ceiling), `DOCUMENT_READ_TIMEOUT_SECONDS`, `DOCUMENT_OCR_ENABLED` (the expensive tier stays opt-in) and `DOCUMENT_MARKDOWN_MAX_PAGES=0`.
- `"markdown"` mode contends for the 2 process-wide parse subprocess slots shared with ingest. Opt-in per call bounds the blast radius; the page ceiling bounds the superlinearity.

---

_This PR was generated with the help of AI, and reviewed by a Human_
