### PR TITLE
feat(security): configurable transport security and CORS origins

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1563,3 +1563,45 @@ Use Docker secrets for sensitive values in production (`TOKEN_ENCRYPTION_KEY`, `
 - [Troubleshooting](troubleshooting.md) - Common configuration issues
 - [ADR-021](ADR-021-configuration-consolidation.md) - Configuration consolidation architecture decision
 - [ADR-022](ADR-022-deployment-mode-consolidation.md) - Deployment mode consolidation
+
+## Transport security
+
+The MCP SDK's DNS-rebinding protection validates the `Host` and `Origin` headers.
+It is **off by default**, which is what this server hardcoded before these
+settings existed: MCP SDK 1.23+ auto-enables localhost-only host checking, and
+that breaks Kubernetes/Docker service DNS names (see
+`docs/MCP-1.23-DNS-REBINDING-FIX.md`).
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MCP_DNS_REBINDING_PROTECTION` | `false` | Enable `Host`/`Origin` validation |
+| `MCP_ALLOWED_HOSTS` | *(empty)* | Comma-separated `Host` allowlist. **Required** when the protection is on |
+| `MCP_ALLOWED_ORIGINS` | *(empty)* | Comma-separated `Origin` allowlist. Optional |
+| `CORS_ALLOW_ORIGINS` | `*` | Comma-separated CORS origin allowlist |
+
+```bash
+MCP_DNS_REBINDING_PROTECTION=true
+MCP_ALLOWED_HOSTS=mcp.example.com,mcp.svc.cluster.local,localhost:*
+```
+
+A `:*` suffix allows any port (`localhost:*`).
+
+**Enabling the protection without `MCP_ALLOWED_HOSTS` fails at startup**, on
+purpose. The SDK rejects any `Host` not in the allowlist, and the default list is
+empty — so the flag alone would produce a server that rejects every request,
+which presents as a total outage rather than a misconfiguration. `MCP_ALLOWED_ORIGINS`
+has no such requirement: `Origin` is absent on same-origin requests and the SDK
+allows that case.
+
+Setting either allowlist while the protection is off logs a warning, since the
+values have no effect.
+
+### CORS
+
+`CORS_ALLOW_ORIGINS` defaults to `*`, unchanged from before. Note that `*`
+combined with credentials is not the inert wildcard it appears to be: Starlette
+echoes the request's `Origin` back rather than `*` (a bare `*` is invalid with
+credentials per the CORS spec), so **any** origin may send credentialed requests.
+That is fine on a private network or for local MCP Inspector use; set an explicit
+list if the server is reachable from a browser. A warning is logged at startup
+while the wildcard is in effect.

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1488,6 +1488,65 @@ async def setup_oauth_config_for_multi_user_basic(
     return (token_verifier, refresh_token_storage, client_id, client_secret)
 
 
+def _csv_setting(raw: str) -> list[str]:
+    """Split a comma-separated setting into a list, dropping blanks."""
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _build_transport_security() -> TransportSecuritySettings:
+    """Assemble TransportSecuritySettings from configuration.
+
+    Defaults to protection *off*, which is what was hardcoded here before these
+    knobs existed: MCP 1.23+ auto-enables localhost-only host checking, and that
+    breaks k8s/Docker service DNS names (docs/MCP-1.23-DNS-REBINDING-FIX.md).
+    Keeping the default preserves every existing deployment's behaviour; the
+    point of this is that re-enabling it no longer requires editing the source.
+
+    ``allowed_hosts``/``allowed_origins`` are only meaningful when the protection
+    is on, so an allowlist set without it is a misconfiguration worth warning
+    about rather than silently ignoring.
+    """
+    settings = get_settings()
+    enabled = settings.mcp_dns_rebinding_protection
+    hosts = _csv_setting(settings.mcp_allowed_hosts)
+    origins = _csv_setting(settings.mcp_allowed_origins)
+
+    if not enabled and (hosts or origins):
+        logger.warning(
+            "MCP_ALLOWED_HOSTS/MCP_ALLOWED_ORIGINS are set but "
+            "MCP_DNS_REBINDING_PROTECTION is false, so they have no effect. "
+            "Set MCP_DNS_REBINDING_PROTECTION=true to enforce them."
+        )
+
+    if enabled and not hosts:
+        # The SDK defaults allowed_hosts to [] and TransportSecurityMiddleware's
+        # _validate_host returns False for a host that is not in the list — with
+        # an empty list that is *every* request. Turning the flag on without an
+        # allowlist therefore yields a server that rejects all traffic, which
+        # presents as a total outage rather than a configuration error. Refuse to
+        # start instead, with the fix in the message.
+        raise ValueError(
+            "MCP_DNS_REBINDING_PROTECTION is enabled but MCP_ALLOWED_HOSTS is "
+            "empty. The MCP SDK rejects any Host not in the allowlist, so an "
+            "empty list would reject every request. Set MCP_ALLOWED_HOSTS to the "
+            "hostnames this server is reached by, e.g. "
+            "'mcp.example.com,mcp.svc.cluster.local' (a ':*' suffix allows any "
+            "port, e.g. 'localhost:*')."
+        )
+
+    kwargs: dict[str, Any] = {"enable_dns_rebinding_protection": enabled}
+    if enabled:
+        kwargs["allowed_hosts"] = hosts
+        if origins:
+            kwargs["allowed_origins"] = origins
+        logger.info(
+            "DNS rebinding protection enabled (allowed_hosts=%s, allowed_origins=%s)",
+            hosts,
+            origins or "any (Origin unset or unchecked)",
+        )
+    return TransportSecuritySettings(**kwargs)
+
+
 def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None = None):
     # Initialize observability (logging will be configured by uvicorn)
     settings = get_settings()
