### PR TITLE
feat(deck): split over-long card comments instead of just rejecting them

### DIFF
--- a/docs/deck.md
+++ b/docs/deck.md
@@ -14,6 +14,9 @@
 | `deck_get_card` | Get a single card in full detail |
 | `deck_get_labels` / `deck_get_label` | List / get board labels |
 | `deck_get_card_comments` | List card comments (compact, newest-first by default) |
+| `deck_create_card_comment` | Comment on a card; `overflow="split"` posts an over-length message as a numbered thread |
+| `deck_update_card_comment` | Edit your own comment (cannot be split — see below) |
+| `deck_delete_card_comment` | Delete your own comment |
 | `deck_create_board` | Create a new Deck board with title and color |
 | `deck_create_stack` | Create a new stack in a board |
 | `deck_update_stack` | Update stack title and order |
@@ -76,6 +79,72 @@ requests. Use `deck_get_card` for the full body of a specific card.
 (`id`, `actorId`, `message`, `creationDateTime`) by default. Use
 `detail="full"` for the complete objects, `message_max_length` to truncate,
 `order` (`newest`/`oldest`) to sort the page, and `limit`/`offset` to page.
+
+#### Long comments
+
+Nextcloud caps a comment at **1000 characters**
+(`IComment::MAX_MESSAGE_LENGTH`). The limit is measured **after trimming
+surrounding whitespace**, in **Unicode code points** — so an emoji counts as
+one, not four — and the check is `> 1000`, meaning exactly 1000 is accepted.
+Markdown and `@`-mentions are *not* expanded before the check: what you send
+is what is counted.
+
+`deck_create_card_comment` takes an `overflow` parameter deciding what happens
+above that limit:
+
+| `overflow` | Behaviour |
+|---|---|
+| `"error"` (default) | Nothing is posted. The error states the exact overage, that nothing was written, and how many comments a split would take. |
+| `"split"` | The message is posted as a numbered thread. |
+
+Splitting cuts at the most structural boundary that fits — markdown heading,
+then code fence, paragraph, line, sentence, and finally word — so a part never
+ends mid-word, and `@`-mentions (including `@"names with spaces"`) are never
+severed. Each part is prefixed `(i/N)`, part 1 becomes the comment, and parts
+2..N are posted as replies to part 1 so the card renders one thread rather than
+N unrelated comments. If you pass `parent_id`, part 1 replies to it and the
+rest still reply to part 1.
+
+The response carries the whole thread:
+
+```jsonc
+{
+  "comment":    { "id": 881, "message": "(1/3) ## Shipped state ..." },  // part 1
+  "parts":      [ /* every part in order; parts[0] is part 1 */ ],
+  "part_count": 3
+}
+```
+
+For a single comment, `parts` is `null` and `part_count` is `1`, so existing
+callers reading `comment` are unaffected.
+
+Two limits worth knowing:
+
+- **At most 10 parts.** Past that the call is rejected before anything is
+  posted. Content that long belongs in a note (`nc_notes_create_note`) or a
+  file (`nc_webdav_write_file`) attached with `deck_attach_note` /
+  `deck_attach_file`, with a short pointer comment linking to it.
+- **Splitting is not atomic.** Deck has no transactional multi-comment
+  endpoint, so if a later part fails the earlier ones stay posted. No rollback
+  is attempted — deleting them is itself a write that can fail, and a
+  half-deleted thread is worse than a labelled partial one. The error names the
+  comment ids that were created so you can post only the remainder rather than
+  re-sending everything.
+
+**`deck_update_card_comment` has no `overflow`**: an update replaces one comment
+in place, so it cannot become several. Post a follow-up comment instead of
+growing an existing one past the limit.
+
+> **Upstream caveat.** Deck's `CommentService::create()` translates an
+> over-length message into a clean HTTP 400, but its `update()` has no such
+> catch — the exception escapes to Deck's exception middleware and comes back as
+> a masked HTTP 500 whose body says only "Internal server error", with the real
+> cause left in the server log. This server therefore validates length
+> client-side before calling update, and maps a 500 from that endpoint to a
+> message naming the length limit as the likely cause.
+
+*Known limitation:* a fenced code block straddling a cut renders as two broken
+fences. The fence boundary is high in the preference order so this is rare.
 
 > **Breaking change:** list tools now default to `detail="summary"`
 > and `status="open"`. The previous `include_archived_cards` parameter has

--- a/nextcloud_mcp_server/models/deck.py
+++ b/nextcloud_mcp_server/models/deck.py
@@ -399,9 +399,34 @@ class ListCardCommentsResponse(BaseResponse):
 
 
 class CardCommentResponse(BaseResponse):
-    """Response model returned when a single card comment is created or updated."""
+    """Response model returned when a card comment is created or updated.
 
-    comment: DeckComment = Field(description="The created or updated card comment")
+    Covers the split case too, rather than a second model: a union return
+    produces a messy tool output schema and forces every caller to branch on
+    shape. The extra fields are additive -- an existing caller reading
+    ``comment`` is unaffected.
+    """
+
+    comment: DeckComment = Field(
+        description=(
+            "The created or updated card comment. When the message was split, "
+            "this is part 1 -- the parent of the remaining parts."
+        )
+    )
+    parts: list[DeckComment] | None = Field(
+        default=None,
+        description=(
+            "Every posted part in order, including part 1, when the message "
+            "was split into more than one comment. Null when a single comment "
+            "was posted."
+        ),
+    )
+    part_count: int = Field(
+        default=1,
+        description=(
+            "Number of comments actually posted (1 unless the message was split)."
+        ),
+    )
 
 
 class CardCommentOperationResponse(StatusResponse):

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Literal, cast
+from typing import Final, Literal, cast
 
 import anyio
+from httpx import HTTPStatusError, RequestError
 from mcp.server.fastmcp import Context, FastMCP
