### PR TITLE
refactor(webdav): route stream_to_file's etag through _normalize_etag

### DIFF
--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -623,9 +623,7 @@ class WebDAVClient(BaseNextcloudClient):
                 content_type = response.headers.get(
                     "content-type", "application/octet-stream"
                 )
-                etag = response.headers.get("etag")
-                if etag is not None:
-                    etag = etag.strip('"')
+                etag = _normalize_etag(response.headers.get("etag"))
                 # anyio's async file wrapper, not pathlib.Path.open: the writes
                 # run on a worker thread, so streaming a multi-hundred-MB
                 # document does not block the event loop (and with it every other


### PR DESCRIPTION
One-line consistency fix — and a note on the change that **didn't** ship.

## What this does

`stream_to_file` still normalised its ETag by hand:

```python
etag = response.headers.get("etag")
if etag is not None:
    etag = etag.strip('"')
```

#1157 introduced `_normalize_etag` and converted six call sites precisely so the
representation the client hands out cannot drift from what
`_write_precondition_header` re-quotes. This one was missed because it lives
inside the streaming path rather than next to the others. Behaviour is identical
— the helper *is* that strip — but there is no longer a second copy to drift.

## What I set out to do, and why I stopped

This branch started as "bound `read_file` with a new `WEBDAV_READ_MAX_MB`",
motivated by `nc_webdav_read_file` doing an **unbounded buffered read** that could
OOM the process on a large file.

**That is no longer true on master.** `nc_webdav_read_file` already streams to a
spool file under `download_ceiling(settings)`:

```python
async with spooled_document(
    client, path, spool_dir=settings.document_spool_dir,
    max_bytes=download_ceiling(settings),
) as source:
```

and `download_ceiling`'s own docstring says it lives in `vector/spool.py` rather
than `vector/processor.py` specifically so *"an interactive caller (the
`nc_webdav_read_file` tool) can spool a document under the same ceiling"*. The
problem was already solved, better than my plan proposed.

The two remaining buffered `read_file` callers are not the risk case either:

- `vector/processor.py` — the explicit opt-out path (`DOCUMENT_STREAM_DOWNLOAD_ENABLED=false`)
- `server/collectives.py` — a collective page's markdown source, decoded as UTF-8

So I reverted it. Shipping `WEBDAV_READ_MAX_MB` would have added a **second,
competing ceiling** alongside `document_max_pdf_size_mb`/`download_ceiling`,
plus a `max_bytes` parameter with no caller that needs it — a knob that makes the
configuration harder to reason about while fixing nothing.

Flagging it here rather than silently dropping it, since the item was on the
plan.

Tiers executed locally: `pytest -m unit` ✅ 2766 passed.

**Contract (Pact): not applicable.**

---

_This PR was generated with the help of AI, and reviewed by a Human_
