### PR TITLE
fix(auth): deny /app in multi-user BasicAuth; warn in single-user

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1557,6 +1557,21 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
     logger.info("✅ Configuration validated successfully for %s mode", mode.value)
     logger.debug("Mode details:\\n%s", get_mode_summary(mode))
 
+    if mode == AuthMode.SINGLE_USER_BASIC:
+        # The /app browser UI has no credential to check in this mode: the
+        # server holds one identity and every request already acts as it, so
+        # anyone who can reach the port gets the admin UI (webhook presets,
+        # vector-viz search over the indexed corpus, revoke). That is the
+        # deployment model for a personal instance, not a bug — but it is only
+        # safe while the port is not reachable by anyone else, and that
+        # assumption was previously undocumented.
+        logger.warning(
+            "⚠️  single_user_basic: the /app browser UI is UNAUTHENTICATED — "
+            "anyone who can reach this port gets admin access to it. Bind to "
+            "loopback or put an authenticating proxy in front; do not expose "
+            "this port to a network you do not control."
+        )
+
     # Derive helper variables for backward compatibility with existing code.
     # `oauth_enabled` is True for the LOGIN_FLOW (formerly OAUTH_SINGLE_AUDIENCE)
     # multi-user OAuth mode — in this mode the MCP server is an OIDC relying
@@ -2982,7 +2997,10 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
     browser_app = Starlette(routes=browser_routes)
     browser_app.add_middleware(
         AuthenticationMiddleware,  # type: ignore[invalid-argument-type]
-        backend=SessionAuthBackend(oauth_enabled=oauth_enabled),
+        backend=SessionAuthBackend(
+            oauth_enabled=oauth_enabled,
+            multi_user_basic=mode == AuthMode.MULTI_USER_BASIC,
+        ),
     )
 
     # Add redirect from /app to /app/ (Starlette requires trailing slash for mounted apps)

--- a/nextcloud_mcp_server/auth/session_backend.py
+++ b/nextcloud_mcp_server/auth/session_backend.py
@@ -21,8 +21,20 @@ logger = logging.getLogger(__name__)
 class SessionAuthBackend(AuthenticationBackend):
     """Authentication backend using signed session cookies.
 
-    For BasicAuth mode: Always authenticates as the configured user.
+    For single-user BasicAuth: authenticates as the one configured user.
+    For multi-user BasicAuth: denies — see below.
     For OAuth mode: Checks for valid session cookie with stored refresh token.
+
+    Why multi-user BasicAuth is denied rather than passed through:
+        ``/app`` is a *session* UI, and that mode has no session concept —
+        callers authenticate per request with their own credentials against
+        ``/mcp``. The pass-through branch used to hand every caller
+        ``["authenticated", "admin"]`` as ``cfg("NEXTCLOUD_USERNAME", "admin")``.
+        In this mode ``NEXTCLOUD_USERNAME`` is *forbidden* config (startup
+        hard-fails via ``config_validators``), so that resolved to a literal
+        ``"admin"`` — granting anyone who could reach the port an admin UI,
+        attributed to a user who may not exist. Nothing legitimate was served
+        by it, so it fails closed.
 
     Behavior note — silent invalidation on refresh-token TTL expiry:
         The OAuth path requires *both* a live ``browser_sessions`` row and a
@@ -37,13 +49,16 @@ class SessionAuthBackend(AuthenticationBackend):
         the cleanup invariant on logout (PR #758 round-4 review medium 2).
     """
 
-    def __init__(self, oauth_enabled: bool = False):
+    def __init__(self, oauth_enabled: bool = False, multi_user_basic: bool = False):
         """Initialize session authentication backend.
 
         Args:
             oauth_enabled: Whether OAuth mode is enabled
+            multi_user_basic: Whether this is multi-user BasicAuth pass-through,
+                which has no browser session and so gets no ``/app`` access.
         """
         self.oauth_enabled = oauth_enabled