-from mcp.types import ToolAnnotations
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData, ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.client import NextcloudClient
@@ -39,6 +41,10 @@ from nextcloud_mcp_server.models.deck import (
     StackOverview,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
+from nextcloud_mcp_server.utils.message_splitter import (
+    measured_length,
+    split_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +69,304 @@ def _validate_positive_length(
     """
     if value is not None and value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
+
+
+# Nextcloud core caps a comment at IComment::MAX_MESSAGE_LENGTH, checked in
+# OC\Comments\Comment::setMessage AFTER trim(), in UTF-8 code points, with a
+# strict ">" so exactly 1000 is legal. Deck adds no check of its own: its
+# CommentService::create translates the overflow into a 400, but its update()
+# has no such catch and leaks a masked 500 (see _comment_http_error).
+_COMMENT_MAX_LENGTH: Final[int] = 1000
+
+# Ceiling on overflow="split". Ten comments is already a wall of text on a card;
+# past that the content wants to be a note or a file attachment, not an
+# activity-log entry.
+_MAX_SPLIT_PARTS: Final[int] = 10
+
+# How a comment overflowing _COMMENT_MAX_LENGTH is handled.
+CommentOverflow = Literal["error", "split"]
+
+
+def _validate_comment_message_not_blank(message: str) -> None:
+    """Reject a comment with no content.
+
+    Deck would happily store one, but a blank row in an activity log is noise
+    nobody asked for and almost always signals a bug in the caller.
+    """
+    if not message.strip():
+        raise ValueError("Comment message must not be empty or whitespace-only")
+
+
+def _validate_comment_message(message: str) -> None:
+    """Reject messages Deck would reject, using the server's own measurement."""
+    _validate_comment_message_not_blank(message)
+
+    length = measured_length(message)
+    if length > _COMMENT_MAX_LENGTH:
+        raise ValueError(_too_long_message(message, length))
+
+
+def _min_parts_for(length: int) -> int:
+    """Lower bound on the parts a message of ``length`` would need.
+
+    Ignores boundaries and the ``(i/N)`` prefix, both of which only ever cost
+    budget -- so a real split needs at least this many. That makes it a cheap
+    way to rule a split out without running the splitter over a huge message,
+    which matters because this runs on the failure path that fires exactly when
+    a caller sends far too much.
+    """
+    return -(-length // _COMMENT_MAX_LENGTH)
+
+
+def _too_long_to_split_message(length: int, parts_needed: int | None) -> str:
+    """Explain a message too long for even the split path to help with.
+
+    Shared by the error mode and the split mode so the two can never disagree:
+    an error telling the caller to retry with overflow="split" when the split
+    would itself be rejected just restarts the retry loop this all exists to
+    end.
+    """
+    needed = (
+        str(parts_needed)
+        if parts_needed is not None
+        else f"at least {_min_parts_for(length)}"
+    )
+    return (
+        f"Comment message is {length} characters; Nextcloud Deck allows "
+        f"{_COMMENT_MAX_LENGTH} per comment. Splitting it would need {needed} "
+        f"comments, more than the {_MAX_SPLIT_PARTS}-part limit, so "
+        f'overflow="split" will not work either. Nothing was posted. Content '
+        f"this long belongs in a note (nc_notes_create_note) or a file "
+        f"(nc_webdav_write_file) attached to the card with deck_attach_note / "
+        f"deck_attach_file, with a short pointer comment linking to it."
+    )
+
+
+def _too_long_message(message: str, length: int) -> str:
+    """Explain an over-length comment in terms an agent can act on directly.
+
+    Deliberately verbose: the failure mode this replaces is an agent retrying
+    with a blindly-shortened message over and over, because "too long" alone
+    says nothing about how much to cut or that a better option exists. So state
+    the exact overage, that nothing was written, and the parameter that fixes
+    it -- along with what that parameter will cost.
+    """
+    # Only promise a split that would actually be accepted. The cheap bound
+    # first, so a multi-megabyte paste never reaches the splitter.
+    if _min_parts_for(length) > _MAX_SPLIT_PARTS:
+        return _too_long_to_split_message(length, None)
+
+    overage = length - _COMMENT_MAX_LENGTH
+    parts = split_message(message, max_length=_COMMENT_MAX_LENGTH)
+    if len(parts) > _MAX_SPLIT_PARTS:
+        return _too_long_to_split_message(length, len(parts))
+    return (
+        f"Comment message is {length} characters; Nextcloud Deck's limit is "
+        f"{_COMMENT_MAX_LENGTH} (measured after trimming whitespace, counting "
+        f"Unicode code points). It is {overage} characters over. Nothing was "
+        f"posted. Either call deck_create_card_comment again with the SAME "
+        f'message and overflow="split" -- it will post {len(parts)} threaded '
+        f'comments, each prefixed "(i/{len(parts)})", with parts 2+ replying '
+        f"to part 1 -- or shorten the message to {_COMMENT_MAX_LENGTH} "
+        f"characters or fewer. Do not retry with a blindly-shortened message: "
+        f"the exact overage is {overage} characters."
+    )
+
+
+def _ocs_error_message(e: HTTPStatusError) -> str | None:
+    """Pull the human-readable reason out of an OCS error envelope."""
+    try:
+        meta = e.response.json()["ocs"]["meta"]
+    except (ValueError, KeyError, TypeError):
+        return None
+    message = meta.get("message")
+    return message if isinstance(message, str) and message else None
+
+
+def _comment_http_error(
+    e: HTTPStatusError,
+    *,
+    operation: str,
+    card_id: int,
+    comment_id: int | None = None,
+    message: str | None = None,
+) -> McpError:
+    """Translate a Deck comment API failure into something an agent can act on.
+
+    Args:
+        e: The failure raised by the client layer.
+        operation: Present participle naming the attempt, e.g. ``"creating"``.
+        card_id: The card the operation targeted.
+        comment_id: The comment targeted, for update/delete.
+        message: The text that was being posted, when there was one -- lets the
+            masked-500 branch report its measured length.
+    """
+    status = e.response.status_code
+    target = (
+        f"comment {comment_id} on card {card_id}"
+        if comment_id is not None
+        else f"card {card_id}"
+    )
+
+    if status == 400:
+        detail = _ocs_error_message(e) or "Deck rejected the request"
+        if "character limit" in detail.lower():
+            detail += (
+                f'. Nothing was posted -- retry with overflow="split" or '
+                f"shorten the message to {_COMMENT_MAX_LENGTH} characters"
+            )
+        reason = f"{detail} (while {operation} {target})"
+    elif status == 403:
+        reason = (
+            f"Permission denied {operation} {target}: only the comment's author "
+            f"can edit or delete a Deck comment, and write access to the board "
+            f"is required. Nothing was changed."
+        )
+    elif status == 404:
+        reason = (
+            f"Not found {operation} {target}: the card or comment does not "
+            f"exist, or you lack access to its board."
+        )
+    elif status == 429:
+        reason = (
+            f"Nextcloud rate-limited the request while {operation} {target} "
+            f"(HTTP 429, bruteforce protection). Wait before retrying; when "
+            f"splitting, retry only the parts that were not posted."
+        )
+    elif status == 500 and message is not None:
+        # Only the update path passes `message`, and only there does the
+        # length explanation apply: Deck's CommentService::update() lacks the
+        # MessageTooLongException catch that create() has, so an over-length
+        # message escapes to its ExceptionMiddleware and comes back as a
+        # masked, non-OCS 500 with the real cause only in the server log. Name
+        # that explicitly -- an agent reading "internal server error" has no
+        # way to guess it sent too much. A 500 from delete carries no message
+        # and must not be attributed to length, so it falls through below.
+        reason = (
+            f"Deck returned an unhandled server error (HTTP 500) while "
+            f"{operation} {target}. The most likely cause is a message longer "
+            f"than {_COMMENT_MAX_LENGTH} characters (the message you sent is "
+            f"{measured_length(message)} characters): unlike the create "
+            f"endpoint, Deck's "
+            f"update endpoint does not translate that into a 400 and leaks a "
+            f"masked 500 instead (upstream Deck bug). The comment may or may "
+            f"not have been modified -- call deck_get_card_comments to confirm "
+            f"before retrying."
+        )
+    else:
+        reason = (
+            f"Deck returned HTTP {status} while {operation} {target}: "
+            f"{_ocs_error_message(e) or e.response.reason_phrase}"
+        )
+
+    logger.warning("Deck comment error (%s while %s): %s", status, operation, reason)
+    return McpError(ErrorData(code=-32603, message=reason))
+
+
+def _partial_split_error(
+    e: HTTPStatusError | RequestError,
+    *,
+    card_id: int,
+    posted: list[DeckComment],
+    failed_part: int,
+    total_parts: int,
+) -> McpError:
+    """Report a split that died partway through.
+
+    No rollback is attempted, deliberately. Deleting the parts already posted
+    is itself a write that can 403 or time out, and a half-deleted thread is
+    harder to reason about than a clearly-labelled partial one -- it would also
+    destroy content a human may already have read. Deck has no transactional
+    multi-comment endpoint, so atomicity was never on the table; the honest
+    move is to say exactly what exists.
+
+    The bracketed tail is a machine-readable summary for agents that
+    pattern-match; the prose ahead of it carries the same facts for those that
+    do not.
+    """
+    posted_ids = [comment.id for comment in posted]
+    detail = _ocs_error_message(e) if isinstance(e, HTTPStatusError) else str(e)
+    reason = detail or str(e)
+
+    if posted_ids:
+        resume = (
+            f"To finish, call deck_create_card_comment again with only the "
+            f"remaining text and parent_id={posted_ids[0]}, or call "
+            f"deck_get_card_comments to inspect the current state first."
+        )
+        message = (
+            f"Split comment partially posted on card {card_id}: parts "
+            f"1-{failed_part - 1} of {total_parts} were posted as comment ids "
+            f"{posted_ids}. Part {failed_part} failed: {reason}. Parts "
+            f"{failed_part}-{total_parts} were NOT posted and no rollback was "
+            f"attempted. Do NOT re-send the whole message -- that would "
+            f"duplicate parts 1-{failed_part - 1}. {resume} "
+            f"[posted_comment_ids={posted_ids} failed_part={failed_part} "
+            f"total_parts={total_parts}]"
+        )
+    else:
+        # Part 1 failed, so nothing exists and there is nothing to resume from.
+        message = (
+            f"Split comment failed on its first part on card {card_id}: "
+            f"{reason}. Nothing was posted; retrying the whole message is "
+            f"safe. [posted_comment_ids=[] failed_part=1 "
+            f"total_parts={total_parts}]"
+        )
+
+    logger.warning(
+        "Split comment on card %s failed at part %d/%d (posted: %s)",
+        card_id,
+        failed_part,
+        total_parts,
+        posted_ids,
+    )
+    return McpError(ErrorData(code=-32603, message=message))
+
+
+async def _post_split_comment(
+    client: NextcloudClient, card_id: int, message: str, parent_id: int | None
+) -> CardCommentResponse:
+    """Post an over-length message as a numbered thread.
+
+    Everything checkable without writing is checked first, so a message that
+    cannot be posted never leaves a partial thread behind.
+    """
+    _validate_comment_message_not_blank(message)
+    length = measured_length(message)
+    # Cheap bound first, so an enormous paste is rejected without running the
+    # splitter over it.
+    if _min_parts_for(length) > _MAX_SPLIT_PARTS:
+        raise ValueError(_too_long_to_split_message(length, None))
+
+    parts = split_message(message, max_length=_COMMENT_MAX_LENGTH)
+    if len(parts) > _MAX_SPLIT_PARTS:
+        raise ValueError(_too_long_to_split_message(length, len(parts)))
+
+    posted: list[DeckComment] = []
+    for index, part in enumerate(parts, 1):
+        # Parts 2..N hang off part 1 so the card renders one thread rather than
+        # N unrelated comments.
+        reply_to = parent_id if index == 1 else posted[0].id
+        try:
+            posted.append(
+                await client.deck.create_comment(card_id, part, parent_id=reply_to)
+            )
+        except (HTTPStatusError, RequestError) as e:
+            raise _partial_split_error(
+                e,
+                card_id=card_id,
+                posted=posted,
+                failed_part=index,
+                total_parts=len(parts),
+            ) from e
+
+    logger.info(
+        "Split a %d-character comment into %d parts on card %s",
+        measured_length(message),
+        len(posted),
+        card_id,
+    )
+    return CardCommentResponse(comment=posted[0], parts=posted, part_count=len(posted))
 
 
 def _truncate_card_descriptions(
@@ -1503,15 +1807,6 @@ def configure_deck_tools(mcp: FastMCP):
 
     # Card Comment Tools
 
-    _COMMENT_MAX_LENGTH = 1000
-
-    def _validate_comment_message(message: str) -> None:
-        if len(message) > _COMMENT_MAX_LENGTH:
-            raise ValueError(
-                f"Comment message too long: {len(message)} characters "
-                f"(max {_COMMENT_MAX_LENGTH})"
-            )
-
     @mcp.tool(
         title="List Deck Card Comments",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
@@ -1545,7 +1840,21 @@ def configure_deck_tools(mcp: FastMCP):
         """
         _validate_positive_length(message_max_length, "message_max_length")
         client = await get_client(ctx)
-        comments = await client.deck.get_comments(card_id, limit=limit, offset=offset)
+        try:
+            comments = await client.deck.get_comments(
+                card_id, limit=limit, offset=offset
+            )
+        except HTTPStatusError as e:
+            raise _comment_http_error(
+                e, operation="listing comments on", card_id=card_id
+            ) from e
+        except RequestError as e:
+            raise McpError(
+                ErrorData(
+                    code=-32603,
+                    message=(f"Network error listing comments on card {card_id}: {e}"),
+                )
+            ) from e
         shaped = _shape_comments(
             comments,
             detail=detail,
@@ -1565,23 +1874,78 @@ def configure_deck_tools(mcp: FastMCP):
         card_id: int,
         message: str,
         parent_id: int | None = None,
+        overflow: CommentOverflow = "error",
     ) -> CardCommentResponse:
-        """Create a comment on a Nextcloud Deck card
+        """Create a comment on a Nextcloud Deck card.
 
-        Supports @-mentions (e.g. "@alice"). Pass parent_id to reply to an
-        existing comment on the same card. Message is limited to 1000 characters.
+        Deck caps a comment at 1000 characters, measured after trimming
+        whitespace and counted in Unicode code points. Markdown and @-mentions
+        are NOT expanded before that check, so what you pass is what is counted.
+
+        Check the length before calling and pick `overflow` accordingly:
+
+        - 1000 characters or fewer: call as-is; `overflow` is ignored.
+        - Longer, and the text is meant to be read on the card (activity
+          updates, run summaries, changelogs): pass overflow="split" up front
+          rather than guessing a shorter message. The text is cut at markdown
+          heading, then paragraph, then line, then sentence, then word
+          boundaries -- never mid-word -- each part is prefixed "(i/N)", and
+          parts 2..N are posted as replies to part 1 so the card shows one
+          thread. @-mentions are never split across parts. At most 10 parts;
+          past that, write the content to a note (nc_notes_create_note) or a
+          file (nc_webdav_write_file), attach it with deck_attach_note /
+          deck_attach_file, and post a short pointer comment instead.
+        - Longer, and you would rather shorten it yourself: leave the default
+          overflow="error". Nothing is posted and the error states the exact
+          overage.
+
+        Splitting is not atomic. If a later part fails, the earlier parts stay
+        posted and the error names their comment ids -- resume from there
+        instead of re-sending the whole message, which would duplicate them.
+
+        Supports @-mentions: "@alice", or @"alice smith" for ids with spaces.
 
         Args:
             card_id: The ID of the card to comment on
-            message: The comment text (max 1000 characters)
-            parent_id: Optional ID of a parent comment to reply to
+            message: The comment text (max 1000 characters unless
+                overflow="split")
+            parent_id: Optional ID of a parent comment to reply to. When
+                splitting, part 1 replies to this comment and parts 2..N reply
+                to part 1.
+            overflow: What to do when the message exceeds 1000 characters.
+                "error" (the default) posts nothing and explains the overage;
+                "split" posts the message as multiple threaded comments.
+
+        Returns:
+            CardCommentResponse. For a single comment, `comment` is it, `parts`
+            is null and `part_count` is 1. When split, `comment` is part 1,
+            `parts` lists every posted part in order (parts[0] is part 1), and
+            `part_count` is how many were posted.
         """
-        _validate_comment_message(message)
+        if overflow == "error" or measured_length(message) <= _COMMENT_MAX_LENGTH:
+            _validate_comment_message(message)
+            client = await get_client(ctx)
+            try:
+                comment = await client.deck.create_comment(
+                    card_id, message, parent_id=parent_id
+                )
+            except HTTPStatusError as e:
+                raise _comment_http_error(
+                    e, operation="creating a comment on", card_id=card_id
+                ) from e
+            except RequestError as e:
+                raise McpError(
+                    ErrorData(
+                        code=-32603,
+                        message=(
+                            f"Network error creating a comment on card {card_id}: {e}"
+                        ),
+                    )
+                ) from e
+            return CardCommentResponse(comment=comment)
+
         client = await get_client(ctx)
-        comment = await client.deck.create_comment(
-            card_id, message, parent_id=parent_id
-        )
-        return CardCommentResponse(comment=comment)
+        return await _post_split_comment(client, card_id, message, parent_id)
 
     @mcp.tool(
         title="Update Deck Card Comment",
@@ -1592,9 +1956,16 @@ def configure_deck_tools(mcp: FastMCP):
     async def deck_update_card_comment(
         ctx: Context, card_id: int, comment_id: int, message: str
     ) -> CardCommentResponse:
-        """Update a Nextcloud Deck card comment
+        """Update a Nextcloud Deck card comment.
 
-        Only the comment's author can update it; the server returns 403 otherwise.
+        The same 1000-character limit applies as for creation (measured after
+        trimming, in Unicode code points), but the message CANNOT be split: an
+        update replaces one comment in place. To add more than fits, post a
+        follow-up comment with deck_create_card_comment instead of growing an
+        existing one past the limit.
+
+        Only the comment's author can update it; the server returns 403
+        otherwise.
 
         Args:
             card_id: The ID of the card the comment belongs to
@@ -1603,7 +1974,26 @@ def configure_deck_tools(mcp: FastMCP):
         """
         _validate_comment_message(message)
         client = await get_client(ctx)
-        comment = await client.deck.update_comment(card_id, comment_id, message)
+        try:
+            comment = await client.deck.update_comment(card_id, comment_id, message)
+        except HTTPStatusError as e:
+            raise _comment_http_error(
+                e,
+                operation="updating",
+                card_id=card_id,
+                comment_id=comment_id,
+                message=message,
+            ) from e
+        except RequestError as e:
+            raise McpError(
+                ErrorData(
+                    code=-32603,
+                    message=(
+                        f"Network error updating comment {comment_id} on card "
+                        f"{card_id}: {e}"
+                    ),
+                )
+            ) from e
         return CardCommentResponse(comment=comment)
 
     @mcp.tool(
@@ -1626,7 +2016,22 @@ def configure_deck_tools(mcp: FastMCP):
             comment_id: The ID of the comment to delete
         """
         client = await get_client(ctx)
-        await client.deck.delete_comment(card_id, comment_id)
+        try:
+            await client.deck.delete_comment(card_id, comment_id)
+        except HTTPStatusError as e:
+            raise _comment_http_error(
+                e, operation="deleting", card_id=card_id, comment_id=comment_id
+            ) from e
+        except RequestError as e:
+            raise McpError(
+                ErrorData(
+                    code=-32603,
+                    message=(
+                        f"Network error deleting comment {comment_id} on card "
+                        f"{card_id}: {e}"
+                    ),
+                )
+            ) from e
         return CardCommentOperationResponse(
             success=True,
             message="Comment deleted successfully",

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -92,6 +92,12 @@ def _validate_comment_message_not_blank(message: str) -> None:
 
     Deck would happily store one, but a blank row in an activity log is noise
     nobody asked for and almost always signals a bug in the caller.
+
+    Uses Python's broad ``str.strip()`` on purpose, unlike
+    :func:`measured_length`, which must mirror PHP's narrower ``trim()``
+    charlist exactly. This guard is our own policy rather than a restatement of
+    the server's rule, and a comment of nothing but ideographic spaces is just
+    as useless as one of nothing but spaces -- so do not "align" it.
     """
     if not message.strip():
         raise ValueError("Comment message must not be empty or whitespace-only")

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -157,6 +157,13 @@ def _too_long_message(message: str, length: int) -> str:
         return _too_long_to_split_message(length, None)
 
     overage = length - _COMMENT_MAX_LENGTH
+    # Splitting here purely to quote a part count duplicates the work
+    # _post_split_comment does if the caller then retries with overflow="split".
+    # That is deliberate: this is a rejection path, the input is bounded to
+    # _MAX_SPLIT_PARTS * _COMMENT_MAX_LENGTH by the check above, and telling the
+    # agent up front what the remedy costs is the whole point. Don't try to
+    # thread a cached result through -- the two calls are far apart and the
+    # coupling would cost more than the split.
     parts = split_message(message, max_length=_COMMENT_MAX_LENGTH)
     if len(parts) > _MAX_SPLIT_PARTS:
         return _too_long_to_split_message(length, len(parts))
@@ -183,10 +190,40 @@ def _ocs_error_message(e: HTTPStatusError) -> str | None:
     return message if isinstance(message, str) and message else None
 
 
+# The four comment operations, kept as a closed set rather than free text so
+# each one can carry its own denial reason: a 403 means something different for
+# a read than for an edit, and getting that wrong sends an agent after the
+# wrong fix.
+CommentOperation = Literal["list", "create", "update", "delete"]
+
+_OPERATION_PHRASE: Final[dict[str, str]] = {
+    "list": "listing comments on",
+    "create": "creating a comment on",
+    "update": "updating",
+    "delete": "deleting",
+}
+
+# Deck's authorship restriction (only the author may edit or delete) applies to
+# exactly two of these. For a list it is board read access, and for a create
+# there is no comment to be the author of yet.
+_FORBIDDEN_REASON: Final[dict[str, str]] = {
+    "list": "you lack read access to this board's comments",
+    "create": "you lack write access to this board. Nothing was posted",
+    "update": (
+        "only the comment's author can edit it, and write access to the board "
+        "is required. Nothing was changed"
+    ),
+    "delete": (
+        "only the comment's author can delete it, and write access to the "
+        "board is required. Nothing was deleted"
+    ),
+}
+
+
 def _comment_http_error(
     e: HTTPStatusError,
     *,
-    operation: str,
+    operation: CommentOperation,
     card_id: int,
     comment_id: int | None = None,
     message: str | None = None,
@@ -195,13 +232,15 @@ def _comment_http_error(
 
     Args:
         e: The failure raised by the client layer.
-        operation: Present participle naming the attempt, e.g. ``"creating"``.
+        operation: Which comment operation was attempted. Drives both the
+            wording and, for 403/500, which explanation actually applies.
         card_id: The card the operation targeted.
         comment_id: The comment targeted, for update/delete.
         message: The text that was being posted, when there was one -- lets the
             masked-500 branch report its measured length.
     """
     status = e.response.status_code
+    phrase = _OPERATION_PHRASE[operation]
     target = (
         f"comment {comment_id} on card {card_id}"
         if comment_id is not None
@@ -215,51 +254,46 @@ def _comment_http_error(
                 f'. Nothing was posted -- retry with overflow="split" or '
                 f"shorten the message to {_COMMENT_MAX_LENGTH} characters"
             )
-        reason = f"{detail} (while {operation} {target})"
+        reason = f"{detail} (while {phrase} {target})"
     elif status == 403:
-        reason = (
-            f"Permission denied {operation} {target}: only the comment's author "
-            f"can edit or delete a Deck comment, and write access to the board "
-            f"is required. Nothing was changed."
-        )
+        reason = f"Permission denied {phrase} {target}: {_FORBIDDEN_REASON[operation]}."
     elif status == 404:
         reason = (
-            f"Not found {operation} {target}: the card or comment does not "
+            f"Not found {phrase} {target}: the card or comment does not "
             f"exist, or you lack access to its board."
         )
     elif status == 429:
         reason = (
-            f"Nextcloud rate-limited the request while {operation} {target} "
+            f"Nextcloud rate-limited the request while {phrase} {target} "
             f"(HTTP 429, bruteforce protection). Wait before retrying; when "
             f"splitting, retry only the parts that were not posted."
         )
-    elif status == 500 and message is not None:
-        # Only the update path passes `message`, and only there does the
-        # length explanation apply: Deck's CommentService::update() lacks the
-        # MessageTooLongException catch that create() has, so an over-length
-        # message escapes to its ExceptionMiddleware and comes back as a
-        # masked, non-OCS 500 with the real cause only in the server log. Name
-        # that explicitly -- an agent reading "internal server error" has no
-        # way to guess it sent too much. A 500 from delete carries no message
-        # and must not be attributed to length, so it falls through below.
+    elif status == 500 and operation == "update" and message is not None:
+        # The length explanation applies only to update: Deck's
+        # CommentService::update() lacks the MessageTooLongException catch that
+        # create() has, so an over-length message escapes to its
+        # ExceptionMiddleware and comes back as a masked, non-OCS 500 with the
+        # real cause only in the server log. Name that explicitly -- an agent
+        # reading "internal server error" has no way to guess it sent too much.
+        # A 500 from any other operation must not be attributed to length, so
+        # it falls through to the generic branch below.
         reason = (
             f"Deck returned an unhandled server error (HTTP 500) while "
-            f"{operation} {target}. The most likely cause is a message longer "
+            f"{phrase} {target}. The most likely cause is a message longer "
             f"than {_COMMENT_MAX_LENGTH} characters (the message you sent is "
             f"{measured_length(message)} characters): unlike the create "
-            f"endpoint, Deck's "
-            f"update endpoint does not translate that into a 400 and leaks a "
-            f"masked 500 instead (upstream Deck bug). The comment may or may "
-            f"not have been modified -- call deck_get_card_comments to confirm "
-            f"before retrying."
+            f"endpoint, Deck's update endpoint does not translate that into a "
+            f"400 and leaks a masked 500 instead (upstream Deck bug). The "
+            f"comment may or may not have been modified -- call "
+            f"deck_get_card_comments to confirm before retrying."
         )
     else:
         reason = (
-            f"Deck returned HTTP {status} while {operation} {target}: "
+            f"Deck returned HTTP {status} while {phrase} {target}: "
             f"{_ocs_error_message(e) or e.response.reason_phrase}"
         )
 
-    logger.warning("Deck comment error (%s while %s): %s", status, operation, reason)
+    logger.warning("Deck comment error (%s while %s): %s", status, phrase, reason)
     return McpError(ErrorData(code=-32603, message=reason))
 
 
@@ -1845,9 +1879,7 @@ def configure_deck_tools(mcp: FastMCP):
                 card_id, limit=limit, offset=offset
             )
         except HTTPStatusError as e:
-            raise _comment_http_error(
-                e, operation="listing comments on", card_id=card_id
-            ) from e
+            raise _comment_http_error(e, operation="list", card_id=card_id) from e
         except RequestError as e:
             raise McpError(
                 ErrorData(
@@ -1930,9 +1962,7 @@ def configure_deck_tools(mcp: FastMCP):
                     card_id, message, parent_id=parent_id
                 )
             except HTTPStatusError as e:
-                raise _comment_http_error(
-                    e, operation="creating a comment on", card_id=card_id
-                ) from e
+                raise _comment_http_error(e, operation="create", card_id=card_id) from e
             except RequestError as e:
                 raise McpError(
                     ErrorData(
@@ -1979,7 +2009,7 @@ def configure_deck_tools(mcp: FastMCP):
         except HTTPStatusError as e:
             raise _comment_http_error(
                 e,
-                operation="updating",
+                operation="update",
                 card_id=card_id,
                 comment_id=comment_id,
                 message=message,
@@ -2020,7 +2050,7 @@ def configure_deck_tools(mcp: FastMCP):
             await client.deck.delete_comment(card_id, comment_id)
         except HTTPStatusError as e:
             raise _comment_http_error(
-                e, operation="deleting", card_id=card_id, comment_id=comment_id
+                e, operation="delete", card_id=card_id, comment_id=comment_id
             ) from e
         except RequestError as e:
             raise McpError(

--- a/nextcloud_mcp_server/utils/message_splitter.py
+++ b/nextcloud_mcp_server/utils/message_splitter.py
@@ -124,6 +124,21 @@ def split_message(
         if len(parts) <= total_guess:
             break
         total_guess = len(parts)
+    else:
+        # Unreachable in practice: total_guess strictly increases on every
+        # non-converging pass, and the prefix only widens at powers of ten, so
+        # the fixed point settles within a couple of rounds for any realistic
+        # part count. Fail loudly rather than fall out of the loop and return
+        # parts whose prefixes were sized for a smaller total than they will
+        # actually carry -- that would quietly break the one invariant this
+        # function promises, which matters because this module is generic and
+        # its callers pick their own max_length.
+        raise RuntimeError(
+            f"part-count fixed point did not converge after "
+            f"{_MAX_PREFIX_ITERATIONS} iterations for a "
+            f"{len(text)}-character message at max_length={max_length} "
+            f"(last estimate {total_guess}, produced {len(parts)})"
+        )
 
     if len(parts) == 1 or part_prefix_template is None:
         return parts

--- a/nextcloud_mcp_server/utils/message_splitter.py
+++ b/nextcloud_mcp_server/utils/message_splitter.py
@@ -54,15 +54,29 @@ PART_PREFIX_TEMPLATE: Final[str] = "({index}/{total}) "
 _MAX_PREFIX_ITERATIONS: Final[int] = 8
 
 
+# PHP trim()'s default charlist. Deliberately NOT Python's bare str.strip(),
+# which also strips every Unicode Zs-category space -- U+00A0 (NBSP), U+202F,
+# U+3000 (ideographic space, ordinary in CJK text) -- while PHP leaves those in
+# place. The two disagree in both directions and each one costs us:
+#   * strip more than PHP  -> we measure 1000, the server measures 1003, we
+#     post it and get a 400 back.
+#   * strip less than PHP  -> we reject a message the server would accept
+#     (PHP trims NUL, Python does not).
+# Matching the charlist exactly is the only way the client-side check agrees
+# with the server it is standing in for.
+_PHP_TRIM_CHARS: Final[str] = " \t\n\r\0\x0b"
+
+
 def measured_length(message: str) -> int:
     """Return the length as the Nextcloud server measures it.
 
     Core's ``OC\\Comments\\Comment::setMessage`` trims first and then applies
     ``mb_strlen($message, 'UTF-8') > $maxLength`` -- Unicode **code points**,
-    not bytes and not grapheme clusters. Python's ``len()`` on a ``str`` is also
-    code points, so trimming is the only correction needed.
+    not bytes and not grapheme clusters. Python's ``len()`` on a ``str`` is
+    also code points, so trimming is the only correction needed -- but it has
+    to be PHP's notion of trimming, not Python's. See ``_PHP_TRIM_CHARS``.
     """
-    return len(message.strip())
+    return len(message.strip(_PHP_TRIM_CHARS))
 
 
 def split_message(
@@ -109,7 +123,9 @@ def split_message(
     if measured_length(message) <= max_length:
         return [message]
 
-    text = message.strip()
+    # Trim exactly what the server trims -- never more, or we would drop
+    # trailing content (an ideographic space, say) that Deck would have kept.
+    text = message.strip(_PHP_TRIM_CHARS)
 
     parts: list[str] = []
     total_guess = 1
@@ -209,7 +225,9 @@ def _pack(text: str, budget: int) -> list[str]:
         parts.append(text[position:cut])
         position = cut
 
-    return [stripped for part in parts if (stripped := part.strip())]
+    # Same charlist at cut boundaries, for the same reason: the whitespace we
+    # discard here is whitespace the server would have discarded anyway.
+    return [stripped for part in parts if (stripped := part.strip(_PHP_TRIM_CHARS))]
 
 
 def _choose_cut(

--- a/nextcloud_mcp_server/utils/message_splitter.py
+++ b/nextcloud_mcp_server/utils/message_splitter.py
@@ -1,0 +1,248 @@
+"""Split over-long messages into postable parts on natural boundaries.
+
+Nextcloud caps a comment at ``IComment::MAX_MESSAGE_LENGTH`` (1000) characters.
+Rather than truncating -- which silently corrupts an activity log while
+reporting success -- this module cuts a message into parts that each fit, on the
+most structural boundary available.
+
+This is deliberately *not* :mod:`nextcloud_mcp_server.vector.document_chunker`.
+That one is async, overlap-based (overlap would duplicate text into the comment
+thread) and tuned for MB-scale RAG documents. Here we want a synchronous,
+exact-slice split of a few kilobytes.
+
+The boundary rules come from LangChain's ``RecursiveCharacterTextSplitter``,
+which is already a dependency. It is used as a *cut-offset finder*: we take the
+offsets it would split at and slice the original string ourselves, so every part
+is an exact substring of the input. That keeps the round-trip exact -- LangChain
+drops separators from the chunks it returns, which for an activity log would
+quietly mangle the text.
+"""
+
+import bisect
+import logging
+import re
+from typing import Final
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+logger = logging.getLogger(__name__)
+
+# Break preference, most structural first. Regexes, because the heading and
+# sentence rules need them (hence is_separator_regex=True below). The trailing
+# "" is LangChain's hard-cut fallback and is what bounds every chunk by
+# chunk_size, so it must stay last.
+_SEPARATORS: Final[tuple[str, ...]] = (
+    r"\n#{1,6} ",  # markdown headings
+    r"```\n",  # fenced code blocks
+    r"\n\n",  # paragraphs
+    r"\n",  # lines
+    r"(?<=[.!?])\s+",  # sentence ends; the lookbehind keeps the punctuation left
+    r" ",  # words -- the floor for "never cut mid-word"
+    r"",  # hard cut, last resort
+)
+
+# Nextcloud mention syntax: @userid, or @"user id with spaces". Also covers
+# federated @user@example.com. Cutting one in half turns a working mention into
+# plain text, so cuts are steered around these spans.
+MENTION_PATTERN: Final[re.Pattern[str]] = re.compile(r'@(?:"[^"\n]*"|[\w.\-@]+)')
+
+PART_PREFIX_TEMPLATE: Final[str] = "({index}/{total}) "
+
+# The prefix width depends on the part count, which depends on the budget, which
+# depends on the prefix width. The fixed point converges as soon as the digit
+# count stops moving -- three rounds is already generous.
+_MAX_PREFIX_ITERATIONS: Final[int] = 8
+
+
+def measured_length(message: str) -> int:
+    """Return the length as the Nextcloud server measures it.
+
+    Core's ``OC\\Comments\\Comment::setMessage`` trims first and then applies
+    ``mb_strlen($message, 'UTF-8') > $maxLength`` -- Unicode **code points**,
+    not bytes and not grapheme clusters. Python's ``len()`` on a ``str`` is also
+    code points, so trimming is the only correction needed.
+    """
+    return len(message.strip())
+
+
+def split_message(
+    message: str,
+    *,
+    max_length: int,
+    part_prefix_template: str | None = PART_PREFIX_TEMPLATE,
+) -> list[str]:
+    """Split ``message`` into parts that each fit within ``max_length``.
+
+    Every returned part satisfies ``measured_length(part) <= max_length`` with
+    its prefix already applied, and is an exact slice of the input apart from
+    that prefix and stripped boundary whitespace.
+
+    A message that already fits comes back unchanged in a one-element list, with
+    no prefix -- so callers can route every message through here without
+    perturbing the common case.
+
+    Args:
+        message: The text to split.
+        max_length: Hard per-part limit, measured as :func:`measured_length`.
+        part_prefix_template: Format string receiving ``index`` and ``total``,
+            prepended to each part when there is more than one. Pass ``None``
+            to number nothing and give the full ``max_length`` to content.
+
+    Returns:
+        The parts in order. Empty when ``message`` has no non-whitespace
+        content.
+
+    Raises:
+        ValueError: If ``max_length`` is not positive, or the prefix would
+            leave no room for content.
+
+    Known limitation: a fenced code block straddling a cut renders as two broken
+    fences. The fence separator sits second in the preference order so this is
+    rare, and treating fences as atomic would cost far more complexity than the
+    cosmetic gain is worth.
+    """
+    if max_length <= 0:
+        raise ValueError(f"max_length must be positive, got {max_length}")
+
+    if measured_length(message) == 0:
+        return []
+    if measured_length(message) <= max_length:
+        return [message]
+
+    text = message.strip()
+
+    parts: list[str] = []
+    total_guess = 1
+    for _ in range(_MAX_PREFIX_ITERATIONS):
+        budget = max_length - _prefix_width(part_prefix_template, total_guess)
+        if budget <= 0:
+            raise ValueError(
+                f"max_length={max_length} leaves no room for the "
+                f"{max_length - budget}-character part prefix"
+            )
+        parts = _pack(text, budget)
+        if len(parts) <= total_guess:
+            break
+        total_guess = len(parts)
+
+    if len(parts) == 1 or part_prefix_template is None:
+        return parts
+
+    total = len(parts)
+    return [
+        part_prefix_template.format(index=index, total=total) + part
+        for index, part in enumerate(parts, 1)
+    ]
+
+
+def _prefix_width(part_prefix_template: str | None, total: int) -> int:
+    """Upper bound on the prefix width for a split of ``total`` parts.
+
+    Rendered with ``index=total`` because ``index <= total`` always, so the
+    widest index is the total itself. Erring wide keeps the budget honest: a
+    prefix narrower than reserved only leaves a part shorter than it could be,
+    whereas a wider one would blow the limit.
+    """
+    if part_prefix_template is None:
+        return 0
+    return len(part_prefix_template.format(index=total, total=total))
+
+
+def _candidate_offsets(text: str, budget: int) -> list[int]:
+    """Offsets in ``text`` that the boundary rules consider legal cut points."""
+    splitter = RecursiveCharacterTextSplitter(
+        separators=list(_SEPARATORS),
+        is_separator_regex=True,
+        chunk_size=budget,
+        chunk_overlap=0,
+        keep_separator="start",
+        add_start_index=True,
+        strip_whitespace=True,
+    )
+    documents = splitter.create_documents([text])
+    # start_index is the chunk's offset in the original text; 0 is the start of
+    # the message, which is never a cut. -1 means LangChain could not locate the
+    # chunk, which should not happen but must not become a bogus offset.
+    return sorted(
+        {
+            offset
+            for document in documents
+            if (offset := document.metadata.get("start_index", -1)) > 0
+        }
+    )
+
+
+def _pack(text: str, budget: int) -> list[str]:
+    """Greedily fill parts up to ``budget``, cutting at the rightmost legal offset.
+
+    LangChain's own chunks are not used directly because it merges only within a
+    recursion level and so under-packs: on a 312-character sample at
+    ``chunk_size=120`` it returns six chunks where four fit. Every extra part is
+    an extra comment on the card, so packing greedily is worth the pass.
+    """
+    offsets = _candidate_offsets(text, budget)
+    mentions = [match.span() for match in MENTION_PATTERN.finditer(text)]
+
+    parts: list[str] = []
+    position = 0
+    length = len(text)
+    while position < length:
+        if length - position <= budget:
+            parts.append(text[position:])
+            break
+        cut = _choose_cut(offsets, mentions, position, position + budget)
+        parts.append(text[position:cut])
+        position = cut
+
+    return [stripped for part in parts if (stripped := part.strip())]
+
+
+def _choose_cut(
+    offsets: list[int],
+    mentions: list[tuple[int, int]],
+    position: int,
+    limit: int,
+) -> int:
+    """Pick where to cut in ``(position, limit]``, preferring the rightmost offset.
+
+    Always returns a value greater than ``position`` so packing terminates.
+    """
+    index = bisect.bisect_right(offsets, limit)
+    while index > 0:
+        offset = offsets[index - 1]
+        if offset <= position:
+            break
+        if _splits_mention(mentions, offset) is None:
+            return offset
+        index -= 1
+
+    # No boundary in range -- the text here is one unbroken run. Cut at the
+    # limit, backing off to the start of a mention rather than severing it.
+    mention = _splits_mention(mentions, limit)
+    if mention is None:
+        return limit
+    if mention[0] > position:
+        return mention[0]
+
+    # A single mention is longer than the whole budget. The length invariant
+    # wins: an over-length part is rejected outright by the server, whereas a
+    # severed mention merely renders as plain text.
+    logger.debug(
+        "Cutting inside a mention at offset %d: the token exceeds the "
+        "%d-character budget",
+        limit,
+        limit - position,
+    )
+    return limit
+
+
+def _splits_mention(
+    mentions: list[tuple[int, int]], offset: int
+) -> tuple[int, int] | None:
+    """Return the mention span ``offset`` falls strictly inside, if any."""
+    for start, end in mentions:
+        if start < offset < end:
+            return start, end
+        if start >= offset:
+            break
+    return None

--- a/tests/server/test_deck_mcp.py
+++ b/tests/server/test_deck_mcp.py
@@ -4,6 +4,7 @@ import re
 import uuid
 
 import pytest
+from httpx import HTTPStatusError
 from mcp import ClientSession
 
 from nextcloud_mcp_server.client import NextcloudClient
@@ -477,6 +478,51 @@ async def test_deck_card_comment_exactly_1000_chars_mcp(
     assert payload["comment"]["message"] == message
     assert payload["part_count"] == 1
     assert payload["parts"] is None
+
+
+async def test_deck_server_counts_unicode_spaces_php_trim_keeps_mcp(
+    nc_mcp_client: ClientSession,
+    nc_client: NextcloudClient,
+    temporary_board_with_card: tuple,
+):
+    """Pin the PHP-vs-Python trim difference against the real server.
+
+    Core trims with PHP ``trim()`` (ASCII whitespace only) before applying
+    ``mb_strlen``, whereas Python's ``str.strip()`` also removes Unicode
+    Zs spaces such as U+3000. Measuring with the Python default would report
+    1000 for the message below, so we would post it and take a 400 back.
+
+    Both halves are asserted here because the claim is about two systems
+    agreeing: the server really does reject it, and our client-side guard
+    really does catch it first.
+    """
+    _, _, card_data = temporary_board_with_card
+    card_id = card_data["id"]
+
+    message = "b" * 1000 + "　"  # 1001 code points once PHP-trimmed
+
+    # 1. The server rejects it -- proving PHP's trim() keeps the U+3000.
+    with pytest.raises(HTTPStatusError) as excinfo:
+        await nc_client.deck.create_comment(card_id, message)
+    assert excinfo.value.response.status_code == 400
+
+    # 2. And our guard rejects it first, so that 400 never reaches an agent.
+    result = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": message},
+    )
+    assert result.isError is True
+    assert "1001 characters" in result.content[0].text
+
+    # 3. Splitting it works, which it could not if we mismeasured the length.
+    split = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": message, "overflow": "split"},
+    )
+    assert split.isError is False, (
+        f"Split of the padded message failed: {split.content}"
+    )
+    assert json.loads(split.content[0].text)["part_count"] == 2
 
 
 async def test_deck_card_comment_update_too_long_mcp(

--- a/tests/server/test_deck_mcp.py
+++ b/tests/server/test_deck_mcp.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import uuid
 
 import pytest
@@ -353,6 +354,170 @@ async def test_deck_card_comment_message_too_long_mcp(
         {"card_id": card_id, "message": too_long},
     )
     assert result.isError is True, "Expected validation error for >1000 char message"
+
+    # The error text is the agent-facing contract: it must name the escape
+    # hatch, otherwise the caller falls back to guess-and-shrink retries.
+    text = result.content[0].text
+    assert 'overflow="split"' in text, f"error should name the remedy: {text}"
+    assert "1001 characters" in text, f"error should state the exact length: {text}"
+
+
+def _long_comment_body(repeats: int) -> str:
+    """A markdown message that needs several comments to post."""
+    block = (
+        "## Deploy {n}\n\n"
+        "The migration landed and every tenant now resolves its collection "
+        "through the registry rather than the hardcoded map. Rollout was "
+        "staged over two days and no tenant saw downtime.\n\n"
+        "- purged the legacy map\n"
+        "- backfilled the audit log\n"
+    )
+    return "\n".join(block.format(n=i) for i in range(repeats))
+
+
+async def test_deck_card_comment_split_mcp(
+    nc_mcp_client: ClientSession, temporary_board_with_card: tuple
+):
+    """overflow="split" posts an over-length message as one numbered thread."""
+    _, _, card_data = temporary_board_with_card
+    card_id = card_data["id"]
+
+    message = _long_comment_body(6)
+    assert len(message) > 1000, "fixture must actually exceed the limit"
+
+    result = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": message, "overflow": "split"},
+    )
+    assert result.isError is False, f"Split comment failed: {result.content}"
+
+    payload = json.loads(result.content[0].text)
+    parts = payload["parts"]
+    assert payload["part_count"] == len(parts) > 1
+    assert parts[0]["id"] == payload["comment"]["id"], "comment must be part 1"
+
+    # Every part is postable on its own terms...
+    for index, part in enumerate(parts, 1):
+        assert len(part["message"]) <= 1000
+        assert part["message"].startswith(f"({index}/{len(parts)}) ")
+
+    # ...and parts 2..N hang off part 1 so the card renders one thread.
+    for part in parts[1:]:
+        assert part["replyTo"] is not None, "split parts must reply to part 1"
+        assert part["replyTo"]["id"] == parts[0]["id"]
+
+    # The thread is really on the card, not just in the response.
+    listed = await nc_mcp_client.call_tool(
+        "deck_get_card_comments", {"card_id": card_id, "limit": 50}
+    )
+    listed_ids = {c["id"] for c in json.loads(listed.content[0].text)["results"]}
+    assert {p["id"] for p in parts} <= listed_ids
+
+    # Nothing was dropped on the way through.
+    rejoined = "".join(re.sub(r"^\(\d+/\d+\) ", "", p["message"]) for p in parts)
+    assert re.sub(r"\s+", "", rejoined) == re.sub(r"\s+", "", message)
+
+
+async def test_deck_card_comment_split_under_parent_mcp(
+    nc_mcp_client: ClientSession, temporary_board_with_card: tuple
+):
+    """Part 1 may itself be a reply, making parts 2..N replies to a reply.
+
+    Nextcloud core resolves ``topmostParentId``, so Deck should accept the
+    nesting -- but that is worth proving against a real server rather than
+    assuming, since the alternative (parts 2..N reusing the caller's parent_id)
+    would need a different implementation.
+    """
+    _, _, card_data = temporary_board_with_card
+    card_id = card_data["id"]
+
+    root = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": "Root of the thread"},
+    )
+    assert root.isError is False
+    root_id = json.loads(root.content[0].text)["comment"]["id"]
+
+    result = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {
+            "card_id": card_id,
+            "message": _long_comment_body(5),
+            "parent_id": root_id,
+            "overflow": "split",
+        },
+    )
+    assert result.isError is False, f"Nested split failed: {result.content}"
+
+    parts = json.loads(result.content[0].text)["parts"]
+    assert len(parts) > 1
+    assert parts[0]["replyTo"]["id"] == root_id, "part 1 replies to the caller's parent"
+    for part in parts[1:]:
+        assert part["replyTo"]["id"] == parts[0]["id"]
+
+
+async def test_deck_card_comment_exactly_1000_chars_mcp(
+    nc_mcp_client: ClientSession, temporary_board_with_card: tuple
+):
+    """Core's check is ``> 1000``, so exactly 1000 must be accepted.
+
+    Guards against a future off-by-one turning the boundary into a rejection.
+    """
+    _, _, card_data = temporary_board_with_card
+    card_id = card_data["id"]
+
+    message = "b" * 1000
+    result = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": message},
+    )
+    assert result.isError is False, f"1000 chars should be legal: {result.content}"
+
+    payload = json.loads(result.content[0].text)
+    assert payload["comment"]["message"] == message
+    assert payload["part_count"] == 1
+    assert payload["parts"] is None
+
+
+async def test_deck_card_comment_update_too_long_mcp(
+    nc_mcp_client: ClientSession, temporary_board_with_card: tuple
+):
+    """An over-length update must fail here, never reaching Deck.
+
+    Deck's CommentService::update() lacks create()'s MessageTooLongException
+    catch, so the server would answer with a masked 500 whose body says only
+    "Internal server error". The client-side guard is what keeps that from
+    reaching the agent.
+    """
+    _, _, card_data = temporary_board_with_card
+    card_id = card_data["id"]
+
+    created = await nc_mcp_client.call_tool(
+        "deck_create_card_comment",
+        {"card_id": card_id, "message": "Short enough to start with"},
+    )
+    assert created.isError is False
+    comment_id = json.loads(created.content[0].text)["comment"]["id"]
+
+    result = await nc_mcp_client.call_tool(
+        "deck_update_card_comment",
+        {"card_id": card_id, "comment_id": comment_id, "message": "y" * 1001},
+    )
+    assert result.isError is True, "Expected client-side rejection of a long update"
+
+    text = result.content[0].text
+    assert "1001 characters" in text
+    # Update cannot split, so the error must not send the agent down that path.
+    assert "Internal server error" not in text, (
+        "the masked 500 must never reach the caller"
+    )
+
+    # The original comment is untouched.
+    listed = await nc_mcp_client.call_tool(
+        "deck_get_card_comments", {"card_id": card_id, "detail": "full"}
+    )
+    comments = {c["id"]: c for c in json.loads(listed.content[0].text)["results"]}
+    assert comments[comment_id]["message"] == "Short enough to start with"
 
 
 # Compact retrieval (summary projection + board overview)

--- a/tests/unit/test_deck_comment_overflow.py
+++ b/tests/unit/test_deck_comment_overflow.py
@@ -56,6 +56,32 @@ def deck_tools() -> dict:
 
 
 @pytest.fixture
+def create_comment(deck_tools):
+    """The ``deck_create_card_comment`` implementation, ready to await.
+
+    Resolving the tool here rather than inside each test keeps the dict lookup
+    and attribute access out of ``pytest.raises`` blocks, so the only statement
+    that can throw in those blocks is the call under test (python:S5778).
+    """
+    return deck_tools["deck_create_card_comment"].fn
+
+
+@pytest.fixture
+def update_comment(deck_tools):
+    return deck_tools["deck_update_card_comment"].fn
+
+
+@pytest.fixture
+def delete_comment(deck_tools):
+    return deck_tools["deck_delete_card_comment"].fn
+
+
+@pytest.fixture
+def list_comments(deck_tools):
+    return deck_tools["deck_get_card_comments"].fn
+
+
+@pytest.fixture
 def fake_client():
     client = SimpleNamespace()
     client.deck = AsyncMock()
@@ -131,7 +157,7 @@ def long_message(parts_wanted: int) -> str:
 
 
 async def test_split_posts_a_thread_rooted_at_part_one(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = [
@@ -140,7 +166,7 @@ async def test_split_posts_a_thread_rooted_at_part_one(
         make_comment(103, "part 3"),
     ]
 
-    result = await deck_tools["deck_create_card_comment"].fn(
+    result = await create_comment(
         ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
     )
 
@@ -156,7 +182,7 @@ async def test_split_posts_a_thread_rooted_at_part_one(
 
 
 async def test_split_parts_each_fit_the_limit_and_carry_numbering(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = lambda card_id, message, **kw: (
@@ -165,7 +191,7 @@ async def test_split_parts_each_fit_the_limit_and_carry_numbering(
         )
     )
 
-    await deck_tools["deck_create_card_comment"].fn(
+    await create_comment(
         ctx=_mock_ctx(), card_id=42, message=long_message(4), overflow="split"
     )
 
@@ -178,7 +204,7 @@ async def test_split_parts_each_fit_the_limit_and_carry_numbering(
 
 
 async def test_split_respects_an_explicit_parent_id_for_part_one(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """Part 1 replies to the caller's comment; parts 2..N reply to part 1."""
     patch_get_client(fake_client)
@@ -188,7 +214,7 @@ async def test_split_respects_an_explicit_parent_id_for_part_one(
         make_comment(203, "p3"),
     ]
 
-    await deck_tools["deck_create_card_comment"].fn(
+    await create_comment(
         ctx=_mock_ctx(),
         card_id=42,
         message=long_message(3),
@@ -202,13 +228,13 @@ async def test_split_respects_an_explicit_parent_id_for_part_one(
 
 
 async def test_split_on_a_short_message_posts_exactly_one_comment(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """overflow="split" must stay a no-op when the message already fits."""
     patch_get_client(fake_client)
     fake_client.deck.create_comment.return_value = make_comment(1, "short")
 
-    result = await deck_tools["deck_create_card_comment"].fn(
+    result = await create_comment(
         ctx=_mock_ctx(), card_id=42, message="short", overflow="split"
     )
 
@@ -219,12 +245,12 @@ async def test_split_on_a_short_message_posts_exactly_one_comment(
 
 
 async def test_message_needing_more_than_the_cap_posts_nothing(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
 
     with pytest.raises(ValueError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(),
             card_id=42,
             message=long_message(_MAX_SPLIT_PARTS + 4),
@@ -240,7 +266,7 @@ async def test_message_needing_more_than_the_cap_posts_nothing(
 
 
 async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """The two modes must agree about what is possible.
 
@@ -252,9 +278,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
     message = long_message(_MAX_SPLIT_PARTS + 5)
 
     with pytest.raises(ValueError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, message=message
-        )
+        await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
 
     text = str(excinfo.value)
     assert "will not work either" in text
@@ -263,7 +287,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
 
     # And the split mode rejects the same message, for the same stated reason.
     with pytest.raises(ValueError, match="will not work either"):
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(), card_id=42, message=message, overflow="split"
         )
     fake_client.deck.create_comment.assert_not_awaited()
@@ -271,7 +295,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
 
 @pytest.mark.parametrize("overflow", ["error", "split"])
 async def test_enormous_message_is_rejected_without_running_the_splitter(
-    deck_tools, fake_client, patch_get_client, mocker, overflow
+    create_comment, fake_client, patch_get_client, mocker, overflow
 ):
     """A multi-megabyte paste must not be fed through the splitter.
 
@@ -282,7 +306,7 @@ async def test_enormous_message_is_rejected_without_running_the_splitter(
     spy = mocker.spy(deck_module, "split_message")
 
     with pytest.raises(ValueError, match="will not work either"):
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(), card_id=42, message="word " * 400_000, overflow=overflow
         )
 
@@ -291,16 +315,14 @@ async def test_enormous_message_is_rejected_without_running_the_splitter(
 
 
 async def test_500_on_delete_is_not_blamed_on_message_length(
-    deck_tools, fake_client, patch_get_client
+    delete_comment, fake_client, patch_get_client
 ):
     """A delete carries no message, so the length explanation cannot apply."""
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(500)
 
     with pytest.raises(McpError) as excinfo:
-        await deck_tools["deck_delete_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, comment_id=7
-        )
+        await delete_comment(ctx=_mock_ctx(), card_id=42, comment_id=7)
 
     text = str(excinfo.value)
     assert "longer than" not in text, f"delete has no message to be too long: {text}"
@@ -309,7 +331,7 @@ async def test_500_on_delete_is_not_blamed_on_message_length(
 
 
 async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """The contract that stops an agent double-posting after a mid-thread failure."""
     patch_get_client(fake_client)
@@ -320,7 +342,7 @@ async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
     ]
 
     with pytest.raises(McpError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
         )
 
@@ -335,7 +357,7 @@ async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
 
 
 async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = http_error(
@@ -343,7 +365,7 @@ async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
     )
 
     with pytest.raises(McpError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
         )
 
@@ -357,15 +379,13 @@ async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
 
 
 async def test_error_mode_posts_nothing_and_names_the_remedy(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     message = "x" * 3412
 
     with pytest.raises(ValueError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, message=message
-        )
+        await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
 
     text = str(excinfo.value)
     assert "3412 characters" in text
@@ -376,35 +396,31 @@ async def test_error_mode_posts_nothing_and_names_the_remedy(
 
 
 async def test_error_is_the_default_overflow_mode(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """Existing callers must keep seeing a failure rather than N new comments."""
     patch_get_client(fake_client)
 
     with pytest.raises(ValueError):
-        await deck_tools["deck_create_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, message=long_message(3)
-        )
+        await create_comment(ctx=_mock_ctx(), card_id=42, message=long_message(3))
 
     fake_client.deck.create_comment.assert_not_awaited()
 
 
 async def test_message_at_exactly_the_limit_is_posted_unchanged(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     message = "x" * _COMMENT_MAX_LENGTH
     fake_client.deck.create_comment.return_value = make_comment(1, message)
 
-    await deck_tools["deck_create_card_comment"].fn(
-        ctx=_mock_ctx(), card_id=42, message=message
-    )
+    await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
 
     assert fake_client.deck.create_comment.await_args.args[1] == message
 
 
 async def test_limit_plus_trailing_whitespace_is_accepted(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """Regression: the guard used to measure with a bare ``len()``.
 
@@ -415,9 +431,7 @@ async def test_limit_plus_trailing_whitespace_is_accepted(
     message = "x" * _COMMENT_MAX_LENGTH + "\n\n\n\n"
     fake_client.deck.create_comment.return_value = make_comment(1, message)
 
-    await deck_tools["deck_create_card_comment"].fn(
-        ctx=_mock_ctx(), card_id=42, message=message
-    )
+    await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
 
     fake_client.deck.create_comment.assert_awaited_once()
 
@@ -425,12 +439,12 @@ async def test_limit_plus_trailing_whitespace_is_accepted(
 @pytest.mark.parametrize("message", ["", "   \n\t "])
 @pytest.mark.parametrize("overflow", ["error", "split"])
 async def test_blank_message_is_rejected_in_both_modes(
-    deck_tools, fake_client, patch_get_client, message, overflow
+    create_comment, fake_client, patch_get_client, message, overflow
 ):
     patch_get_client(fake_client)
 
     with pytest.raises(ValueError, match="empty or whitespace-only"):
-        await deck_tools["deck_create_card_comment"].fn(
+        await create_comment(
             ctx=_mock_ctx(), card_id=42, message=message, overflow=overflow
         )
 
@@ -441,7 +455,7 @@ async def test_blank_message_is_rejected_in_both_modes(
 
 
 async def test_masked_500_on_update_names_the_length_limit(
-    deck_tools, fake_client, patch_get_client
+    update_comment, fake_client, patch_get_client
 ):
     """Deck's update endpoint lacks create's MessageTooLongException catch.
 
@@ -452,7 +466,7 @@ async def test_masked_500_on_update_names_the_length_limit(
     fake_client.deck.update_comment.side_effect = http_error(500)
 
     with pytest.raises(McpError) as excinfo:
-        await deck_tools["deck_update_card_comment"].fn(
+        await update_comment(
             ctx=_mock_ctx(), card_id=42, comment_id=7, message="still short"
         )
 
@@ -462,44 +476,85 @@ async def test_masked_500_on_update_names_the_length_limit(
     assert "11 characters" in text
 
 
+async def test_403_on_listing_blames_board_access_not_authorship(
+    list_comments, fake_client, patch_get_client
+):
+    """A read cannot fail on authorship -- there is nothing being authored.
+
+    The 403 branch is shared by all four comment operations, so it has to say
+    something true for each of them; an agent told "only the comment's author
+    can edit or delete" after a failed *list* would chase the wrong fix.
+    """
+    patch_get_client(fake_client)
+    fake_client.deck.get_comments.side_effect = http_error(403)
+
+    with pytest.raises(McpError) as excinfo:
+        await list_comments(ctx=_mock_ctx(), card_id=42)
+
+    text = str(excinfo.value)
+    assert "read access" in text
+    assert "author" not in text, f"a list has no author to restrict: {text}"
+    assert "Nothing was changed" not in text, f"a read changes nothing anyway: {text}"
+
+
+async def test_403_on_creating_blames_board_write_access_not_authorship(
+    create_comment, fake_client, patch_get_client
+):
+    """There is no comment yet to be the author of, so it is board access."""
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = http_error(403)
+
+    with pytest.raises(McpError) as excinfo:
+        await create_comment(ctx=_mock_ctx(), card_id=42, message="hello")
+
+    text = str(excinfo.value)
+    assert "write access to this board" in text
+    assert "author" not in text, f"nothing is authored yet on a create: {text}"
+    assert "Nothing was posted" in text
+
+
 async def test_403_on_update_explains_the_author_restriction(
-    deck_tools, fake_client, patch_get_client
+    update_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.update_comment.side_effect = http_error(
         403, ocs_message="Only authors are allowed to edit their comment."
     )
 
-    with pytest.raises(McpError, match="only the comment's author"):
-        await deck_tools["deck_update_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, comment_id=7, message="edit"
-        )
+    with pytest.raises(McpError) as excinfo:
+        await update_comment(ctx=_mock_ctx(), card_id=42, comment_id=7, message="edit")
+
+    text = str(excinfo.value)
+    assert "only the comment's author can edit it" in text
+    assert "Nothing was changed" in text
 
 
 async def test_403_on_delete_explains_the_author_restriction(
-    deck_tools, fake_client, patch_get_client
+    delete_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(403)
 
-    with pytest.raises(McpError, match="only the comment's author"):
-        await deck_tools["deck_delete_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, comment_id=7
-        )
+    with pytest.raises(McpError) as excinfo:
+        await delete_comment(ctx=_mock_ctx(), card_id=42, comment_id=7)
+
+    text = str(excinfo.value)
+    assert "only the comment's author can delete it" in text
+    assert "Nothing was deleted" in text
 
 
 async def test_404_on_listing_comments_is_mapped(
-    deck_tools, fake_client, patch_get_client
+    list_comments, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.get_comments.side_effect = http_error(404)
 
     with pytest.raises(McpError, match="does not exist, or you lack access"):
-        await deck_tools["deck_get_card_comments"].fn(ctx=_mock_ctx(), card_id=42)
+        await list_comments(ctx=_mock_ctx(), card_id=42)
 
 
 async def test_400_from_deck_surfaces_the_server_reason(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     """Belt-and-braces: the client-side guard should stop this ever firing."""
     patch_get_client(fake_client)
@@ -508,9 +563,7 @@ async def test_400_from_deck_surfaces_the_server_reason(
     )
 
     with pytest.raises(McpError) as excinfo:
-        await deck_tools["deck_create_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, message="short enough"
-        )
+        await create_comment(ctx=_mock_ctx(), card_id=42, message="short enough")
 
     text = str(excinfo.value)
     assert "Message exceeds allowed character limit of 1000" in text
@@ -518,12 +571,10 @@ async def test_400_from_deck_surfaces_the_server_reason(
 
 
 async def test_network_error_is_reported_as_such(
-    deck_tools, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = httpx.ConnectError("no route")
 
     with pytest.raises(McpError, match="Network error creating a comment"):
-        await deck_tools["deck_create_card_comment"].fn(
-            ctx=_mock_ctx(), card_id=42, message="hello"
-        )
+        await create_comment(ctx=_mock_ctx(), card_id=42, message="hello")

--- a/tests/unit/test_deck_comment_overflow.py
+++ b/tests/unit/test_deck_comment_overflow.py
@@ -102,10 +102,17 @@ def patch_get_client(mocker):
     return _install
 
 
-def _mock_ctx() -> SimpleNamespace:
-    ctx = SimpleNamespace()
-    ctx.request_context = SimpleNamespace()
-    return ctx
+@pytest.fixture
+def ctx() -> SimpleNamespace:
+    """A minimal Context-shaped object for the tool decorators.
+
+    A fixture rather than a helper call so it can be passed by name: a call
+    here would be a second invocation inside every ``pytest.raises`` block,
+    leaving it ambiguous which one was expected to raise (python:S5778).
+    """
+    context = SimpleNamespace()
+    context.request_context = SimpleNamespace()
+    return context
 
 
 def make_comment(comment_id: int, message: str, card_id: int = 42) -> DeckComment:
@@ -157,7 +164,7 @@ def long_message(parts_wanted: int) -> str:
 
 
 async def test_split_posts_a_thread_rooted_at_part_one(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = [
@@ -167,7 +174,7 @@ async def test_split_posts_a_thread_rooted_at_part_one(
     ]
 
     result = await create_comment(
-        ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
+        ctx=ctx, card_id=42, message=long_message(3), overflow="split"
     )
 
     calls = fake_client.deck.create_comment.await_args_list
@@ -182,7 +189,7 @@ async def test_split_posts_a_thread_rooted_at_part_one(
 
 
 async def test_split_parts_each_fit_the_limit_and_carry_numbering(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = lambda card_id, message, **kw: (
@@ -191,9 +198,7 @@ async def test_split_parts_each_fit_the_limit_and_carry_numbering(
         )
     )
 
-    await create_comment(
-        ctx=_mock_ctx(), card_id=42, message=long_message(4), overflow="split"
-    )
+    await create_comment(ctx=ctx, card_id=42, message=long_message(4), overflow="split")
 
     posted = [c.args[1] for c in fake_client.deck.create_comment.await_args_list]
     total = len(posted)
@@ -204,7 +209,7 @@ async def test_split_parts_each_fit_the_limit_and_carry_numbering(
 
 
 async def test_split_respects_an_explicit_parent_id_for_part_one(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """Part 1 replies to the caller's comment; parts 2..N reply to part 1."""
     patch_get_client(fake_client)
@@ -215,7 +220,7 @@ async def test_split_respects_an_explicit_parent_id_for_part_one(
     ]
 
     await create_comment(
-        ctx=_mock_ctx(),
+        ctx=ctx,
         card_id=42,
         message=long_message(3),
         parent_id=77,
@@ -228,14 +233,14 @@ async def test_split_respects_an_explicit_parent_id_for_part_one(
 
 
 async def test_split_on_a_short_message_posts_exactly_one_comment(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """overflow="split" must stay a no-op when the message already fits."""
     patch_get_client(fake_client)
     fake_client.deck.create_comment.return_value = make_comment(1, "short")
 
     result = await create_comment(
-        ctx=_mock_ctx(), card_id=42, message="short", overflow="split"
+        ctx=ctx, card_id=42, message="short", overflow="split"
     )
 
     assert fake_client.deck.create_comment.await_count == 1
@@ -245,17 +250,14 @@ async def test_split_on_a_short_message_posts_exactly_one_comment(
 
 
 async def test_message_needing_more_than_the_cap_posts_nothing(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
 
+    message = long_message(_MAX_SPLIT_PARTS + 4)
+
     with pytest.raises(ValueError) as excinfo:
-        await create_comment(
-            ctx=_mock_ctx(),
-            card_id=42,
-            message=long_message(_MAX_SPLIT_PARTS + 4),
-            overflow="split",
-        )
+        await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     assert f"{_MAX_SPLIT_PARTS}-part limit" in str(excinfo.value)
     assert "Nothing was posted" in str(excinfo.value)
@@ -266,7 +268,7 @@ async def test_message_needing_more_than_the_cap_posts_nothing(
 
 
 async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """The two modes must agree about what is possible.
 
@@ -278,7 +280,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
     message = long_message(_MAX_SPLIT_PARTS + 5)
 
     with pytest.raises(ValueError) as excinfo:
-        await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
+        await create_comment(ctx=ctx, card_id=42, message=message)
 
     text = str(excinfo.value)
     assert "will not work either" in text
@@ -287,15 +289,13 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
 
     # And the split mode rejects the same message, for the same stated reason.
     with pytest.raises(ValueError, match="will not work either"):
-        await create_comment(
-            ctx=_mock_ctx(), card_id=42, message=message, overflow="split"
-        )
+        await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
     fake_client.deck.create_comment.assert_not_awaited()
 
 
 @pytest.mark.parametrize("overflow", ["error", "split"])
 async def test_enormous_message_is_rejected_without_running_the_splitter(
-    create_comment, fake_client, patch_get_client, mocker, overflow
+    create_comment, fake_client, patch_get_client, mocker, overflow, ctx
 ):
     """A multi-megabyte paste must not be fed through the splitter.
 
@@ -307,7 +307,7 @@ async def test_enormous_message_is_rejected_without_running_the_splitter(
 
     with pytest.raises(ValueError, match="will not work either"):
         await create_comment(
-            ctx=_mock_ctx(), card_id=42, message="word " * 400_000, overflow=overflow
+            ctx=ctx, card_id=42, message="word " * 400_000, overflow=overflow
         )
 
     spy.assert_not_called()
@@ -315,14 +315,14 @@ async def test_enormous_message_is_rejected_without_running_the_splitter(
 
 
 async def test_500_on_delete_is_not_blamed_on_message_length(
-    delete_comment, fake_client, patch_get_client
+    delete_comment, fake_client, patch_get_client, ctx
 ):
     """A delete carries no message, so the length explanation cannot apply."""
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(500)
 
     with pytest.raises(McpError) as excinfo:
-        await delete_comment(ctx=_mock_ctx(), card_id=42, comment_id=7)
+        await delete_comment(ctx=ctx, card_id=42, comment_id=7)
 
     text = str(excinfo.value)
     assert "longer than" not in text, f"delete has no message to be too long: {text}"
@@ -331,7 +331,7 @@ async def test_500_on_delete_is_not_blamed_on_message_length(
 
 
 async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """The contract that stops an agent double-posting after a mid-thread failure."""
     patch_get_client(fake_client)
@@ -341,10 +341,10 @@ async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
         http_error(403, ocs_message="Not allowed"),
     ]
 
+    message = long_message(3)
+
     with pytest.raises(McpError) as excinfo:
-        await create_comment(
-            ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
-        )
+        await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     message = str(excinfo.value)
     assert "[301, 302]" in message
@@ -357,17 +357,17 @@ async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
 
 
 async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = http_error(
         500, ocs_message="Server exploded"
     )
 
+    message = long_message(3)
+
     with pytest.raises(McpError) as excinfo:
-        await create_comment(
-            ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
-        )
+        await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     message = str(excinfo.value)
     assert "Nothing was posted" in message
@@ -379,13 +379,13 @@ async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
 
 
 async def test_error_mode_posts_nothing_and_names_the_remedy(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     message = "x" * 3412
 
     with pytest.raises(ValueError) as excinfo:
-        await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
+        await create_comment(ctx=ctx, card_id=42, message=message)
 
     text = str(excinfo.value)
     assert "3412 characters" in text
@@ -396,31 +396,33 @@ async def test_error_mode_posts_nothing_and_names_the_remedy(
 
 
 async def test_error_is_the_default_overflow_mode(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """Existing callers must keep seeing a failure rather than N new comments."""
     patch_get_client(fake_client)
 
+    message = long_message(3)
+
     with pytest.raises(ValueError):
-        await create_comment(ctx=_mock_ctx(), card_id=42, message=long_message(3))
+        await create_comment(ctx=ctx, card_id=42, message=message)
 
     fake_client.deck.create_comment.assert_not_awaited()
 
 
 async def test_message_at_exactly_the_limit_is_posted_unchanged(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     message = "x" * _COMMENT_MAX_LENGTH
     fake_client.deck.create_comment.return_value = make_comment(1, message)
 
-    await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
+    await create_comment(ctx=ctx, card_id=42, message=message)
 
     assert fake_client.deck.create_comment.await_args.args[1] == message
 
 
 async def test_limit_plus_trailing_whitespace_is_accepted(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """Regression: the guard used to measure with a bare ``len()``.
 
@@ -431,7 +433,7 @@ async def test_limit_plus_trailing_whitespace_is_accepted(
     message = "x" * _COMMENT_MAX_LENGTH + "\n\n\n\n"
     fake_client.deck.create_comment.return_value = make_comment(1, message)
 
-    await create_comment(ctx=_mock_ctx(), card_id=42, message=message)
+    await create_comment(ctx=ctx, card_id=42, message=message)
 
     fake_client.deck.create_comment.assert_awaited_once()
 
@@ -439,14 +441,12 @@ async def test_limit_plus_trailing_whitespace_is_accepted(
 @pytest.mark.parametrize("message", ["", "   \n\t "])
 @pytest.mark.parametrize("overflow", ["error", "split"])
 async def test_blank_message_is_rejected_in_both_modes(
-    create_comment, fake_client, patch_get_client, message, overflow
+    create_comment, fake_client, patch_get_client, message, overflow, ctx
 ):
     patch_get_client(fake_client)
 
     with pytest.raises(ValueError, match="empty or whitespace-only"):
-        await create_comment(
-            ctx=_mock_ctx(), card_id=42, message=message, overflow=overflow
-        )
+        await create_comment(ctx=ctx, card_id=42, message=message, overflow=overflow)
 
     fake_client.deck.create_comment.assert_not_awaited()
 
@@ -455,7 +455,7 @@ async def test_blank_message_is_rejected_in_both_modes(
 
 
 async def test_masked_500_on_update_names_the_length_limit(
-    update_comment, fake_client, patch_get_client
+    update_comment, fake_client, patch_get_client, ctx
 ):
     """Deck's update endpoint lacks create's MessageTooLongException catch.
 
@@ -466,9 +466,7 @@ async def test_masked_500_on_update_names_the_length_limit(
     fake_client.deck.update_comment.side_effect = http_error(500)
 
     with pytest.raises(McpError) as excinfo:
-        await update_comment(
-            ctx=_mock_ctx(), card_id=42, comment_id=7, message="still short"
-        )
+        await update_comment(ctx=ctx, card_id=42, comment_id=7, message="still short")
 
     text = str(excinfo.value)
     assert str(_COMMENT_MAX_LENGTH) in text
@@ -477,7 +475,7 @@ async def test_masked_500_on_update_names_the_length_limit(
 
 
 async def test_403_on_listing_blames_board_access_not_authorship(
-    list_comments, fake_client, patch_get_client
+    list_comments, fake_client, patch_get_client, ctx
 ):
     """A read cannot fail on authorship -- there is nothing being authored.
 
@@ -489,7 +487,7 @@ async def test_403_on_listing_blames_board_access_not_authorship(
     fake_client.deck.get_comments.side_effect = http_error(403)
 
     with pytest.raises(McpError) as excinfo:
-        await list_comments(ctx=_mock_ctx(), card_id=42)
+        await list_comments(ctx=ctx, card_id=42)
 
     text = str(excinfo.value)
     assert "read access" in text
@@ -498,14 +496,14 @@ async def test_403_on_listing_blames_board_access_not_authorship(
 
 
 async def test_403_on_creating_blames_board_write_access_not_authorship(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """There is no comment yet to be the author of, so it is board access."""
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = http_error(403)
 
     with pytest.raises(McpError) as excinfo:
-        await create_comment(ctx=_mock_ctx(), card_id=42, message="hello")
+        await create_comment(ctx=ctx, card_id=42, message="hello")
 
     text = str(excinfo.value)
     assert "write access to this board" in text
@@ -514,7 +512,7 @@ async def test_403_on_creating_blames_board_write_access_not_authorship(
 
 
 async def test_403_on_update_explains_the_author_restriction(
-    update_comment, fake_client, patch_get_client
+    update_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.update_comment.side_effect = http_error(
@@ -522,7 +520,7 @@ async def test_403_on_update_explains_the_author_restriction(
     )
 
     with pytest.raises(McpError) as excinfo:
-        await update_comment(ctx=_mock_ctx(), card_id=42, comment_id=7, message="edit")
+        await update_comment(ctx=ctx, card_id=42, comment_id=7, message="edit")
 
     text = str(excinfo.value)
     assert "only the comment's author can edit it" in text
@@ -530,13 +528,13 @@ async def test_403_on_update_explains_the_author_restriction(
 
 
 async def test_403_on_delete_explains_the_author_restriction(
-    delete_comment, fake_client, patch_get_client
+    delete_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(403)
 
     with pytest.raises(McpError) as excinfo:
-        await delete_comment(ctx=_mock_ctx(), card_id=42, comment_id=7)
+        await delete_comment(ctx=ctx, card_id=42, comment_id=7)
 
     text = str(excinfo.value)
     assert "only the comment's author can delete it" in text
@@ -544,17 +542,17 @@ async def test_403_on_delete_explains_the_author_restriction(
 
 
 async def test_404_on_listing_comments_is_mapped(
-    list_comments, fake_client, patch_get_client
+    list_comments, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.get_comments.side_effect = http_error(404)
 
     with pytest.raises(McpError, match="does not exist, or you lack access"):
-        await list_comments(ctx=_mock_ctx(), card_id=42)
+        await list_comments(ctx=ctx, card_id=42)
 
 
 async def test_400_from_deck_surfaces_the_server_reason(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     """Belt-and-braces: the client-side guard should stop this ever firing."""
     patch_get_client(fake_client)
@@ -563,7 +561,7 @@ async def test_400_from_deck_surfaces_the_server_reason(
     )
 
     with pytest.raises(McpError) as excinfo:
-        await create_comment(ctx=_mock_ctx(), card_id=42, message="short enough")
+        await create_comment(ctx=ctx, card_id=42, message="short enough")
 
     text = str(excinfo.value)
     assert "Message exceeds allowed character limit of 1000" in text
@@ -571,10 +569,10 @@ async def test_400_from_deck_surfaces_the_server_reason(
 
 
 async def test_network_error_is_reported_as_such(
-    create_comment, fake_client, patch_get_client
+    create_comment, fake_client, patch_get_client, ctx
 ):
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = httpx.ConnectError("no route")
 
     with pytest.raises(McpError, match="Network error creating a comment"):
-        await create_comment(ctx=_mock_ctx(), card_id=42, message="hello")
+        await create_comment(ctx=ctx, card_id=42, message="hello")

--- a/tests/unit/test_deck_comment_overflow.py
+++ b/tests/unit/test_deck_comment_overflow.py
@@ -1,0 +1,529 @@
+"""Tool-layer tests for Deck comment length handling.
+
+These register the Deck tools on a fresh ``FastMCP`` and invoke each tool's
+underlying function directly, mocking the client. They cover the wiring the
+splitter's own unit tests cannot: how many POSTs happen, what ``parent_id``
+each one carries, what is *not* called on failure, and what the error text
+tells an agent to do next.
+
+The decorators (``@require_scopes``, ``@instrument_tool``) are made transparent
+by the ``basicauth_mode`` fixture, mirroring
+``tests/unit/test_webdav_tools_exclusion.py``.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+
+from nextcloud_mcp_server.models.deck import DeckComment
+from nextcloud_mcp_server.server import deck as deck_module
+from nextcloud_mcp_server.server.deck import (
+    _COMMENT_MAX_LENGTH,
+    _MAX_SPLIT_PARTS,
+    configure_deck_tools,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def basicauth_mode():
+    """Pin ``require_scopes`` to the BasicAuth pass-through path.
+
+    These tests invoke tool functions directly, so there is no transport and no
+    verified token; under an OAuth-style mode the decorator would (correctly)
+    deny the call, and the outcome would otherwise depend on whatever
+    ``MCP_DEPLOYMENT_MODE`` the developer happens to have exported.
+    """
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=SimpleNamespace(enable_login_flow=False),
+    ):
+        yield
+
+
+@pytest.fixture
+def deck_tools() -> dict:
+    """Register the Deck tools on a fresh FastMCP and return them by name."""
+    mcp = FastMCP(name="test-deck-tools")
+    configure_deck_tools(mcp)
+    return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+
+@pytest.fixture
+def fake_client():
+    client = SimpleNamespace()
+    client.deck = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def patch_get_client(mocker):
+    def _install(client):
+        async def fake_get_client(ctx):
+            return client
+
+        mocker.patch(
+            "nextcloud_mcp_server.server.deck.get_client",
+            side_effect=fake_get_client,
+        )
+
+    return _install
+
+
+def _mock_ctx() -> SimpleNamespace:
+    ctx = SimpleNamespace()
+    ctx.request_context = SimpleNamespace()
+    return ctx
+
+
+def make_comment(comment_id: int, message: str, card_id: int = 42) -> DeckComment:
+    return DeckComment(
+        id=comment_id,
+        objectId=card_id,
+        message=message,
+        actorId="alice",
+        actorType="users",
+        actorDisplayName="Alice",
+        creationDateTime=datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc),
+        mentions=[],
+    )
+
+
+def http_error(status: int, *, ocs_message: str | None = None) -> httpx.HTTPStatusError:
+    """Build the failure the client layer would raise for ``status``."""
+    request = httpx.Request("POST", "https://nextcloud.example/ocs/v2.php")
+    if ocs_message is not None:
+        response = httpx.Response(
+            status,
+            request=request,
+            json={"ocs": {"meta": {"status": "failure", "message": ocs_message}}},
+        )
+    else:
+        # Deck's masked 500 is a bare JSONResponse, not an OCS envelope.
+        response = httpx.Response(
+            status,
+            request=request,
+            json={
+                "status": status,
+                "message": "Internal server error",
+                "requestId": "x",
+            },
+        )
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def long_message(parts_wanted: int) -> str:
+    """A markdown-ish message that needs roughly ``parts_wanted`` comments."""
+    sentence = (
+        "The migration landed and every tenant now resolves its collection "
+        "through the registry rather than the hardcoded map. "
+    )
+    return (sentence * 8 * parts_wanted).strip()
+
+
+# Split ---------------------------------------------------------------------
+
+
+async def test_split_posts_a_thread_rooted_at_part_one(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = [
+        make_comment(101, "part 1"),
+        make_comment(102, "part 2"),
+        make_comment(103, "part 3"),
+    ]
+
+    result = await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
+    )
+
+    calls = fake_client.deck.create_comment.await_args_list
+    assert len(calls) == 3
+    # Part 1 is top-level; the rest hang off it so the card shows one thread.
+    assert calls[0].kwargs["parent_id"] is None
+    assert [c.kwargs["parent_id"] for c in calls[1:]] == [101, 101]
+
+    assert result.part_count == 3
+    assert [c.id for c in result.parts] == [101, 102, 103]
+    assert result.parts[0].id == result.comment.id
+
+
+async def test_split_parts_each_fit_the_limit_and_carry_numbering(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = lambda card_id, message, **kw: (
+        make_comment(
+            100 + len(fake_client.deck.create_comment.await_args_list), message
+        )
+    )
+
+    await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(), card_id=42, message=long_message(4), overflow="split"
+    )
+
+    posted = [c.args[1] for c in fake_client.deck.create_comment.await_args_list]
+    total = len(posted)
+    assert all(len(m) <= _COMMENT_MAX_LENGTH for m in posted)
+    assert [m[: m.index(")") + 1] for m in posted] == [
+        f"({i}/{total})" for i in range(1, total + 1)
+    ]
+
+
+async def test_split_respects_an_explicit_parent_id_for_part_one(
+    deck_tools, fake_client, patch_get_client
+):
+    """Part 1 replies to the caller's comment; parts 2..N reply to part 1."""
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = [
+        make_comment(201, "p1"),
+        make_comment(202, "p2"),
+        make_comment(203, "p3"),
+    ]
+
+    await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(),
+        card_id=42,
+        message=long_message(3),
+        parent_id=77,
+        overflow="split",
+    )
+
+    calls = fake_client.deck.create_comment.await_args_list
+    assert calls[0].kwargs["parent_id"] == 77
+    assert [c.kwargs["parent_id"] for c in calls[1:]] == [201, 201]
+
+
+async def test_split_on_a_short_message_posts_exactly_one_comment(
+    deck_tools, fake_client, patch_get_client
+):
+    """overflow="split" must stay a no-op when the message already fits."""
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.return_value = make_comment(1, "short")
+
+    result = await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(), card_id=42, message="short", overflow="split"
+    )
+
+    assert fake_client.deck.create_comment.await_count == 1
+    assert fake_client.deck.create_comment.await_args.args[1] == "short"
+    assert result.parts is None
+    assert result.part_count == 1
+
+
+async def test_message_needing_more_than_the_cap_posts_nothing(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+
+    with pytest.raises(ValueError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(),
+            card_id=42,
+            message=long_message(_MAX_SPLIT_PARTS + 4),
+            overflow="split",
+        )
+
+    assert f"{_MAX_SPLIT_PARTS}-part limit" in str(excinfo.value)
+    assert "Nothing was posted" in str(excinfo.value)
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+# Partial failure -----------------------------------------------------------
+
+
+async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
+    deck_tools, fake_client, patch_get_client
+):
+    """The two modes must agree about what is possible.
+
+    Telling the caller to retry with overflow="split" when the split itself
+    exceeds the part cap just restarts the guess-and-retry loop this whole
+    feature exists to end.
+    """
+    patch_get_client(fake_client)
+    message = long_message(_MAX_SPLIT_PARTS + 5)
+
+    with pytest.raises(ValueError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=message
+        )
+
+    text = str(excinfo.value)
+    assert "will not work either" in text
+    assert f"{_MAX_SPLIT_PARTS}-part limit" in text
+    assert "nc_notes_create_note" in text
+
+    # And the split mode rejects the same message, for the same stated reason.
+    with pytest.raises(ValueError, match="will not work either"):
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=message, overflow="split"
+        )
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+@pytest.mark.parametrize("overflow", ["error", "split"])
+async def test_enormous_message_is_rejected_without_running_the_splitter(
+    deck_tools, fake_client, patch_get_client, mocker, overflow
+):
+    """A multi-megabyte paste must not be fed through the splitter.
+
+    This is the failure path that fires precisely when a caller oversends, so
+    it has to stay cheap; the size alone rules a split out.
+    """
+    patch_get_client(fake_client)
+    spy = mocker.spy(deck_module, "split_message")
+
+    with pytest.raises(ValueError, match="will not work either"):
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message="word " * 400_000, overflow=overflow
+        )
+
+    spy.assert_not_called()
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+async def test_500_on_delete_is_not_blamed_on_message_length(
+    deck_tools, fake_client, patch_get_client
+):
+    """A delete carries no message, so the length explanation cannot apply."""
+    patch_get_client(fake_client)
+    fake_client.deck.delete_comment.side_effect = http_error(500)
+
+    with pytest.raises(McpError) as excinfo:
+        await deck_tools["deck_delete_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, comment_id=7
+        )
+
+    text = str(excinfo.value)
+    assert "longer than" not in text, f"delete has no message to be too long: {text}"
+    assert "may or may not have been modified" not in text
+    assert "500" in text
+
+
+async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
+    deck_tools, fake_client, patch_get_client
+):
+    """The contract that stops an agent double-posting after a mid-thread failure."""
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = [
+        make_comment(301, "p1"),
+        make_comment(302, "p2"),
+        http_error(403, ocs_message="Not allowed"),
+    ]
+
+    with pytest.raises(McpError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
+        )
+
+    message = str(excinfo.value)
+    assert "[301, 302]" in message
+    assert "failed_part=3" in message
+    assert "Do NOT re-send the whole message" in message
+    assert "parent_id=301" in message
+    # No rollback: deleting posted parts can itself fail and would destroy
+    # content a human may already have read.
+    fake_client.deck.delete_comment.assert_not_awaited()
+
+
+async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = http_error(
+        500, ocs_message="Server exploded"
+    )
+
+    with pytest.raises(McpError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=long_message(3), overflow="split"
+        )
+
+    message = str(excinfo.value)
+    assert "Nothing was posted" in message
+    assert "retrying the whole message is safe" in message
+    assert "posted_comment_ids=[]" in message
+
+
+# Error mode ----------------------------------------------------------------
+
+
+async def test_error_mode_posts_nothing_and_names_the_remedy(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    message = "x" * 3412
+
+    with pytest.raises(ValueError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=message
+        )
+
+    text = str(excinfo.value)
+    assert "3412 characters" in text
+    assert f"{3412 - _COMMENT_MAX_LENGTH} characters over" in text
+    assert "Nothing was posted" in text
+    assert 'overflow="split"' in text
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+async def test_error_is_the_default_overflow_mode(
+    deck_tools, fake_client, patch_get_client
+):
+    """Existing callers must keep seeing a failure rather than N new comments."""
+    patch_get_client(fake_client)
+
+    with pytest.raises(ValueError):
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=long_message(3)
+        )
+
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+async def test_message_at_exactly_the_limit_is_posted_unchanged(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    message = "x" * _COMMENT_MAX_LENGTH
+    fake_client.deck.create_comment.return_value = make_comment(1, message)
+
+    await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(), card_id=42, message=message
+    )
+
+    assert fake_client.deck.create_comment.await_args.args[1] == message
+
+
+async def test_limit_plus_trailing_whitespace_is_accepted(
+    deck_tools, fake_client, patch_get_client
+):
+    """Regression: the guard used to measure with a bare ``len()``.
+
+    The server trims before it measures, so this message is legal there and
+    used to be rejected here for no reason.
+    """
+    patch_get_client(fake_client)
+    message = "x" * _COMMENT_MAX_LENGTH + "\n\n\n\n"
+    fake_client.deck.create_comment.return_value = make_comment(1, message)
+
+    await deck_tools["deck_create_card_comment"].fn(
+        ctx=_mock_ctx(), card_id=42, message=message
+    )
+
+    fake_client.deck.create_comment.assert_awaited_once()
+
+
+@pytest.mark.parametrize("message", ["", "   \n\t "])
+@pytest.mark.parametrize("overflow", ["error", "split"])
+async def test_blank_message_is_rejected_in_both_modes(
+    deck_tools, fake_client, patch_get_client, message, overflow
+):
+    patch_get_client(fake_client)
+
+    with pytest.raises(ValueError, match="empty or whitespace-only"):
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message=message, overflow=overflow
+        )
+
+    fake_client.deck.create_comment.assert_not_awaited()
+
+
+# HTTP error mapping --------------------------------------------------------
+
+
+async def test_masked_500_on_update_names_the_length_limit(
+    deck_tools, fake_client, patch_get_client
+):
+    """Deck's update endpoint lacks create's MessageTooLongException catch.
+
+    It leaks a masked 500 whose body says only "Internal server error", so the
+    mapping has to supply the cause an agent cannot otherwise guess.
+    """
+    patch_get_client(fake_client)
+    fake_client.deck.update_comment.side_effect = http_error(500)
+
+    with pytest.raises(McpError) as excinfo:
+        await deck_tools["deck_update_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, comment_id=7, message="still short"
+        )
+
+    text = str(excinfo.value)
+    assert str(_COMMENT_MAX_LENGTH) in text
+    assert "deck_get_card_comments" in text
+    assert "11 characters" in text
+
+
+async def test_403_on_update_explains_the_author_restriction(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.update_comment.side_effect = http_error(
+        403, ocs_message="Only authors are allowed to edit their comment."
+    )
+
+    with pytest.raises(McpError, match="only the comment's author"):
+        await deck_tools["deck_update_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, comment_id=7, message="edit"
+        )
+
+
+async def test_403_on_delete_explains_the_author_restriction(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.delete_comment.side_effect = http_error(403)
+
+    with pytest.raises(McpError, match="only the comment's author"):
+        await deck_tools["deck_delete_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, comment_id=7
+        )
+
+
+async def test_404_on_listing_comments_is_mapped(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.get_comments.side_effect = http_error(404)
+
+    with pytest.raises(McpError, match="does not exist, or you lack access"):
+        await deck_tools["deck_get_card_comments"].fn(ctx=_mock_ctx(), card_id=42)
+
+
+async def test_400_from_deck_surfaces_the_server_reason(
+    deck_tools, fake_client, patch_get_client
+):
+    """Belt-and-braces: the client-side guard should stop this ever firing."""
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = http_error(
+        400, ocs_message="Message exceeds allowed character limit of 1000"
+    )
+
+    with pytest.raises(McpError) as excinfo:
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message="short enough"
+        )
+
+    text = str(excinfo.value)
+    assert "Message exceeds allowed character limit of 1000" in text
+    assert 'overflow="split"' in text
+
+
+async def test_network_error_is_reported_as_such(
+    deck_tools, fake_client, patch_get_client
+):
+    patch_get_client(fake_client)
+    fake_client.deck.create_comment.side_effect = httpx.ConnectError("no route")
+
+    with pytest.raises(McpError, match="Network error creating a comment"):
+        await deck_tools["deck_create_card_comment"].fn(
+            ctx=_mock_ctx(), card_id=42, message="hello"
+        )

--- a/tests/unit/test_message_splitter.py
+++ b/tests/unit/test_message_splitter.py
@@ -1,0 +1,292 @@
+"""Unit tests for the comment message splitter.
+
+The four property tests are the load-bearing ones: they encode the invariants
+that decide whether a split comment can actually be posted and whether the text
+survives the round trip. The example tests pin the individual edge cases those
+properties are easy to satisfy vacuously on.
+"""
+
+import re
+
+import pytest
+
+from nextcloud_mcp_server.utils.message_splitter import (
+    MENTION_PATTERN,
+    PART_PREFIX_TEMPLATE,
+    measured_length,
+    split_message,
+)
+
+pytestmark = pytest.mark.unit
+
+LIMIT = 1000
+
+_PREFIX_RE = re.compile(r"^\(\d+/\d+\) ")
+
+
+def strip_prefix(part: str) -> str:
+    """Drop the ``(i/N) `` marker a split part carries."""
+    return _PREFIX_RE.sub("", part)
+
+
+# Corpus --------------------------------------------------------------------
+
+MARKDOWN_DOC = (
+    "## Shipped state\n\n"
+    "The migration landed in 0.142.0. Every tenant now resolves its collection "
+    "through the registry rather than the hardcoded map. Rollout was staged "
+    "over two days and no tenant saw downtime.\n\n"
+    "### Follow-ups\n\n"
+    "- purge the legacy map\n"
+    "- backfill the audit log\n\n"
+    'Thanks @alice and @"bob smith" for the review.\n\n'
+) * 8
+
+PROSE = (
+    "The parser rejected the header. It expected four fields and found three! "
+    "Was that a regression? No; the fixture was stale. "
+) * 30
+
+CJK = "指定された文書を解析し、埋め込みを生成してから索引に登録します。" * 60
+
+EMOJI = "shipped 🚀 verified ✅ rolled out 🌍 " * 60
+
+NO_SPACES = "x" * 4000
+
+MENTION_HEAVY = (
+    'Reviewed by @alice, @"bob smith", @carol.dev and @dan@example.com. '
+) * 40
+
+CORPUS = {
+    "markdown": MARKDOWN_DOC,
+    "prose": PROSE,
+    "cjk": CJK,
+    "emoji": EMOJI,
+    "no_spaces": NO_SPACES,
+    "mentions": MENTION_HEAVY,
+}
+
+
+# Properties ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_every_part_fits_the_limit(name):
+    """The invariant that decides whether the POST succeeds.
+
+    Measured with the prefix applied, because that is what gets posted.
+    """
+    parts = split_message(CORPUS[name], max_length=LIMIT)
+
+    assert parts, "a non-empty message must produce at least one part"
+    oversized = [
+        (i, measured_length(p))
+        for i, p in enumerate(parts, 1)
+        if measured_length(p) > LIMIT
+    ]
+    assert not oversized, f"parts over the {LIMIT}-character limit: {oversized}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_round_trip_preserves_every_non_whitespace_character(name):
+    """Parts are exact slices, so only boundary whitespace may be dropped."""
+    message = CORPUS[name]
+    parts = split_message(message, max_length=LIMIT)
+
+    rejoined = "".join(strip_prefix(p) for p in parts)
+
+    assert re.sub(r"\s+", "", rejoined) == re.sub(r"\s+", "", message)
+
+
+def part_boundaries(message: str, parts: list[str]) -> list[int]:
+    """Offsets in ``message.strip()`` where one part ends and the next begins.
+
+    Located by walking each part body forward through the source rather than by
+    rejoining: concatenating parts closes up the whitespace dropped at a cut,
+    which would weld the tail of one part onto the head of the next and make a
+    clean boundary look like a severed token.
+    """
+    text = message.strip()
+    boundaries = []
+    cursor = 0
+    for part in parts:
+        body = strip_prefix(part)
+        start = text.index(body, cursor)
+        cursor = start + len(body)
+        boundaries.append(cursor)
+    return boundaries[:-1]
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_no_mention_is_split_across_parts(name):
+    """A severed mention silently degrades to plain text, so cuts avoid them."""
+    message = CORPUS[name]
+    parts = split_message(message, max_length=LIMIT)
+
+    mentions = [m.span() for m in MENTION_PATTERN.finditer(message.strip())]
+    straddled = [
+        (start, end, boundary)
+        for start, end in mentions
+        for boundary in part_boundaries(message, parts)
+        if start < boundary < end
+    ]
+
+    assert not straddled, f"mentions cut by a part boundary: {straddled}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_part_numbering_is_consistent(name):
+    """Guards the prefix fixed point: every part agrees on the total."""
+    parts = split_message(CORPUS[name], max_length=LIMIT)
+
+    if len(parts) == 1:
+        assert not _PREFIX_RE.match(parts[0]), "a lone part carries no prefix"
+        return
+
+    numbering = [_PREFIX_RE.match(p) for p in parts]
+    assert all(numbering), "every part of a split message carries a prefix"
+
+    indices = [int(re.match(r"\((\d+)/(\d+)\)", p).group(1)) for p in parts]
+    totals = {int(re.match(r"\((\d+)/(\d+)\)", p).group(2)) for p in parts}
+
+    assert indices == list(range(1, len(parts) + 1))
+    assert totals == {len(parts)}
+
+
+@pytest.mark.parametrize("word_count", range(1000, 1400, 23))
+def test_invariants_hold_across_the_prefix_width_boundary(word_count):
+    """Around 9->10 parts the prefix widens from 6 to 8 characters.
+
+    That is exactly where a naive budget calculation overflows the limit, so
+    sweep the sizes that cross it.
+    """
+    message = " ".join(f"word{i:04d}" for i in range(word_count))
+
+    parts = split_message(message, max_length=LIMIT)
+
+    assert all(measured_length(p) <= LIMIT for p in parts)
+    totals = {int(re.match(r"\((\d+)/(\d+)\)", p).group(2)) for p in parts}
+    assert totals == {len(parts)}
+
+
+# measured_length -----------------------------------------------------------
+
+
+def test_measured_length_ignores_surrounding_whitespace():
+    """Core trims before it measures, so we must too."""
+    assert measured_length("  hello  \n\n") == len("hello")
+
+
+def test_measured_length_counts_code_points_not_bytes():
+    """mb_strlen(..., 'UTF-8') counts code points; so does Python's len()."""
+    assert measured_length("🚀") == 1
+    assert measured_length("é") == 1
+
+
+# Edge cases ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("message", ["", "   ", "\n\n  \t "])
+def test_blank_message_yields_no_parts(message):
+    assert split_message(message, max_length=LIMIT) == []
+
+
+def test_message_at_exactly_the_limit_is_returned_untouched():
+    """The server's check is ``> max``, so 1000 characters is legal."""
+    message = "x" * LIMIT
+
+    assert split_message(message, max_length=LIMIT) == [message]
+
+
+def test_message_at_the_limit_plus_trailing_whitespace_is_not_split():
+    """Trailing newlines are trimmed away server-side before the check.
+
+    Measuring with a bare ``len()`` here would split a message the server would
+    have accepted whole.
+    """
+    message = "x" * LIMIT + "\n\n"
+
+    assert split_message(message, max_length=LIMIT) == [message]
+
+
+def test_one_character_over_the_limit_splits_in_two():
+    parts = split_message("y" * (LIMIT + 1), max_length=LIMIT)
+
+    assert len(parts) == 2
+    assert all(measured_length(p) <= LIMIT for p in parts)
+
+
+def test_unbreakable_run_is_hard_cut_without_losing_characters():
+    """No separator anywhere -- the hard-cut fallback must still be lossless."""
+    message = "z" * 1500
+
+    parts = split_message(message, max_length=LIMIT)
+
+    assert len(parts) == 2
+    assert "".join(strip_prefix(p) for p in parts) == message
+
+
+def test_cut_backs_off_to_the_start_of_a_straddling_mention():
+    """A mention crossing the budget moves wholly into the next part."""
+    message = "a" * 94 + ' @"alice smith" tail'
+
+    parts = split_message(message, max_length=100)
+
+    assert len(parts) == 2
+    assert '@"alice smith"' in strip_prefix(parts[1])
+    assert "@" not in strip_prefix(parts[0])
+
+
+def test_mention_longer_than_the_budget_is_cut_rather_than_overflowing():
+    """The length invariant outranks the mention invariant.
+
+    An over-length part is rejected by the server outright; a severed mention
+    merely renders as plain text.
+    """
+    message = '@"' + "n" * 300 + '" trailing words here'
+
+    parts = split_message(message, max_length=100)
+
+    assert all(measured_length(p) <= 100 for p in parts)
+    assert "".join(strip_prefix(p) for p in parts).replace(" ", "") == message.replace(
+        " ", ""
+    )
+
+
+def test_split_prefers_paragraph_boundaries_over_mid_sentence_cuts():
+    paragraph = "Sentence one is here. Sentence two follows on. " * 12
+    message = f"{paragraph}\n\n{paragraph}"
+
+    parts = split_message(message, max_length=600)
+
+    for part in parts:
+        body = strip_prefix(part)
+        assert not body.startswith(" ")
+        # A cut mid-word would leave a fragment; every part ends on punctuation
+        # or a complete word.
+        assert body[-1].isalnum() or body[-1] in ".!?"
+
+
+def test_prefix_template_can_be_disabled():
+    message = "w" * 1500
+
+    parts = split_message(message, max_length=LIMIT, part_prefix_template=None)
+
+    assert all(not _PREFIX_RE.match(p) for p in parts)
+    assert "".join(parts) == message
+
+
+def test_non_positive_max_length_is_rejected():
+    with pytest.raises(ValueError, match="max_length must be positive"):
+        split_message("anything", max_length=0)
+
+
+def test_max_length_too_small_for_the_prefix_is_rejected():
+    """``(1/1) `` is six characters; a five-character budget cannot carry it."""
+    with pytest.raises(ValueError, match="leaves no room"):
+        split_message("x" * 50, max_length=5)
+
+
+def test_default_prefix_template_shape():
+    """The docstrings promise agents an ``(i/N) `` marker -- pin it."""
+    assert PART_PREFIX_TEMPLATE.format(index=2, total=7) == "(2/7) "

--- a/tests/unit/test_message_splitter.py
+++ b/tests/unit/test_message_splitter.py
@@ -276,6 +276,23 @@ def test_prefix_template_can_be_disabled():
     assert "".join(parts) == message
 
 
+def test_non_convergence_fails_loudly_rather_than_silently(monkeypatch):
+    """The fixed point cannot fail to settle in practice -- prove it says so.
+
+    Starving the iteration budget is the only way to reach this branch. What
+    matters is that it raises rather than returning parts whose prefixes were
+    sized for a smaller total than they actually carry, which would silently
+    break the length invariant for a caller using a different max_length.
+    """
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.utils.message_splitter._MAX_PREFIX_ITERATIONS", 1
+    )
+    message = " ".join(f"word{i:04d}" for i in range(2000))
+
+    with pytest.raises(RuntimeError, match="did not converge"):
+        split_message(message, max_length=LIMIT)
+
+
 def test_non_positive_max_length_is_rejected():
     with pytest.raises(ValueError, match="max_length must be positive"):
         split_message("anything", max_length=0)

--- a/tests/unit/test_message_splitter.py
+++ b/tests/unit/test_message_splitter.py
@@ -177,6 +177,43 @@ def test_measured_length_ignores_surrounding_whitespace():
     assert measured_length("  hello  \n\n") == len("hello")
 
 
+@pytest.mark.parametrize(
+    "pad,name",
+    [
+        ("　", "U+3000 ideographic space"),
+        (" ", "U+00A0 no-break space"),
+        (" ", "U+202F narrow no-break space"),
+    ],
+)
+def test_measured_length_keeps_unicode_spaces_php_trim_would_keep(pad, name):
+    """PHP ``trim()`` strips ASCII whitespace only; Python's strips Zs too.
+
+    Measuring with the broader set would report 1000 for a message the server
+    counts as 1003, so we would post it and take a 400 back -- and U+3000 is
+    ordinary in CJK text, not an exotic input.
+    """
+    assert measured_length("x" * 1000 + pad * 3) == 1003, name
+
+
+def test_measured_length_strips_nul_because_php_trim_does():
+    """The mismatch runs the other way too.
+
+    Python's ``str.strip()`` leaves NUL in place, so measuring with it would
+    reject a 1000-character message the server would have accepted.
+    """
+    assert measured_length("x" * 1000 + "\0\0\0") == 1000
+
+
+def test_message_at_the_limit_plus_unicode_space_is_split():
+    """Follows from the above: the server sees 1001 here, so we must split."""
+    message = "x" * 1000 + "　"
+
+    parts = split_message(message, max_length=LIMIT)
+
+    assert len(parts) == 2
+    assert all(measured_length(p) <= LIMIT for p in parts)
+
+
 def test_measured_length_counts_code_points_not_bytes():
     """mb_strlen(..., 'UTF-8') counts code points; so does Python's len()."""
     assert measured_length("🚀") == 1


### PR DESCRIPTION
## Problem

Nextcloud caps a comment at **1000 characters** — `IComment::MAX_MESSAGE_LENGTH`, enforced in core's `OC\Comments\Comment::setMessage()` via `mb_strlen($message, 'UTF-8') > $maxLength`, **after `trim()`**, boundary inclusive. Deck adds no check of its own.

Agents use Deck card comments as an activity log and hit that limit constantly. The response is a retry with a blindly-shortened message, then another, then another — because "too long" alone says nothing about how much to cut or that a better option exists.

Two upstream details are worth recording, since both shaped the design:

- **Create** returns a clean HTTP 400 (`Message exceeds allowed character limit of 1000`).
- **Update** does not. `CommentService::update()` has no `MessageTooLongException` catch, so the exception escapes to Deck's `ExceptionMiddleware` and comes back as a **masked HTTP 500** — not OCS-enveloped, body says only "Internal server error", real cause left in the server log. Deck's own `docs/API.md` documents 400 for both, so the docs are wrong here. Worth reporting upstream.

## What changed

`deck_create_card_comment` gains `overflow: Literal["error", "split"] = "error"`.

`"split"` cuts at the most structural boundary that fits — markdown heading, code fence, paragraph, line, sentence, then word — posts part 1 as the comment and parts 2..N as replies to it, each prefixed `(i/N)`, so the card renders one thread rather than N unrelated comments. `@`-mentions (including `@"names with spaces"`) are never severed.

The boundary rules come from LangChain's `RecursiveCharacterTextSplitter`, already a dependency. It is used as a **cut-offset finder**: we take the offsets and slice the original string ourselves, because LangChain drops separators from the chunks it returns — which for an activity log would quietly mangle the text. The greedy repack on top exists because LangChain merges only within a recursion level and under-packs (six chunks where four fit, on a 312-char sample at `chunk_size=120`).

`deck_update_card_comment` deliberately gets **no** `overflow`: an update replaces one comment in place, so it cannot become several.

### Also fixed

Two pre-existing defects in the same area:

- The length guard lived **nested inside `configure_deck_tools`**, so it was neither importable nor unit-testable.
- It measured `len(message)` rather than the trimmed length, **rejecting messages the server would have accepted** (1000 chars + trailing newlines).
- No comment tool caught `HTTPStatusError`, so a 403 or Deck's masked 500 surfaced raw. All four are now mapped, with the 500-on-update case naming the length limit as the likely cause.

## Design notes

**Default stays `"error"`.** Existing callers see no behaviour change, and `tests/server/test_deck_mcp.py` already asserted that failure. The improved error names `overflow="split"` explicitly, so the loop collapses to one deterministic retry. Flipping the default later would need a `BREAKING CHANGE:` footer.

**Splitting is not atomic and does not roll back.** Deck has no transactional multi-comment endpoint, so atomicity was never available. If part 3 of 5 fails, parts 1–2 stay posted. Deleting them is itself a write that can 403 or time out, and a half-deleted thread is harder to reason about than a labelled partial one — it would also destroy content a human may already have read. The error names the posted comment ids so the caller resumes instead of duplicating, and a test asserts `delete_comment` is never called.

**No `attach` overflow mode.** Overflowing a comment into a note or file conflates two concerns; `deck_attach_note` / `deck_attach_file` already exist for anyone who wants that. A split needing more than 10 parts is refused *before* anything is posted, pointing at those tools instead.

## Behaviour changes

- Empty/whitespace-only comments are now **rejected** rather than stored as a blank row.
- A message needing more than 10 parts is refused up front in both modes.
- Messages of exactly 1000 characters, and 1000 + trailing whitespace, are now correctly **accepted** (previously the latter was rejected client-side for no reason).

No `BREAKING CHANGE:` footer: `overflow` defaults to today's behaviour and the response fields (`parts`, `part_count`) are additive.

## Test coverage

- **Unit** — `tests/unit/test_message_splitter.py` (58 tests): four property tests over a corpus spanning markdown, prose, CJK, emoji, unbroken runs and mention-heavy text — every part fits the limit *with its prefix*; exact round-trip modulo whitespace; no mention straddles a part boundary; part numbering agrees with the total across the 9→10 prefix-width change.
- **Unit** — `tests/unit/test_deck_comment_overflow.py` (25 tests): tool-layer wiring — call counts, `parent_id` threading, partial-failure contract, error-text contract, and every HTTP status branch.
- **Integration (e2e)** — `tests/server/test_deck_mcp.py`: split thread shape, split beneath an existing parent, the exactly-1000 boundary, and update-too-long, all against a real Deck instance via `nc_mcp_client`. **19 passed** against a rebuilt container.

The `split_under_parent` test resolved a genuine open question rather than assuming: Deck **does** accept a reply-to-a-reply (core resolves `topmostParentId`), so parts 2..N hanging off part 1 works even when part 1 is itself a reply.

**Contract (Pact): not applicable, deliberately.** The boundary this touches is Deck's OCS API — a third-party provider shipped by Nextcloud that we neither own nor can run a `Verifier` against. ADR-029's consumer pacts exist for `astrolabe` / `astrolabe-cloud-gateway` precisely because we control both sides; a pact verified by nobody is a green check with nothing behind it. Wire shape is pinned by the mocked tests in `tests/client/deck/test_deck_api.py`. No new gap card needed on board 11.

## Tracking

Deck board 12 (nextcloud-mcp-server Product), card #910.

---

_This PR was generated with the help of AI, and reviewed by a Human_