### PR TITLE
fix(pdf): restore the parse worker's memory headroom and unmask its failures

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -81,7 +81,26 @@ The Helm chart has moved to a [separate repository](https://github.com/cbcoutinh
 - `mcp_vector_sync_documents_processed_total` - Processing results
 - `mcp_vector_sync_processing_duration_seconds` - Processing latency
 - `mcp_vector_sync_queue_size` - Current queue depth
+- `mcp_vector_sync_dead_lettered_documents` - Documents parked as permanently-failed
 - `mcp_qdrant_operations_total` - Qdrant DB operations
+
+**Alerting on permanently-failed documents.** Prefer the
+`mcp_vector_sync_dead_lettered_documents` **gauge** over the
+`astrolabe_document_dead_lettered_total` / `astrolabe_document_parse_failed_total`
+counters. Those counters only ever increment in the ingest worker, whose container
+is not a scrape target, and whose tiers are scaled to zero between batches — so a
+counter can fire and terminate without ever being scraped, and resets on scale-up.
+The gauge is published by the long-lived (scraped) backend from the dead-letter
+tombstones in Qdrant, so it survives worker lifecycle:
+
+```promql
+# Any document given up on — parse failures never retried until its etag changes.
+mcp_vector_sync_dead_lettered_documents > 0
+```
+
+A dead-lettered document looks fully indexed to every count-based check (the
+tombstone keeps folder totals reconciling) and its ingest job completes with
+status *success*, so this gauge is the only signal that it is missing from search.
 
 ### Document Ingest Metrics
 

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -242,6 +242,11 @@ def _parse_pdf_worker(
         )
     except MemoryError as exc:
         raise MemoryError(_picklable_message(exc)) from exc
+    # Unreachable today -- nothing under _parse_pdf_extract raises this. Kept so
+    # the normalisation stays idempotent if a helper down there ever does: without
+    # it, the clause below would re-wrap an already-normalised error and its
+    # message would grow a "PdfWorkerError: " prefix per layer. Not dead code by
+    # oversight.
     except PdfWorkerError:
         raise
     except Exception as exc:

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -184,7 +184,9 @@ def _picklable_message(exc: BaseException) -> str:
     """
     try:
         return f"{type(exc).__name__}: {exc}"
-    except Exception:  # noqa: BLE001 -- last-resort, must not mask the failure
+    # Last resort: this already runs on the failure path, so a secondary error
+    # while formatting must not mask the failure being reported.
+    except Exception:  # noqa: BLE001
         return type(exc).__name__
 
 

--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -22,6 +22,10 @@ import anyio.to_process
 from anyio import BrokenWorkerProcess, CapacityLimiter
 from anyio.lowlevel import RunVar
 
+from nextcloud_mcp_server.document_processors._pymupdf4llm_classic import (
+    load_classic_pymupdf4llm,
+)
+
 # ``resource`` is a Unix-only stdlib module -- it does not exist on Windows, and
 # importing it unconditionally crashed Windows startup (#877). The RLIMIT_AS cap
 # it provides is a Linux-pod safety measure, not a correctness requirement, so on
@@ -150,6 +154,40 @@ class PdfParseFailed(Exception):
         super().__init__(message or f"PDF parse failed ({reason})")
 
 
+class PdfWorkerError(Exception):
+    """A parse failure re-raised from the worker as plain, picklable data.
+
+    Deliberately carries a single string arg and no attributes, so
+    ``BaseException.__reduce__`` round-trips it as ``cls(message)``.
+
+    This exists because the worker's exception is pickled back to the parent by
+    ``anyio.to_process``, and pymupdf raises errors that hold SWIG objects. When
+    that pickling fails, anyio does NOT propagate the original -- it catches the
+    pickling error and sends THAT instead (anyio/to_process.py, the
+    ``except BaseException`` around ``pickle.dumps(exception, ...)``). The real
+    cause is destroyed in transit and the parent sees only
+    ``TypeError: cannot pickle 'swig_runtime_data5.SwigPyObject' object``.
+
+    That is not cosmetic: an out-of-memory parse arrived as reason=``error``
+    instead of reason=``oom``, which the caller treats as terminal, so healthy
+    documents were dead-lettered permanently rather than retried (Deck #911).
+    Normalising to a string here keeps the classification honest.
+    """
+
+
+def _picklable_message(exc: BaseException) -> str:
+    """``TypeName: message`` for ``exc``, tolerating a broken ``__str__``.
+
+    pymupdf's SWIG-backed exceptions can raise while formatting themselves, and
+    this runs on the failure path -- losing the reason to a secondary error
+    would put us right back to an opaque boundary failure.
+    """
+    try:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception:  # noqa: BLE001 -- last-resort, must not mask the failure
+        return type(exc).__name__
+
+
 def _apply_mem_limit(mem_limit_mb: int) -> None:
     """Cap the worker's address space (RLIMIT_AS) so a bomb raises MemoryError.
 
@@ -182,6 +220,42 @@ def _parse_pdf_worker(
     mem_limit_mb: int,
     markdown_max_pages: int,
 ) -> list[dict[str, Any]]:
+    """Extract a PDF in the worker subprocess, raising only picklable errors.
+
+    Thin wrapper over :func:`_parse_pdf_extract`. Everything it raises must
+    survive ``pickle.dumps`` in the child, because anyio replaces an unpicklable
+    exception with the pickling error itself -- see :class:`PdfWorkerError`.
+
+    ``MemoryError`` is re-raised as ``MemoryError`` (rather than folded into
+    ``PdfWorkerError``) because the caller maps it to reason=``oom``, which is
+    retryable; a fresh instance is raised so a SWIG object in the original's
+    ``args`` cannot break pickling on the way back.
+    """
+    try:
+        return _parse_pdf_extract(
+            source_path,
+            write_images,
+            image_path,
+            graphics_limit,
+            mem_limit_mb,
+            markdown_max_pages,
+        )
+    except MemoryError as exc:
+        raise MemoryError(_picklable_message(exc)) from exc
+    except PdfWorkerError:
+        raise
+    except Exception as exc:
+        raise PdfWorkerError(_picklable_message(exc)) from exc
+
+
+def _parse_pdf_extract(
+    source_path: str,
+    write_images: bool,
+    image_path: str | None,
+    graphics_limit: int,
+    mem_limit_mb: int,
+    markdown_max_pages: int,
+) -> list[dict[str, Any]]:
     """Extract a PDF in the worker subprocess (positional args only).
 
     Runs ``pymupdf4llm.to_markdown`` when :func:`uses_markdown` allows it for this
@@ -205,16 +279,15 @@ def _parse_pdf_worker(
     # Imported inside the worker so the parent process (and any module that
     # imports this one) doesn't load pymupdf4llm -- which prints a banner to
     # stdout on import, the channel anyio's worker uses for IPC.
-    # Stay on pymupdf4llm's classic (pymupdf_rag) extractor.
     #
-    # 1.27.2.1 made ``import pymupdf4llm`` initialise pymupdf_layout and route
-    # to_markdown through an ONNX layout-detection model. That default is a poor
-    # fit for this worker, in four independent ways:
+    # Stay on pymupdf4llm's classic (pymupdf_rag) extractor, via the shared
+    # loader that owns that mechanism (see _pymupdf4llm_classic for the full
+    # rationale). Layout mode is a poor fit for this worker in four independent
+    # ways:
     #
     # * The import alone costs ~1157 MiB of address space (VmSize 34 -> 1191
-    #   MiB) against our 1536 MiB RLIMIT_AS, leaving ~345 MiB for the parse
-    #   itself. That is what surfaces as "Error during worker process
-    #   initialization" classified as oom.
+    #   MiB) against our 1536 MiB RLIMIT_AS, leaving ~117 MiB for the parse
+    #   itself -- which is how a healthy document dead-letters (Deck #911).
     # * Inference aborts under the same cap with "[ONNXRuntimeError] Missing
     #   Input: image_features", failing the parse. It is content-dependent, so
     #   PDFs fail unpredictably rather than consistently. Raising the cap is not
@@ -225,36 +298,15 @@ def _parse_pdf_worker(
     # * It reconstructs from the visual layout, dropping text rendered outside
     #   the page box that the classic extractor kept.
     #
-    # Two mechanisms, because they do different things. pymupdf4llm decides at
-    # import time with
-    #     try: import pymupdf.layout
-    #     except ImportError: use_layout(False)
-    #     else: use_layout(True)
-    # so binding that name to None in sys.modules -- the standard way to make an
-    # import raise -- takes the classic branch and avoids the address-space cost
-    # entirely (VmSize 499 MiB). The explicit use_layout(False) then still
-    # disables inference if that block ever stops working (upstream renaming the
-    # module, say); it cannot undo the import, hence both. Both are
-    # worker-process-local and never affect the parent.
-    #
     # Net effect: the extractor we were on before the bump -- plain picklable
     # dicts, ``metadata["page"]``, no ML inference in the ingest path. The exact
     # pin in pyproject.toml keeps that a fixed, known target. Adopting layout
     # mode later needs its own memory budget plus a re-check of the chunk type
     # and the metadata key; test_worker_disables_pymupdf4llm_layout_mode fails
     # loudly if it turns back on by accident.
-    # NB: this is process-wide and sticky for the life of the process, not
-    # scoped to this call. That is intended in the parse subprocess, but note it
-    # also applies to any process that calls this function directly -- the unit
-    # tests do, so pytest workers get the same block. Nothing here needs real
-    # layout mode; anything that later does must not share a process with this
-    # function, because ``setdefault`` cannot be undone by a subsequent import.
-    sys.modules.setdefault("pymupdf.layout", None)  # type: ignore[assignment, ty:no-matching-overload]
-
     import pymupdf  # noqa: PLC0415
-    import pymupdf4llm  # noqa: PLC0415
 
-    pymupdf4llm.use_layout(False)
+    pymupdf4llm = load_classic_pymupdf4llm()
 
     doc = pymupdf.open(source_path)
     try:
@@ -337,6 +389,11 @@ async def run_isolated_pdf_parse(
             # Worker died without a clean exception (e.g. SIGKILL from the OS OOM
             # killer beating the rlimit). Treat as an out-of-memory failure.
             raise PdfParseFailed("oom", str(e)) from e
+        except PdfWorkerError as e:
+            # Already normalised in the worker: its message is
+            # "OriginalType: text", so re-prefixing would read
+            # "PdfWorkerError: FzErrorBase: ...".
+            raise PdfParseFailed("error", str(e)) from e
         except Exception as e:
             raise PdfParseFailed("error", f"{type(e).__name__}: {e}") from e
     # Reached only when move_on_after swallowed the timeout cancellation.

--- a/nextcloud_mcp_server/document_processors/_pymupdf4llm_classic.py
+++ b/nextcloud_mcp_server/document_processors/_pymupdf4llm_classic.py
@@ -1,0 +1,54 @@
+"""Load pymupdf4llm pinned to its classic (``pymupdf_rag``) extractor.
+
+Every caller of ``pymupdf4llm.to_markdown`` in this codebase must go through
+:func:`load_classic_pymupdf4llm`. Two independent reasons:
+
+* **Memory.** 1.27.2.1 made ``import pymupdf4llm`` initialise ``pymupdf.layout``
+  and route ``to_markdown`` through an ONNX layout-detection model. The import
+  alone costs ~1157 MiB of address space (VmSize 34 -> 1191 MiB). The isolated
+  parse worker runs under a 1536 MiB RLIMIT_AS, so paying that cost leaves
+  ~117 MiB for the parse itself -- which is how a perfectly healthy document
+  ends up dead-lettered (Deck #911). Binding ``pymupdf.layout`` to None in
+  ``sys.modules`` -- the standard way to make an import raise -- takes
+  pymupdf4llm's classic branch and avoids the cost entirely (VmSize 499 MiB).
+* **Consistency.** The classic and layout extractors emit different markdown
+  (and name the page key ``page`` vs ``page_number``). ``search/pdf_highlighter``
+  recomputes offsets that must match what indexing produced, so the two must
+  agree on the extractor or highlight offsets silently misalign.
+
+pymupdf4llm decides at import time with::
+
+    try: import pymupdf.layout
+    except ImportError: use_layout(False)
+    else: use_layout(True)
+
+hence both mechanisms here: the ``sys.modules`` block avoids the address-space
+cost, and the explicit ``use_layout(False)`` still disables inference if that
+block ever stops working (upstream renaming the module, say). The block cannot
+undo an import that already happened, so **this must run before anything else
+imports pymupdf4llm** -- which is why every caller imports it lazily rather than
+at module scope. A module-level ``import pymupdf4llm`` anywhere in the app's
+import graph re-breaks the memory guarantee for the whole process tree, because
+``anyio.to_process`` re-imports the parent's ``__main__`` inside every parse
+worker before the worker function runs.
+
+Both effects are process-wide and sticky for the life of the process; nothing in
+this codebase needs real layout mode. Anything that later does must not share a
+process with these callers, because ``setdefault`` cannot be undone by a
+subsequent import.
+"""
+
+import sys
+from typing import Any
+
+__all__ = ["load_classic_pymupdf4llm"]
+
+
+def load_classic_pymupdf4llm() -> Any:
+    """Import pymupdf4llm with layout mode disabled, and return the module."""
+    sys.modules.setdefault("pymupdf.layout", None)  # type: ignore[assignment, ty:no-matching-overload]
+
+    import pymupdf4llm  # noqa: PLC0415
+
+    pymupdf4llm.use_layout(False)
+    return pymupdf4llm

--- a/nextcloud_mcp_server/document_processors/_pymupdf4llm_classic.py
+++ b/nextcloud_mcp_server/document_processors/_pymupdf4llm_classic.py
@@ -4,13 +4,19 @@ Every caller of ``pymupdf4llm.to_markdown`` in this codebase must go through
 :func:`load_classic_pymupdf4llm`. Two independent reasons:
 
 * **Memory.** 1.27.2.1 made ``import pymupdf4llm`` initialise ``pymupdf.layout``
-  and route ``to_markdown`` through an ONNX layout-detection model. The import
-  alone costs ~1157 MiB of address space (VmSize 34 -> 1191 MiB). The isolated
-  parse worker runs under a 1536 MiB RLIMIT_AS, so paying that cost leaves
-  ~117 MiB for the parse itself -- which is how a perfectly healthy document
-  ends up dead-lettered (Deck #911). Binding ``pymupdf.layout`` to None in
-  ``sys.modules`` -- the standard way to make an import raise -- takes
-  pymupdf4llm's classic branch and avoids the cost entirely (VmSize 499 MiB).
+  and route ``to_markdown`` through an ONNX layout-detection model, which costs
+  ~1157 MiB of address space. The isolated parse worker runs under a 1536 MiB
+  RLIMIT_AS, so paying that cost leaves ~117 MiB for the parse itself -- which is
+  how a perfectly healthy document ends up dead-lettered (Deck #911). Binding
+  ``pymupdf.layout`` to None in ``sys.modules`` -- the standard way to make an
+  import raise -- takes pymupdf4llm's classic branch and avoids the cost.
+
+  Two baselines get quoted for that saving; they measure different processes, so
+  to be explicit about which is which. Importing *only* pymupdf4llm: VmSize 1191
+  MiB with layout, 499 MiB without. The ingest worker, which also carries the
+  whole app: 1476 MiB with, 891 MiB without (its ``to_process`` parse child
+  tracks ~55 MiB below each, so 1419 MiB was the figure that actually blew the
+  1536 MiB cap).
 * **Consistency.** The classic and layout extractors emit different markdown
   (and name the page key ``page`` vs ``page_number``). ``search/pdf_highlighter``
   recomputes offsets that must match what indexing produced, so the two must

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -194,6 +194,26 @@ vector_sync_indexed_chunks = Gauge(
     "Total indexed chunks (non-placeholder points) in the vector store",
 )
 
+# Documents parked as permanently-failed, published as a GAUGE from the
+# long-lived backend rather than left to the worker-side counters.
+#
+# ``astrolabe_document_dead_lettered_total`` increments in the ingest worker,
+# which is the wrong place to alert from on two counts: the worker container is
+# not a Prometheus scrape target (only the backend Pod is), and KEDA scales the
+# ingest tiers 0<->1, so a counter that fires and then terminates may never be
+# scraped at all and resets on every scale-up. Four dead-letter events in a day
+# produced no time series whatsoever (Deck #911).
+#
+# Dead-lettering is *durable state* in Qdrant (a tombstone point per document),
+# not just an event, so a gauge read back from the collection is both the honest
+# representation and immune to Pod lifecycle. Alert on ``> 0`` or on an increase
+# over a window; it falls back to 0 when the tombstones are cleared or their
+# etag/tier signature changes and the documents are re-attempted.
+vector_sync_dead_lettered_documents = Gauge(
+    "mcp_vector_sync_dead_lettered_documents",
+    "Documents parked as permanently-failed (dead-letter tombstones in Qdrant)",
+)
+
 # Dense-vector RAM footprint of the collection — the real cost driver for hybrid
 # search (billing is on source bytes, not vector RAM). Two views published by the
 # periodic vector_sync metrics task so operators can watch the "density risk"
@@ -1001,6 +1021,11 @@ def update_vector_sync_indexed_documents(count: int) -> None:
 def update_vector_sync_indexed_chunks(count: int) -> None:
     """Set the total-indexed-chunks gauge."""
     vector_sync_indexed_chunks.set(count)
+
+
+def update_vector_sync_dead_lettered_documents(count: int) -> None:
+    """Set the dead-lettered-documents gauge."""
+    vector_sync_dead_lettered_documents.set(count)
 
 
 def update_vector_sync_estimated_vector_bytes(byte_estimate: float) -> None:

--- a/nextcloud_mcp_server/search/pdf_highlighter.py
+++ b/nextcloud_mcp_server/search/pdf_highlighter.py
@@ -18,8 +18,11 @@ from pathlib import Path
 from typing import Optional
 
 import pymupdf
-import pymupdf4llm
 from PIL import Image, ImageDraw
+
+from nextcloud_mcp_server.document_processors._pymupdf4llm_classic import (
+    load_classic_pymupdf4llm,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +90,19 @@ class PDFHighlighter:
         page_boundaries = []
         text_parts = []
         current_offset = 0
+
+        # Loaded lazily, and through the shared classic-extractor loader, for two
+        # reasons. (1) Offsets: indexing runs the classic (pymupdf_rag)
+        # extractor, so recomputing them under layout mode would silently
+        # misalign every highlight -- the exact failure the write_images note
+        # above guards against. (2) Memory: a module-level ``import pymupdf4llm``
+        # here put pymupdf.layout (~1.1 GiB of address space) into the app's
+        # import graph, and ``anyio.to_process`` re-imports the parent's
+        # ``__main__`` inside every PDF parse worker before the worker function
+        # runs -- so this import, in a module the ingest path never calls, was
+        # what left the 1536 MiB RLIMIT_AS worker with ~117 MiB to parse in and
+        # dead-lettered healthy documents (Deck #911).
+        pymupdf4llm = load_classic_pymupdf4llm()
 
         # Use temp directory for image output (images are discarded after extraction)
         temp_dir = Path(tempfile.mkdtemp(prefix="pdf_highlight_"))

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -35,6 +35,7 @@ from nextcloud_mcp_server.observability.metrics import (
     estimate_vector_bytes,
     update_ingest_queue_depth,
     update_qdrant_chunk_density_snapshot,
+    update_vector_sync_dead_lettered_documents,
     update_vector_sync_estimated_vector_bytes,
     update_vector_sync_indexed_chunks,
     update_vector_sync_indexed_documents,
@@ -44,6 +45,7 @@ from nextcloud_mcp_server.observability.metrics import (
     update_vector_sync_queue_size,
 )
 from nextcloud_mcp_server.vector import payload_keys
+from nextcloud_mcp_server.vector.dead_letter import DEAD_LETTER_KEY
 from nextcloud_mcp_server.vector.ingest_status import get_ingest_pending
 from nextcloud_mcp_server.vector.placeholder import get_placeholder_filter
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
@@ -102,6 +104,26 @@ async def count_hybrid_chunks(
                     match=MatchValue(value=payload_keys.INDEX_MODE_HYBRID),
                 ),
             ]
+        ),
+        exact=exact,
+    )
+    return result.count
+
+
+async def count_dead_lettered(
+    qdrant_client: AsyncQdrantClient, collection: str, *, exact: bool = True
+) -> int:
+    """Return the number of documents parked as permanently-failed.
+
+    One tombstone point per ``(doc_type, doc_id)`` (``mark_dead_letter`` upserts
+    a deterministic ID), so this counts documents, not chunks. ``dead_letter`` is
+    payload-indexed -- required, since Qdrant strict mode rejects a filter on an
+    unindexed field.
+    """
+    result = await qdrant_client.count(
+        collection_name=collection,
+        count_filter=Filter(
+            must=[FieldCondition(key=DEAD_LETTER_KEY, match=MatchValue(value=True))]
         ),
         exact=exact,
     )
@@ -206,6 +228,23 @@ async def publish_vector_sync_metrics(
         )
     except Exception as exc:  # noqa: BLE001 — metrics must not break ingest
         logger.warning("Failed to publish vector-RAM gauges: %s", exc)
+
+    # Permanently-failed documents. Published from here (the scraped, long-lived
+    # backend) because the worker-side counters never reach Prometheus — see the
+    # gauge's definition in observability/metrics.py. Own try/except so a Qdrant
+    # hiccup counting tombstones cannot suppress the gauges above.
+    try:
+        qdrant_client = await get_qdrant_client()
+        # Exact: this is a small, bounded population (one point per failed
+        # document) and an approximate count that drifts to 0 would silence the
+        # alert this gauge exists to raise.
+        update_vector_sync_dead_lettered_documents(
+            await count_dead_lettered(
+                qdrant_client, settings.get_collection_name(), exact=True
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — metrics must not break ingest
+        logger.warning("Failed to publish dead-lettered-documents gauge: %s", exc)
 
 
 async def vector_sync_metrics_task(

--- a/tests/unit/test_pdf_parse_isolation.py
+++ b/tests/unit/test_pdf_parse_isolation.py
@@ -13,6 +13,8 @@ check on the sample PDFs, not here (unit tests must not spawn the heavy worker
 or depend on the sample files).
 """
 
+import pickle
+import subprocess
 import sys
 
 import anyio
@@ -700,3 +702,97 @@ async def test_parse_mode_counter_increments(monkeypatch):
     await proc.process(_tiny_pdf(), "application/pdf", filename="t.pdf")
 
     assert _value("markdown") == before + 1
+
+
+# --- Deck #911: the worker boundary must not destroy the real failure --------
+
+
+def test_worker_normalises_unpicklable_exceptions(monkeypatch):
+    """An unpicklable worker exception must be converted, not left to anyio.
+
+    pymupdf raises errors holding SWIG objects. When the child cannot pickle the
+    exception, ``anyio.to_process`` does NOT propagate it -- it catches the
+    pickling failure and sends THAT back instead, so the parent sees only
+    ``TypeError: cannot pickle 'swig_runtime_data5.SwigPyObject' object`` and the
+    real cause is gone. Converting inside the worker keeps the reason legible.
+    """
+
+    class Boom(Exception):
+        pass
+
+    def raiser(*args, **kwargs):
+        # args holds a local function -> the exception itself cannot pickle,
+        # standing in for pymupdf's SWIG-backed errors.
+        raise Boom(lambda: None)
+
+    monkeypatch.setattr(_isolation, "_parse_pdf_extract", raiser)
+
+    with pytest.raises(_isolation.PdfWorkerError) as exc:
+        _isolation._parse_pdf_worker("f.pdf", False, None, 1000, 0, 100)
+
+    # Survives the boundary, and still names the original failure.
+    assert pickle.loads(pickle.dumps(exc.value)).args == exc.value.args
+    assert "Boom" in str(exc.value)
+
+
+def test_worker_preserves_memory_error_for_oom_classification(monkeypatch):
+    """MemoryError must stay a MemoryError so the caller can label it oom.
+
+    This is the difference between a retryable oom and a terminal ``error`` that
+    dead-letters a healthy document permanently (Deck #911).
+    """
+
+    class Unpicklable(MemoryError):
+        pass
+
+    def raiser(*args, **kwargs):
+        raise Unpicklable(lambda: None)
+
+    monkeypatch.setattr(_isolation, "_parse_pdf_extract", raiser)
+
+    with pytest.raises(MemoryError) as exc:
+        _isolation._parse_pdf_worker("f.pdf", False, None, 1000, 0, 100)
+
+    assert pickle.loads(pickle.dumps(exc.value)).args == exc.value.args
+
+
+async def test_worker_error_classified_as_error_without_double_prefix(monkeypatch):
+    """A normalised worker error keeps its original type name, once."""
+
+    async def fake(*args, **kwargs):
+        raise _isolation.PdfWorkerError("FzErrorBase: cannot open document")
+
+    with pytest.raises(PdfParseFailed) as exc:
+        await _run(monkeypatch, fake)
+
+    assert exc.value.reason == "error"
+    assert str(exc.value) == "FzErrorBase: cannot open document"
+
+
+def test_ingest_import_graph_does_not_load_pymupdf4llm():
+    """Nothing on the ingest path may import pymupdf4llm at module scope.
+
+    ``anyio.to_process`` re-imports the parent's ``__main__`` inside every parse
+    worker before the worker function runs, so a module-level import anywhere in
+    that graph loads ``pymupdf.layout`` (~1.1 GiB of address space) into the
+    child. Under the 1536 MiB RLIMIT_AS that left ~117 MiB to parse in, and
+    healthy documents were dead-lettered (Deck #911). The worker's own
+    ``sys.modules`` guard cannot help -- by then the import already happened.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, nextcloud_mcp_server.vector.processor;"
+            "print('pymupdf4llm' in sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[-1] == "False", (
+        "pymupdf4llm is imported at module scope somewhere on the ingest path; "
+        "load it lazily via load_classic_pymupdf4llm() instead"
+    )

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -548,3 +548,95 @@ class TestVectorDensitySnapshotTask:
         await mp.vector_density_snapshot_task(shutdown)
 
         assert published == 1
+
+
+class TestCountDeadLettered:
+    """Deck #911: dead-letter state must be observable from the scraped backend.
+
+    ``astrolabe_document_dead_lettered_total`` only ever increments in the ingest
+    worker, whose container is not a scrape target and which KEDA scales to zero
+    -- four dead-letter events in a day produced no time series at all. The
+    tombstones themselves are durable state in Qdrant, so a gauge read back from
+    the collection is what alerting can actually rely on.
+    """
+
+    async def test_counts_dead_letter_tombstones(self) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(4)
+
+        assert await mp.count_dead_lettered(qc, _COLLECTION) == 4
+
+    async def test_filters_on_the_indexed_dead_letter_flag(self) -> None:
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(0)
+
+        await mp.count_dead_lettered(qc, _COLLECTION)
+
+        count_filter = qc.count.await_args.kwargs["count_filter"]
+        # dead_letter carries its own payload index; Qdrant strict mode rejects a
+        # filter on an unindexed field, which would fail the count entirely.
+        assert _must_keys(count_filter) == ["dead_letter"]
+        assert count_filter.must[0].match.value is True
+
+    async def test_counts_exactly(self) -> None:
+        # An approximate count that drifts to 0 would silence the alert this
+        # gauge exists to raise, so this one does not trade accuracy for cost.
+        qc = AsyncMock()
+        qc.count.return_value = _count_obj(1)
+
+        await mp.count_dead_lettered(qc, _COLLECTION)
+
+        assert qc.count.await_args.kwargs["exact"] is True
+
+
+class TestPublishDeadLetteredGauge:
+    @pytest.fixture(autouse=True)
+    def _stub_settings(self, monkeypatch) -> None:
+        settings = SimpleNamespace(
+            ingest_queue="memory",
+            get_collection_name=lambda: _COLLECTION,
+            vector_ram_hnsw_overhead_factor=1.5,
+        )
+        monkeypatch.setattr(mp, "get_settings", lambda: settings)
+        monkeypatch.setattr(
+            mp, "get_ingest_pending", AsyncMock(return_value=IngestPending(pending=0))
+        )
+        monkeypatch.setattr(
+            mp,
+            "get_embedding_service",
+            lambda: SimpleNamespace(get_dimension=lambda: 1024),
+        )
+
+    async def test_publishes_the_tombstone_count(self, monkeypatch) -> None:
+        gauge = MagicMock()
+        monkeypatch.setattr(mp, "update_vector_sync_dead_lettered_documents", gauge)
+        monkeypatch.setattr(mp, "count_dead_lettered", AsyncMock(return_value=7))
+        monkeypatch.setattr(
+            mp, "get_qdrant_client", AsyncMock(return_value=AsyncMock())
+        )
+
+        await mp.publish_vector_sync_metrics(
+            task_producer=None, document_receive_stream=object()
+        )
+
+        gauge.assert_called_once_with(7)
+
+    async def test_qdrant_failure_does_not_raise(self, monkeypatch) -> None:
+        # A metrics refresh must never disturb ingest, and must not take the
+        # other gauges down with it.
+        gauge = MagicMock()
+        monkeypatch.setattr(mp, "update_vector_sync_dead_lettered_documents", gauge)
+        monkeypatch.setattr(
+            mp,
+            "count_dead_lettered",
+            AsyncMock(side_effect=RuntimeError("qdrant down")),
+        )
+        monkeypatch.setattr(
+            mp, "get_qdrant_client", AsyncMock(return_value=AsyncMock())
+        )
+
+        await mp.publish_vector_sync_metrics(
+            task_producer=None, document_receive_stream=object()
+        )
+
+        gauge.assert_not_called()


### PR DESCRIPTION
## Problem

A healthy 15-page PDF (1.93 MB, PDF 2.0, one embedded image per page — the
document from Deck card #911) is dead-lettered permanently on every re-index,
reported as:

```
Isolated PDF parse failed (reason=error): TypeError: cannot pickle 'swig_runtime_data5.SwigPyObject' object
Parsed with 'pymupdf': 15 pages, 0 chars in 10.09s   status=error
```

It parses fine in-process with both parsers, so it is not a scanned document and
OCR would not help. Reproduced locally against the released image with the exact
error string.

The pickling error is a **symptom**, not the cause. Two defects compound.

### 1. The parse worker had no memory left

`search/pdf_highlighter` imported `pymupdf4llm` at module scope, and
`vector/processor` imports that module eagerly. pymupdf4llm 1.28 initialises
`pymupdf.layout` on import (~1.1 GiB of address space), and `anyio.to_process`
**re-imports the parent's `__main__` inside every parse child** before the worker
function runs.

Measured in the released image: the child started at **1419 MiB** against
`DOCUMENT_PARSE_MEM_LIMIT_MB=1536` — about **117 MiB** for the whole parse.

The worker's existing `sys.modules.setdefault("pymupdf.layout", None)` guard was
a **no-op**: by the time it runs, the import has already happened during child
init. The guard was written to avoid precisely this cost.

### 2. The real failure was destroyed in transit

The parse then failed inside MuPDF, and pymupdf's exception holds a SWIG object.
anyio cannot pickle that — and rather than propagating it, it catches the
pickling failure and sends **that** back instead. So an out-of-memory parse
arrived as `reason=error` (terminal → dead-letter) instead of `reason=oom`
(retryable).

## Regression window

`pymupdf-layout` became a hard dependency of pymupdf4llm when the lock moved
0.2.7 → 1.28.0, first released in **0.143.1**. Before that the child had ~1.4 GiB
of headroom and the same document parsed successfully.

## Fix

- Both `to_markdown` call sites now load pymupdf4llm through one shared
  `load_classic_pymupdf4llm()` helper, imported lazily. Child baseline drops
  **1419 → ~891 MiB** and the document parses.
- `_parse_pdf_worker` normalises everything it raises into picklable data, so
  `MemoryError` survives as `reason=oom` instead of becoming a permanent
  dead-letter.
- Also fixes a **latent correctness bug**: the highlighter ran `to_markdown` in
  layout mode while indexing used the classic extractor, so the character offsets
  it exists to keep aligned could silently diverge.

### Verified against the released image

Patched files mounted into the image that produces the failure:

| RLIMIT_AS | before | after |
|---|---|---|
| 1536 MiB | marginal | ✅ 25,002 chars |
| 1470 MiB | ❌ SwigPyObject | ✅ |
| 1440 MiB | ❌ SwigPyObject | ✅ |

## Alerting (second commit)

`astrolabe_document_dead_lettered_total` and `astrolabe_document_parse_failed_total`
exist and are wired, but **never reach Prometheus**: they only increment in the
ingest worker, whose container is not a scrape target and whose tiers autoscale to
zero between batches — so a counter can fire and terminate unscraped, and resets on
scale-up. Four dead-letter events in a day produced no time series at all.

Dead-lettering is durable state, so it is now also published as a gauge from the
long-lived backend that *is* scraped:

```promql
mcp_vector_sync_dead_lettered_documents > 0
```

This matters because a dead-lettered document looks fully indexed to every
count-based check (the tombstone keeps folder totals reconciling) and its ingest
job completes with status *success*.

## Test coverage

No API surface (MCP tool, `/api/v1/*` route, or cross-service boundary) is added
or changed, so the e2e + contract gate does not apply here.

- 4 new isolation tests, including a **subprocess guard** that fails if anything
  re-introduces a module-level `pymupdf4llm` import on the ingest path — the
  invariant cannot be asserted in-process once the module is cached.
- 5 new metrics-publisher tests (filter shape, exactness, gauge publication,
  fail-safe on Qdrant errors).
- Full unit suite: 2562 passed. ruff / ruff format / ty clean.

## Not included

The tombstone-GC items on card #911 (orphaned placeholders and stale
`document_paths` rows left by deprovision/reprovision cycles) are independent of
this fix and are not addressed here.

This does not retroactively clear existing tombstones — affected documents stay
dead-lettered until their etag changes or they are cleared manually, which will
now stick.

---

_This PR was generated with the help of AI, and reviewed by a Human_