+        self.multi_user_basic = multi_user_basic
 
     async def authenticate(
         self, conn: HTTPConnection
@@ -60,8 +75,20 @@ class SessionAuthBackend(AuthenticationBackend):
         Returns:
             Tuple of (credentials, user) if authenticated, None otherwise
         """
-        # BasicAuth mode: Always authenticated as the configured user
         if not self.oauth_enabled:
+            # Multi-user BasicAuth has no browser session to authenticate, and
+            # no configured identity to fall back on. Deny rather than invent one.
+            if self.multi_user_basic:
+                logger.info(
+                    "Denying /app access: multi-user BasicAuth mode has no "
+                    "browser session (use /mcp with per-request credentials)"
+                )
+                return None
+
+            # Single-user BasicAuth: the server holds exactly one identity and
+            # every request already acts as it, so there is nothing to
+            # distinguish callers by. Startup warns that /app is unauthenticated
+            # and must not be exposed beyond loopback.
             username = cfg("NEXTCLOUD_USERNAME", "admin")
             return AuthCredentials(["authenticated", "admin"]), SimpleUser(username)
 

--- a/tests/unit/test_app_ui_basicauth_access.py
+++ b/tests/unit/test_app_ui_basicauth_access.py
@@ -1,0 +1,92 @@
+"""The /app browser UI must not hand out admin access without a credential.
+
+`SessionAuthBackend` used to return ``["authenticated", "admin"]`` for *any*
+caller whenever OAuth was off — no cookie, no header, nothing. `/app` is mounted
+unconditionally in every deployment mode, so in multi-user BasicAuth that meant
+anyone reaching the port got the admin UI (webhook presets, vector-viz search
+over the indexed corpus, revoke), attributed to ``cfg("NEXTCLOUD_USERNAME",
+"admin")`` — a user that mode forbids configuring, so literally ``"admin"``.
+
+Single-user keeps the pass-through: the server holds exactly one identity and
+every request already acts as it, so there is nothing to distinguish callers by.
+That is the deployment model, guarded by a startup warning instead.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from starlette.authentication import SimpleUser
+
+from nextcloud_mcp_server.auth.session_backend import SessionAuthBackend
+from nextcloud_mcp_server.config import Settings
+from nextcloud_mcp_server.config_validators import (
+    AuthMode,
+    detect_auth_mode,
+    validate_configuration,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _conn_without_credentials() -> SimpleNamespace:
+    """An HTTPConnection-shaped object carrying no cookie and no auth header."""
+    return SimpleNamespace(cookies={}, scope={"state": {}}, app=SimpleNamespace())
+
+
+async def test_multi_user_basic_denies_app_without_session():
+    """The bypass: no credential must mean no /app access in multi-user mode."""
+    backend = SessionAuthBackend(oauth_enabled=False, multi_user_basic=True)
+
+    assert await backend.authenticate(_conn_without_credentials()) is None
+
+
+async def test_single_user_basic_still_passes_through():
+    """Single-user is one identity by design; the guard is the startup warning."""
+    backend = SessionAuthBackend(oauth_enabled=False, multi_user_basic=False)
+
+    with patch("nextcloud_mcp_server.auth.session_backend.cfg", return_value="alice"):
+        result = await backend.authenticate(_conn_without_credentials())
+
+    assert result is not None
+    credentials, user = result
+    assert isinstance(user, SimpleUser)
+    assert user.username == "alice"
+    assert "admin" in credentials.scopes
+
+
+async def test_multi_user_basic_denies_even_with_username_configured():
+    """Belt and braces: the deny must not depend on NEXTCLOUD_USERNAME being unset.
+
+    Config validation already hard-fails that combination (see
+    ``test_multi_user_basic_rejects_configured_nextcloud_username``), but the
+    backend must not rely on another layer having caught it.
+    """
+    backend = SessionAuthBackend(oauth_enabled=False, multi_user_basic=True)
+
+    with patch("nextcloud_mcp_server.auth.session_backend.cfg", return_value="admin"):
+        assert await backend.authenticate(_conn_without_credentials()) is None
+
+
+def test_multi_user_basic_rejects_configured_nextcloud_username():
+    """A single-user credential in multi-user mode is a misconfiguration.
+
+    It signals an operator who thinks they configured one mode but got another,
+    so startup refuses rather than silently ignoring the credential. Pinning the
+    existing behaviour: ``nextcloud_username``/``nextcloud_password`` are in
+    multi-user's ``forbidden`` list, and ``get_app`` raises on any config error.
+    """
+    settings = Settings(
+        deployment_mode="multi_user_basic",
+        nextcloud_host="http://nc.test",
+        nextcloud_username="admin",
+        nextcloud_password="secret",
+    )
+
+    mode = detect_auth_mode(settings)
+    assert mode is AuthMode.MULTI_USER_BASIC
+
+    _mode, errors = validate_configuration(settings)
+    joined = " ".join(errors)
+    assert "NEXTCLOUD_USERNAME" in joined
+    assert "NEXTCLOUD_PASSWORD" in joined


### PR DESCRIPTION
Closes Deck #853. Third item from the multi-user security audit, after #1150 and #1161.

## The problem

`SessionAuthBackend.authenticate()` returned `["authenticated", "admin"]` for **any** caller whenever OAuth was off — no cookie, no header, no credential of any kind:

```python
if not self.oauth_enabled:
    username = cfg("NEXTCLOUD_USERNAME", "admin")
    return AuthCredentials(["authenticated", "admin"]), SimpleUser(username)
```

`/app` is mounted **unconditionally** in every deployment mode (the `Mount("/app", …)` sits at top-level indentation in `get_app()`, not inside a mode conditional), so in multi-user BasicAuth anyone who could reach the port got the admin UI: webhook enable/disable, vector-viz search over the whole indexed corpus, and revoke.

Worse, the identity it granted was `cfg("NEXTCLOUD_USERNAME", "admin")` — and that mode **forbids** configuring `NEXTCLOUD_USERNAME`, so it resolved to a literal `"admin"`, a user who need not exist.

## The fix is mode-aware, because the two modes are genuinely different

**Multi-user BasicAuth → deny.** `/app` is a *session* UI and this mode has no session concept; callers authenticate per request with their own credentials against `/mcp`. Nothing legitimate was served by that branch — it only ever showed a static, forbidden-to-configure identity — so it now fails closed.

**Single-user BasicAuth → unchanged, plus a startup warning.** The server holds exactly one identity and every request already acts as it, so there is nothing to distinguish callers by. That is the deployment model for a personal instance, not a bug. What was missing is that the assumption was undocumented, so startup now warns:

```
⚠️  single_user_basic: the /app browser UI is UNAUTHENTICATED — anyone who can
reach this port gets admin access to it. Bind to loopback or put an
authenticating proxy in front; do not expose this port to a network you do not control.
```

A blanket denial would have broken working personal deployments for no security gain, which is why this isn't one gate.

## On the misconfiguration hard-fail

Multi-user with `NEXTCLOUD_USERNAME` set **already hard-fails at startup** — I verified rather than assumed:

- `nextcloud_username`/`nextcloud_password` are in that mode's `forbidden` list (`config_validators.py:97-100`)
- forbidden vars append to `errors`, and `get_app()` does `raise ValueError(error_msg)` (`app.py:1555`)
- explicit `MCP_DEPLOYMENT_MODE` wins over auto-detection, so the mode really is multi-user when set

Confirmed live: `validate_configuration` returns both `Forbidden configuration: NEXTCLOUD_USERNAME/NEXTCLOUD_PASSWORD` errors. That behaviour is now **pinned by a test** so it can't regress silently — and the backend's deny deliberately does not depend on it (`test_multi_user_basic_denies_even_with_username_configured`).

## Test coverage

`tests/unit/test_app_ui_basicauth_access.py` — 4 tests. The two deny tests are **verified to fail against the previous behaviour**, so they pin the fix rather than restate it.

**2786 unit tests pass** under a CI-equivalent clean environment; `ruff`, `ruff format`, `ty`, secrets scan green.

## Breaking change

Not flagged. Multi-user BasicAuth `/app` access is removed, but it was never functional in that mode — it served a static identity the mode forbids configuring. No `/mcp` behaviour changes, and single-user is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_This PR was generated with the help of AI, and reviewed by a Human_