### PR TITLE
docs(adr-005): record that /mcp authorizes by audience, not client identity

### DIFF
--- a/docs/ADR-005-token-audience-validation.md
+++ b/docs/ADR-005-token-audience-validation.md
@@ -854,7 +854,7 @@ the Astrolabe client id in `ALLOWED_MCP_CLIENTS`?".
 
 | Surface | Verification entry point | Client allowlist |
 |---|---|---|
-| `/oauth/authorize`, `/oauth/register` (AS proxy, ADR-023) | `ClientRegistry.validate_client` (`auth/client_registry.py:158`), called from `auth/oauth_routes.py:260`. The DCR proxy consults the same registry by other methods — `find_client_for_redirect_uris` (`:1360`) and `register_proxy_client` (`:1439`) | **`ALLOWED_MCP_CLIENTS`**, fail-closed (empty ⇒ every client rejected) |
+| `/oauth/authorize`, `/oauth/register` (AS proxy, ADR-023) | `ClientRegistry.validate_client` (`auth/client_registry.py:158`), called from `auth/oauth_routes.py:260`. The DCR proxy consults the same registry by other methods — `find_client_for_redirect_uris` (`:1360`) and `register_proxy_client` (`:1440`) | **`ALLOWED_MCP_CLIENTS`**, fail-closed (empty ⇒ every client rejected) |
 | `/api/v1/*` (management API, ADR-018) | `UnifiedTokenVerifier.verify_token_for_management_api` (`auth/unified_verifier.py:169`) | **`ALLOWED_MGMT_CLIENT`**, fail-closed, checked against the token's `client_id` claim at `:275` — relaxed *only* for opaque tokens validated via the userinfo fallback, which carry no verifiable `client_id` |
 | `/mcp` | `UnifiedTokenVerifier.verify_token` → `_verify_mcp_audience` (`auth/unified_verifier.py:144`, `:284`) | **none** |
 

--- a/docs/ADR-005-token-audience-validation.md
+++ b/docs/ADR-005-token-audience-validation.md
@@ -2,8 +2,8 @@
 
 **Status**: Implemented
 **Date**: 2025-01-05
-**Updated**: 2025-11-05
-**Related**: Issue #261, ADR-004, upstream-oauth.md, RFC 7519, RFC 8707, RFC 9728
+**Updated**: 2026-07-26
+**Related**: Issue #261, ADR-004, ADR-018 (management API), ADR-023 (AS proxy), upstream-oauth.md, RFC 7519, RFC 8707, RFC 9728
 **Supersedes**: Token passthrough mode in ADR-004
 
 ## Implementation Note
