### PR TITLE
fix(api): resolve webhook uri server-side and gate registration on admin

### DIFF
--- a/nextcloud_mcp_server/api/webhooks.py
+++ b/nextcloud_mcp_server/api/webhooks.py
@@ -30,8 +30,10 @@ from nextcloud_mcp_server.api.management import (
 from nextcloud_mcp_server.auth.scope_authorization import ProvisioningRequiredError
 from nextcloud_mcp_server.auth.webhook_routes import (
     WebhookSecretNotConfigured,
+    get_webhook_uri,
     webhook_auth_pair,
 )
+from nextcloud_mcp_server.client.users import UsersClient
 from nextcloud_mcp_server.client.webhooks import WebhooksClient
 
 from ..http import nextcloud_httpx_client
@@ -170,13 +172,23 @@ async def create_webhook(request: Request) -> JSONResponse:
     Request body:
     {
         "event": "OCP\\Files\\Events\\Node\\NodeCreatedEvent",
-        "uri": "http://mcp:8000/webhooks/nextcloud",
         "eventFilter": {"event.node.path": "/^\\/.*\\/files\\/Notes\\//"}
     }
 
     Returns the created webhook data including the webhook ID.
 
-    Requires OAuth bearer token for authentication.
+    Requires an OAuth bearer token, and the caller must be a Nextcloud
+    administrator — verified with their own app password, mirroring
+    ``/api/v1/vector-sync/purge``.
+
+    The delivery ``uri`` is resolved **server-side** via ``get_webhook_uri()``
+    and any client-supplied value is ignored. Registrations carry the global
+    ``WEBHOOK_SECRET`` as a delivery ``Authorization`` header, so honouring a
+    caller-chosen URI would hand that secret to an arbitrary host on the first
+    delivery — and the secret is the only thing guarding the ingress endpoint,
+    which trusts the ``user.uid`` in the payload it receives
+    (GHSA-8vh3-g2qg-2h2c). There is no legitimate reason for a caller to pick
+    the destination: it is always this server's own ingress.
     """
     try:
         # Validate OAuth token and extract user
@@ -214,17 +226,29 @@ async def create_webhook(request: Request) -> JSONResponse:
         )
 
     event = body.get("event")
-    uri = body.get("uri")
     # Accept both camelCase (eventFilter) and snake_case (event_filter)
     event_filter = body.get("eventFilter") or body.get("event_filter")
 
-    if not event or not uri:
+    if not event:
         return JSONResponse(
             {
                 "error": _BAD_REQUEST,
-                "message": "Missing required fields: event, uri",
+                "message": "Missing required field: event",
             },
             status_code=400,
+        )
+
+    # Always our own ingress. `uri` is still accepted in the body so existing
+    # callers don't break, but it is never used — a caller that supplies a
+    # different one is either misconfigured or probing for the delivery secret,
+    # so say so in the log rather than failing the request silently.
+    uri = get_webhook_uri()
+    requested_uri = body.get("uri")
+    if requested_uri and requested_uri != uri:
+        logger.warning(
+            "Ignoring client-supplied webhook uri from user %s (registering %s)",
+            user_id,
+            uri,
         )
 
     try:
@@ -240,6 +264,25 @@ async def create_webhook(request: Request) -> JSONResponse:
             auth=httpx.BasicAuth(username, app_password),
             timeout=30.0,
         ) as client:
+            # Verify admin with the caller's own app password before registering
+            # anything — a registration attaches WEBHOOK_SECRET to its delivery
+            # headers, so its blast radius is global, matching the reasoning on
+            # /api/v1/vector-sync/purge. Nextcloud gates webhook_listeners on
+            # admin too; checking here fails earlier and more clearly.
+            users_client = UsersClient(client, username)
+            user_groups = await users_client.get_user_groups(username)
+            if "admin" not in user_groups:
+                logger.warning(
+                    "Non-admin user %s attempted webhook registration", user_id
+                )
+                return JSONResponse(
+                    {
+                        "error": "Forbidden",
+                        "message": "Administrator privileges required",
+                    },
+                    status_code=403,
+                )
+
             # Inject delivery auth headers when WEBHOOK_SECRET is configured so
             # that webhook deliveries from Nextcloud back to us are authenticated.
             webhooks_client = WebhooksClient(client, username)

--- a/nextcloud_mcp_server/api/webhooks.py
+++ b/nextcloud_mcp_server/api/webhooks.py
@@ -248,9 +248,11 @@ async def create_webhook(request: Request) -> JSONResponse:
         # Log what they asked for, not just what we did: the threat model here is
         # a caller probing for the delivery secret with their own host, so the
         # requested value is the part worth having during incident triage.
-        # Lazy %s keeps the untrusted value out of the format string.
+        # %.200r, not %s: the value is attacker-chosen, and repr escapes any
+        # embedded CR/LF that would otherwise forge extra lines in the very log
+        # this line exists to support. The precision caps runaway input.
         logger.warning(
-            "Ignoring client-supplied webhook uri from user %s: requested %s, "
+            "Ignoring client-supplied webhook uri from user %s: requested %.200r, "
             "registering %s",
             user_id,
             requested_uri,

--- a/nextcloud_mcp_server/api/webhooks.py
+++ b/nextcloud_mcp_server/api/webhooks.py
@@ -245,9 +245,15 @@ async def create_webhook(request: Request) -> JSONResponse:
     uri = get_webhook_uri()
     requested_uri = body.get("uri")
     if requested_uri and requested_uri != uri:
+        # Log what they asked for, not just what we did: the threat model here is
+        # a caller probing for the delivery secret with their own host, so the
+        # requested value is the part worth having during incident triage.
+        # Lazy %s keeps the untrusted value out of the format string.
         logger.warning(
-            "Ignoring client-supplied webhook uri from user %s (registering %s)",
+            "Ignoring client-supplied webhook uri from user %s: requested %s, "
+            "registering %s",
             user_id,
+            requested_uri,
             uri,
         )
 

--- a/nextcloud_mcp_server/auth/webhook_routes.py
+++ b/nextcloud_mcp_server/auth/webhook_routes.py
@@ -77,7 +77,7 @@ async def _get_installed_apps(http_client: httpx.AsyncClient) -> list[str]:
         return []
 
 
-def _get_webhook_uri() -> str:
+def get_webhook_uri() -> str:
     """Get the webhook endpoint URI for this MCP server.
 
     Priority (highest first):
@@ -319,7 +319,7 @@ async def _get_enabled_presets(
 
         # Fallback to API query
         registered_webhooks = await webhooks_client.list_webhooks()
-        webhook_uri = _get_webhook_uri()
+        webhook_uri = get_webhook_uri()
 
         # Group webhooks by preset based on matching events
         enabled_presets: dict[str, list[int]] = {}
@@ -449,7 +449,7 @@ async def webhook_management_pane(request: Request) -> HTMLResponse:
             """
 
         # Get webhook endpoint URL for display
-        webhook_uri = _get_webhook_uri()
+        webhook_uri = get_webhook_uri()
 
         html_content = f"""
         <h2>Webhook Management</h2>
@@ -516,7 +516,7 @@ async def enable_webhook_preset(request: Request) -> HTMLResponse:
 
         # Register webhooks
         webhooks_client = WebhooksClient(http_client, username)
-        webhook_uri = _get_webhook_uri()
+        webhook_uri = get_webhook_uri()
         registered_ids = await _register_preset_webhooks(
             webhooks_client, preset, webhook_uri
         )

--- a/tests/unit/test_webhook_uri.py
+++ b/tests/unit/test_webhook_uri.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``_get_webhook_uri`` priority order and the
+"""Unit tests for ``get_webhook_uri`` priority order and the
 ``webhook_auth_pair`` registration helper.
 
 Cloud deployments register the webhook URI returned by this function with
@@ -15,7 +15,7 @@ import pytest
 from nextcloud_mcp_server.auth import webhook_routes
 from nextcloud_mcp_server.auth.webhook_routes import (
     WebhookSecretNotConfigured,
-    _get_webhook_uri,
+    get_webhook_uri,
     webhook_auth_pair,
 )
 from nextcloud_mcp_server.config import Settings
@@ -67,7 +67,7 @@ def test_webhook_internal_url_wins_over_everything(monkeypatch):
     )
     _docker_markers(monkeypatch)
 
-    assert _get_webhook_uri() == "https://internal.example.com/webhooks/nextcloud"
+    assert get_webhook_uri() == "https://internal.example.com/webhooks/nextcloud"
 
 
 @pytest.mark.unit
@@ -81,7 +81,7 @@ def test_public_url_wins_over_docker_detection(monkeypatch):
     _docker_markers(monkeypatch)
 
     assert (
-        _get_webhook_uri()
+        get_webhook_uri()
         == "https://holy-bluegill.astrolabecloud.com/webhooks/nextcloud"
     )
 
@@ -93,7 +93,7 @@ def test_docker_detection_used_when_no_public_url(monkeypatch):
     _patch_settings(monkeypatch)
     _docker_markers(monkeypatch)
 
-    assert _get_webhook_uri() == "http://mcp:8000/webhooks/nextcloud"
+    assert get_webhook_uri() == "http://mcp:8000/webhooks/nextcloud"
 
 
 @pytest.mark.unit
@@ -107,7 +107,7 @@ def test_docker_detection_honors_service_name_and_port_overrides(monkeypatch):
     _reload_config()
     _docker_markers(monkeypatch)
 
-    assert _get_webhook_uri() == "http://mcp-login-flow:8004/webhooks/nextcloud"
+    assert get_webhook_uri() == "http://mcp-login-flow:8004/webhooks/nextcloud"
 
 
 @pytest.mark.unit
@@ -120,7 +120,7 @@ def test_docker_container_env_var_triggers_docker_branch(monkeypatch):
     _reload_config()
     _no_docker_markers(monkeypatch)
 
-    assert _get_webhook_uri() == "http://mcp:8000/webhooks/nextcloud"
+    assert get_webhook_uri() == "http://mcp:8000/webhooks/nextcloud"
 
 
 @pytest.mark.unit
@@ -128,7 +128,7 @@ def test_localhost_fallback_when_nothing_set(monkeypatch):
     _patch_settings(monkeypatch)
     _no_docker_markers(monkeypatch)
 
-    assert _get_webhook_uri() == "http://localhost:8000/webhooks/nextcloud"
+    assert get_webhook_uri() == "http://localhost:8000/webhooks/nextcloud"
 
 
 # --- webhook_auth_pair() --------------------------------------------------

--- a/tests/unit/test_webhooks_api_auth.py
+++ b/tests/unit/test_webhooks_api_auth.py
@@ -69,6 +69,20 @@ def _patch_webhooks_client(mocker, **methods) -> MagicMock:
     return cls
 
 
+def _patch_users_client(mocker, groups: list[str] | None = None) -> MagicMock:
+    """Replace UsersClient so the admin gate on create_webhook resolves.
+
+    Defaults to an admin caller; pass ``groups=[]`` to exercise the 403 path.
+    """
+    instance = MagicMock()
+    instance.get_user_groups = AsyncMock(
+        return_value=["admin"] if groups is None else groups
+    )
+    cls = MagicMock(return_value=instance)
+    mocker.patch("nextcloud_mcp_server.api.webhooks.UsersClient", cls)
+    return cls
+
+
 def _patch_outbound_client_factory(mocker) -> MagicMock:
     """Patch nextcloud_httpx_client so we can assert on the kwargs (esp.
     ``auth=``) the handler called it with."""
@@ -140,6 +154,7 @@ async def test_create_webhook_uses_basic_auth(mocker):
     _patch_token_validation(mocker)
     _patch_basic_auth(mocker, username="bob", app_password="bob-pwd")
     factory = _patch_outbound_client_factory(mocker)
+    _patch_users_client(mocker)
     _patch_webhooks_client(
         mocker,
         create_webhook={"id": 42, "event": "OCP\\Events\\NodeCreated"},
@@ -170,21 +185,17 @@ async def test_create_webhook_returns_503_when_secret_unset(mocker):
     _patch_token_validation(mocker)
     _patch_basic_auth(mocker, username="bob", app_password="bob-pwd")
     _patch_outbound_client_factory(mocker)
+    _patch_users_client(mocker)
     mocker.patch(
         "nextcloud_mcp_server.api.webhooks.webhook_auth_pair",
         side_effect=WebhookSecretNotConfigured("WEBHOOK_SECRET must be set"),
     )
 
     client = TestClient(_build_test_app())
-    # https example URL — registration is refused before the uri is used, and
-    # an https literal avoids a spurious S5332 "use https" hotspot in new code.
     resp = client.post(
         "/api/v1/webhooks",
         headers={"Authorization": "Bearer mcp-token"},
-        json={
-            "event": "OCP\\Events\\NodeCreated",
-            "uri": "https://mcp.example.com/webhooks/nextcloud",
-        },
+        json={"event": "OCP\\Events\\NodeCreated"},
     )
 
     assert resp.status_code == 503
@@ -192,6 +203,7 @@ async def test_create_webhook_returns_503_when_secret_unset(mocker):
 
 
 async def test_create_webhook_validates_required_fields(mocker):
+    """``event`` is required; ``uri`` is not — it is resolved server-side."""
     _patch_token_validation(mocker)
     _patch_basic_auth(mocker)
 
@@ -199,7 +211,7 @@ async def test_create_webhook_validates_required_fields(mocker):
     resp = client.post(
         "/api/v1/webhooks",
         headers={"Authorization": "Bearer mcp-token"},
-        json={"event": "X"},  # missing uri
+        json={},  # missing event
     )
 
     assert resp.status_code == 400
@@ -216,11 +228,76 @@ async def test_create_webhook_returns_428_when_unprovisioned(mocker):
     resp = client.post(
         "/api/v1/webhooks",
         headers={"Authorization": "Bearer mcp-token"},
-        json={"event": "X", "uri": "http://x"},
+        json={"event": "X"},
     )
 
     assert resp.status_code == 428
     assert resp.json()["error"] == "Provisioning required"
+
+
+async def test_create_webhook_ignores_client_supplied_uri(mocker):
+    """A caller must not be able to choose the delivery destination.
+
+    Registrations attach the global ``WEBHOOK_SECRET`` as a delivery
+    ``Authorization`` header, so honouring a caller-chosen URI would hand that
+    secret to an arbitrary host on the first delivery — and the secret is the
+    only guard on the ingress endpoint, which trusts the ``user.uid`` in the
+    payloads it receives (GHSA-8vh3-g2qg-2h2c).
+    """
+    _patch_token_validation(mocker)
+    _patch_basic_auth(mocker, username="mallory", app_password="mallory-pwd")
+    _patch_outbound_client_factory(mocker)
+    _patch_users_client(mocker)
+    cls = _patch_webhooks_client(mocker, create_webhook={"id": 7})
+    mocker.patch(
+        "nextcloud_mcp_server.api.webhooks.get_webhook_uri",
+        return_value="https://mcp.internal.test/webhooks/nextcloud",
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.api.webhooks.webhook_auth_pair",
+        return_value=("header", {"Authorization": "Bearer supersecret"}),
+    )
+
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        "/api/v1/webhooks",
+        headers={"Authorization": "Bearer mcp-token"},
+        json={
+            "event": "OCP\\Events\\NodeCreated",
+            "uri": "https://attacker.example/collect",
+        },
+    )
+
+    assert resp.status_code == 200
+    registered_uri = cls.return_value.create_webhook.call_args.kwargs["uri"]
+    assert registered_uri == "https://mcp.internal.test/webhooks/nextcloud"
+    assert "attacker.example" not in registered_uri
+
+
+async def test_create_webhook_rejects_non_admin(mocker):
+    """Registration is admin-only: its blast radius is global (the shared secret)."""
+    _patch_token_validation(mocker, user_id="carol")
+    _patch_basic_auth(mocker, username="carol", app_password="carol-pwd")
+    _patch_outbound_client_factory(mocker)
+    _patch_users_client(mocker, groups=["users"])
+    cls = _patch_webhooks_client(mocker, create_webhook={"id": 9})
+    auth_pair = mocker.patch(
+        "nextcloud_mcp_server.api.webhooks.webhook_auth_pair",
+        return_value=("header", {"Authorization": "Bearer supersecret"}),
+    )
+
+    client = TestClient(_build_test_app())
+    resp = client.post(
+        "/api/v1/webhooks",
+        headers={"Authorization": "Bearer mcp-token"},
+        json={"event": "OCP\\Events\\NodeCreated"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "Forbidden"
+    # The secret must not even be resolved for a non-admin caller.
+    auth_pair.assert_not_called()
+    cls.return_value.create_webhook.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -376,11 +453,15 @@ class TestCreateWebhookMalformedBody:
         assert response.json()["error"] == "Bad request"
 
     def test_missing_fields_still_returns_400(self, mocker):
-        """The pre-existing required-field check must survive the refactor."""
+        """The required-field check must survive the refactor.
+
+        Only ``event`` is required now — ``uri`` is resolved server-side and a
+        client-supplied one is ignored, so its absence is no longer a 400.
+        """
         _patch_token_validation(mocker)
         client = TestClient(_build_test_app())
 
-        response = client.post("/api/v1/webhooks", json={"event": "SomeEvent"})
+        response = client.post("/api/v1/webhooks", json={})
 
         assert response.status_code == 400
-        assert "Missing required fields" in response.json()["message"]
+        assert "Missing required field" in response.json()["message"]

--- a/tests/unit/test_webhooks_api_auth.py
+++ b/tests/unit/test_webhooks_api_auth.py
@@ -10,6 +10,7 @@ merged and is incompatible with admin endpoints gated by
 ``@PasswordConfirmationRequired`` (e.g. ``webhook_listeners``).
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -272,6 +273,43 @@ async def test_create_webhook_ignores_client_supplied_uri(mocker):
     registered_uri = cls.return_value.create_webhook.call_args.kwargs["uri"]
     assert registered_uri == "https://mcp.internal.test/webhooks/nextcloud"
     assert "attacker.example" not in registered_uri
+
+
+async def test_create_webhook_rejected_uri_is_escaped_in_logs(mocker, caplog):
+    """A rejected uri must not be able to forge log lines.
+
+    The value is attacker-chosen by definition, and it is logged specifically to
+    support incident triage — so letting an embedded CRLF inject a fabricated
+    line would undermine the thing the log exists for.
+    """
+    _patch_token_validation(mocker)
+    _patch_basic_auth(mocker, username="mallory", app_password="mallory-pwd")
+    _patch_outbound_client_factory(mocker)
+    _patch_users_client(mocker)
+    _patch_webhooks_client(mocker, create_webhook={"id": 7})
+    mocker.patch(
+        "nextcloud_mcp_server.api.webhooks.get_webhook_uri",
+        return_value="https://mcp.internal.test/webhooks/nextcloud",
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.api.webhooks.webhook_auth_pair",
+        return_value=("header", {"Authorization": "Bearer supersecret"}),
+    )
+
+    caplog.set_level(logging.WARNING, logger="nextcloud_mcp_server.api.webhooks")
+    client = TestClient(_build_test_app())
+    client.post(
+        "/api/v1/webhooks",
+        headers={"Authorization": "Bearer mcp-token"},
+        json={
+            "event": "OCP\\Events\\NodeCreated",
+            "uri": "https://evil.test/x\r\nCRITICAL forged entry",
+        },
+    )
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "\\r\\n" in logged, "CR/LF should be escaped, not emitted raw"
+    assert "\nCRITICAL forged entry" not in logged, "log line forging must not work"
 
 
 async def test_create_webhook_rejects_non_admin(mocker):


### PR DESCRIPTION
Closes the `WEBHOOK_SECRET` exfiltration path (Deck #851). Second item from the multi-user security audit, after #1150.

## The problem

`POST /api/v1/webhooks` took the delivery `uri` verbatim from the request body and attached the global `WEBHOOK_SECRET` to it as an `Authorization` header:

```python
uri = body.get("uri")            # unvalidated
auth_method, auth_data = webhook_auth_pair()   # → Bearer <WEBHOOK_SECRET>
await webhooks_client.create_webhook(event=event, uri=uri, auth_data=auth_data)
```

Any caller could point it at their own host and receive the secret on the first delivery. That secret is the **only** guard on the ingress endpoint, which trusts the `user.uid` in the payloads it receives (GHSA-8vh3-g2qg-2h2c) — so holding it allows forged delete/re-index events for **any** user. It is global, shared across tenants, and has no rotation path.

## The fix

**Resolve the uri server-side** with `get_webhook_uri()`. A registration's destination is always this server's own ingress; there is no legitimate reason for a caller to choose it. A body `uri` is still accepted so existing callers don't break, but it is ignored, and a differing value is logged as a warning — that's either a misconfigured client or someone probing for the secret.

**Gate registration on Nextcloud admin**, verified with the caller's own app password, mirroring `/api/v1/vector-sync/purge`. The reasoning is identical: a registration's blast radius is global. The browser preset flow already required admin; this route did not. Nextcloud gates `webhook_listeners` on admin too, so this mainly fails earlier and more clearly.

`_get_webhook_uri` becomes public `get_webhook_uri` now that it's shared across modules — matching `webhook_auth_pair`, which is public for exactly that reason, rather than importing a private name across a module boundary.

## Test coverage

- `test_create_webhook_ignores_client_supplied_uri` — posts `https://attacker.example/collect` and asserts the registered URI is our own ingress. **Verified to fail against the previous behaviour**, where it registered the attacker's URI, so it pins the fix rather than restating it.
- `test_create_webhook_rejects_non_admin` — 403, and asserts `webhook_auth_pair` is never called, so the secret isn't even resolved for a non-admin.
- Existing cases updated: `uri` is no longer required (only `event` is), and the admin gate now precedes the secret lookup.

**2710 unit tests pass** under a CI-equivalent clean environment; `ruff`, `ruff format`, `ty`, and the secrets scan are green.

## API-surface disclosure (per CLAUDE.md review gate)

This changes `/api/v1/*` surface, so stating the coverage position explicitly:

- **No consumer pact covers this endpoint**, and provider verification currently reaches only the public endpoints — so no existing contract changes. That gap is pre-existing and tracked on Deck board 11, card **#564**.
- **No e2e tier exercises it.** Coverage here is unit-level.
- Worth noting: `createWebhook()` has **no production caller** in the astrolabe app — only the client method and one unit test — so the blast radius of the behaviour change is small.

## Breaking change

Not flagged as `BREAKING CHANGE`. `uri` is still accepted (ignored), so no caller's request shape becomes invalid. The admin requirement is a genuine tightening, but registration already required Nextcloud admin server-side, so a non-admin call could not have succeeded end-to-end before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_This PR was generated with the help of AI, and reviewed by a Human_