### PR TITLE
fix(mail): index the singleton view, not the threaded one

### DIFF
--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -53,7 +53,7 @@ from nextcloud_mcp_server.search.algorithms import (
 )
 from nextcloud_mcp_server.utils.validation import is_valid_nextcloud_doc_id
 from nextcloud_mcp_server.vector.eviction import delete_document_points
-from nextcloud_mcp_server.vector.mail_content import MAIL_SCAN_MAX_PER_MAILBOX
+from nextcloud_mcp_server.vector.mail_content import list_index_window
 
 logger = logging.getLogger(__name__)
 
@@ -505,9 +505,9 @@ async def _verify_mail_messages(
     ``mail.get_message`` triggers a server-side IMAP body fetch, so a per-result
     verify would issue one IMAP FETCH per hit — multiple seconds for an active
     inbox. Instead we batch by ``mailbox_id`` (propagated into ``result.metadata``
-    from the Qdrant payload) and call ``mail.list_messages`` once per mailbox,
+    from the Qdrant payload) and call ``list_index_window`` once per mailbox,
     which reads the Mail app's DB cache (no IMAP). A message is accessible iff it
-    is present in its mailbox's newest-N listing — the same window the scanner
+    is present in that listing — by construction the *same* window the scanner
     indexes, so anything aged out of the window is being evicted anyway.
 
     Failure policy mirrors ``_verify_news_items``: a definitive 403/404 for a