@@ -841,6 +841,125 @@ This implementation ensures **full compliance** with:
 - [MCP Security Best Practices - Token Passthrough](https://modelcontextprotocol.io/specification/2025-06-18/basic/security_best_practices#token-passthrough)
 - OAuth 2.0 Resource Indicators (RFC 8707)
 - OAuth 2.0 Token Exchange (RFC 8693)
+
+## Client Identity Is Not an Authorization Gate on `/mcp`
+
+**Added 2026-07-26.** `/mcp` authorizes by **audience and `sub`**, never by client
+identity. This section records that explicitly, because the server has two
+client-allowlist env vars and neither one gates `/mcp` — a shape that reads as an
+oversight until you trace it, and that has already prompted the question "why isn't
+the Astrolabe client id in `ALLOWED_MCP_CLIENTS`?".
+
+### Three surfaces, two allowlists
+
+| Surface | Verification entry point | Client allowlist |
+|---|---|---|
+| `/oauth/authorize`, `/oauth/register` (AS proxy, ADR-023) | `ClientRegistry.validate_client` (`auth/client_registry.py:158`), called from `auth/oauth_routes.py:260` and the DCR short-circuit at `:1360`/`:1439` | **`ALLOWED_MCP_CLIENTS`**, fail-closed (empty ⇒ every client rejected) |
+| `/api/v1/*` (management API, ADR-018) | `UnifiedTokenVerifier.verify_token_for_management_api` (`auth/unified_verifier.py:169`) | **`ALLOWED_MGMT_CLIENT`**, fail-closed, checked against the token's `client_id` claim at `:275` — relaxed *only* for opaque tokens validated via the userinfo fallback, which carry no verifiable `client_id` |
+| `/mcp` | `UnifiedTokenVerifier.verify_token` → `_verify_mcp_audience` (`auth/unified_verifier.py:144`, `:284`) | **none** |
+
+`ALLOWED_MCP_CLIENTS` is an **authorization-server** gate, not a resource-server gate.
+It exists because the MCP server acts as its own AS proxy (ADR-023): it decides which
+`client_id` may drive *our* `/oauth/authorize` and which redirect URIs that client may
+use. It says nothing about tokens obtained anywhere else, and it is not consulted on
+any request to `/mcp`.
+
+### What `/mcp` actually validates
+
+For a JWT (`_verify_jwt_signature`, `auth/unified_verifier.py:516`):
+
+1. **Signature** against the IdP's JWKS, plus `exp` and `iat`.
+2. **Issuer**, checked manually against `valid_issuers` — `OIDC_ISSUER` and
+   `NEXTCLOUD_HOST` — so internal and public URLs can both be accepted.
+3. **Audience**, via `_has_mcp_audience` (`:462`): the token must name the MCP server's
+   own `oidc_client_id`, or `NEXTCLOUD_MCP_SERVER_URL`, or `<NEXTCLOUD_MCP_SERVER_URL>/mcp`
+   (with a `client_id` fallback for IdPs like Cognito that omit `aud` on access tokens).
+4. **Identity** from `sub`, stored as `AccessToken.resource`
+   (`_create_access_token_with_cache_key`) and read back by `auth/context_helper.py` —
+   this is what scopes every result to one user.
+5. **Capability** from the `scope` claim, which `@require_scopes` uses to filter the
+   tool catalogue and reject individual calls; in `login_flow` mode
+   `@require_provisioning` additionally requires that the user has completed Flow 2.
+
+There is **no `azp`/`client_id` comparison** anywhere on this path. That is deliberate
+and RFC-correct: per RFC 7519 §4.1.3 a resource server validates its own presence in
+`aud`. Which client obtained the token is the authorization server's business.
+
+### Worked example: Astrolabe needs no `ALLOWED_MCP_CLIENTS` entry
+
+The Astrolabe Nextcloud app talks to this server over two channels, and neither one
+goes through our AS proxy:
+
+- **Management API** — `lib/Service/McpServerClient.php` → `/api/v1/*`. Its token's
+  `client_id` claim **must** appear in `ALLOWED_MGMT_CLIENT` (see the dev stack's
+  `docker-compose.yml`).
+- **`/mcp`** — `lib/Service/Mcp/McpClientFactory.php`, used by the Assistant agent
+  (`ContextAgentProvider`, registering for the core `core:contextagent:interaction`
+  task type). Its token comes from `lib/Service/McpTokenMinter.php`, which dispatches
+  the Nextcloud `oidc` app's `TokenGenerationRequestEvent` in-process: no browser, no
+  redirect, no PKCE, no call to `/oauth/*`. The `oidc` app looks the client up in *its
+  own* registry (`astrolabe_client_id` system config) and mints a JWT whose `aud` is
+  the RFC 8707 resource indicator Astrolabe passed — `mcp_server_public_url`.
+
+So when that bearer arrives at `/mcp`, the only questions asked are the five above, and
+all five are answerable. There is nothing for `ALLOWED_MCP_CLIENTS` to match — and no
+entry could be written even if one were wanted, since its entry format is
+`client_id|redirect_uri` and this client has no redirect URI.
+
+The corollary is a configuration invariant worth stating plainly: Astrolabe's
+`mcp_server_public_url` must equal this server's `NEXTCLOUD_MCP_SERVER_URL`, because
+that string is the token audience. When they disagree, `/mcp` returns 401 for every
+call **while the management API keeps working** — `/api/v1/*` deliberately skips both
+the audience and the issuer check — so half the integration looks healthy.
+
+### `/mcp` requires a JWT
+
+The opaque-token escape hatches are management-only. `_verify_without_audience_check`
+(`:356`) falls back from introspection to the userinfo endpoint (`:641`) precisely to
+accept opaque tokens minted for a *different* OIDC client, which our own introspection
+reports `active=false` cross-client. `_verify_mcp_audience` has no such fallback: an
+opaque cross-client token is rejected at `/mcp`. Deployments driving `/mcp` from a
+Nextcloud-app-minted token therefore depend on the `oidc` app issuing **JWT** access
+tokens.
+
+### The trust boundary this implies
+
+Any OIDC client registered in Nextcloud can request `resource=<mcp url>` and reach
+`/mcp` as the consenting user. The gates on that are:
+
+- **Nextcloud's own client registry**, which only an administrator can add to;
+- the **`sub` binding** — a token is bound to one user, and every tool call resolves
+  its Nextcloud credentials for that user only;
+- **scope filtering**, which bounds what the holder can do with it.
+
+This is the intended model, but note what it does *not* do: `ALLOWED_MCP_CLIENTS` is
+**not** a perimeter around the tool surface. A reader who assumes it is will
+mis-estimate the blast radius of registering a new OIDC client in Nextcloud.
+
+### Alternatives considered
+
+#### Enforce an `azp`/`client_id` allowlist on `/mcp`
+
+**Not taken.** The gate would duplicate Nextcloud's own OIDC client registry — already
+admin-controlled — while any token that reaches `/mcp` is already bound to a single
+`sub` with a scope-filtered tool catalogue. It would also have to fail *open* when
+unset to avoid breaking every existing deployment, which makes it a weak control.
+Revisit only if a deployment needs to admit a Nextcloud-registered client to
+`/api/v1/*` but not to `/mcp`.
+
+### If the two allowlist env vars are consolidated
+
+`auth/client_registry.py:78` and `auth/unified_verifier.py:107` both note that
+`ALLOWED_MCP_CLIENTS` and `ALLOWED_MGMT_CLIENT` are separate "for now". If they are
+merged, the merged list must remain an **AS-proxy** gate:
+
+- Applying it to `/mcp` would break Astrolabe and every other resource-indicator
+  client that legitimately obtains its token from the IdP directly.
+- The redirect-URI validation `ALLOWED_MCP_CLIENTS` performs is meaningless for such
+  clients — they have no redirect URI.
+- `ALLOWED_MGMT_CLIENT` matches a token's `client_id` **claim**; `ALLOWED_MCP_CLIENTS`
+  matches a `client_id` **request parameter** at the authorize endpoint. They are the
+  same word for two different things, and a merged var must pick one meaning.
 
 ## Migration Guide
 

--- a/docs/ADR-005-token-audience-validation.md
+++ b/docs/ADR-005-token-audience-validation.md
@@ -854,7 +854,7 @@ the Astrolabe client id in `ALLOWED_MCP_CLIENTS`?".
 
 | Surface | Verification entry point | Client allowlist |
 |---|---|---|
-| `/oauth/authorize`, `/oauth/register` (AS proxy, ADR-023) | `ClientRegistry.validate_client` (`auth/client_registry.py:158`), called from `auth/oauth_routes.py:260` and the DCR short-circuit at `:1360`/`:1439` | **`ALLOWED_MCP_CLIENTS`**, fail-closed (empty ⇒ every client rejected) |
+| `/oauth/authorize`, `/oauth/register` (AS proxy, ADR-023) | `ClientRegistry.validate_client` (`auth/client_registry.py:158`), called from `auth/oauth_routes.py:260`. The DCR proxy consults the same registry by other methods — `find_client_for_redirect_uris` (`:1360`) and `register_proxy_client` (`:1439`) | **`ALLOWED_MCP_CLIENTS`**, fail-closed (empty ⇒ every client rejected) |
 | `/api/v1/*` (management API, ADR-018) | `UnifiedTokenVerifier.verify_token_for_management_api` (`auth/unified_verifier.py:169`) | **`ALLOWED_MGMT_CLIENT`**, fail-closed, checked against the token's `client_id` claim at `:275` — relaxed *only* for opaque tokens validated via the userinfo fallback, which carry no verifiable `client_id` |
 | `/mcp` | `UnifiedTokenVerifier.verify_token` → `_verify_mcp_audience` (`auth/unified_verifier.py:144`, `:284`) | **none** |
 

--- a/docs/ADR-023-oauth-as-proxy.md
+++ b/docs/ADR-023-oauth-as-proxy.md
@@ -102,6 +102,8 @@ The `authorization_servers` field in the PRM response now points to the MCP serv
 
 Client registration requests at `/oauth/register` are proxied to Nextcloud's DCR endpoint. The resulting `client_id` is stored in the local `ClientRegistry` so that `/oauth/authorize` can validate it. The client receives the same DCR response it would get from Nextcloud directly.
 
+The `ClientRegistry` — and therefore `ALLOWED_MCP_CLIENTS` — gates **only** these AS-proxy endpoints. `/mcp` never consults it: it authorizes by audience and `sub`, so a client that obtains its token straight from the IdP (as the Astrolabe Nextcloud app does) needs no entry. See [ADR-005 → *Client Identity Is Not an Authorization Gate on `/mcp`*](ADR-005-token-audience-validation.md#client-identity-is-not-an-authorization-gate-on-mcp).
+
 ## Alternatives Considered
 
 ### 1. Relax Audience Validation

--- a/docs/login-flow-v2.md
+++ b/docs/login-flow-v2.md
@@ -112,7 +112,7 @@ mismatches across them.
 | Client | Required? | What it represents |
 |---|---|---|
 | **MCP server** | Yes | The MCP server's RP relationship with the IdP. Configured via `NEXTCLOUD_OIDC_CLIENT_ID` / `NEXTCLOUD_OIDC_CLIENT_SECRET`. Used for OIDC discovery, JWKS retrieval, and token validation. |
-| **Astrolabe** | Only if Astrolabe is installed | Used by the Astrolabe Nextcloud app for its own per-user OAuth flow against the MCP server. |
+| **Astrolabe** | Only if Astrolabe is installed | Used by the Astrolabe Nextcloud app for its own per-user OAuth flow against the MCP server. Its `client_id` must be listed in `ALLOWED_MGMT_CLIENT` (the management API matches it against the token's `client_id` claim), but **not** in `ALLOWED_MCP_CLIENTS` — Astrolabe never uses the MCP server's AS proxy, and `/mcp` authorizes by audience + `sub` rather than by client identity. See [ADR-005 → *Client Identity Is Not an Authorization Gate on `/mcp`*](ADR-005-token-audience-validation.md#client-identity-is-not-an-authorization-gate-on-mcp). |
 | **MCP client** (e.g. Claude.ai, Claude Code) | Optional | The MCP server supports RFC 7591 Dynamic Client Registration, so MCP clients are auto-registered on first connect. Only register a static client if your IdP rejects DCR-issued clients or your MCP client cannot do DCR (see [#752 thread](https://github.com/cbcoutinho/nextcloud-mcp-server/issues/752#issuecomment-4362197279) for the Claude Code workarounds). When pre-allowlisting static MCP clients, set `ALLOWED_MCP_CLIENTS` — see [`auth/client_registry.py`](../nextcloud_mcp_server/auth/client_registry.py) for the format. |
 
 #### Scopes the IdP must advertise on the MCP-server client

--- a/env.sample
+++ b/env.sample
@@ -127,7 +127,7 @@ NEXTCLOUD_PASSWORD=
 
 # ===== ALLOWED_MGMT_CLIENT =====
 # OIDC client_ids whose tokens are accepted by the management API
-# (/api/management/*). Comma-separated. The token's `client_id` claim must
+# (/api/v1/*). Comma-separated. The token's `client_id` claim must
 # match one of these entries. Typical value: the Astrolabe NC PHP app's
 # OAuth client_id (ADR-018).
 #ALLOWED_MGMT_CLIENT=astrolabe

--- a/env.sample
+++ b/env.sample
@@ -110,6 +110,12 @@ NEXTCLOUD_PASSWORD=
 # Note: ALLOWED_MCP_CLIENTS and ALLOWED_MGMT_CLIENT are currently separate to
 # keep the MCP-route and management-API auth surfaces independent. They may be
 # consolidated into a single env var later.
+#
+# Neither one gates /mcp. That route authorizes by token audience + `sub`, never
+# by client identity, so a client that obtains its token directly from the IdP
+# (e.g. the Astrolabe Nextcloud app) needs no entry in either list. See
+# docs/ADR-005-token-audience-validation.md → "Client Identity Is Not an
+# Authorization Gate on /mcp".
 
 # ===== ALLOWED_MCP_CLIENTS =====
 # Clients allowed to use the OAuth AS proxy (/oauth/authorize, /oauth/token).


### PR DESCRIPTION
## Why

Astrolabe 0.39.0 backs the Nextcloud Assistant's agent chat ("Chat with AI") by
opening a real MCP session against this server's `/mcp`. That surfaced a question
whose answer is not discoverable from the code without tracing three files:
**why is Astrolabe's OIDC client id not required in `ALLOWED_MCP_CLIENTS`?**

Because `ALLOWED_MCP_CLIENTS` is an **authorization-server** gate, not a
resource-server one. It is read only by `ClientRegistry`
(`auth/client_registry.py:82`), whose `validate_client` is called only from the
AS-proxy endpoints (`auth/oauth_routes.py:260`, plus the DCR short-circuit at
`:1360`/`:1439`). `/mcp` goes through `verify_token` → `_verify_mcp_audience`,
which validates signature, issuer and audience — **no `azp`/`client_id`
comparison exists on that path**. Identity comes from `sub`, capability from
`scope`.

Two things made this worth writing down rather than leaving in the code:

1. The asymmetry is easy to misread. `/api/v1/*` **does** enforce a client
   allowlist (`ALLOWED_MGMT_CLIENT`, which is where Astrolabe *is* listed), while
   `/mcp` — the larger surface — enforces none. A reader who assumes
   `ALLOWED_MCP_CLIENTS` is a perimeter around the tool surface will
   mis-estimate the blast radius of registering a new OIDC client in Nextcloud.
2. `client_registry.py:78` and `unified_verifier.py:107` both float consolidating
   the two env vars. A merged allowlist applied to `/mcp` would break Astrolabe
   and every other resource-indicator client, and the redirect-URI validation
   `ALLOWED_MCP_CLIENTS` performs is meaningless for a client with no redirect URI.

## What changed

Docs and `env.sample` only — no code paths touched.

- **`docs/ADR-005-token-audience-validation.md`** — new section *Client Identity
  Is Not an Authorization Gate on `/mcp`*: the three surfaces and their two
  allowlists; what `/mcp` actually validates (signature → issuer → audience →
  `sub` → scopes); Astrolabe as a worked example, including the
  `mcp_server_public_url` == `NEXTCLOUD_MCP_SERVER_URL` invariant and why a
  mismatch presents as "`/mcp` 401s while the management API stays healthy";
  the JWT-only constraint (the userinfo fallback is management-only); the trust
  boundary that follows; an `azp` allowlist recorded as an alternative **not**
  taken; and what a future env-var consolidation must preserve.
- **Cross-references** so a reader arriving at either allowlist learns which
  surface it covers: `docs/ADR-023-oauth-as-proxy.md` (§ DCR Proxy),
  `env.sample` (above both allowlist blocks), `docs/login-flow-v2.md` (the
  Astrolabe client row).

## Verification

- Every code citation in the new section was checked against the current line
  (14 references across `client_registry.py`, `oauth_routes.py`,
  `unified_verifier.py`).
- `uv run ruff check` ✅ · `uv run pytest tests/unit/` ✅ 2530 passed — no Python
  changed, run as a branch-state check.

## Test coverage

No API surface is added or changed (documentation + a commented env var
example), so the e2e + Pact contract requirement does not apply to this PR.

## Related

Companion docs PR in the Astrolabe repo: cbcoutinho/astrolabe#272 — the admin
guide for running Astrolabe as a Context Agent replacement, which links this ADR
section for the `ALLOWED_MCP_CLIENTS` question.

---

_This PR was generated with the help of AI, and reviewed by a Human_