@@ -1736,11 +1795,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             lifespan=oauth_lifespan,
             token_verifier=token_verifier,
             auth=auth_settings,
-            # Disable DNS rebinding protection for containerized deployments (k8s, Docker)
-            # MCP 1.23+ auto-enables this for localhost, breaking k8s service DNS names
-            transport_security=TransportSecuritySettings(
-                enable_dns_rebinding_protection=False
-            ),
+            transport_security=_build_transport_security(),
         )
     else:
         # BasicAuth modes (single-user or multi-user)
@@ -1748,11 +1803,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
         mcp = FastMCP(
             "Nextcloud MCP",
             lifespan=app_lifespan_basic,
-            # Disable DNS rebinding protection for containerized deployments (k8s, Docker)
-            # MCP 1.23+ auto-enables this for localhost, breaking k8s service DNS names
-            transport_security=TransportSecuritySettings(
-                enable_dns_rebinding_protection=False
-            ),
+            transport_security=_build_transport_security(),
         )
 
     @mcp.resource("nc://capabilities")
@@ -3068,10 +3119,26 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             )
         return await call_next(request)
 
-    # Add CORS middleware to allow browser-based clients like MCP Inspector
+    # Add CORS middleware to allow browser-based clients like MCP Inspector.
+    #
+    # The default is still "*", so behaviour is unchanged — but it is now a
+    # setting rather than a literal, and the wildcard is called out at startup.
+    # "*" together with allow_credentials=True is not the permissive-but-inert
+    # combination it looks like: Starlette echoes the request's Origin back
+    # instead of "*" (a bare "*" is invalid with credentials per the CORS spec),
+    # so *any* origin may send credentialed requests. Fine behind a private
+    # network or for local Inspector use; not something to leave unexamined on a
+    # server reachable from a browser.
+    cors_origins = _csv_setting(get_settings().cors_allow_origins)
+    if "*" in cors_origins:
+        logger.warning(
+            "CORS allows any origin with credentials (CORS_ALLOW_ORIGINS='*'). "
+            "Set CORS_ALLOW_ORIGINS to an explicit comma-separated list if this "
+            "server is reachable from a browser."
+        )
     app.add_middleware(
         CORSMiddleware,  # type: ignore[invalid-argument-type]
-        allow_origins=["*"],  # Allow all origins for development
+        allow_origins=cors_origins or ["*"],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -217,6 +217,18 @@ _DEFAULTS: dict[str, Any] = {
     # timing out or exhausting memory rather than failing predictably. 0
     # disables the guard.
     "webdav_write_max_mb": 50.0,
+    # Transport security (MCP SDK TransportSecuritySettings). Default False
+    # preserves the behaviour hardcoded before these knobs existed: MCP 1.23+
+    # auto-enables localhost-only host checking, which breaks k8s/Docker service
+    # DNS names (docs/MCP-1.23-DNS-REBINDING-FIX.md). Enable it plus
+    # MCP_ALLOWED_HOSTS when the server is reachable from a browser.
+    "mcp_dns_rebinding_protection": False,
+    # Comma-separated Host / Origin allowlists, honoured only when the above is
+    # enabled. Empty means "the SDK's own defaults".
+    "mcp_allowed_hosts": "",
+    "mcp_allowed_origins": "",
+    # Comma-separated CORS origin allowlist. "*" preserves today's behaviour.
+    "cors_allow_origins": "*",
     # Page ceiling for markdown reconstruction (see document_markdown_max_pages).
     "document_markdown_max_pages": 150,
     # Pages per pypdfium2 extraction window (see document_parse_page_window).
@@ -1160,6 +1172,12 @@ class Settings:
     # Pre-flight cap (MB) on nc_webdav_write_file's content (see _DEFAULTS
     # for rationale). 0 disables the guard.
     webdav_write_max_mb: float = 50.0
+    # Transport security. See _DEFAULTS for why the protection defaults off.
+    mcp_dns_rebinding_protection: bool = False
+    mcp_allowed_hosts: str = ""
+    mcp_allowed_origins: str = ""
+    # CORS origin allowlist; "*" is today's behaviour.
+    cors_allow_origins: str = "*"
     # Page ceiling above which the structured tier skips pymupdf4llm.to_markdown
     # and returns the raw text layer instead. 0 disables markdown entirely
     # (every document takes the raw-text path), matching how
@@ -2023,6 +2041,10 @@ def _build_settings() -> Settings:
         "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
         "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
         "webdav_write_max_mb": "WEBDAV_WRITE_MAX_MB",
+        "mcp_dns_rebinding_protection": "MCP_DNS_REBINDING_PROTECTION",
+        "mcp_allowed_hosts": "MCP_ALLOWED_HOSTS",
+        "mcp_allowed_origins": "MCP_ALLOWED_ORIGINS",
+        "cors_allow_origins": "CORS_ALLOW_ORIGINS",
         "document_markdown_max_pages": "DOCUMENT_MARKDOWN_MAX_PAGES",
         "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
         "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",

--- a/tests/unit/test_transport_security_config.py
+++ b/tests/unit/test_transport_security_config.py
@@ -1,0 +1,117 @@
+"""Transport-security and CORS configuration.
+
+Both were hardcoded literals before: ``enable_dns_rebinding_protection=False``
+and ``allow_origins=["*"]``. Making them settings must not change any existing
+deployment's behaviour, which is what most of these assert.
+
+Overrides go through ``set_override`` — the documented path, which also drops the
+settings caches — with ``_reload_config`` restoring the baseline afterwards.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from nextcloud_mcp_server.app import _build_transport_security, _csv_setting
+from nextcloud_mcp_server.config import _reload_config, set_override
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def clean_settings():
+    """Override settings, restoring each key's default afterwards.
+
+    ``_reload_config`` only drops the memoisation cache — a ``set_override``
+    value persists in dynaconf, so without explicit restoration the overrides
+    leak into whichever test runs next (they did, on the first attempt).
+    """
+    from nextcloud_mcp_server.config import _DEFAULTS
+
+    applied: list[str] = []
+
+    def _apply(key: str, value) -> None:
+        applied.append(key)
+        set_override(key, value)
+
+    _reload_config()
+    yield _apply
+    for key in applied:
+        set_override(key, _DEFAULTS[key.lower()])
+    _reload_config()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", []),
+        ("*", ["*"]),
+        ("a.example", ["a.example"]),
+        ("a.example,b.example", ["a.example", "b.example"]),
+        (" a.example , b.example ", ["a.example", "b.example"]),
+        ("a.example,,b.example", ["a.example", "b.example"]),
+        (",", []),
+    ],
+)
+def test_csv_setting(raw, expected):
+    assert _csv_setting(raw) == expected
+
+
+def test_protection_defaults_off(clean_settings):
+    """The default must preserve what was hardcoded: MCP 1.23+'s localhost-only
+    host checking breaks k8s/Docker service DNS names."""
+    settings = _build_transport_security()
+
+    assert settings.enable_dns_rebinding_protection is False
+
+
+def test_protection_can_be_enabled_with_allowlists(clean_settings):
+    clean_settings("MCP_DNS_REBINDING_PROTECTION", "true")
+    clean_settings("MCP_ALLOWED_HOSTS", "mcp.internal,mcp.svc.cluster.local")
+    clean_settings("MCP_ALLOWED_ORIGINS", "https://app.example")
+
+    settings = _build_transport_security()
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert settings.allowed_hosts == ["mcp.internal", "mcp.svc.cluster.local"]
+    assert settings.allowed_origins == ["https://app.example"]
+
+
+def test_enabled_without_allowed_hosts_refuses_to_start(clean_settings):
+    """Enabling the protection with no allowlist would reject *every* request.
+
+    The SDK's _validate_host returns False for any host not in allowed_hosts, and
+    the default is []. So the flag alone produces a server that answers nothing —
+    an outage that looks nothing like a config error. Fail at startup instead,
+    with the remedy in the message.
+    """
+    clean_settings("MCP_DNS_REBINDING_PROTECTION", "true")
+
+    with pytest.raises(ValueError, match="MCP_ALLOWED_HOSTS"):
+        _build_transport_security()
+
+
+def test_origins_are_optional_when_hosts_are_set(clean_settings):
+    """Origin is absent on same-origin requests and _validate_origin allows that,
+    so an empty origin list is safe — unlike an empty host list."""
+    clean_settings("MCP_DNS_REBINDING_PROTECTION", "true")
+    clean_settings("MCP_ALLOWED_HOSTS", "mcp.internal")
+
+    settings = _build_transport_security()
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert settings.allowed_hosts == ["mcp.internal"]
+
+
+def test_allowlist_without_protection_warns(clean_settings, caplog):
+    """An allowlist set while the protection is off does nothing — a
+    misconfiguration worth surfacing rather than silently ignoring."""
+    clean_settings("MCP_ALLOWED_HOSTS", "mcp.internal")
+
+    with caplog.at_level(logging.WARNING, logger="nextcloud_mcp_server.app"):
+        settings = _build_transport_security()
+
+    assert settings.enable_dns_rebinding_protection is False
+    assert any("have no effect" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

Two security-relevant values were hardcoded literals:

- `enable_dns_rebinding_protection=False` at **both** FastMCP call sites
  (`app.py:1741`, `:1753`)
- `allow_origins=["*"]` at the CORS middleware

Re-enabling either meant editing the source. `docs/MCP-1.23-DNS-REBINDING-FIX.md`
even documents re-enabling as a manual code edit.

## Change

Both are now settings, plumbed through this repo's dynaconf + `Settings`
dataclass idiom — `_DEFAULTS` entry, dataclass field, env mapping. (All three are
needed: a key missing from `_DEFAULTS` is silently ignored by dynaconf's
`ignore_unknown_envvars`.)

| Variable | Default | Meaning |
|---|---|---|
| `MCP_DNS_REBINDING_PROTECTION` | `false` | Enable `Host`/`Origin` validation |
| `MCP_ALLOWED_HOSTS` | *(empty)* | `Host` allowlist; **required** when protection is on |
| `MCP_ALLOWED_ORIGINS` | *(empty)* | `Origin` allowlist; optional |
| `CORS_ALLOW_ORIGINS` | `*` | CORS origin allowlist |

**Defaults preserve today's behaviour exactly** — no deployment changes. The
point is that changing it no longer requires a code edit.

## A footgun my own test found

Enabling the protection without an allowlist **now fails at startup**, on purpose.

I'd originally written it to omit `allowed_hosts` and let the SDK default apply.
A test asserting "we didn't pass `[]`" failed, which sent me to the SDK source:

```python
def _validate_host(self, host: str | None) -> bool:
    if host in self.settings.allowed_hosts:
        return True
    ...
    return False
```

`allowed_hosts` defaults to `[]`, so with the protection on and no allowlist,
**every request is rejected**. Someone flipping the flag to harden their server
would take it completely offline, and the symptom — everything 421s — looks
nothing like a configuration error.

So it raises at startup instead, with the remedy in the message. `MCP_ALLOWED_ORIGINS`
carries no such requirement: `Origin` is absent on same-origin requests and
`_validate_origin` explicitly allows that.

Setting an allowlist *while the protection is off* logs a warning, since the
values otherwise silently do nothing.

## CORS

Default is unchanged (`*`), but it now warns at startup — because the wildcard
isn't as inert as it looks. Combined with `allow_credentials=True`, Starlette
echoes the request's `Origin` back rather than `*` (a bare `*` is invalid with
credentials per the CORS spec), so **any** origin may send credentialed requests.
Fine on a private network or for local Inspector use; worth knowing about on
anything browser-reachable.

## Test coverage

`tests/unit/test_transport_security_config.py` — `_csv_setting` parsing
(whitespace, empties, bare comma); protection defaults off; enabling with
allowlists populates both; **enabling without hosts raises**; origins stay
optional; allowlist-without-protection warns.

Note the fixture explicitly restores each overridden key: `_reload_config()` only
drops the memoisation cache, so a `set_override` value persists in dynaconf and
leaks into the next test — which it did, on the first attempt.

Tiers executed locally: `pytest -m unit` ✅ 2720 passed (CI's exact selection).

**Contract (Pact): not applicable** — provider verification covers only `/api/v1/*`.

Docs: `docs/configuration.md` gains a "Transport security" section covering both
knobs, the `:*` port-wildcard syntax, and why the empty-allowlist case is fatal.

---

_This PR was generated with the help of AI, and reviewed by a Human_