@@ -548,9 +548,7 @@ async def _verify_mail_messages(
     async def check_mailbox(mailbox_id: int, mb_results: list[SearchResult]) -> None:
         async with semaphore:
             try:
-                messages = await client.mail.list_messages(
-                    mailbox_id, limit=MAIL_SCAN_MAX_PER_MAILBOX
-                )
+                messages = await list_index_window(client.mail, mailbox_id)
             except HTTPStatusError as e:
                 if _is_definitive_404_or_403(e):
                     # Mailbox/account gone — all its results are inaccessible.

--- a/nextcloud_mcp_server/vector/mail_content.py
+++ b/nextcloud_mcp_server/vector/mail_content.py
@@ -1,21 +1,66 @@
-"""Shared reconstruction of mail-message content for indexing and context.
+"""Shared mail-message plumbing for indexing, verification and context.
 
-The vector processor (index-time) and search context expansion (query-time)
-must build the *identical* text for a mail message so chunk offsets align.
-Keeping that logic here — rather than copy-pasted in both call sites — is the
-single source of truth for the reconstruction.
+Two things live here, both because *two* call sites must agree exactly:
+
+1. Content reconstruction (:func:`build_mail_content`) — the vector processor
+   (index-time) and search context expansion (query-time) must build the
+   identical text for a message so chunk offsets align.
+2. The listing window (:func:`list_index_window`) — the scanner (index window)
+   and the verifier (presence window) must list messages identically, or the
+   verifier evicts messages the scanner legitimately indexed.
 """
 
 from typing import Any
 
 from nextcloud_mcp_server.vector.html_processor import html_to_markdown
 
-# Newest-N messages indexed (and verified) per mailbox. This equals the Mail
-# OCS API's per-request maximum (it clamps ``limit`` to 1..100), so it cannot be
-# raised without adding cursor pagination — hence a documented constant rather
-# than a config knob that would silently cap at 100. Shared by the scanner
-# (index window) and the verifier (presence window) so they stay consistent.
+# Messages indexed (and verified) per mailbox. This equals the Mail API's
+# per-request maximum (it clamps ``limit`` to 1..100), so it cannot be raised
+# without adding cursor pagination — hence a documented constant rather than a
+# config knob that would silently cap at 100. Shared by the scanner (index
+# window) and the verifier (presence window) so they stay consistent.
+#
+# Which end of the mailbox this window covers is the *user's* Mail ``sort-order``
+# preference, not ours: newest-first by default, oldest-first if they changed it.
 MAIL_SCAN_MAX_PER_MAILBOX = 100
+
+
+async def list_index_window(
+    mail_client: Any,
+    mailbox_id: int,
+    index_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """List the messages of one mailbox that make up the index window.
+
+    The single listing call shared by the scanner (which decides what to index)
+    and the verifier (which decides what is still present). Pinning the limit,
+    the view and the filter in one place is what keeps those two windows from
+    drifting apart — a message the scanner indexes but the verifier cannot see
+    is dropped from search results and evicted from the index.
+
+    ``view="singleton"`` is load-bearing, not a default. The Mail app coerces
+    anything that is not literally ``"singleton"`` to its threaded view, which
+    self-joins the message table and returns only the newest message of each
+    thread — so thread replies would never be indexed, and (with a filter) a
+    matching message would silently drop out of the listing as soon as a reply
+    arrived, because the thread self-join carries no filter predicate.
+
+    Args:
+        mail_client: A ``MailClient`` (or the ``mail`` attribute of a client
+            protocol — typed loosely so both pass).
+        mailbox_id: Mailbox database ID to list.
+        index_filter: Optional Mail filter string (see
+            :func:`mail_index_filter`); ``None`` lists every message.
+
+    Returns:
+        Message summary dicts, at most ``MAIL_SCAN_MAX_PER_MAILBOX``.
+    """
+    return await mail_client.list_messages(
+        mailbox_id,
+        limit=MAIL_SCAN_MAX_PER_MAILBOX,
+        search_filter=index_filter,
+        view="singleton",
+    )
 
 
 def format_mail_addresses(addrs: list[dict[str, Any]] | None) -> str:

--- a/nextcloud_mcp_server/vector/mail_content.py
+++ b/nextcloud_mcp_server/vector/mail_content.py
@@ -51,8 +51,8 @@ async def list_index_window(
             concretely so a signature change in ``MailClient.list_messages``
             fails type-checking here rather than silently drifting the window.
         mailbox_id: Mailbox database ID to list.
-        index_filter: Optional Mail filter string (see
-            :func:`mail_index_filter`); ``None`` lists every message.
+        index_filter: Optional Mail search-filter string (e.g. ``tags:7``);
+            ``None`` lists every message.
 
     Returns:
         Message summary dicts, at most ``MAIL_SCAN_MAX_PER_MAILBOX``.

--- a/nextcloud_mcp_server/vector/mail_content.py
+++ b/nextcloud_mcp_server/vector/mail_content.py
@@ -12,6 +12,7 @@ Two things live here, both because *two* call sites must agree exactly:
 
 from typing import Any
 
+from nextcloud_mcp_server.client.mail import MailClient
 from nextcloud_mcp_server.vector.html_processor import html_to_markdown
 
 # Messages indexed (and verified) per mailbox. This equals the Mail API's
@@ -26,7 +27,7 @@ MAIL_SCAN_MAX_PER_MAILBOX = 100
 
 
 async def list_index_window(
-    mail_client: Any,
+    mail_client: MailClient,
     mailbox_id: int,
     index_filter: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -46,8 +47,9 @@ async def list_index_window(
     arrived, because the thread self-join carries no filter predicate.
 
     Args:
-        mail_client: A ``MailClient`` (or the ``mail`` attribute of a client
-            protocol — typed loosely so both pass).
+        mail_client: The ``mail`` attribute of a Nextcloud client. Typed
+            concretely so a signature change in ``MailClient.list_messages``
+            fails type-checking here rather than silently drifting the window.
         mailbox_id: Mailbox database ID to list.
         index_filter: Optional Mail filter string (see
             :func:`mail_index_filter`); ``None`` lists every message.

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -1957,6 +1957,11 @@ async def scan_mail_messages(
     accounts = await nc_client.mail.list_accounts()
     nextcloud_message_ids: set[str] = set()
     message_count = 0
+    # Set when any account/mailbox listing fails. Such a listing contributes no
+    # ids to ``nextcloud_message_ids``, so its already-indexed messages look
+    # deleted to the pass below — the same false-eviction the zero-message guard
+    # prevents, just scoped to a subset of mailboxes rather than all of them.
+    listing_failed = False
 
     for account in accounts:
         account_id = account.get("id")
@@ -1965,6 +1970,7 @@ async def scan_mail_messages(
         try:
             mailboxes = await nc_client.mail.get_mailboxes(account_id)
         except Exception as e:
+            listing_failed = True
             logger.warning(
                 "[SCAN-%s] Failed to list mailboxes for account %s: %s",
                 scan_id,
@@ -1980,6 +1986,7 @@ async def scan_mail_messages(
             try:
                 messages = await list_index_window(nc_client.mail, mailbox_id)
             except Exception as e:
+                listing_failed = True
                 logger.warning(
                     "[SCAN-%s] Failed to list messages for mailbox %s: %s",
                     scan_id,
@@ -2104,20 +2111,30 @@ async def scan_mail_messages(
 
     # Check for deleted / aged-out messages (not initial sync).
     #
-    # A listing that came back completely empty while we hold an index is
-    # treated as suspect, not as "everything was deleted": every mailbox listing
-    # failing (Mail app down, mailboxes not yet cached) looks identical in the
-    # response to a genuinely emptied account, and the conservative reading is
-    # the only safe one — the alternative evicts a user's entire mail index on a
-    # transient outage and re-embeds it on recovery. Stale points that survive
-    # this guard are storage cost, not exposure: verify-on-read still drops and
-    # evicts them on any search that would surface them.
-    if message_count == 0 and indexed_message_ids:
+    # The deletion pass is only safe when this scan actually observed every
+    # mailbox. Two ways it might not have:
+    #
+    # 1. A listing came back completely empty while we hold an index. Every
+    #    mailbox listing failing (Mail app down, mailboxes not yet cached) looks
+    #    identical in the response to a genuinely emptied account.
+    # 2. Some listings raised while others succeeded. Those mailboxes contribute
+    #    no ids, so their indexed messages are indistinguishable here from
+    #    deleted ones — and ``message_count`` is nonzero, so case 1 misses it.
+    #
+    # The conservative reading is the only safe one either way: the alternative
+    # evicts mail on a transient outage and re-embeds it on recovery. Deletion
+    # is deferred, not skipped — the next clean scan runs the pass. Stale points
+    # that survive are storage cost, not exposure: verify-on-read still drops
+    # and evicts them on any search that would surface them.
+    if indexed_message_ids and (message_count == 0 or listing_failed):
         logger.warning(
-            "[SCAN-%s] Mail listing returned zero messages for %s while %s are "
-            "indexed; skipping the deletion pass this cycle",
+            "[SCAN-%s] Mail listing was incomplete for %s (%s messages seen, "
+            "listing_failed=%s) while %s are indexed; skipping the deletion "
+            "pass this cycle",
             scan_id,
             user_id,
+            message_count,
+            listing_failed,
             len(indexed_message_ids),
         )
     elif not initial_sync:

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -41,7 +41,10 @@ from nextcloud_mcp_server.server.tag_exclusion import (
 )
 from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.dead_letter import is_dead_lettered
-from nextcloud_mcp_server.vector.mail_content import MAIL_SCAN_MAX_PER_MAILBOX
+from nextcloud_mcp_server.vector.mail_content import (
+    MAIL_SCAN_MAX_PER_MAILBOX,
+    list_index_window,
+)
 from nextcloud_mcp_server.vector.placeholder import (
     query_document_metadata,
     write_placeholder_point,
@@ -1863,14 +1866,14 @@ async def scan_news_items(
     return queued
 
 
-# Newest-N messages indexed per mailbox (= the Mail OCS per-request maximum;
-# imported from mail_content so the scanner index window and the search-time
-# verifier presence window stay identical). Older messages age out of the index
-# as newer ones arrive — the deletion-tracking pass below evicts them, the same
-# way it handles actually-deleted messages. Going beyond 100 would require
-# cursor pagination, so the value is fixed rather than configurable.
+# The per-mailbox index window is ``list_index_window`` (imported from
+# mail_content), which the search-time verifier calls too so the two windows stay
+# identical. Messages that fall out of the window as newer ones arrive are evicted
+# by the deletion-tracking pass below, the same way actually-deleted messages are.
+# Going beyond MAIL_SCAN_MAX_PER_MAILBOX would require cursor pagination, so the
+# value is fixed rather than configurable.
 #
-# Per-process record of (user_id, mailbox_id) for which the newest-N cap has
+# Per-process record of (user_id, mailbox_id) for which the window cap has
 # already been logged, so the "older mail not indexed" notice is emitted once at
 # info level (discoverable) rather than on every scan tick (which would flood
 # multi-tenant logs). Insertion-ordered dict + bounded eviction (mirrors
@@ -1905,12 +1908,13 @@ async def scan_mail_messages(
     """
     Scan a user's Mail messages and queue changed messages for indexing.
 
-    Enumerates accounts → mailboxes → newest ``MAIL_SCAN_MAX_PER_MAILBOX``
-    messages per mailbox. Email is immutable, so a message's ``dateInt`` (sent
+    Enumerates accounts → mailboxes → ``list_index_window`` per mailbox (at most
+    ``MAIL_SCAN_MAX_PER_MAILBOX`` messages, the same call the search-time
+    verifier makes). Email is immutable, so a message's ``dateInt`` (sent
     timestamp) is used as the change-detection ``modified_at`` — a message is
