### PR TITLE
fix(observability): never let profiling crashloop the ingest worker

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1307,7 +1307,6 @@ EMBEDDING_GATEWAY_CLIENT_SECRET=...
 INGEST_QUEUE=postgres         # memory | postgres
 # Process role (informational; the worker is launched via the `worker` command):
 MCP_ROLE=all                  # api | worker | all (default)
-TENANT_ID=<uuid>              # per-tenant identity (used in collection naming)
 ```
 
 ### Postgres ingest queue + worker (api/worker split)

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -330,8 +330,7 @@ def _init_worker_observability(settings: Settings) -> None:
     # the worker CrashLoop indefinitely on psycopg pool-open timeouts, where a
     # byte-identical worker with profiling off starts in <1s (Deck #908,
     # observed on a dev tenant 2026-07-27: 127 PoolTimeouts, zero documents
-    # processed). See _start_worker_profiling() at the worker entrypoint, which
-    # starts it once the pool is up.
+    # processed). _run_ingest_worker() starts it once the pool is up.
 
 
 async def _run_ingest_worker(

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -1,8 +1,12 @@
 import logging
 from importlib.metadata import version
+from typing import TYPE_CHECKING
 
 import click
 import uvicorn
+
+if TYPE_CHECKING:  # heavy optional import; keep it out of CLI startup
+    import procrastinate
 
 from nextcloud_mcp_server.config import (
     Settings,
@@ -334,7 +338,7 @@ def _init_worker_observability(settings: Settings) -> None:
 
 
 async def _run_ingest_worker(
-    app,
+    app: "procrastinate.App",
     settings: Settings,
     *,
     queues: list[str],
@@ -383,6 +387,16 @@ async def _run_ingest_worker(
         # schema apply (the always-on API pod is the authoritative applier) and
         # the worker loop — manage_connection=False avoids a redundant
         # open/close cycle on startup.
+        #
+        # Safe to re-enter on the retry below: procrastinate's AwaitableContext
+        # __aexit__ calls connector.close_async(), which sets _async_pool=None,
+        # so the second open_async() builds a fresh pool rather than handing
+        # back the dead one (open_async() early-returns while _async_pool is
+        # set). That holds because the retry can only follow a *successful*
+        # __aenter__ — a failure inside open_async() itself means the profiler
+        # never started, so shutdown_profiling() returns False and the guard
+        # re-raises instead of retrying. Which is just as well: __aexit__ does
+        # not run when __aenter__ raises, so _async_pool would still be set.
         async with app.open_async():
             _start_profiling()
             await apply_ingest_queue_schema(app, manage_connection=False)

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -334,6 +334,102 @@ def _init_worker_observability(settings: Settings) -> None:
     # starts it once the pool is up.
 
 
+async def _run_ingest_worker(
+    app,
+    settings: Settings,
+    *,
+    queues: list[str],
+    workers: int,
+    tier: str | None,
+) -> None:
+    """Open the pool, start profiling, and run the ingest worker loop.
+
+    Extracted from ``worker()`` so the profiling-safety logic is readable and
+    testable on its own (and to keep ``worker()`` under the Sonar cognitive
+    complexity limit).
+
+    Profiling must NEVER be the reason this worker cannot start. Two guards:
+
+    1. The sampler starts only *after* ``app.open_async()`` succeeds. Started
+       before, every libpq connect in the pool's 30s init window times out and
+       the worker CrashLoops forever, while a byte-identical worker with
+       profiling off starts in <1s (Deck #908). The connect-time mechanism is
+       still unestablished; this orders around it rather than claiming a fix.
+    2. If startup fails anyway with the profiler running, shed it and retry
+       once — a pod with degraded telemetry beats one in CrashLoopBackOff
+       indexing nothing.
+    """
+    from nextcloud_mcp_server.vector.queue.procrastinate import (  # noqa: PLC0415
+        apply_ingest_queue_schema,
+    )
+
+    # startup_complete: once the worker loop is entered, a failure is a real
+    # error and must propagate rather than silently restart the loop.
+    # profiling_shed: shutdown_profiling() clears setup_profiling()'s
+    # idempotence guard, so without this the retry would re-arm the very thing
+    # that just prevented startup.
+    state = {"startup_complete": False, "profiling_shed": False}
+
+    def _start_profiling() -> None:
+        if state["profiling_shed"]:
+            return
+        setup_profiling(
+            application_name=f"{settings.otel_service_name}-worker",
+            server_address=settings.pyroscope_server_address,
+            enabled=settings.pyroscope_enabled,
+        )
+
+    async def _loop() -> None:
+        # Open the connector pool once and reuse it for both the defensive
+        # schema apply (the always-on API pod is the authoritative applier) and
+        # the worker loop — manage_connection=False avoids a redundant
+        # open/close cycle on startup.
+        async with app.open_async():
+            _start_profiling()
+            await apply_ingest_queue_schema(app, manage_connection=False)
+            # Structured log (not click.echo) so it lands in the JSON / OTel
+            # pipeline like every other startup message.
+            logger.info(
+                "Ingest worker started: tier=%s queues=%s concurrency=%s "
+                "delete_succeeded=%s listen_notify=%s",
+                tier or "all",
+                queues,
+                workers,
+                settings.ingest_delete_succeeded_jobs,
+                settings.ingest_listen_notify,
+            )
+            state["startup_complete"] = True
+            await app.run_worker_async(
+                queues=queues,
+                concurrency=workers,
+                install_signal_handlers=True,
+                # Drop succeeded jobs (default) so the queue table stays lean and
+                # the KEDA queue-depth metric reflects only outstanding work; set
+                # INGEST_DELETE_SUCCEEDED_JOBS=false to retain them for audit.
+                delete_jobs="successful"
+                if settings.ingest_delete_succeeded_jobs
+                else "never",
+                # LISTEN/NOTIFY for near-instant job pickup. Set
+                # INGEST_LISTEN_NOTIFY=false to run poll-only when DATABASE_URL
+                # routes through a transaction-mode pooler (PgBouncer), which
+                # drops the LISTEN registration on backend checkin (Deck #424).
+                listen_notify=settings.ingest_listen_notify,
+            )
+
+    try:
+        await _loop()
+    except Exception:
+        if state["startup_complete"] or not shutdown_profiling():
+            raise
+        state["profiling_shed"] = True
+        logger.exception(
+            "Ingest worker startup failed with Pyroscope profiling running; "
+            "shed the profiler and retrying once (this worker will have no "
+            "profiles — see Deck #908)"
+        )
+        await _loop()
+
+
 def _sweep_spools_at_startup(settings) -> int:
     """Clear ingest spool files left behind by a previous worker; returns count.
 
@@ -443,7 +539,6 @@ def worker(concurrency: int | None, tier: str | None):
         LEGACY_INGEST_QUEUE,
         LEGACY_OCR_QUEUES,
         TIER_QUEUES,
-        apply_ingest_queue_schema,
         get_procrastinate_app,
     )
 
@@ -490,98 +585,11 @@ def worker(concurrency: int | None, tier: str | None):
 
     initialize_document_processors()
 
-    # True once startup is done and the worker loop is entered, so the
-    # profiler-shedding retry below can tell "never got going" from "failed
-    # later, mid-run" — only the former is worth retrying.
-    startup_complete = False
-    # Set when the backstop below sheds the profiler, so the retry does not
-    # start it again: shutdown_profiling() clears setup_profiling()'s
-    # idempotence guard, so without this the retry would re-arm the very thing
-    # that just prevented startup.
-    profiling_shed = False
-
-    def _start_worker_profiling() -> None:
-        """Start the profiler, once the database pool is up.
-
-        Deferred from _init_worker_observability deliberately: with the sampler
-        already running, every libpq connect in the pool's 30s init window times
-        out and the worker CrashLoops forever (Deck #908). Opening the pool
-        first sidesteps that window, so the worker keeps full profiling for the
-        whole of its actual working life -- which is what we want profiled
-        anyway. The connect-time mechanism is still unestablished; this orders
-        around it rather than claiming to fix it.
-        """
-        if profiling_shed:
-            return
-        setup_profiling(
-            application_name=f"{settings.otel_service_name}-worker",
-            server_address=settings.pyroscope_server_address,
-            enabled=settings.pyroscope_enabled,
+    anyio.run(
+        lambda: _run_ingest_worker(
+            app, settings, queues=queues, workers=workers, tier=tier
         )
-
-    async def _run_worker_loop() -> None:
-        nonlocal startup_complete
-        # Open the connector pool once and reuse it for both the defensive
-        # schema apply (the always-on API pod is the authoritative applier) and
-        # the worker loop — manage_connection=False avoids a redundant
-        # open/close cycle on startup.
-        async with app.open_async():
-            _start_worker_profiling()
-            await apply_ingest_queue_schema(app, manage_connection=False)
-            # Structured log (not click.echo) so it lands in the JSON / OTel
-            # pipeline like every other startup message.
-            logger.info(
-                "Ingest worker started: tier=%s queues=%s concurrency=%s "
-                "delete_succeeded=%s listen_notify=%s",
-                tier or "all",
-                queues,
-                workers,
-                settings.ingest_delete_succeeded_jobs,
-                settings.ingest_listen_notify,
-            )
-            startup_complete = True
-            await app.run_worker_async(
-                queues=queues,
-                concurrency=workers,
-                install_signal_handlers=True,
-                # Drop succeeded jobs (default) so the queue table stays lean and
-                # the KEDA queue-depth metric reflects only outstanding work; set
-                # INGEST_DELETE_SUCCEEDED_JOBS=false to retain them for audit.
-                delete_jobs="successful"
-                if settings.ingest_delete_succeeded_jobs
-                else "never",
-                # LISTEN/NOTIFY for near-instant job pickup. Set
-                # INGEST_LISTEN_NOTIFY=false to run poll-only when DATABASE_URL
-                # routes through a transaction-mode pooler (PgBouncer), which
-                # drops the LISTEN registration on backend checkin (Deck #424).
-                listen_notify=settings.ingest_listen_notify,
-            )
-
-    async def _run() -> None:
-        # Backstop to the deferral above: profiling is optional telemetry and
-        # must NEVER be the reason this worker cannot start. If startup fails
-        # for any reason while the profiler is running, shed it and retry once
-        # — a pod running with degraded telemetry beats a pod in
-        # CrashLoopBackOff indexing nothing (Deck #908).
-        #
-        # Scoped to startup via startup_complete: once the worker loop is
-        # entered, a failure is a real error and must propagate rather than
-        # silently restart the loop.
-        nonlocal profiling_shed
-        try:
-            await _run_worker_loop()
-        except Exception:
-            if startup_complete or not shutdown_profiling():
-                raise
-            profiling_shed = True
-            logger.exception(
-                "Ingest worker startup failed with Pyroscope profiling running; "
-                "shed the profiler and retrying once (this worker will have no "
-                "profiles — see Deck #908)"
-            )
-            await _run_worker_loop()
-
-    anyio.run(_run)
+    )
 
 
 @click.group()

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -25,6 +25,7 @@ from nextcloud_mcp_server.observability import (
     setup_metrics,
     setup_profiling,
     setup_tracing,
+    shutdown_profiling,
 )
 from nextcloud_mcp_server.server import AVAILABLE_APPS
 
@@ -323,13 +324,14 @@ def _init_worker_observability(settings: Settings) -> None:
             "OpenTelemetry tracing disabled (set OTEL_EXPORTER_OTLP_ENDPOINT to enable)"
         )
 
-    # Continuous profiling (optional). The worker is the highest-value target
-    # (CPU-bound parse/chunk/embed), so profile it in its own process.
-    setup_profiling(
-        application_name=f"{settings.otel_service_name}-worker",
-        server_address=settings.pyroscope_server_address,
-        enabled=settings.pyroscope_enabled,
-    )
+    # Continuous profiling is deliberately NOT started here. The worker is the
+    # highest-value profiling target (CPU-bound parse/chunk/embed), so it stays
+    # enabled — but starting the sampler before the database pool is open makes
+    # the worker CrashLoop indefinitely on psycopg pool-open timeouts, where a
+    # byte-identical worker with profiling off starts in <1s (Deck #908,
+    # observed on a dev tenant 2026-07-27: 127 PoolTimeouts, zero documents
+    # processed). See _start_worker_profiling() at the worker entrypoint, which
+    # starts it once the pool is up.
 
 
 def _sweep_spools_at_startup(settings) -> int:
@@ -488,12 +490,43 @@ def worker(concurrency: int | None, tier: str | None):
 
     initialize_document_processors()
 
-    async def _run() -> None:
+    # True once startup is done and the worker loop is entered, so the
+    # profiler-shedding retry below can tell "never got going" from "failed
+    # later, mid-run" — only the former is worth retrying.
+    startup_complete = False
+    # Set when the backstop below sheds the profiler, so the retry does not
+    # start it again: shutdown_profiling() clears setup_profiling()'s
+    # idempotence guard, so without this the retry would re-arm the very thing
+    # that just prevented startup.
+    profiling_shed = False
+
+    def _start_worker_profiling() -> None:
+        """Start the profiler, once the database pool is up.
+
+        Deferred from _init_worker_observability deliberately: with the sampler
+        already running, every libpq connect in the pool's 30s init window times
+        out and the worker CrashLoops forever (Deck #908). Opening the pool
+        first sidesteps that window, so the worker keeps full profiling for the
+        whole of its actual working life -- which is what we want profiled
+        anyway. The connect-time mechanism is still unestablished; this orders
+        around it rather than claiming to fix it.
+        """
+        if profiling_shed:
+            return
+        setup_profiling(
+            application_name=f"{settings.otel_service_name}-worker",
+            server_address=settings.pyroscope_server_address,
+            enabled=settings.pyroscope_enabled,
+        )
+
+    async def _run_worker_loop() -> None:
+        nonlocal startup_complete
         # Open the connector pool once and reuse it for both the defensive
         # schema apply (the always-on API pod is the authoritative applier) and
         # the worker loop — manage_connection=False avoids a redundant
         # open/close cycle on startup.
         async with app.open_async():
+            _start_worker_profiling()
             await apply_ingest_queue_schema(app, manage_connection=False)
             # Structured log (not click.echo) so it lands in the JSON / OTel
             # pipeline like every other startup message.
@@ -506,6 +539,7 @@ def worker(concurrency: int | None, tier: str | None):
                 settings.ingest_delete_succeeded_jobs,
                 settings.ingest_listen_notify,
             )
+            startup_complete = True
             await app.run_worker_async(
                 queues=queues,
                 concurrency=workers,
@@ -522,6 +556,30 @@ def worker(concurrency: int | None, tier: str | None):
                 # drops the LISTEN registration on backend checkin (Deck #424).
                 listen_notify=settings.ingest_listen_notify,
             )
+
+    async def _run() -> None:
+        # Backstop to the deferral above: profiling is optional telemetry and
+        # must NEVER be the reason this worker cannot start. If startup fails
+        # for any reason while the profiler is running, shed it and retry once
+        # — a pod running with degraded telemetry beats a pod in
+        # CrashLoopBackOff indexing nothing (Deck #908).
+        #
+        # Scoped to startup via startup_complete: once the worker loop is
+        # entered, a failure is a real error and must propagate rather than
+        # silently restart the loop.
+        nonlocal profiling_shed
+        try:
+            await _run_worker_loop()
+        except Exception:
+            if startup_complete or not shutdown_profiling():
+                raise
+            profiling_shed = True
+            logger.exception(
+                "Ingest worker startup failed with Pyroscope profiling running; "
+                "shed the profiler and retrying once (this worker will have no "
+                "profiles — see Deck #908)"
+            )
+            await _run_worker_loop()
 
     anyio.run(_run)
 

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -298,6 +298,10 @@ _DEFAULTS: dict[str, Any] = {
     "otel_traces_sampler_arg": 1.0,
     "pyroscope_enabled": False,
     "pyroscope_server_address": None,
+    # Pod identity from the Kubernetes downward API (chart-injected). Facts
+    # about the pod, not user config — absent off-Kubernetes.
+    "pod_namespace": None,
+    "pod_name": None,
     "log_format": "text",
     "log_level": "INFO",
     "log_include_trace_context": True,
@@ -439,7 +443,6 @@ _DEFAULTS: dict[str, Any] = {
     "embedding_gateway_client_id": None,
     "embedding_gateway_client_secret": None,
     "embedding_gateway_scope": None,  # e.g. astrolabe-embedding-gateway/embed
-    "tenant_id": None,  # per-tenant identity (UUID form); see vector/payload_keys
     # Query-side ACL pre-filter (design §11). OFF by default: a Qdrant
     # `match any` on `acl_hash` excludes points missing the key, so enabling
     # this before a real ACL backfill would silently drop legacy results.
@@ -1313,6 +1316,10 @@ class Settings:
     # Pyroscope. Disabled by default; enabled per-deployment via env.
     pyroscope_enabled: bool = False
     pyroscope_server_address: str | None = None
+    # Kubernetes downward-API pod identity; tags profiles so a tenant's
+    # profiles are separable (Deck #48). None off-Kubernetes.
+    pod_namespace: str | None = None
+    pod_name: str | None = None
     log_format: str = "text"  # "json" or "text"
     log_level: str = "INFO"
     log_include_trace_context: bool = True
@@ -1347,7 +1354,6 @@ class Settings:
     embedding_gateway_client_id: str | None = None
     embedding_gateway_client_secret: str | None = None
     embedding_gateway_scope: str | None = None
-    tenant_id: str | None = None  # per-tenant identity (UUID form)
     acl_prefilter_enabled: bool = False  # query-side ACL pre-filter (§11); OFF
     # Usage metering (Deck #67); OFF by default. When true, billable ops
     # record best-effort rows into the app-DB usage_events table for the
@@ -2094,6 +2100,8 @@ def _build_settings() -> Settings:
         "otel_traces_sampler_arg": "OTEL_TRACES_SAMPLER_ARG",
         "pyroscope_enabled": "PYROSCOPE_ENABLED",
         "pyroscope_server_address": "PYROSCOPE_SERVER_ADDRESS",
+        "pod_namespace": "POD_NAMESPACE",
+        "pod_name": "POD_NAME",
         "log_format": "LOG_FORMAT",
         "log_level": "LOG_LEVEL",
         "log_include_trace_context": "LOG_INCLUDE_TRACE_CONTEXT",
@@ -2117,7 +2125,6 @@ def _build_settings() -> Settings:
         "embedding_gateway_client_id": "EMBEDDING_GATEWAY_CLIENT_ID",
         "embedding_gateway_client_secret": "EMBEDDING_GATEWAY_CLIENT_SECRET",
         "embedding_gateway_scope": "EMBEDDING_GATEWAY_SCOPE",
-        "tenant_id": "TENANT_ID",
         "acl_prefilter_enabled": "ACL_PREFILTER_ENABLED",
         "usage_metering_enabled": "USAGE_METERING_ENABLED",
     }

--- a/nextcloud_mcp_server/observability/__init__.py
+++ b/nextcloud_mcp_server/observability/__init__.py
@@ -20,7 +20,10 @@ from nextcloud_mcp_server.observability.logging_config import (
 )
 from nextcloud_mcp_server.observability.metrics import setup_metrics
 from nextcloud_mcp_server.observability.middleware import ObservabilityMiddleware
-from nextcloud_mcp_server.observability.profiling import setup_profiling
+from nextcloud_mcp_server.observability.profiling import (
+    setup_profiling,
+    shutdown_profiling,
+)
 from nextcloud_mcp_server.observability.tracing import setup_tracing
 
 __all__ = [
@@ -28,6 +31,7 @@ __all__ = [
     "get_uvicorn_logging_config",
     "setup_metrics",
     "setup_profiling",
+    "shutdown_profiling",
     "setup_tracing",
     "ObservabilityMiddleware",
 ]

--- a/nextcloud_mcp_server/observability/middleware.py
+++ b/nextcloud_mcp_server/observability/middleware.py
@@ -17,7 +17,6 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
-from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.observability.metrics import (
     http_request_duration_seconds,
     http_requests_in_progress,
@@ -98,7 +97,6 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                         "http.path": path,
                         "http.scheme": request.url.scheme,
                         "http.host": request.url.hostname,
-                        **self._tenant_attributes(),
                         **self._correlation_attributes(request),
                     },
                 ) as span:
@@ -202,17 +200,6 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         if not request_id:
             return {}
         return {"client.request.id": request_id[:_MAX_REQUEST_ID_LEN]}
-
-    def _tenant_attributes(self) -> dict[str, str]:
-        """Tenant identity for the span, when this deployment has one.
-
-        One Tempo/Loki stack aggregates every tenant, so without this a trace
-        cannot be attributed to a tenant without correlating on pod name.
-        Resolved per request rather than snapshotted at import so test overrides
-        of the setting take effect (single-tenant deployments leave it unset).
-        """
-        tenant_id = get_settings().tenant_id
-        return {"tenant.id": tenant_id} if tenant_id else {}
 
     def _get_endpoint_label(self, path: str) -> str:
         """

--- a/nextcloud_mcp_server/observability/profiling.py
+++ b/nextcloud_mcp_server/observability/profiling.py
@@ -116,7 +116,10 @@ def setup_profiling(
         "Pyroscope profiling enabled (application=%s, server=%s, tags=%s)",
         application_name,
         server_address,
-        sorted(resolved_tags),
+        # Keys AND values: the whole point of this line is confirming a pod
+        # actually picked up its namespace/pod identity, which the key alone
+        # cannot tell you. Sorted for stable, diffable log output.
+        dict(sorted(resolved_tags.items())),
     )
 
 

--- a/nextcloud_mcp_server/observability/profiling.py
+++ b/nextcloud_mcp_server/observability/profiling.py
@@ -17,6 +17,32 @@ logger = logging.getLogger(__name__)
 _configured = False
 
 
+def _pod_identity_tags() -> dict[str, str]:
+    """Pyroscope tags identifying which pod a profile came from.
+
+    Every tenant's pod pushes under the same ``application_name``, so without
+    these the whole fleet collapses into one unattributable series -- there is
+    no per-tenant profile at all. Tenants are identified by their
+    ``tenant-<slug>`` namespace, matching how metrics and logs are already
+    attributed (Deck #48).
+
+    ``POD_NAMESPACE``/``POD_NAME`` are injected by the chart from the Kubernetes
+    downward API. Read through ``Settings`` (not ``os.environ``) like every
+    other config in this repo, and resolved per call so test overrides apply.
+    Blank/unset values are skipped so non-Kubernetes deployments do not gain
+    empty labels.
+    """
+    from nextcloud_mcp_server.config import get_settings  # noqa: PLC0415
+
+    settings = get_settings()
+    candidates = {"namespace": settings.pod_namespace, "pod": settings.pod_name}
+    return {
+        tag: value.strip()
+        for tag, value in candidates.items()
+        if value and value.strip()
+    }
+
+
 def setup_profiling(
     application_name: str,
     server_address: str | None,
@@ -32,7 +58,9 @@ def setup_profiling(
         server_address: Alloy pyroscope.receive_http URL (e.g.
             ``http://alloy.alloy.svc.cluster.local:4041``). Required when enabled.
         enabled: Master switch (``PYROSCOPE_ENABLED``). No-op when False.
-        tags: Optional extra tags to attach to every profile.
+        tags: Optional extra tags to attach to every profile. Pod identity
+            (``namespace``/``pod``, from the downward API) is added
+            automatically; a tag passed here with the same name overrides it.
 
     Idempotent: only the first successful call per process takes effect.
     """
@@ -62,11 +90,14 @@ def setup_profiling(
         logger.warning("pyroscope-io is not installed; continuous profiling disabled")
         return
 
+    # Pod identity first so an explicit caller tag of the same name wins.
+    resolved_tags = {**_pod_identity_tags(), **(tags or {})}
+
     try:
         pyroscope.configure(
             application_name=application_name,
             server_address=server_address,
-            tags=tags or {},
+            tags=resolved_tags,
         )
     except Exception:  # noqa: BLE001 - profiling is optional; never crash startup
         # Fail open, matching setup_tracing()'s defensive OTLP-exporter handling:
@@ -82,7 +113,34 @@ def setup_profiling(
 
     _configured = True
     logger.info(
-        "Pyroscope profiling enabled (application=%s, server=%s)",
+        "Pyroscope profiling enabled (application=%s, server=%s, tags=%s)",
         application_name,
         server_address,
+        sorted(resolved_tags),
     )
+
+
+def shutdown_profiling() -> bool:
+    """Stop the profiler if it is running. Returns True if it was shut down.
+
+    Profiling is optional telemetry, so it must never be the reason a process
+    cannot start. Callers use this to *shed* the profiler when startup fails
+    with it enabled (see the ingest worker in ``cli.py``): a pod running with
+    degraded telemetry beats a pod in CrashLoopBackOff processing nothing.
+
+    Never raises — a failure to stop the profiler must not mask the original
+    startup error the caller is recovering from.
+    """
+    global _configured
+    if not _configured:
+        return False
+    try:
+        import pyroscope  # noqa: PLC0415
+
+        pyroscope.shutdown()
+    except Exception:  # noqa: BLE001 - best-effort; see docstring
+        logger.warning("Failed to shut down the Pyroscope profiler", exc_info=True)
+        return False
+    _configured = False
+    logger.info("Pyroscope profiling shut down")
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -434,10 +434,17 @@ def test_init_worker_observability_skips_tracing_without_endpoint(
     assert "tracing" not in patched_observability
 
 
-def test_init_worker_observability_configures_profiling(patched_observability):
-    """Worker wires Pyroscope profiling with the -worker application name and the
-    pyroscope_* settings, mirroring the API entrypoint (setup_profiling gates on
-    `enabled` internally, so it is always called)."""
+def test_init_worker_observability_does_not_start_profiling(patched_observability):
+    """Profiling must NOT start during the worker's observability bootstrap.
+
+    Starting the sampler before the database pool is open makes the worker
+    CrashLoop forever on psycopg pool-open timeouts (Deck #908, observed on a
+    dev tenant 2026-07-27). Profiling stays enabled for the worker — it is
+    the highest-value target — but the `worker` command starts it only once the
+    pool is up. Guarding the ordering here because a well-meaning "make the
+    worker bootstrap mirror the API's" refactor would silently reintroduce the
+    CrashLoop.
+    """
     _init_worker_observability(
         _fake_settings(
             pyroscope_enabled=True,
@@ -445,11 +452,7 @@ def test_init_worker_observability_configures_profiling(patched_observability):
         )
     )
 
-    assert patched_observability["profiling"]["kwargs"] == {
-        "application_name": "nextcloud-mcp-server-worker",
-        "server_address": "alloy.alloy.svc.cluster.local:4041",
-        "enabled": True,
-    }
+    assert "profiling" not in patched_observability
 
 
 def test_worker_initializes_observability_on_postgres_queue(runner, monkeypatch):
@@ -492,3 +495,134 @@ def test_worker_rejects_non_postgres_queue_before_observability(runner, monkeypa
     assert result.exit_code != 0
     assert "INGEST_QUEUE=postgres" in result.output
     assert "init" not in called
+
+
+# ---------------------------------------------------------------------------
+# Worker startup: profiling must never CrashLoop the pod (Deck #908)
+# ---------------------------------------------------------------------------
+
+
+class _FakePool:
+    """Async context manager standing in for procrastinate's App.open_async()."""
+
+    def __init__(self, fail_times: int, opens: list[int]):
+        self._fail_times = fail_times
+        self._opens = opens
+
+    async def __aenter__(self):
+        self._opens.append(1)
+        if len(self._opens) <= self._fail_times:
+            raise RuntimeError("connection timeout expired")
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_worker_machinery(monkeypatch, *, fail_times):
+    """Drive cli.worker() with the procrastinate/document machinery stubbed out.
+
+    Returns the bookkeeping dict the assertions read.
+    """
+    state: dict = {"opens": [], "profiling_started": 0, "shed": 0, "ran": 0}
+
+    fake_app = SimpleNamespace(
+        open_async=lambda: _FakePool(fail_times, state["opens"]),
+        run_worker_async=_make_async(
+            lambda **kw: state.__setitem__("ran", state["ran"] + 1)
+        ),
+    )
+
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.cli.get_settings",
+        lambda: _fake_settings(
+            pyroscope_enabled=True,
+            pyroscope_server_address="a:4041",
+            vector_sync_fast_concurrency=None,
+            vector_sync_structured_concurrency=None,
+            vector_sync_processor_workers=1,
+            ingest_delete_succeeded_jobs=True,
+            ingest_listen_notify=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.cli._init_worker_observability", lambda settings: None
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.cli._sweep_spools_at_startup", lambda settings: 0
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.app.initialize_document_processors", lambda: None
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.vector.queue.procrastinate.get_procrastinate_app",
+        lambda: fake_app,
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.vector.queue.procrastinate.apply_ingest_queue_schema",
+        _make_async(lambda *a, **kw: None),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.cli.setup_profiling",
+        lambda **kw: state.__setitem__(
+            "profiling_started", state["profiling_started"] + 1
+        ),
+    )
+
+    def fake_shutdown():
+        state["shed"] += 1
+        return True
+
+    monkeypatch.setattr("nextcloud_mcp_server.cli.shutdown_profiling", fake_shutdown)
+    return state
+
+
+def _make_async(fn):
+    async def _inner(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return _inner
+
+
+def test_worker_starts_profiling_only_after_the_pool_is_open(runner, monkeypatch):
+    """Ordering guard: the sampler must not be running during pool init.
+
+    Starting it first is what made ingest workers CrashLoop forever on psycopg
+    pool-open timeouts (Deck #908).
+    """
+    state = _patch_worker_machinery(monkeypatch, fail_times=0)
+
+    result = runner.invoke(worker, [])
+
+    assert result.exit_code == 0, result.output
+    assert state["opens"] == [1], "pool should open exactly once on the happy path"
+    assert state["profiling_started"] == 1
+    assert state["shed"] == 0, "nothing to shed when startup succeeds"
+
+
+def test_worker_sheds_profiler_and_retries_when_startup_fails(runner, monkeypatch):
+    """Profiling must never be the reason the worker cannot start (Deck #908).
+
+    First pool-open raises; the worker sheds the profiler and retries once
+    rather than dying into CrashLoopBackOff.
+    """
+    state = _patch_worker_machinery(monkeypatch, fail_times=1)
+
+    result = runner.invoke(worker, [])
+
+    assert result.exit_code == 0, result.output
+    assert len(state["opens"]) == 2, "should retry the pool open exactly once"
+    assert state["shed"] == 1
+    assert state["ran"] == 1, "worker loop runs on the retry"
+
+
+def test_worker_retry_does_not_restart_the_profiler(runner, monkeypatch):
+    """shutdown_profiling() clears setup_profiling()'s idempotence guard, so the
+    retry would re-arm the very thing that just blocked startup."""
+    state = _patch_worker_machinery(monkeypatch, fail_times=1)
+
+    runner.invoke(worker, [])
+
+    assert state["profiling_started"] == 0, (
+        "profiler must not be started again after being shed"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -502,6 +502,13 @@ def test_worker_rejects_non_postgres_queue_before_observability(runner, monkeypa
 # ---------------------------------------------------------------------------
 
 
+def _make_async(fn):
+    async def _inner(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return _inner
+
+
 class _FakePool:
     """Async context manager standing in for procrastinate's App.open_async()."""
 
@@ -519,19 +526,49 @@ class _FakePool:
         return False
 
 
-def _patch_worker_machinery(monkeypatch, *, fail_times):
+def _patch_worker_machinery(
+    monkeypatch,
+    *,
+    pool_fail_times=0,
+    schema_fail_times=0,
+    run_worker_fail_times=0,
+    shutdown_returns=True,
+):
     """Drive cli.worker() with the procrastinate/document machinery stubbed out.
 
-    Returns the bookkeeping dict the assertions read.
+    The failure knobs map onto the three phases of `_run_ingest_worker`, which
+    is what makes the guard's branches distinguishable:
+
+    - `pool_fail_times`  -> `open_async()` raises, i.e. BEFORE the profiler is
+      started. This is the original production failure mode; the real
+      `shutdown_profiling()` returns False here because nothing is running.
+    - `schema_fail_times` -> raises AFTER `_start_profiling()` but before
+      `startup_complete`, the only window where the backstop can fire.
+    - `run_worker_fail_times` -> raises after `startup_complete = True`, which
+      must always propagate rather than restart a running worker.
     """
-    state: dict = {"opens": [], "profiling_started": 0, "shed": 0, "ran": 0}
+    state: dict = {
+        "opens": [],
+        "profiling_started": 0,
+        "shed": 0,
+        "ran": 0,
+        "schema": 0,
+    }
+
+    def _run_worker(**kwargs):
+        state["ran"] += 1
+        if state["ran"] <= run_worker_fail_times:
+            raise RuntimeError("worker loop exploded")
 
     fake_app = SimpleNamespace(
-        open_async=lambda: _FakePool(fail_times, state["opens"]),
-        run_worker_async=_make_async(
-            lambda **kw: state.__setitem__("ran", state["ran"] + 1)
-        ),
+        open_async=lambda: _FakePool(pool_fail_times, state["opens"]),
+        run_worker_async=_make_async(_run_worker),
     )
+
+    def _apply_schema(*args, **kwargs):
+        state["schema"] += 1
+        if state["schema"] <= schema_fail_times:
+            raise RuntimeError("schema apply failed")
 
     monkeypatch.setattr(
         "nextcloud_mcp_server.cli.get_settings",
@@ -560,7 +597,7 @@ def _patch_worker_machinery(monkeypatch, *, fail_times):
     )
     monkeypatch.setattr(
         "nextcloud_mcp_server.vector.queue.procrastinate.apply_ingest_queue_schema",
-        _make_async(lambda *a, **kw: None),
+        _make_async(_apply_schema),
     )
     monkeypatch.setattr(
         "nextcloud_mcp_server.cli.setup_profiling",
@@ -571,17 +608,10 @@ def _patch_worker_machinery(monkeypatch, *, fail_times):
 
     def fake_shutdown():
         state["shed"] += 1
-        return True
+        return shutdown_returns
 
     monkeypatch.setattr("nextcloud_mcp_server.cli.shutdown_profiling", fake_shutdown)
     return state
-
-
-def _make_async(fn):
-    async def _inner(*args, **kwargs):
-        return fn(*args, **kwargs)
-
-    return _inner
 
 
 def test_worker_starts_profiling_only_after_the_pool_is_open(runner, monkeypatch):
@@ -590,7 +620,7 @@ def test_worker_starts_profiling_only_after_the_pool_is_open(runner, monkeypatch
     Starting it first is what made ingest workers CrashLoop forever on psycopg
     pool-open timeouts (Deck #908).
     """
-    state = _patch_worker_machinery(monkeypatch, fail_times=0)
+    state = _patch_worker_machinery(monkeypatch)
 
     result = runner.invoke(worker, [])
 
@@ -603,15 +633,14 @@ def test_worker_starts_profiling_only_after_the_pool_is_open(runner, monkeypatch
 def test_worker_sheds_profiler_and_retries_when_startup_fails(runner, monkeypatch):
     """Profiling must never be the reason the worker cannot start (Deck #908).
 
-    First pool-open raises; the worker sheds the profiler and retries once
-    rather than dying into CrashLoopBackOff.
+    Failure is injected in the schema apply — i.e. after the profiler started —
+    because that is the only window the backstop can actually fire in.
     """
-    state = _patch_worker_machinery(monkeypatch, fail_times=1)
+    state = _patch_worker_machinery(monkeypatch, schema_fail_times=1)
 
     result = runner.invoke(worker, [])
 
     assert result.exit_code == 0, result.output
-    assert len(state["opens"]) == 2, "should retry the pool open exactly once"
     assert state["shed"] == 1
     assert state["ran"] == 1, "worker loop runs on the retry"
 
@@ -619,10 +648,44 @@ def test_worker_sheds_profiler_and_retries_when_startup_fails(runner, monkeypatc
 def test_worker_retry_does_not_restart_the_profiler(runner, monkeypatch):
     """shutdown_profiling() clears setup_profiling()'s idempotence guard, so the
     retry would re-arm the very thing that just blocked startup."""
-    state = _patch_worker_machinery(monkeypatch, fail_times=1)
+    state = _patch_worker_machinery(monkeypatch, schema_fail_times=1)
 
     runner.invoke(worker, [])
 
-    assert state["profiling_started"] == 0, (
-        "profiler must not be started again after being shed"
+    assert state["profiling_started"] == 1, (
+        "profiler started once before the failure, and must not start again"
     )
+
+
+def test_worker_propagates_when_profiler_was_never_running(runner, monkeypatch):
+    """A pool-open failure must NOT be retried — nothing was shed, so a retry
+    would just fail again.
+
+    This is the original production failure mode: with the new ordering the
+    profiler has not started when open_async() times out, so the real
+    shutdown_profiling() returns False and the guard re-raises.
+    """
+    state = _patch_worker_machinery(
+        monkeypatch, pool_fail_times=1, shutdown_returns=False
+    )
+
+    result = runner.invoke(worker, [])
+
+    assert result.exit_code != 0, "startup failure must surface, not be swallowed"
+    assert len(state["opens"]) == 1, "must not retry when nothing was shed"
+    assert state["profiling_started"] == 0
+
+
+def test_worker_propagates_failures_after_startup_completes(runner, monkeypatch):
+    """Once the worker loop is running, a failure is a real error.
+
+    Retrying here would silently restart a live worker, so the guard must let
+    it propagate even though the profiler is running and could be shed.
+    """
+    state = _patch_worker_machinery(monkeypatch, run_worker_fail_times=1)
+
+    result = runner.invoke(worker, [])
+
+    assert result.exit_code != 0
+    assert state["ran"] == 1, "must not restart the worker loop"
+    assert state["shed"] == 0, "guard short-circuits on startup_complete"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -200,6 +200,23 @@ class TestGetSettings:
         assert settings.pyroscope_enabled is True
         assert settings.pyroscope_server_address == "alloy.alloy.svc.cluster.local:4041"
 
+    @patch.dict(
+        os.environ,
+        {"POD_NAMESPACE": "tenant-example", "POD_NAME": "backend-7c95d96fd9-mh2d7"},
+        clear=True,
+    )
+    def test_get_settings_pod_identity_from_env(self):
+        """POD_NAMESPACE / POD_NAME must reach settings (Deck #48).
+
+        Same guard as the pyroscope pair above: these are what tag profiles and
+        make a tenant's profiles separable, and a missing _DEFAULTS / _field_map
+        entry would silently drop them with no other test noticing.
+        """
+        _reload_config()
+        settings = get_settings()
+        assert settings.pod_namespace == "tenant-example"
+        assert settings.pod_name == "backend-7c95d96fd9-mh2d7"
+
     @patch.dict(os.environ, {}, clear=True)
     def test_pyroscope_disabled_by_default(self):
         """Profiling is opt-in: default off with no server address."""

--- a/tests/unit/test_decomposition_config.py
+++ b/tests/unit/test_decomposition_config.py
@@ -22,7 +22,6 @@ class TestDecompositionDefaults:
         assert s.mcp_role == "all"
         assert s.collection_metadata_source == "qdrant"
         assert s.embedding_gateway_url is None
-        assert s.tenant_id is None
         # LISTEN/NOTIFY stays on by default — poll-only is opt-in for
         # transaction-mode poolers (Deck #424).
         assert s.ingest_listen_notify is True
@@ -177,14 +176,6 @@ class TestConditionalRequired:
             embedding_gateway_url="https://gateway:8083",
         )
         assert s.embedding_provider == "gateway"
-
-
-class TestTenantId:
-    def test_arbitrary_tenant_id_accepted(self):
-        # The old NATS-subject charset restriction was dropped with NATS
-        # (Deck #183); tenant_id is now just an opaque per-tenant identity.
-        s = Settings(tenant_id="0a1b2c3d-0000-0000-0000-000000000000")
-        assert s.tenant_id == "0a1b2c3d-0000-0000-0000-000000000000"
 
 
 class TestProcrastinateConninfo:

--- a/tests/unit/test_observability_trace_propagation.py
+++ b/tests/unit/test_observability_trace_propagation.py
@@ -122,17 +122,19 @@ def test_span_is_server_kind_with_route(client, exporter):
     assert span.attributes["http.method"] == "GET"
 
 
-def test_tenant_id_is_attached_when_configured(client, exporter, monkeypatch):
-    """One observability stack aggregates every tenant, so spans carry theirs."""
-    from nextcloud_mcp_server.config import get_settings
+def test_no_bespoke_tenant_attribute_on_spans(client, exporter):
+    """Tenant attribution is by Kubernetes namespace, not a bespoke attribute.
 
-    monkeypatch.setattr(
-        type(get_settings()), "tenant_id", property(lambda self: "tenant-abc")
-    )
-
+    The middleware used to stamp ``tenant.id`` from a ``TENANT_ID`` setting, but
+    that only ever reached HTTP *server* spans — background and ingest spans had
+    no tenant at all. It is replaced by ``k8s.namespace.name`` in the OTel
+    Resource, which the chart supplies via OTEL_RESOURCE_ATTRIBUTES and the SDK
+    applies to EVERY span. That also matches how metrics and logs are already
+    attributed (Deck #48), so one query shape works across all four signals.
+    """
     client.get("/api/v1/status")
 
-    assert _finished_span(exporter).attributes["tenant.id"] == "tenant-abc"
+    assert "tenant.id" not in _finished_span(exporter).attributes
 
 
 def test_handler_exception_marks_the_span_and_is_logged(client, exporter, caplog):

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -38,7 +38,7 @@ def test_setup_profiling_noop_when_server_unset(caplog):
     assert "PYROSCOPE_SERVER_ADDRESS" in caplog.text
 
 
-def test_setup_profiling_configures_when_enabled():
+def test_setup_profiling_configures_when_enabled(monkeypatch):
     """Enabled + server address → pyroscope.configure() called with the exact
     kwargs. Guards against a wrong/renamed kwarg against the pinned pyroscope-io
     API (e.g. tags=) that would otherwise only surface at deploy time.
@@ -47,6 +47,9 @@ def test_setup_profiling_configures_when_enabled():
     # runtime SDK isn't installed rather than fail.
     pytest.importorskip("pyroscope")
     _reset()
+    # No downward API → no pod identity tags, so the assertion below stays exact
+    # even when the test host happens to export these.
+    _patch_pod_identity(monkeypatch)
     with patch("pyroscope.configure") as mock_configure:
         profiling.setup_profiling(
             "nextcloud-mcp-server-worker",
@@ -83,3 +86,89 @@ def test_setup_profiling_degrades_on_configure_error(caplog):
         profiling.setup_profiling("svc", SERVER, enabled=True)  # must not raise
     assert profiling._configured is False
     assert "failed to configure" in caplog.text
+
+
+def _patch_pod_identity(monkeypatch, *, namespace=None, pod=None):
+    """Override the downward-API settings the profiler reads.
+
+    Patched as class-level ``property`` objects: Settings is a dataclass, so a
+    plain class attribute would lose to the instance's own value. A property is
+    a data descriptor and wins.
+    """
+    from nextcloud_mcp_server.config import get_settings
+
+    cls = type(get_settings())
+    monkeypatch.setattr(cls, "pod_namespace", property(lambda self: namespace))
+    monkeypatch.setattr(cls, "pod_name", property(lambda self: pod))
+
+
+def test_pod_identity_tags_absent_without_downward_api(monkeypatch):
+    """Self-hosted deployments must not gain empty namespace/pod labels."""
+    _patch_pod_identity(monkeypatch)
+    assert profiling._pod_identity_tags() == {}
+
+
+def test_pod_identity_tags_skip_blank_values(monkeypatch):
+    """A var set but empty is treated as absent, not as an empty label."""
+    _patch_pod_identity(monkeypatch, namespace="   ", pod="backend-abc")
+    assert profiling._pod_identity_tags() == {"pod": "backend-abc"}
+
+
+def test_setup_profiling_tags_include_pod_identity(monkeypatch):
+    """Deck #48: profiles must be attributable to a tenant by namespace.
+
+    Without these every tenant's pod pushes under the same application_name and
+    collapses into one unattributable series.
+    """
+    pytest.importorskip("pyroscope")
+    _reset()
+    _patch_pod_identity(
+        monkeypatch, namespace="tenant-example", pod="backend-65df7d54-mtrtn"
+    )
+    with patch("pyroscope.configure") as mock_configure:
+        profiling.setup_profiling("nextcloud-mcp-server-api", SERVER, enabled=True)
+    assert mock_configure.call_args.kwargs["tags"] == {
+        "namespace": "tenant-example",
+        "pod": "backend-65df7d54-mtrtn",
+    }
+
+
+def test_setup_profiling_explicit_tag_overrides_pod_identity(monkeypatch):
+    pytest.importorskip("pyroscope")
+    _reset()
+    _patch_pod_identity(monkeypatch, namespace="tenant-example")
+    with patch("pyroscope.configure") as mock_configure:
+        profiling.setup_profiling(
+            "svc", SERVER, enabled=True, tags={"namespace": "override"}
+        )
+    assert mock_configure.call_args.kwargs["tags"] == {"namespace": "override"}
+
+
+def test_shutdown_profiling_noop_when_not_configured():
+    """Nothing to shed → False, and pyroscope is never touched."""
+    _reset()
+    assert profiling.shutdown_profiling() is False
+
+
+def test_shutdown_profiling_stops_running_profiler():
+    """The worker sheds the profiler rather than CrashLooping (Deck #908)."""
+    pytest.importorskip("pyroscope")
+    _reset()
+    profiling._configured = True
+    with patch("pyroscope.shutdown") as mock_shutdown:
+        assert profiling.shutdown_profiling() is True
+    mock_shutdown.assert_called_once_with()
+    assert profiling._configured is False
+
+
+def test_shutdown_profiling_never_raises(caplog):
+    """A failure to stop the profiler must not mask the caller's original error."""
+    pytest.importorskip("pyroscope")
+    _reset()
+    profiling._configured = True
+    with (
+        patch("pyroscope.shutdown", side_effect=RuntimeError("boom")),
+        caplog.at_level(logging.WARNING, logger=profiling.logger.name),
+    ):
+        assert profiling.shutdown_profiling() is False  # must not raise
+    assert "Failed to shut down" in caplog.text

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -150,22 +150,20 @@ def test_shutdown_profiling_noop_when_not_configured():
     assert profiling.shutdown_profiling() is False
 
 
-def test_shutdown_profiling_stops_running_profiler():
+def test_shutdown_profiling_stops_running_profiler(monkeypatch):
     """The worker sheds the profiler rather than CrashLooping (Deck #908)."""
     pytest.importorskip("pyroscope")
-    _reset()
-    profiling._configured = True
+    monkeypatch.setattr(profiling, "_configured", True)
     with patch("pyroscope.shutdown") as mock_shutdown:
         assert profiling.shutdown_profiling() is True
     mock_shutdown.assert_called_once_with()
     assert profiling._configured is False
 
 
-def test_shutdown_profiling_never_raises(caplog):
+def test_shutdown_profiling_never_raises(caplog, monkeypatch):
     """A failure to stop the profiler must not mask the caller's original error."""
     pytest.importorskip("pyroscope")
-    _reset()
-    profiling._configured = True
+    monkeypatch.setattr(profiling, "_configured", True)
     with (
         patch("pyroscope.shutdown", side_effect=RuntimeError("boom")),
         caplog.at_level(logging.WARNING, logger=profiling.logger.name),


### PR DESCRIPTION
## Problem

Ingest workers CrashLooped indefinitely on `psycopg_pool.PoolTimeout` at pool-open with `PYROSCOPE_ENABLED=true`. A byte-identical worker with profiling off starts in <1s. Observed on a dev tenant on 2026-07-27: **127 PoolTimeouts, zero documents processed** until profiling was turned off.

Separately, ~1% of profile pushes are rejected server-side with `invalid utf8 string`. That is **unrelated** to the CrashLoop — it happens after the profile is built, Alloy logs a warning, and the pod never sees it. Not addressed here; tracked on Deck #908.

## Approach

Profiling stays **ON for both roles** — the worker is the highest-value profiling target. Two changes make it safe:

1. **Ordering.** The worker starts its sampler only after `app.open_async()` succeeds, so the pool's 30s connect window runs without the profiler. The worker then profiles for its whole working life, which is the part worth profiling anyway.
2. **Backstop.** If startup fails for *any* reason while the profiler is running, shed it and retry once. Scoped by `startup_complete`, so a failure once the worker loop is running still propagates. A pod with degraded telemetry beats CrashLoopBackOff indexing nothing.

The shed path clears `setup_profiling()`'s idempotence guard, so a `profiling_shed` flag stops the retry re-arming the very thing that blocked startup.

### On the mechanism — deliberately not claimed

The connect-time mechanism is **not established**. A `SIGPROF`/`EINTR` hypothesis (signal-based sampling interrupting libpq's blocking connect, which Python retries per PEP 475 but libpq does not) was tested and **disproved** — the `pyroscope-io`/py-spy backend delivers no signals at all. This change orders around the failure rather than claiming a root cause, and the comments say so.

## Also: per-tenant observability (Deck #48)

- **Profiles** gain `namespace`/`pod` tags. Every tenant's pod pushes under the same `application_name`, so the fleet collapsed into one unattributable series — there was no per-tenant profile at all. Alloy's `pyroscope.receive_http` cannot know which pod pushed, so the tags must come from the process.
- **The bespoke `tenant.id` span attribute is removed.** It only ever reached HTTP server spans, leaving background and ingest spans unattributed. Traces now carry `k8s.namespace.name` via `OTEL_RESOURCE_ATTRIBUTES`, which the SDK applies to *every* span — matching how metrics and logs are already attributed.

Verified nothing consumes it: `settings.tenant_id` had exactly one reader (the removed middleware helper), `point_id()` has no callers at all, and the Tenant Fleet dashboard already slices everything by `namespace`.

## Companion PRs

The downward-API env vars come from the chart — `helm-charts` PR (`feat/profiling-role-toggle-and-pod-identity`) and the gitops comment correction (`docs/correct-profiling-crashloop-comment`). No merge ordering required: without the chart change the pod-identity tags are simply absent, which is the current behaviour.

## Testing

- 3 new tests for the worker startup path: ordering (profiler not started during pool init), shed-and-retry, and the no-re-arm guard.
- Pod-identity tag tests for set / unset / blank / explicit-override.
- `shutdown_profiling()` tests including the never-raises contract.
- Unit suite: **2552 passed**. `ruff`, `ruff format`, `ty` clean.

`tests/test_cli.py` has 4 failures that also fail on pristine `master` (CLI option → env var handling) — pre-existing and unrelated; verified in a throwaway worktree at the merge base.

**No e2e/contract tests added:** this changes no API surface — no MCP tool, no `/api/v1` route, no cross-service boundary. The removed `tenant.id` is a telemetry attribute, not a contract.

## Not verified

The ordering fix is **not verified against the live failure** — there is no local Postgres reproduction of the PoolTimeout, so its effectiveness is reasoned from the production timeline, not measured. Rolling to one dev tenant and watching the worker start is the real test.

---

_This PR was generated with the help of AI, and reviewed by a Human_