### PR TITLE
docs: the Assistant has two backends now, not one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Enable Large Language Models like Claude, GPT, and Gemini to interact with your 
 This is a **dedicated standalone MCP server** designed for external MCP clients like Claude Code and IDEs. It runs independently of Nextcloud (Docker, VM, Kubernetes, or local) and provides deep CRUD operations across Nextcloud apps.
 
 > [!NOTE]
-> **Looking for AI features inside Nextcloud?** Nextcloud also provides [Context Agent](https://github.com/nextcloud/context_agent), which powers the Assistant app and runs as an ExApp inside Nextcloud. See [docs/comparison-context-agent.md](docs/comparison-context-agent.md) for a detailed comparison of use cases.
+> **Want AI features inside Nextcloud instead?** You can point Nextcloud's own Assistant at this server — see [AI inside Nextcloud](#ai-inside-nextcloud) below.
 
 > [!TIP]
 > **Don't want to self-host?** [Astrolabe Cloud](https://astrolabecloud.com) is a managed hosting service for this MCP server, aimed at users and teams who want advanced features like background sync and semantic search without operating the infrastructure themselves. The service is currently under development — sign up on the landing page to join the early-adopter list.
@@ -110,6 +110,21 @@ The MCP server authenticates to Nextcloud using **app-specific passwords** (Basi
 OAuth-direct-to-Nextcloud is no longer supported (it required upstream patches to `user_oidc` that were never merged). Login Flow v2 replaces it for multi-user deployments and works with stock Nextcloud.
 
 See [docs/authentication.md](docs/authentication.md) for setup instructions.
+
+## AI inside Nextcloud
+
+This server was built for AI assistants that live *outside* Nextcloud — Claude Code, an IDE, a desktop client. But Nextcloud has its own chat, the **Assistant** app, and there are two ways to give it access to your content.
+
+| Answering the Assistant's "Chat with AI" | What it needs | What it does |
+|---|---|---|
+| **[Context Agent](https://github.com/nextcloud/context_agent)** (by Nextcloud) | AppAPI and a separate container to run the ExApp | Acts on your Nextcloud — sends Talk messages, creates events, and other write actions, with a confirmation step |
+| **[Astrolabe](https://github.com/cbcoutinho/astrolabe)** + this server | The Astrolabe app, and this server reachable from it | Answers *from your own documents* and cites them: every claim links to the file, note or card it came from. Read-only |
+
+Astrolabe is a Nextcloud app that registers itself as the Assistant's agent provider, so no AppAPI and no extra container are involved — the Assistant talks to it, and it searches your content through this server. Each user's questions run under their own identity, so nobody sees anything they couldn't already open.
+
+You can install both and pick per instance, or neither: none of this is required to use this server from an external MCP client.
+
+To set it up, see the [Astrolabe setup guide](https://docs.astrolabecloud.com/using/assistant). For the architectural detail behind the comparison, see [docs/comparison-context-agent.md](docs/comparison-context-agent.md).
 
 ## Semantic Search
 

--- a/docs/comparison-context-agent.md
+++ b/docs/comparison-context-agent.md
@@ -1,6 +1,6 @@
 # MCP Server Comparison: Nextcloud MCP Server vs Context Agent
 
-This document compares the two MCP server implementations in the Nextcloud ecosystem:
+This document compares the MCP server implementations in the Nextcloud ecosystem:
 
 1. **Nextcloud MCP Server** (this project) - Standalone MCP server for external access to Nextcloud
 2. **Context Agent MCP Server** - MCP server embedded within Nextcloud as an External App
@@ -11,6 +11,19 @@ Both projects expose Nextcloud functionality via the Model Context Protocol (MCP
 
 - **Nextcloud MCP Server**: Brings Nextcloud OUT to external MCP clients (Claude Code, etc.)
 - **Context Agent**: Brings external MCP servers IN to Nextcloud's AI Assistant
+
+> [!IMPORTANT]
+> **A third path exists as of Astrolabe 0.39.0**, and it breaks the neat
+> out-vs-in split above: the [Astrolabe](https://github.com/cbcoutinho/astrolabe)
+> Nextcloud app registers itself as a provider for the **core**
+> `core:contextagent:interaction` task type, which is what the Assistant asks for
+> when it needs an agent. Astrolabe then drives *this* server's `/mcp` endpoint.
+>
+> So the Assistant can be backed by Context Agent **or** by Astrolabe + this
+> server, with no AppAPI and no ExApp in the second case. See
+> [Two ways to back the Assistant](#two-ways-to-back-the-assistant) below; the
+> sections after it describe Context Agent and this server on their own terms,
+> which remains accurate.
 
 ## Architecture Overview
 
@@ -114,6 +127,54 @@ graph LR
 - **Deployment**: Managed by Nextcloud AppAPI
 - **Connection**: Native nc-py-api integration
 - **Integration**: Deep Nextcloud integration
+
+## Two ways to back the Assistant
+
+Nextcloud's Assistant does not depend on Context Agent specifically. It asks
+whether *any* provider has registered for the core task type
+`core:contextagent:interaction` (`ChatService::isContextAgentAvailable()`), and
+uses whatever it finds. Two implementations answer that call:
+
+| | **Context Agent** | **Astrolabe + this server** |
+|---|---|---|
+| Registers as | ExApp providing the task type | PHP app providing the task type |
+| Needs AppAPI / a container | Yes | No |
+| Reaches Nextcloud via | `nc-py-api`, in-process | This server's `/mcp`, over HTTP |
+| Can write | Yes — with a confirmation round-trip for dangerous tools | No: the token carries read scopes only, so `tools/list` returns nothing that writes |
+| Cites its sources | Not by design | Yes — citations are built from tool results and deep-link to the passage |
+| Aggregates other MCP servers | Yes | No — it consumes this one |
+| Identity model | ExApp session, `nc.set_user()` per request | A short-lived OIDC token minted per user, per turn |
+
+Both can be installed at once. They then both claim the task type, and the admin
+picks one under **Administration → Artificial intelligence**; Astrolabe's
+registration is additionally gated on an admin opt-in, so installing it does not
+silently rewire an instance's chat.
+
+The trade is roughly: Context Agent is an **actor** that can change things on the
+user's behalf, while Astrolabe is a **reader** that answers from the user's own
+documents and shows its evidence. Neither replaces the other's core strength.
+
+### How Astrolabe reaches this server
+
+```mermaid
+graph LR
+    User[User] --> Assistant[Assistant<br/>Chat with AI]
+    Assistant -->|core:contextagent:interaction| Astrolabe[Astrolabe app<br/>inside Nextcloud]
+    Astrolabe -->|per-user OIDC token| MCP[Nextcloud MCP Server<br/>/mcp]
+    MCP -->|read scopes only| Apps[Notes, Files, Calendar,<br/>Deck, Contacts]
+    Astrolabe -->|tool results| Citations[Citations that<br/>link to the passage]
+
+    classDef internal fill:#e8f5e9
+    classDef standalone fill:#fff4e1
+
+    class User,Assistant,Astrolabe,Apps,Citations internal
+    class MCP standalone
+```
+
+The token is minted per user and per turn through Nextcloud's `oidc` app, so
+results are scoped to whoever is asking — a shared credential would leak one
+user's content into another's answer. Setup is documented in the
+[Astrolabe setup guide](https://docs.astrolabecloud.com/using/assistant).
 
 ## Authentication Architecture
 
@@ -692,7 +753,20 @@ Both MCP servers serve important but different roles in the Nextcloud ecosystem:
 - **Strength**: Action-oriented, safe/dangerous tools, MCP aggregation
 - **Audience**: Nextcloud users via Assistant app, AI-driven workflows
 
-**Key Insight**: These are complementary, not competing. Context Agent could even consume Nextcloud MCP Server as one of its external MCP sources, creating a unified ecosystem where:
-- External clients access Nextcloud via Nextcloud MCP Server
-- Internal users leverage Context Agent for AI assistance
-- Context Agent aggregates both internal tools and external MCP servers (including Nextcloud MCP Server)
+### Astrolabe (Nextcloud app)
+- **Purpose**: Let the Assistant answer from the user's own content, with citations
+- **Strength**: No AppAPI or ExApp, per-user tokens, read-only by construction, evidence the user can open
+- **Audience**: Nextcloud users via the Assistant app, on instances that want retrieval rather than actions
+
+**Key Insight**: These are complementary, not competing. There are two distinct
+ways to combine them, and they are often confused:
+
+- **Context Agent consuming this server** as one of its external MCP sources —
+  the Assistant gains Nextcloud CRUD tools alongside its own, and keeps its
+  write/confirmation model.
+- **Astrolabe providing the agent instead**, driving this server's `/mcp` — the
+  Assistant answers from the user's documents and cites them, with no ExApp in
+  the picture.
+
+Either way, external clients keep talking to this server directly, which is what
+it was built for.


### PR DESCRIPTION
## Why

The README's framing of AI-inside-Nextcloud was written when Context Agent was
the only answer: an ExApp, behind AppAPI, in its own container. Astrolabe 0.39.0
changed that. The Assistant doesn't ask for Context Agent specifically — it asks
whether *any* provider registered for the core `core:contextagent:interaction`
task type (`ChatService::isContextAgentAvailable()`) — and Astrolabe now answers
that call, driving this server's `/mcp` endpoint.

A reader arriving at the README today is told the wrong thing about their own
options.

## What changed

**`README.md`** — a short **AI inside Nextcloud** section replacing the old
one-line note, comparing the two backends on the axes someone actually chooses
between:

| Answering "Chat with AI" | What it needs | What it does |
|---|---|---|
| Context Agent | AppAPI + a container for the ExApp | Acts on your Nextcloud, with a confirmation step |
| Astrolabe + this server | The Astrolabe app, this server reachable from it | Answers from your own documents and cites them. Read-only |

Deliberately light on architecture — whoever is reading the README is deciding
whether this concerns them at all, not how it works. It also says plainly that
none of it is required to use this server from an external MCP client.

**`docs/comparison-context-agent.md`** — keeps its detail and its out-vs-in
framing, which is still the right way to describe the two *projects*. What's
added is the case it didn't anticipate:

- a callout up front, so the executive summary isn't quietly contradicted 100
  lines later;
- **Two ways to back the Assistant** — a table on the axes that actually
  separate the backends (registration, AppAPI, write capability, citations, MCP
  aggregation, identity model), plus the note that both can be installed and the
  admin picks one under *Artificial intelligence*;
- a diagram of how Astrolabe reaches this server, and why the token is minted per
  user and per turn;
- an updated Summary: "complementary, not competing" still holds, but there are
  now **two** ways to combine these, and they're easy to confuse — Context Agent
  *consuming* this server as an MCP source, versus Astrolabe *providing the
  agent* that drives it.

**Submodule** — `third_party/astrolabe` bumped `a3099221` → `f9be3705`
(0.39.0 → 0.39.1), which carries the provider itself plus the setup guide and the
instance-aware agent prompt. The dev-stack mount in `docker-compose.yml` stays
commented out, as required.

## Verification

- Claims checked against the shipped code rather than memory: the task type id,
  `isContextAgentAvailable()`, the admin opt-in gate, the read-only scope
  behaviour (a live probe lists 39 read tools and nothing that writes), and the
  provider-selection UI. The "confirmation for dangerous tools" line matches this
  document's own Safety Model section.
- Both new anchors resolve (`#ai-inside-nextcloud`, `#two-ways-to-back-the-assistant`).
- `ruff check` ✅ · `ruff format --check` ✅ — no Python touched.

## Test coverage

Documentation and a submodule pointer only; no API surface, so the e2e + Pact
gate doesn't apply.

---

_This PR was generated with the help of AI, and reviewed by a Human_