-    indexed once and not re-sent. Messages that drop out of the newest-N window
-    (or are deleted) are evicted via the deletion-tracking pass, keeping the
-    index bounded to recent mail.
+    indexed once and not re-sent. Messages that drop out of the window (or are
+    deleted) are evicted via the deletion-tracking pass, keeping the index
+    bounded.
 
     The MCP server never speaks IMAP: listing reads the Mail app's DB-cached
     envelopes, and the body fetch (in the processor) goes through the Mail app's
@@ -1974,9 +1978,7 @@ async def scan_mail_messages(
             if mailbox_id is None:
                 continue
             try:
-                messages = await nc_client.mail.list_messages(
-                    mailbox_id, limit=MAIL_SCAN_MAX_PER_MAILBOX
-                )
+                messages = await list_index_window(nc_client.mail, mailbox_id)
             except Exception as e:
                 logger.warning(
                     "[SCAN-%s] Failed to list messages for mailbox %s: %s",
@@ -2100,8 +2102,25 @@ async def scan_mail_messages(
     )
     record_vector_sync_scan(message_count)
 
-    # Check for deleted / aged-out messages (not initial sync)
-    if not initial_sync:
+    # Check for deleted / aged-out messages (not initial sync).
+    #
+    # A listing that came back completely empty while we hold an index is
+    # treated as suspect, not as "everything was deleted": every mailbox listing
+    # failing (Mail app down, mailboxes not yet cached) looks identical in the
+    # response to a genuinely emptied account, and the conservative reading is
+    # the only safe one — the alternative evicts a user's entire mail index on a
+    # transient outage and re-embeds it on recovery. Stale points that survive
+    # this guard are storage cost, not exposure: verify-on-read still drops and
+    # evicts them on any search that would surface them.
+    if message_count == 0 and indexed_message_ids:
+        logger.warning(
+            "[SCAN-%s] Mail listing returned zero messages for %s while %s are "
+            "indexed; skipping the deletion pass this cycle",
+            scan_id,
+            user_id,
+            len(indexed_message_ids),
+        )
+    elif not initial_sync:
         grace_period = settings.vector_sync_scan_interval * 1.5
         current_time = time.time()
 

--- a/tests/unit/search/test_verification.py
+++ b/tests/unit/search/test_verification.py
@@ -253,8 +253,12 @@ async def test_verify_mail_batches_one_list_per_mailbox(mocker):
     )
     # 10 and 30 present; 20 absent (deleted/aged out) -> dropped.
     assert result == {"10", "30"}
-    # One DB-cached list call for the single mailbox, not one per result.
-    list_messages.assert_awaited_once_with(10, limit=MAIL_SCAN_MAX_PER_MAILBOX)
+    # One DB-cached list call for the single mailbox, not one per result — and
+    # it must be the *same* window the scanner indexes (same limit, same
+    # singleton view), or the verifier evicts messages the scanner just indexed.
+    list_messages.assert_awaited_once_with(
+        10, limit=MAIL_SCAN_MAX_PER_MAILBOX, search_filter=None, view="singleton"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/search/test_verification.py
+++ b/tests/unit/search/test_verification.py
@@ -340,7 +340,10 @@ async def test_verify_mail_non_numeric_id_kept_when_mailbox_listed(mocker):
 async def test_verify_mail_partitions_distinct_mailboxes(mocker):
     """Results in different mailboxes each get their own list call."""
 
-    async def list_messages(mailbox_id, *, limit):
+    # Signature must match what list_index_window actually calls with: a stale
+    # stub raises TypeError, which the verifier's fail-open branch swallows, and
+    # the test then passes without exercising partitioning at all.
+    async def list_messages(mailbox_id, *, limit, search_filter, view):
         return {10: [{"databaseId": 1}], 20: [{"databaseId": 2}]}[mailbox_id]
 
     mail_client = SimpleNamespace(
@@ -350,7 +353,15 @@ async def test_verify_mail_partitions_distinct_mailboxes(mocker):
 
     result = await _verify_mail_messages(
         client,
-        [_mail_result(1, mailbox_id=10), _mail_result(2, mailbox_id=20)],
+        [
+            _mail_result(1, mailbox_id=10),
+            _mail_result(2, mailbox_id=20),
+            # Absent from mailbox 10's listing. This is what makes the test
+            # load-bearing: the real path drops it, whereas the fail-open branch
+            # (which a stub whose signature has drifted from list_index_window
+            # would silently take, via TypeError) would keep it.
+            _mail_result(3, mailbox_id=10),
+        ],
         _sem(),
     )
     assert result == {"1", "2"}

--- a/tests/unit/vector/test_mail_content.py
+++ b/tests/unit/vector/test_mail_content.py
@@ -1,18 +1,52 @@
-"""Unit tests for the shared mail content reconstruction.
+"""Unit tests for the shared mail content reconstruction and listing window.
 
 ``build_mail_content`` is the single source of truth for index-time and
 query-time chunk offsets; these tests pin the exact layout so a change to the
 separators or header order can't silently misalign every indexed message.
+``list_index_window`` is the equivalent for the scanner/verifier listing.
 """
+
+from unittest.mock import AsyncMock
 
 import pytest
 
 from nextcloud_mcp_server.vector.mail_content import (
+    MAIL_SCAN_MAX_PER_MAILBOX,
     build_mail_content,
     format_mail_addresses,
+    list_index_window,
 )
 
 pytestmark = pytest.mark.unit
+
+
+async def test_list_index_window_pins_limit_and_singleton_view():
+    """The window must request singleton view — threaded hides every reply.
+
+    The Mail app coerces any view that isn't literally "singleton" to its
+    threaded view, which returns only the newest message per thread.
+    """
+    mail_client = AsyncMock()
+    mail_client.list_messages.return_value = [{"databaseId": 1}]
+
+    result = await list_index_window(mail_client, 10)
+
+    assert result == [{"databaseId": 1}]
+    mail_client.list_messages.assert_awaited_once_with(
+        10,
+        limit=MAIL_SCAN_MAX_PER_MAILBOX,
+        search_filter=None,
+        view="singleton",
+    )
+
+
+async def test_list_index_window_passes_filter_through():
+    mail_client = AsyncMock()
+    mail_client.list_messages.return_value = []
+
+    await list_index_window(mail_client, 10, "tags:7")
+
+    assert mail_client.list_messages.await_args.kwargs["search_filter"] == "tags:7"
 
 
 def test_format_addresses_variants():

--- a/tests/unit/vector/test_scanner_mail.py
+++ b/tests/unit/vector/test_scanner_mail.py
@@ -290,6 +290,46 @@ async def test_empty_listing_skips_deletion_pass(mocker):
     assert ("alice", "999", "mail_message") in scanner_module._potentially_deleted
 
 
+async def test_partial_listing_failure_skips_deletion_pass(mocker):
+    """One mailbox failing must not evict the messages indexed from it.
+
+    The all-empty guard does not cover this: the surviving mailbox makes
+    ``message_count`` nonzero, so without tracking the failure the scanner would
+    read "mailbox 11's messages are gone" from what is really a transient error
+    on that one mailbox.
+    """
+    _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
+    # Well past the grace period — only the incomplete-listing guard holds it back.
+    scanner_module._potentially_deleted[("alice", "999", "mail_message")] = 0.0
+
+    nc_client = MagicMock()
+    nc_client.mail.list_accounts = AsyncMock(return_value=[{"id": 1}])
+    nc_client.mail.get_mailboxes = AsyncMock(
+        return_value=[{"databaseId": 10}, {"databaseId": 11}]
+    )
+
+    async def _list_messages(mailbox_id, **kwargs):
+        if mailbox_id == 11:
+            raise RuntimeError("mailbox 11 is not cached")
+        return [{"databaseId": 100, "dateInt": 1700000000}]
+
+    nc_client.mail.list_messages = AsyncMock(side_effect=_list_messages)
+
+    stream = _CollectingStream()
+    queued = await scan_mail_messages(
+        user_id="alice",
+        send_stream=stream,
+        nc_client=nc_client,
+        initial_sync=False,
+        scan_id=1,
+    )
+
+    # 100 is queued (no stored metadata), but 999 is NOT evicted.
+    assert queued == 1
+    assert [(t.doc_id, t.operation) for t in stream.tasks] == [("100", "index")]
+    assert ("alice", "999", "mail_message") in scanner_module._potentially_deleted
+
+
 async def test_empty_listing_with_empty_index_is_not_guarded(mocker):
     """Nothing indexed yet + nothing listed is the normal empty case, not a fault."""
     _patch_incremental(mocker, indexed_ids=[], existing_metadata=None)

--- a/tests/unit/vector/test_scanner_mail.py
+++ b/tests/unit/vector/test_scanner_mail.py
@@ -67,7 +67,7 @@ async def test_initial_sync_enumerates_accounts_mailboxes_messages(mocker):
         return_value=[{"databaseId": 10}, {"databaseId": 11}]
     )
 
-    async def list_messages(mailbox_id, *, limit):
+    async def list_messages(mailbox_id, *, limit, search_filter, view):
         if mailbox_id == 10:
             return [
                 {"databaseId": 100, "dateInt": 1700000000},
@@ -102,9 +102,13 @@ async def test_initial_sync_enumerates_accounts_mailboxes_messages(mocker):
     assert t100.metadata == {"account_id": 1, "mailbox_id": 10}
     # A placeholder is written per message before queueing.
     assert placeholder.await_count == 3
-    # The per-mailbox cap is passed through.
+    # The shared index window is used: per-mailbox cap, no filter, and the
+    # singleton view (threaded would hide every reply — see list_index_window).
     nc_client.mail.list_messages.assert_any_await(
-        10, limit=scanner_module.MAIL_SCAN_MAX_PER_MAILBOX
+        10,
+        limit=scanner_module.MAIL_SCAN_MAX_PER_MAILBOX,
+        search_filter=None,
+        view="singleton",
     )
 
 
@@ -116,7 +120,7 @@ async def test_initial_sync_skips_mailbox_on_list_error(mocker):
         return_value=[{"databaseId": 10}, {"databaseId": 11}]
     )
 
-    async def list_messages(mailbox_id, *, limit):
+    async def list_messages(mailbox_id, *, limit, search_filter, view):
         if mailbox_id == 10:
             raise RuntimeError("imap hiccup")
         return [{"databaseId": 200, "dateInt": 1700000002}]
@@ -208,11 +212,14 @@ async def test_incremental_reappeared_message_clears_grace(mocker):
 
 async def test_incremental_deletes_after_grace_period(mocker):
     """An indexed message gone from Nextcloud past the grace period is deleted."""
-    _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
+    _patch_incremental(
+        mocker, indexed_ids=["999"], existing_metadata={"modified_at": 1700000000}
+    )
     # Seed the grace period far in the past so the delta exceeds grace_period.
     scanner_module._potentially_deleted[("alice", "999", "mail_message")] = 0.0
-    # Mailbox now returns no messages, so 999 is missing.
-    nc_client = _single_message_client([])
+    # The mailbox still lists other (already up-to-date) mail, so 999 is
+    # genuinely missing rather than the whole listing having failed.
+    nc_client = _single_message_client([{"databaseId": 100, "dateInt": 1700000000}])
 
     stream = _CollectingStream()
     queued = await scan_mail_messages(
@@ -234,9 +241,11 @@ async def test_incremental_deletes_after_grace_period(mocker):
 
 async def test_incremental_first_missing_starts_grace(mocker):
     """A newly-missing indexed message enters the grace period (no delete yet)."""
-    _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
-    # Not previously seen as missing, and the mailbox now returns no messages.
-    nc_client = _single_message_client([])
+    _patch_incremental(
+        mocker, indexed_ids=["999"], existing_metadata={"modified_at": 1700000000}
+    )
+    # Not previously seen as missing; the mailbox still lists other mail.
+    nc_client = _single_message_client([{"databaseId": 100, "dateInt": 1700000000}])
 
     stream = _CollectingStream()
     queued = await scan_mail_messages(
@@ -251,6 +260,52 @@ async def test_incremental_first_missing_starts_grace(mocker):
     assert queued == 0
     assert stream.tasks == []
     assert ("alice", "999", "mail_message") in scanner_module._potentially_deleted
+
+
+async def test_empty_listing_skips_deletion_pass(mocker):
+    """An all-empty listing while an index exists must not evict anything.
+
+    Every mailbox listing failing (Mail app down, mailboxes not yet cached) is
+    indistinguishable in the response from a genuinely emptied account, so the
+    scanner declines to delete rather than wiping a user's whole mail index on a
+    transient outage.
+    """
+    _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
+    # Well past the grace period — only the empty-listing guard holds it back.
+    scanner_module._potentially_deleted[("alice", "999", "mail_message")] = 0.0
+    nc_client = _single_message_client([])
+
+    stream = _CollectingStream()
+    queued = await scan_mail_messages(
+        user_id="alice",
+        send_stream=stream,
+        nc_client=nc_client,
+        initial_sync=False,
+        scan_id=1,
+    )
+
+    assert queued == 0
+    assert stream.tasks == []
+    # Still mid-grace: a later scan that lists successfully can still delete it.
+    assert ("alice", "999", "mail_message") in scanner_module._potentially_deleted
+
+
+async def test_empty_listing_with_empty_index_is_not_guarded(mocker):
+    """Nothing indexed yet + nothing listed is the normal empty case, not a fault."""
+    _patch_incremental(mocker, indexed_ids=[], existing_metadata=None)
+    nc_client = _single_message_client([])
+
+    stream = _CollectingStream()
+    queued = await scan_mail_messages(
+        user_id="alice",
+        send_stream=stream,
+        nc_client=nc_client,
+        initial_sync=False,
+        scan_id=1,
+    )
+
+    assert queued == 0
+    assert stream.tasks == []
 
 
 async def test_grace_key_isolated_by_doc_type(mocker):


### PR DESCRIPTION
## What

`MailClient.list_messages` was called with `view=None`. The Mail app coerces any
view that is not literally `"singleton"` to its **threaded** view
(`MessagesController::index`), which adds a self-join plus `m2.id IS NULL` and
returns **only the newest message of each thread**.

Consequences today: every reply in a thread is silently absent from the vector
index. A busy thread contributes exactly one indexed message.

It also blocks filtered listings: the thread self-join carries no predicate from
the `filter` query param, so a matching message drops out of the listing as soon
as a reply lands, and `_verify_mail_messages` then evicts it. Any future
index-scoping filter is unsound until this is fixed, which is why it lands on its
own first.

## Changes

- **`vector/mail_content.py`** — new `list_index_window()`, the single listing
  call shared by the scanner (what to index) and the verifier (what is still
  present). It pins the limit, the view and the filter in one place; those two
  windows drifting apart is precisely what causes an indexed message to be
  dropped from results and evicted. It sits next to `MAIL_SCAN_MAX_PER_MAILBOX`,
  which already existed for the same reason.
- **`vector/scanner.py`, `search/verification.py`** — both call it.
- **`vector/scanner.py`** — guard the mail deletion pass against an all-empty
  listing. Pre-existing bug, found while tracing the above: `scan_mail_messages`
  `continue`s past a failed per-mailbox listing and then runs the deletion pass
  unconditionally, so a transient Mail outage (or mailboxes not yet cached)
  evicts a user's **entire** mail index and re-embeds it on recovery. An empty
  listing is indistinguishable in the response from a genuinely emptied account,
  so the conservative reading is the only safe one.

  Cost stated honestly: a user who genuinely empties their mail is no longer
  purged by the scanner. Those points are storage cost, never exposure —
  verify-on-read still drops and evicts them on any search that would surface
  them.

## Test coverage

- `test_mail_content.py` — new: the window pins `limit` + `view="singleton"` and
  passes a filter through.
- `test_scanner_mail.py` — new: empty listing + non-empty index skips the
  deletion pass; empty listing + empty index is untouched (the normal case). The
  two existing deletion tests encoded the old behaviour via a fully-empty
  listing; they now model a message genuinely missing from a mailbox that still
  lists other mail.
- `test_verification.py` — asserts the verifier requests the *same* window the
  scanner does.
- Full unit suite: 2657 passed. `ruff` / `ruff format` / `ty` clean.

No API surface changes, so no e2e or contract (Pact) work is required for this
one — the write-tool PR that follows carries that.

Deck: card #917 (board 12).

---

_This PR was generated with the help of AI, and reviewed by a Human_