### PR TITLE
feat(mail): add write tools — flags, tags, move, delete (closes #1148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For Kubernetes, see [cbcoutinho/helm-charts](https://github.com/cbcoutinho/helm-
 | **Tables** | 5 | Row operations on Nextcloud Tables |
 | **Sharing** | 10+ | Create and manage shares |
 | **News** | 8 | Feeds, folders, items, feed health monitoring |
-| **Mail** | 5 | Read-only: accounts, mailboxes, messages, attachments (via Mail app's REST API) |
+| **Mail** | 12 | Accounts, mailboxes, messages, attachments, send; flags (read/unread, star), tags, move, delete |
 | **Collectives** | 16 | Full CRUD on collectives, pages, and tags |
 | **Talk (spreed)** | 6 | List conversations, read/post messages, mark as read, list participants |
 | **Semantic Search** | 2+ | Vector search for Notes, Files, News items, Deck cards, and Mail messages (experimental, opt-in, requires infrastructure) |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For Kubernetes, see [cbcoutinho/helm-charts](https://github.com/cbcoutinho/helm-
 | **Tables** | 5 | Row operations on Nextcloud Tables |
 | **Sharing** | 10+ | Create and manage shares |
 | **News** | 8 | Feeds, folders, items, feed health monitoring |
-| **Mail** | 12 | Accounts, mailboxes, messages, attachments, send; flags (read/unread, star), tags, move, delete |
+| **Mail** | 13 | Accounts, mailboxes, messages, attachments, send; flags (read/unread, star), tags, move, delete |
 | **Collectives** | 16 | Full CRUD on collectives, pages, and tags |
 | **Talk (spreed)** | 6 | List conversations, read/post messages, mark as read, list participants |
 | **Semantic Search** | 2+ | Vector search for Notes, Files, News items, Deck cards, and Mail messages (experimental, opt-in, requires infrastructure) |

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -104,8 +104,9 @@ The Mail app publishes only a small OCS API; most of what these tools need lives
 on its internal `/index.php/apps/mail/api/...` routes, which are CSRF-gated for
 browser sessions. Nextcloud exempts any request carrying `OCS-APIRequest: true`
 from that check, so an app password plus that header is sufficient — no
-`requesttoken` round-trip. This is verified end-to-end by the GreenMail
-integration lane rather than assumed.
+`requesttoken` round-trip. The GreenMail integration lane exercises this for
+both the read and the write routes, so a regression shows up as a test failure
+rather than as a silent assumption.
 
 Because those routes are internal, the Mail app marks them
 `OpenAPI::SCOPE_IGNORE` and may change them between releases. Breakage there

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -1,0 +1,112 @@
+# Mail App
+
+Tools for the [Nextcloud Mail](https://github.com/nextcloud/mail) app: browsing
+accounts and mailboxes, reading and searching messages, sending, and managing
+message state (flags, tags, move, delete).
+
+### Mail Tools
+
+| Tool | Description |
+|------|-------------|
+| `nc_mail_list_accounts` | List the user's configured mail accounts |
+| `nc_mail_list_mailboxes` | List the mailboxes (folders) of an account |
+| `nc_mail_list_messages` | List message envelopes in a mailbox, with an optional filter query (see below) |
+| `nc_mail_get_message` | Get one message with its full body and attachment metadata |
+| `nc_mail_get_message_source` | Get a message's raw RFC 2822 source (all headers) |
+| `nc_mail_get_attachment` | Download one attachment (base64; capped at 5 MB inline) |
+| `nc_mail_send_message` | Send a message via the account's outbox |
+| `nc_mail_set_flags` | Mark read/unread, star, mark answered or junk |
+| `nc_mail_create_tag` | Create a tag, or look up an existing one by name |
+| `nc_mail_set_tag` / `nc_mail_remove_tag` | Add / remove a tag on a message |
+| `nc_mail_move_message` | Move a message to another mailbox |
+| `nc_mail_delete_message` | Move a message to trash (or expunge it if already there) |
+
+### Scopes
+
+| Scope | Covers |
+|-------|--------|
+| `mail.read` | The listing, reading and attachment tools |
+| `mail.write` | Flags, tags, move, delete |
+| `mail.send` | `nc_mail_send_message` |
+
+### Marking messages read
+
+`nc_mail_set_flags` changes only the flags you pass; everything else is left
+alone. It is the tool to reach for after an agent has processed a message, so it
+does not keep looking unhandled:
+
+```
+nc_mail_set_flags(message_id=42, seen=True)              # mark read
+nc_mail_set_flags(message_id=42, seen=False)             # back to unread
+nc_mail_set_flags(message_id=42, flagged=True)           # star it
+```
+
+`seen`, `flagged` and `answered` are standard IMAP flags and always apply.
+`junk` is a custom IMAP keyword — mail servers that do not advertise custom
+keywords for the mailbox silently ignore it.
+
+There is **no bulk flag endpoint** in the Mail app; call the tool per message.
+
+### Filtering messages
+
+`nc_mail_list_messages` accepts the Mail app's own filter grammar in
+`search_filter`: space-separated `token:value` terms, ANDed together.
+
+| Token | Values |
+|-------|--------|
+| `is:` / `not:` | `read`, `unread`, `starred`, `answered`, `important` |
+| `from:` `to:` `cc:` `bcc:` | substring of the address or display name |
+| `subject:` | substring |
+| `body:` | substring — searched on the IMAP server, so slower |
+| `tags:` | comma-separated tag **database ids** (not names) |
+| `start:` / `end:` | date bounds |
+| `flags:` | comma-separated `read`, `unread`, `starred`, `answered`, `important`, `attachments` |
+| `match:anyof` | OR the from/to/cc/bcc/subject/body terms instead of ANDing |
+
+```
+nc_mail_list_messages(mailbox_id=10, search_filter="is:unread from:alice")
+nc_mail_list_messages(mailbox_id=10, search_filter="subject:invoice start:2026-01-01")
+```
+
+### Tags
+
+Mail tags are IMAP keywords, private to each user. A few notes that follow from
+how the Mail app implements them:
+
+- **Names normalise.** The IMAP label is derived as `$` + the lowercased name
+  with spaces turned into underscores, so `"AI Index"`, `"ai index"` and
+  `"ai_index"` are all the same tag.
+- **`nc_mail_create_tag` is create-or-get.** Calling it for a name that already
+  exists returns that tag instead of creating a duplicate. Since the Mail app
+  exposes no tag-listing endpoint, this is also how you look a tag's id up —
+  and the id is what the `tags:` filter needs.
+- **`nc_mail_set_tag` creates the tag if needed**, so tagging works in one call.
+- Tags attach to a message by its RFC `Message-ID`, so tagging propagates to
+  copies of the same message in other mailboxes.
+
+```
+tag = nc_mail_create_tag(display_name="AI Index")        # -> tag.id = 7
+nc_mail_set_tag(message_id=42, tag="AI Index")
+nc_mail_list_messages(mailbox_id=10, search_filter="tags:7")
+```
+
+### Semantic search
+
+Mail messages are indexed for semantic search as `doc_type="mail_message"` when
+vector sync is enabled — see [semantic-search.md](semantic-search.md). Indexing
+covers up to 100 messages per mailbox (the Mail API's per-request maximum;
+paging beyond it is not implemented yet), and a message's sent timestamp is used
+for change detection, since mail is immutable.
+
+### Implementation notes
+
+The Mail app publishes only a small OCS API; most of what these tools need lives
+on its internal `/index.php/apps/mail/api/...` routes, which are CSRF-gated for
+browser sessions. Nextcloud exempts any request carrying `OCS-APIRequest: true`
+from that check, so an app password plus that header is sufficient — no
+`requesttoken` round-trip. This is verified end-to-end by the GreenMail
+integration lane rather than assumed.
+
+Because those routes are internal, the Mail app marks them
+`OpenAPI::SCOPE_IGNORE` and may change them between releases. Breakage there
+shows up as a failing integration test rather than a silent behaviour change.

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -105,6 +105,7 @@ from nextcloud_mcp_server.config_validators import (
 )
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
 from nextcloud_mcp_server.http import nextcloud_httpx_client
+from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 from nextcloud_mcp_server.observability import (
     ObservabilityMiddleware,
     setup_metrics,
@@ -858,15 +859,12 @@ async def load_oauth_client_credentials(
         # External clients will request tokens with resource=http://localhost:8001/mcp
         # and the authorization server will limit them to these allowed scopes.
         #
-        # The PRM endpoint advertises the same scopes dynamically via @require_scopes decorators.
-        # These must stay in sync — any scope a tool uses via @require_scopes must be listed here.
-        dcr_scopes = (
-            "openid profile email "
-            "notes.read notes.write calendar.read calendar.write todo.read todo.write "
-            "contacts.read contacts.write cookbook.read cookbook.write deck.read deck.write "
-            "tables.read tables.write files.read files.write sharing.read sharing.write "
-            "news.read news.write collectives.read collectives.write"
-        )
+        # The PRM endpoint advertises the same scopes dynamically via @require_scopes
+        # decorators, so this list must cover every scope any tool requires. It is
+        # derived from ALL_SUPPORTED_SCOPES rather than hand-maintained: the two were
+        # a duplicated pair that silently drifted, leaving mail.send (and every mail
+        # scope) ungrantable in OAuth mode despite being in use.
+        dcr_scopes = "openid profile email " + " ".join(sorted(ALL_SUPPORTED_SCOPES))
 
         # Add conditional scopes based on server configuration
         dcr_settings = get_settings()

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -11,9 +11,8 @@ Uses two endpoint types:
    mailboxes, and messages, downloading attachments, the two-step outbox send, and
    every write operation (flags, tags, move, delete), none of which has an OCS
    equivalent. These REST resource routes (from ``'resources'`` in ``routes.php``)
-   are
-   CSRF-gated for browser sessions, but Nextcloud exempts any request carrying the
-   ``OCS-APIRequest: true`` header from the CSRF check — so Basic Auth (App
+   are CSRF-gated for browser sessions, but Nextcloud exempts any request carrying
+   the ``OCS-APIRequest: true`` header from the CSRF check — so Basic Auth (App
    Password) + that header is sufficient. No ``requesttoken`` round-trip is needed
    (verified end-to-end against a live Mail 5.x backend; see the GreenMail
    integration tests).
@@ -32,6 +31,11 @@ from urllib.parse import quote
 from httpx import HTTPStatusError, RequestError, Response
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+
+# Nextcloud's primary blue. Shared with the nc_mail_create_tag tool so the two
+# defaults cannot drift into creating differently-coloured tags for the same
+# nominal "default".
+DEFAULT_TAG_COLOR = "#0082c9"
 
 
 def _ocs_response(response: Response) -> Any:
@@ -446,7 +450,7 @@ class MailClient(BaseNextcloudClient):
         )
 
     async def ensure_tag(
-        self, display_name: str, color: str = "#0082c9"
+        self, display_name: str, color: str = DEFAULT_TAG_COLOR
     ) -> dict[str, Any]:
         """Create a mail tag, or return the existing one with that name.
 

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -8,8 +8,10 @@ Uses two endpoint types:
    ``'ocs'`` section of the Mail app's ``routes.php``.
 
 2. **Direct app routes** — ``/index.php/apps/mail/api/...`` — for listing accounts,
-   mailboxes, and messages, downloading attachments, and the two-step outbox send.
-   These REST resource routes (from ``'resources'`` in ``routes.php``) are
+   mailboxes, and messages, downloading attachments, the two-step outbox send, and
+   every write operation (flags, tags, move, delete), none of which has an OCS
+   equivalent. These REST resource routes (from ``'resources'`` in ``routes.php``)
+   are
    CSRF-gated for browser sessions, but Nextcloud exempts any request carrying the
    ``OCS-APIRequest: true`` header from the CSRF check — so Basic Auth (App
    Password) + that header is sufficient. No ``requesttoken`` round-trip is needed
@@ -154,27 +156,40 @@ class MailClient(BaseNextcloudClient):
         # ``_make_request`` (base) already raised on any non-2xx status.
         return response.json()
 
-    async def _api_post(
-        self, path: str, json_data: dict[str, Any] | None = None
+    async def _api_write(
+        self, method: str, path: str, json_data: dict[str, Any] | None = None
     ) -> Any:
-        """POST to a direct API endpoint (CSRF-exempt via the OCS-APIRequest header).
+        """Send a mutating request to a direct API endpoint.
+
+        CSRF-exempt via the OCS-APIRequest header, exactly like the GETs — the
+        Mail app's write routes carry no ``@NoCSRFRequired``, so the header is
+        what makes them reachable with an app password.
 
         Args:
+            method: ``POST``, ``PUT`` or ``DELETE``.
             path: Path relative to :attr:`API_BASE` (e.g. ``/outbox``).
-            json_data: JSON body to send.
+            json_data: JSON body to send, or ``None`` for a bodyless call.
 
         Returns:
-            The parsed JSON response body.
+            The parsed JSON response body, or ``{}`` when there is no body.
         """
+        # Only declare a JSON content type when there is actually a body: the
+        # tag assign/remove and delete routes take none, and announcing
+        # application/json for a bodyless request is misleading.
+        headers = dict(self._API_HEADERS)
+        if json_data is not None:
+            headers["Content-Type"] = "application/json"
+
         response = await self._make_request(
-            "POST",
+            method,
             f"{self.API_BASE}{path}",
             json=json_data,
-            headers={**self._API_HEADERS, "Content-Type": "application/json"},
+            headers=headers,
         )
-        # ``_make_request`` (base) already raised on any non-2xx status. The
-        # outbox send step can legitimately return an empty body (e.g. 204);
-        # don't choke trying to JSON-decode it.
+        # ``_make_request`` (base) already raised on any non-2xx status. Several
+        # write routes legitimately return an empty body (setFlags returns a
+        # bare JSONResponse; the outbox send step can 204), so don't choke
+        # trying to JSON-decode nothing.
         return response.json() if response.content else {}
 
     # ------------------------------------------------------------------
@@ -388,7 +403,7 @@ class MailClient(BaseNextcloudClient):
         if references:
             create_data["inReplyToMessageId"] = references
 
-        create_result = await self._api_post("/outbox", json_data=create_data)
+        create_result = await self._api_write("POST", "/outbox", json_data=create_data)
         outbox_id = create_result.get("data", {}).get("id")
         if not outbox_id:
             # Raise (don't return an error dict) so the server tool's
@@ -398,7 +413,9 @@ class MailClient(BaseNextcloudClient):
                 f"Outbox create returned no id; response: {create_result!r}"
             )
 
-        send_result = await self._api_post(f"/outbox/{outbox_id}", json_data={})
+        send_result = await self._api_write(
+            "POST", f"/outbox/{outbox_id}", json_data={}
+        )
 
         return {
             "success": True,
@@ -406,6 +423,118 @@ class MailClient(BaseNextcloudClient):
             "outbox_id": outbox_id,
             "response": send_result,
         }
+
+    async def set_flags(self, message_id: int, flags: dict[str, bool]) -> None:
+        """Set IMAP flags on a message.
+
+        Uses ``PUT /index.php/apps/mail/api/messages/{id}/flags``. Note the body
+        shape: a *map* of flag name → bool, not a list of ``\\Seen``-style IMAP
+        flag names. Only the keys passed are touched; omitted flags are left
+        alone.
+
+        System flags (always applied): ``seen``, ``answered``, ``flagged``,
+        ``deleted``, ``draft``, ``recent``. Any other key is treated as a custom
+        IMAP keyword (e.g. ``$junk``) and is silently ignored by the server
+        unless the mailbox advertises it in ``PERMANENTFLAGS``.
+
+        Args:
+            message_id: The message database ID.
+            flags: Flag name → desired state.
+        """
+        await self._api_write(
+            "PUT", f"/messages/{message_id}/flags", json_data={"flags": flags}
+        )
+
+    async def ensure_tag(
+        self, display_name: str, color: str = "#0082c9"
+    ) -> dict[str, Any]:
+        """Create a mail tag, or return the existing one with that name.
+
+        Uses ``POST /index.php/apps/mail/api/tags``, which is idempotent:
+        ``MailManager::createTag`` derives the IMAP label from the display name
+        and returns the existing row when one matches. That matters because the
+        Mail app exposes **no** tag-listing route — this is the only way to
+        resolve a tag's per-user database ID.
+
+        Display names are normalised into the IMAP label as
+        ``'$' + lowercase(name with spaces as underscores)``, so ``"AI Index"``,
+        ``"ai index"`` and ``"ai_index"`` all resolve to the same tag.
+
+        Args:
+            display_name: Tag display name (max 128 characters).
+            color: Hex colour used only when the tag is created.
+
+        Returns:
+            The tag dict — ``{"id", "displayName", "imapLabel", "color", ...}``.
+            Note this route returns the bare tag, *not* wrapped in ``data`` the
+            way the outbox routes are.
+        """
+        tag = await self._api_write(
+            "POST", "/tags", json_data={"displayName": display_name, "color": color}
+        )
+        # Both callers depend on these: the id addresses the tag in a ``tags:``
+        # listing filter, the imapLabel addresses it in the assign/remove routes.
+        # Fail loudly here rather than KeyError-ing at the use site.
+        if not isinstance(tag, dict) or "id" not in tag or "imapLabel" not in tag:
+            raise RequestError(
+                f"Tag create returned an unusable tag for {display_name!r}: {tag!r}"
+            )
+        return tag
+
+    async def set_tag(self, message_id: int, imap_label: str) -> None:
+        """Assign an existing tag to a message.
+
+        Uses ``PUT /index.php/apps/mail/api/messages/{id}/tags/{imapLabel}``.
+        The label must already exist for this user (see :meth:`ensure_tag`); the
+        server answers 403 for an unknown one.
+
+        Args:
+            message_id: The message database ID.
+            imap_label: The tag's ``imapLabel`` (e.g. ``$vector_index``).
+        """
+        await self._api_write(
+            "PUT", f"/messages/{message_id}/tags/{quote(imap_label, safe='')}"
+        )
+
+    async def remove_tag(self, message_id: int, imap_label: str) -> None:
+        """Remove a tag from a message.
+
+        Uses ``DELETE /index.php/apps/mail/api/messages/{id}/tags/{imapLabel}``.
+
+        Args:
+            message_id: The message database ID.
+            imap_label: The tag's ``imapLabel``.
+        """
+        await self._api_write(
+            "DELETE", f"/messages/{message_id}/tags/{quote(imap_label, safe='')}"
+        )
+
+    async def move_message(self, message_id: int, destination_mailbox_id: int) -> None:
+        """Move a message to another mailbox.
+
+        Uses ``POST /index.php/apps/mail/api/messages/{id}/move``.
+
+        Args:
+            message_id: The message database ID.
+            destination_mailbox_id: Target mailbox database ID.
+        """
+        await self._api_write(
+            "POST",
+            f"/messages/{message_id}/move",
+            json_data={"destFolderId": destination_mailbox_id},
+        )
+
+    async def delete_message(self, message_id: int) -> None:
+        """Delete a message.
+
+        Uses ``DELETE /index.php/apps/mail/api/messages/{id}``. The Mail app
+        moves it to the account's trash mailbox, or expunges it outright when
+        the message is already in trash.
+
+        Args:
+            message_id: The message database ID.
+        """
+        await self._api_write("DELETE", f"/messages/{message_id}")
 
     async def get_message_raw(self, message_id: int) -> str | None:
         """Get the raw RFC 2822 source of a message.

--- a/nextcloud_mcp_server/models/auth.py
+++ b/nextcloud_mcp_server/models/auth.py
@@ -75,6 +75,10 @@ ALL_SUPPORTED_SCOPES: frozenset[str] = frozenset(
         "news.read",
         "news.write",
         "mail.read",
+        "mail.write",
+        "mail.send",
+        "talk.read",
+        "talk.write",
         "collectives.read",
         "collectives.write",
     }

--- a/nextcloud_mcp_server/models/mail.py
+++ b/nextcloud_mcp_server/models/mail.py
@@ -1,8 +1,8 @@
-"""Pydantic models for Nextcloud Mail app responses (read-only)."""
+"""Pydantic models for Nextcloud Mail app responses."""
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .base import BaseResponse
+from .base import BaseResponse, StatusResponse
 
 
 class MailAddress(BaseModel):
@@ -62,6 +62,24 @@ class MailMessageFlags(BaseModel):
     forwarded: bool = False
     has_attachments: bool = Field(False, alias="hasAttachments")
     important: bool = False
+
+
+class MailTag(BaseModel):
+    """A mail tag (an IMAP keyword, scoped to one user).
+
+    ``imap_label`` is derived by the server from the display name and is what
+    the tag assign/remove routes address, so it is carried through rather than
+    re-derived client-side.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(description="Tag database ID (per-user)")
+    display_name: str | None = Field(None, alias="displayName")
+    imap_label: str | None = Field(
+        None, alias="imapLabel", description="IMAP keyword, e.g. $vector_index"
+    )
+    color: str | None = Field(None, description="Hex colour")
 
 
 class MailAttachment(BaseModel):
@@ -185,6 +203,32 @@ class SendMessageResponse(BaseResponse):
         default=True, description="Whether the message was sent successfully"
     )
     message: str = Field(default="", description="Status or error message")
+
+
+class MailActionResponse(StatusResponse):
+    """Response model for a write that returns no data (flags, move, delete).
+
+    The Mail app answers these with an empty body, so the useful payload is the
+    affected message ID plus the human-readable summary from ``StatusResponse``.
+    """
+
+    message_id: int = Field(description="Database ID of the affected message")
+
+
+class MailTagResponse(BaseResponse):
+    """Response model for tag create/assign/remove."""
+
+    tag: MailTag = Field(description="The affected tag")
+    message_id: int | None = Field(
+        None, description="Message the tag was assigned to or removed from"
+    )
+
+
+class GetMessageSourceResponse(BaseResponse):
+    """Response model for the raw RFC 2822 source of a message."""
+
+    message_id: int = Field(description="Database ID of the message")
+    source: str | None = Field(None, description="Raw RFC 2822 message source")
 
 
 class GetAttachmentResponse(BaseResponse):

--- a/nextcloud_mcp_server/models/mail.py
+++ b/nextcloud_mcp_server/models/mail.py
@@ -159,6 +159,10 @@ class MailMessage(BaseModel):
     attachments: list[MailAttachment] = Field(
         default_factory=list, description="Message attachments"
     )
+    # The message endpoint returns flags just like the listing does. Carrying
+    # them here is what makes nc_mail_set_flags verifiable: without it the only
+    # way to read back a flag you just wrote is to re-list the whole mailbox.
+    flags: MailMessageFlags | None = Field(None, description="IMAP flags")
 
 
 # --- Response Models ---

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -597,8 +597,12 @@ def configure_mail_tools(mcp: FastMCP):
     @mcp.tool(
         title="Move Mail Message",
         annotations=ToolAnnotations(
-            # Moving to the mailbox a message already sits in is a no-op.
-            idempotentHint=True,
+            # NOT idempotent. The move drops the cached row and the message is
+            # re-cached in the destination under a *new* database id, so a retry
+            # with the same message_id is rejected (the Mail app answers 403)
+            # rather than being a harmless no-op. Verified against a live Mail
+            # app -- see test_move_message_between_mailboxes.
+            idempotentHint=False,
             openWorldHint=True,
         ),
     )
@@ -615,8 +619,11 @@ def configure_mail_tools(mcp: FastMCP):
                 nc_mail_list_mailboxes)
 
         Returns:
-            MailActionResponse. Note the message keeps its id only within the
-            same account; re-list the destination mailbox to find it again.
+            MailActionResponse. ``message_id`` echoes what you passed in and is
+            **stale on return**: the move invalidates it, and the message is
+            re-cached in the destination under a new id. Re-list the destination
+            mailbox to address it again — do not retry this call with the same
+            id, which fails rather than repeating the move.
         """
         client = await get_client(ctx)
         with _mail_errors(f"moving message {message_id}"):
@@ -630,7 +637,11 @@ def configure_mail_tools(mcp: FastMCP):
         title="Delete Mail Message",
         annotations=ToolAnnotations(
             destructiveHint=True,  # Removes the message from its mailbox
-            idempotentHint=True,  # Same end state when repeated
+            # NOT idempotent, unlike most deletes. Trashing is a move, so it
+            # invalidates the id: a retry is rejected (403) instead of being a
+            # no-op, and if the message was already in trash the first call
+            # expunges it permanently. Verified against a live Mail app.
+            idempotentHint=False,
             openWorldHint=True,
         ),
     )
@@ -642,13 +653,17 @@ def configure_mail_tools(mcp: FastMCP):
         """Delete a message (requires mail.write scope).
 
         The Mail app moves the message to the account's trash mailbox, or
-        expunges it permanently if it is already in trash.
+        expunges it permanently if it is already in trash. Requires the account
+        to have a trash mailbox — without one the Mail app rejects the call
+        ("No trash mailbox configured").
 
         Args:
             message_id: Numeric message id
 
         Returns:
-            MailActionResponse confirming the deletion.
+            MailActionResponse confirming the deletion. ``message_id`` echoes
+            the input and is **stale on return** — trashing re-caches the
+            message under a new id, so retrying with the same id fails.
         """
         client = await get_client(ctx)
         with _mail_errors(f"deleting message {message_id}"):

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -1,30 +1,61 @@
-"""MCP tools for Nextcloud Mail app (read, send)."""
+"""MCP tools for Nextcloud Mail app (read, send, flags, tags, move, delete)."""
 
 import json
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Annotated
 
 from httpx import HTTPStatusError, RequestError
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, ToolAnnotations
+from pydantic import Field
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.mail import (
     GetAttachmentResponse,
     GetMessageResponse,
+    GetMessageSourceResponse,
     ListAccountsResponse,
     ListMailboxesResponse,
     ListMessagesResponse,
     MailAccount,
+    MailActionResponse,
     MailMailbox,
     MailMessage,
     MailMessageSummary,
+    MailTag,
+    MailTagResponse,
     SendMessageResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _mail_errors(action: str) -> Iterator[None]:
+    """Map client transport errors onto ``McpError`` with a consistent message.
+
+    Args:
+        action: Present-participle description used in the message, e.g.
+            ``"setting flags on message 42"``.
+    """
+    try:
+        yield
+    except RequestError as e:
+        raise McpError(
+            ErrorData(code=-1, message=f"Network error {action}: {str(e)}")
+        ) from e
+    except HTTPStatusError as e:
+        raise McpError(
+            ErrorData(
+                code=-1, message=f"Failed {action}: HTTP {e.response.status_code}"
+            )
+        ) from e
+
 
 # Hard cap on inlined attachment content. The Mail attachment endpoint returns
 # the full attachment body (base64-encoded) in the response, which then has to
@@ -58,7 +89,7 @@ def _cap_attachment_content(content: str | None) -> str | None:
 
 
 def configure_mail_tools(mcp: FastMCP):
-    """Configure Mail app MCP tools (read, send)."""
+    """Configure Mail app MCP tools (read, send, flags, tags, move, delete)."""
 
     @mcp.tool(
         title="List Mail Accounts",
@@ -141,7 +172,24 @@ def configure_mail_tools(mcp: FastMCP):
         Args:
             mailbox_id: Numeric mailbox id (``database_id`` from nc_mail_list_mailboxes)
             cursor: Pagination cursor from a prior page
-            search_filter: Optional search/filter query
+            search_filter: Optional filter query — space-separated ``token:value``
+                terms, ANDed together. Supported tokens:
+
+                * ``is:``/``not:`` — ``read``, ``unread``, ``starred``,
+                  ``answered``, ``important``
+                * ``from:``, ``to:``, ``cc:``, ``bcc:`` — substring match on the
+                  address or display name
+                * ``subject:``, ``body:`` — substring match (``body:`` searches
+                  IMAP server-side and is slower)
+                * ``tags:`` — comma-separated tag *database ids* (not names;
+                  get one from nc_mail_create_tag)
+                * ``start:``, ``end:`` — date bounds
+                * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
+                  ``answered``/``important``/``attachments``
+                * ``match:anyof`` — OR the from/to/cc/bcc/subject/body terms
+                  instead of ANDing them
+
+                Example: ``is:unread from:alice subject:invoice``
             limit: Max messages to return (1-100, default 20)
 
         Returns:
@@ -353,3 +401,256 @@ def configure_mail_tools(mcp: FastMCP):
                     message=f"Failed to get attachment: {e.response.status_code}",
                 )
             )
+
+    @mcp.tool(
+        title="Get Mail Message Source",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
+    @require_scopes("mail.read")
+    @instrument_tool
+    async def nc_mail_get_message_source(
+        message_id: int, ctx: Context
+    ) -> GetMessageSourceResponse:
+        """Get a message's raw RFC 2822 source (requires mail.read scope).
+
+        The complete original message including all headers — use this when the
+        parsed view from nc_mail_get_message is not enough (checking
+        Received/DKIM headers, List-Unsubscribe, custom X- headers).
+
+        Args:
+            message_id: Numeric message id
+
+        Returns:
+            GetMessageSourceResponse with the raw source. ``source`` is None if
+            the Mail app returns no content for the message.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"getting source of message {message_id}"):
+            source = await client.mail.get_message_raw(message_id)
+        return GetMessageSourceResponse(message_id=message_id, source=source)
+
+    @mcp.tool(
+        title="Set Mail Message Flags",
+        annotations=ToolAnnotations(
+            # Same inputs -> same end state (a flag set twice stays set).
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_set_flags(
+        message_id: int,
+        ctx: Context,
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
+        junk: bool | None = None,
+    ) -> MailActionResponse:
+        """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
+
+        Only the flags you pass are changed; omitted ones are left alone. Use
+        ``seen=True`` after processing a message so it does not look unhandled,
+        and ``seen=False`` to mark it unread again.
+
+        Args:
+            message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
+            seen: Mark read (True) or unread (False)
+            flagged: Star (True) or unstar (False)
+            answered: Mark as replied-to
+            junk: Mark as junk/spam. Unlike the others this is a custom IMAP
+                keyword, so the mail server silently ignores it unless the
+                mailbox permits custom keywords.
+
+        Returns:
+            MailActionResponse naming the flags that were applied. Passing no
+            flags at all is an error rather than a silent no-op.
+        """
+        flags = {
+            name: value
+            for name, value in (
+                ("seen", seen),
+                ("flagged", flagged),
+                ("answered", answered),
+                ("$junk", junk),
+            )
+            if value is not None
+        }
+        if not flags:
+            raise McpError(
+                ErrorData(
+                    code=-1,
+                    message="No flags given; pass at least one of seen, flagged, "
+                    "answered, junk",
+                )
+            )
+
+        client = await get_client(ctx)
+        with _mail_errors(f"setting flags on message {message_id}"):
+            await client.mail.set_flags(message_id, flags)
+
+        applied = ", ".join(f"{name}={value}" for name, value in flags.items())
+        return MailActionResponse(
+            message_id=message_id, message=f"Flags updated: {applied}"
+        )
+
+    @mcp.tool(
+        title="Create Mail Tag",
+        annotations=ToolAnnotations(
+            # Create-or-get: the Mail app returns the existing tag for a name
+            # that already resolves to the same IMAP label.
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_create_tag(
+        display_name: Annotated[str, Field(max_length=128)],
+        ctx: Context,
+        color: str = "#0082c9",
+    ) -> MailTagResponse:
+        """Create a mail tag, or return the existing one (requires mail.write scope).
+
+        Tags are IMAP keywords private to the user. The Mail app has no
+        tag-listing endpoint, so this is also how you look a tag up — calling it
+        for an existing name returns that tag rather than creating a duplicate.
+
+        Names normalise to a lowercase IMAP label with spaces as underscores, so
+        "AI Index", "ai index" and "ai_index" are all the same tag.
+
+        Args:
+            display_name: Tag name (max 128 characters)
+            color: Hex colour, applied only when the tag is created
+
+        Returns:
+            MailTagResponse with the tag, including the ``id`` needed for the
+            ``tags:<id>`` filter of nc_mail_list_messages.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"creating tag {display_name!r}"):
+            tag = await client.mail.ensure_tag(display_name, color)
+        return MailTagResponse(tag=MailTag(**tag))
+
+    @mcp.tool(
+        title="Tag Mail Message",
+        annotations=ToolAnnotations(
+            idempotentHint=True,  # Re-tagging a tagged message is a no-op
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_set_tag(
+        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+    ) -> MailTagResponse:
+        """Assign a tag to a message (requires mail.write scope).
+
+        The tag is created if it does not exist yet, so this works without a
+        separate nc_mail_create_tag call.
+
+        Args:
+            message_id: Numeric message id
+            tag: Tag display name
+
+        Returns:
+            MailTagResponse with the assigned tag.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"tagging message {message_id} with {tag!r}"):
+            # Resolve through create-or-get: it yields the server's own
+            # imapLabel, so we never have to re-derive the label encoding.
+            tag_data = await client.mail.ensure_tag(tag)
+            await client.mail.set_tag(message_id, tag_data["imapLabel"])
+        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+    @mcp.tool(
+        title="Untag Mail Message",
+        annotations=ToolAnnotations(
+            idempotentHint=True,  # Removing an absent tag leaves the same state
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_remove_tag(
+        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+    ) -> MailTagResponse:
+        """Remove a tag from a message (requires mail.write scope).
+
+        Args:
+            message_id: Numeric message id
+            tag: Tag display name
+
+        Returns:
+            MailTagResponse with the removed tag.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"removing tag {tag!r} from message {message_id}"):
+            # Resolve the same way as tagging. For a name that has never been
+            # used this creates an empty tag row before removing nothing from
+            # the message — harmless, and it keeps one resolution path.
+            tag_data = await client.mail.ensure_tag(tag)
+            await client.mail.remove_tag(message_id, tag_data["imapLabel"])
+        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+    @mcp.tool(
+        title="Move Mail Message",
+        annotations=ToolAnnotations(
+            # Moving to the mailbox a message already sits in is a no-op.
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_move_message(
+        message_id: int, destination_mailbox_id: int, ctx: Context
+    ) -> MailActionResponse:
+        """Move a message to another mailbox (requires mail.write scope).
+
+        Args:
+            message_id: Numeric message id
+            destination_mailbox_id: Target mailbox id (``database_id`` from
+                nc_mail_list_mailboxes)
+
+        Returns:
+            MailActionResponse. Note the message keeps its id only within the
+            same account; re-list the destination mailbox to find it again.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"moving message {message_id}"):
+            await client.mail.move_message(message_id, destination_mailbox_id)
+        return MailActionResponse(
+            message_id=message_id,
+            message=f"Message moved to mailbox {destination_mailbox_id}",
+        )
+
+    @mcp.tool(
+        title="Delete Mail Message",
+        annotations=ToolAnnotations(
+            destructiveHint=True,  # Removes the message from its mailbox
+            idempotentHint=True,  # Same end state when repeated
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("mail.write")
+    @instrument_tool
+    async def nc_mail_delete_message(
+        message_id: int, ctx: Context
+    ) -> MailActionResponse:
+        """Delete a message (requires mail.write scope).
+
+        The Mail app moves the message to the account's trash mailbox, or
+        expunges it permanently if it is already in trash.
+
+        Args:
+            message_id: Numeric message id
+
+        Returns:
+            MailActionResponse confirming the deletion.
+        """
+        client = await get_client(ctx)
+        with _mail_errors(f"deleting message {message_id}"):
+            await client.mail.delete_message(message_id)
+        return MailActionResponse(message_id=message_id, message="Message deleted")

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -13,6 +13,7 @@ from mcp.types import ErrorData, ToolAnnotations
 from pydantic import Field
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.client.mail import DEFAULT_TAG_COLOR
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.mail import (
     GetAttachmentResponse,
@@ -508,7 +509,7 @@ def configure_mail_tools(mcp: FastMCP):
     async def nc_mail_create_tag(
         display_name: Annotated[str, Field(max_length=128)],
         ctx: Context,
-        color: str = "#0082c9",
+        color: str = DEFAULT_TAG_COLOR,
     ) -> MailTagResponse:
         """Create a mail tag, or return the existing one (requires mail.write scope).
 

--- a/scripts/provision-greenmail-account.sh
+++ b/scripts/provision-greenmail-account.sh
@@ -6,14 +6,80 @@
 # GreenMail runs with `-Dgreenmail.auth.disabled`, so any IMAP/SMTP login
 # succeeds and the mailbox is auto-created — the password below is arbitrary.
 # Plaintext ports: IMAP 3143, SMTP 3025 (ssl-mode "none"). Idempotent: skips if
-# the user already has a mail account.
+# the user already has a mail account, but always re-checks the mailboxes.
 #
-# Usage: scripts/provision-greenmail-account.sh [user_id] [email]
+# GreenMail auto-creates INBOX and nothing else, which is not enough to exercise
+# the write tools: `nc_mail_delete_message` needs a trash mailbox (the Mail app
+# answers 400 "No trash mailbox configured" without one) and
+# `nc_mail_move_message` needs somewhere to move to (its test otherwise skips
+# itself for lack of a destination). So also create Trash + Archive, which the
+# Mail app maps onto the `trash`/`archive` special roles by name.
+#
+# Usage: scripts/provision-greenmail-account.sh [user_id] [email] [password]
 set -euo pipefail
 
 USER_ID="${1:-admin}"
 EMAIL="${2:-${USER_ID}@example.org}"
+# Only used for the Mail HTTP API calls below (occ needs no password). The test
+# stacks run as admin/admin; override for any other user.
+PASSWORD="${3:-${NEXTCLOUD_PASSWORD:-admin}}"
 GREENMAIL_READINESS_URL="${GREENMAIL_READINESS_URL:-http://localhost:8085/api/service/readiness}"
+
+# Run a Mail API call from inside the `app` container, so this works regardless
+# of which host port (if any) the container is published on.
+mail_api() {
+    local method="$1" path="$2" body="${3:-}"
+    docker compose exec -T app curl -sS -X "${method}" \
+        -u "${USER_ID}:${PASSWORD}" \
+        -H 'OCS-APIRequest: true' \
+        -H 'Content-Type: application/json' \
+        ${body:+-d "${body}"} \
+        "http://localhost/index.php/apps/mail/api/${path}"
+}
+
+# Create Trash/Archive, then opt them into background sync. Both steps matter:
+# creating the mailbox is what gives the account a trash role (so delete works)
+# and a move destination, but a freshly-created mailbox is not *cached*, and
+# listing an uncached mailbox fails with 400 "mailbox N is not cached" — even
+# after `mail:account:sync --force`. Setting `syncInBackground` is what gets it
+# cached, mirroring what the Mail UI does when you first open a folder.
+#
+# Re-creating an existing mailbox is rejected by the Mail app rather than
+# duplicating it, and curl without `-f` does not treat an HTTP error as a
+# failure, so the create step is idempotent by construction.
+ensure_mailboxes() {
+    local account_id ids
+    # `mail:account:export` prints "Account <id>:" — the same output the
+    # idempotency check above greps, so no HTTP round-trip to find the id.
+    account_id=$(docker compose exec -T app php occ mail:account:export "${USER_ID}" 2>/dev/null \
+        | sed -nE 's/^Account ([0-9]+):.*/\1/p' | head -1)
+    if [ -z "${account_id}" ]; then
+        echo "WARNING: no mail account found; skipping mailbox creation" >&2
+        return 0
+    fi
+
+    for name in Trash Archive; do
+        echo "Ensuring ${name} mailbox on account ${account_id} ..."
+        mail_api POST "mailboxes" "{\"accountId\":${account_id},\"name\":\"${name}\"}" \
+            >/dev/null 2>&1 || true
+    done
+
+    # Re-read rather than using the create response: on a re-run the create is a
+    # no-op error and returns no id.
+    ids=$(mail_api GET "mailboxes?accountId=${account_id}" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+boxes = d.get("mailboxes", d) if isinstance(d, dict) else d
+print(" ".join(
+    str(m["databaseId"]) for m in boxes if m.get("name") in ("Trash", "Archive")
+))')
+    for id in ${ids}; do
+        mail_api PATCH "mailboxes/${id}" '{"syncInBackground":true}' >/dev/null 2>&1 || true
+    done
+
+    # First sync populates the message cache for the newly-tracked mailboxes.
+    docker compose exec -T app php occ mail:account:sync --force "${account_id}" >/dev/null 2>&1 || true
+}
 
 echo "Waiting for GreenMail readiness at ${GREENMAIL_READINESS_URL} ..."
 ready=0
@@ -33,14 +99,15 @@ fi
 # Idempotency: mail:account:export prints a human-readable "Account N:" block
 # per existing account (and nothing matching when the user has none).
 if docker compose exec -T app php occ mail:account:export "${USER_ID}" 2>/dev/null | grep -qiE '^Account [0-9]+:'; then
-    echo "Mail account already exists for ${USER_ID}; skipping provisioning"
-    exit 0
+    echo "Mail account already exists for ${USER_ID}; skipping account creation"
+else
+    echo "Creating GreenMail mail account for ${USER_ID} (${EMAIL}) ..."
+    docker compose exec -T app php occ mail:account:create \
+        "${USER_ID}" "${USER_ID} (GreenMail)" "${EMAIL}" \
+        greenmail 3143 none "${EMAIL}" greenmail-test-pw \
+        greenmail 3025 none "${EMAIL}" greenmail-test-pw
 fi
 
-echo "Creating GreenMail mail account for ${USER_ID} (${EMAIL}) ..."
-docker compose exec -T app php occ mail:account:create \
-    "${USER_ID}" "${USER_ID} (GreenMail)" "${EMAIL}" \
-    greenmail 3143 none "${EMAIL}" greenmail-test-pw \
-    greenmail 3025 none "${EMAIL}" greenmail-test-pw
+ensure_mailboxes
 
 echo "Provisioned GreenMail mail account for ${USER_ID}"

--- a/scripts/provision-greenmail-account.sh
+++ b/scripts/provision-greenmail-account.sh
@@ -27,14 +27,18 @@ GREENMAIL_READINESS_URL="${GREENMAIL_READINESS_URL:-http://localhost:8085/api/se
 
 # Run a Mail API call from inside the `app` container, so this works regardless
 # of which host port (if any) the container is published on.
+#
+# Credentials go in via `--config -` (stdin) rather than `-u`, so they never
+# appear in the container's process list. The default here is the throwaway
+# admin/admin test account, but NEXTCLOUD_PASSWORD may point this at a real one.
 mail_api() {
     local method="$1" path="$2" body="${3:-}"
-    docker compose exec -T app curl -sS -X "${method}" \
-        -u "${USER_ID}:${PASSWORD}" \
-        -H 'OCS-APIRequest: true' \
-        -H 'Content-Type: application/json' \
-        ${body:+-d "${body}"} \
-        "http://localhost/index.php/apps/mail/api/${path}"
+    printf 'user = "%s:%s"\n' "${USER_ID}" "${PASSWORD}" \
+        | docker compose exec -T app curl -sS --config - -X "${method}" \
+            -H 'OCS-APIRequest: true' \
+            -H 'Content-Type: application/json' \
+            ${body:+-d "${body}"} \
+            "http://localhost/index.php/apps/mail/api/${path}"
 }
 
 # Create Trash/Archive, then opt them into background sync. Both steps matter:

--- a/tests/client/mail/test_mail_api.py
+++ b/tests/client/mail/test_mail_api.py
@@ -367,3 +367,154 @@ async def test_send_message_missing_outbox_id_raises(mocker):
     client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
     with pytest.raises(httpx.RequestError):
         await client.send_message(1, [{"email": "a@b.com", "label": "A"}], "Hi", "body")
+
+
+# --- Write operations -------------------------------------------------------
+
+
+async def test_set_flags_sends_flag_map_not_imap_names(mocker):
+    """setFlags takes a {name: bool} map, not a list of ``\\Seen``-style names.
+
+    The Mail app's ``MessagesController::setFlags`` iterates the map and runs
+    each entry through ``FILTER_VALIDATE_BOOLEAN``; a list of IMAP flag names
+    would be silently ignored, so the body shape is worth pinning.
+    """
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.set_flags(42, {"seen": True, "flagged": False})
+
+    call = mock_make_request.call_args
+    assert call.args == ("PUT", "/apps/mail/api/messages/42/flags")
+    assert call.kwargs["json"] == {"flags": {"seen": True, "flagged": False}}
+
+
+async def test_ensure_tag_reads_bare_tag_response(mocker):
+    """POST /tags returns the bare Tag JSON, not a ``data``-wrapped envelope.
+
+    The outbox routes wrap their payload in ``data``; the tag route does not
+    (``TagsController::create`` returns ``new JSONResponse($tag)``), so reading
+    ``data.id`` here would always come back empty.
+    """
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(
+            json_data={
+                "id": 7,
+                "displayName": "Vector Index",
+                "imapLabel": "$vector_index",
+                "color": "#0082c9",
+            }
+        ),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    tag = await client.ensure_tag("Vector Index")
+
+    assert tag["id"] == 7
+    assert tag["imapLabel"] == "$vector_index"
+    call = mock_make_request.call_args
+    assert call.args == ("POST", "/apps/mail/api/tags")
+    assert call.kwargs["json"]["displayName"] == "Vector Index"
+
+
+async def test_ensure_tag_without_id_raises(mocker):
+    """An unexpected tag payload raises rather than yielding an id-less tag."""
+    mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(json_data={"unexpected": "shape"}),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    with pytest.raises(httpx.RequestError):
+        await client.ensure_tag("Vector Index")
+
+
+async def test_set_and_remove_tag_url_encode_the_label(mocker):
+    """IMAP labels start with ``$`` and may contain characters needing quoting."""
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.set_tag(42, "$to do")
+    await client.remove_tag(42, "$to do")
+
+    calls = mock_make_request.call_args_list
+    assert calls[0].args == ("PUT", "/apps/mail/api/messages/42/tags/%24to%20do")
+    assert calls[1].args == ("DELETE", "/apps/mail/api/messages/42/tags/%24to%20do")
+
+
+async def test_move_message_sends_dest_folder_id(mocker):
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.move_message(42, 9)
+
+    call = mock_make_request.call_args
+    assert call.args == ("POST", "/apps/mail/api/messages/42/move")
+    assert call.kwargs["json"] == {"destFolderId": 9}
+
+
+async def test_delete_message_issues_delete(mocker):
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.delete_message(42)
+
+    assert mock_make_request.call_args.args == (
+        "DELETE",
+        "/apps/mail/api/messages/42",
+    )
+
+
+async def test_write_helpers_send_the_csrf_exempting_header(mocker):
+    """Writes need ``OCS-APIRequest`` too — the Mail write routes are CSRF-gated.
+
+    None of ``setFlags``/``setTag``/``move`` carries ``@NoCSRFRequired``, so the
+    header is what makes them reachable with an app password.
+    """
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.set_flags(42, {"seen": True})
+
+    headers = mock_make_request.call_args.kwargs["headers"]
+    assert headers["OCS-APIRequest"] == "true"
+    assert headers["Content-Type"] == "application/json"
+
+
+async def test_bodyless_writes_declare_no_json_content_type(mocker):
+    """Tag remove / delete send no body, so they must not claim to send JSON."""
+    mock_make_request = mocker.patch.object(
+        MailClient,
+        "_make_request",
+        return_value=create_mock_response(status_code=200, content=b""),
+    )
+
+    client = MailClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.delete_message(42)
+
+    call = mock_make_request.call_args
+    assert call.kwargs["json"] is None
+    assert "Content-Type" not in call.kwargs["headers"]

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -335,3 +335,174 @@ async def test_send_message_via_outbox(nc_mcp_client, provisioned_mail_account):
         )
     )
     assert data["success"] is True
+
+
+# --- Write operations -------------------------------------------------------
+#
+# These are the decisive CSRF evidence for the *mutating* routes: PUT/POST/DELETE
+# on /index.php/apps/mail/api/... carry no @NoCSRFRequired either, so if the
+# OCS-APIRequest header did not exempt them, every test below would fail.
+
+
+async def _seeded_message_id(nc_mcp_client, subject: str) -> int:
+    """Seed a message, sync, and return its database id."""
+    _seed_inbox_message(subject, "write-tool probe")
+    full = await _sync_and_fetch_message(nc_mcp_client, subject)
+    return full["id"]
+
+
+async def test_set_flags_marks_message_read_and_unread(
+    nc_mcp_client, provisioned_mail_account
+):
+    """GH #1148: mark a message read, then unread, and observe the flag flip."""
+    message_id = await _seeded_message_id(nc_mcp_client, "Flag probe: seen")
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_set_flags", {"message_id": message_id, "seen": True}
+        )
+    )
+    seen = _tool_payload(
+        await nc_mcp_client.call_tool("nc_mail_get_message", {"message_id": message_id})
+    )["message"]
+    assert seen["flags"]["seen"] is True
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_set_flags", {"message_id": message_id, "seen": False}
+        )
+    )
+    unseen = _tool_payload(
+        await nc_mcp_client.call_tool("nc_mail_get_message", {"message_id": message_id})
+    )["message"]
+    assert unseen["flags"]["seen"] is False
+
+
+async def test_set_flags_stars_without_touching_seen(
+    nc_mcp_client, provisioned_mail_account
+):
+    """Omitted flags must be left alone, not reset."""
+    message_id = await _seeded_message_id(nc_mcp_client, "Flag probe: starred")
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_set_flags", {"message_id": message_id, "seen": True}
+        )
+    )
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_set_flags", {"message_id": message_id, "flagged": True}
+        )
+    )
+
+    message = _tool_payload(
+        await nc_mcp_client.call_tool("nc_mail_get_message", {"message_id": message_id})
+    )["message"]
+    assert message["flags"]["flagged"] is True
+    assert message["flags"]["seen"] is True
+
+
+async def test_tag_lifecycle_and_tags_filter(nc_mcp_client, provisioned_mail_account):
+    """Create-or-get a tag, assign it, find the message via ``tags:<id>``, remove it."""
+    message_id = await _seeded_message_id(nc_mcp_client, "Tag probe")
+
+    created = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_create_tag", {"display_name": "MCP Integration"}
+        )
+    )
+    tag_id = created["tag"]["id"]
+    # Create-or-get: a second call must return the same tag, not a duplicate.
+    again = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_create_tag", {"display_name": "MCP Integration"}
+        )
+    )
+    assert again["tag"]["id"] == tag_id
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_set_tag", {"message_id": message_id, "tag": "MCP Integration"}
+        )
+    )
+
+    account_id = await _first_account_id(nc_mcp_client)
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+
+    tagged = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages",
+            {
+                "mailbox_id": inbox["databaseId"],
+                "search_filter": f"tags:{tag_id}",
+                "limit": 20,
+            },
+        )
+    )["results"]
+    assert message_id in [m["databaseId"] for m in tagged]
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_remove_tag", {"message_id": message_id, "tag": "MCP Integration"}
+        )
+    )
+    still_tagged = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages",
+            {
+                "mailbox_id": inbox["databaseId"],
+                "search_filter": f"tags:{tag_id}",
+                "limit": 20,
+            },
+        )
+    )["results"]
+    assert message_id not in [m["databaseId"] for m in still_tagged]
+
+
+async def test_get_message_source_returns_headers(
+    nc_mcp_client, provisioned_mail_account
+):
+    subject = "Source probe"
+    message_id = await _seeded_message_id(nc_mcp_client, subject)
+
+    data = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_get_message_source", {"message_id": message_id}
+        )
+    )
+    assert data["source"] is not None
+    assert f"Subject: {subject}" in data["source"]
+
+
+async def test_delete_message_removes_it_from_the_inbox(
+    nc_mcp_client, provisioned_mail_account
+):
+    """Delete moves the message out of INBOX (into the account's trash)."""
+    subject = "Delete probe"
+    message_id = await _seeded_message_id(nc_mcp_client, subject)
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_delete_message", {"message_id": message_id}
+        )
+    )
+
+    account_id = await _first_account_id(nc_mcp_client)
+    _sync_mail_account(account_id)
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+    remaining = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+        )
+    )["results"]
+    assert message_id not in [m["databaseId"] for m in remaining]

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -506,3 +506,48 @@ async def test_delete_message_removes_it_from_the_inbox(
         )
     )["results"]
     assert message_id not in [m["databaseId"] for m in remaining]
+
+
+async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_account):
+    """Move a message out of INBOX and confirm it lands in the destination."""
+    subject = "Move probe"
+    message_id = await _seeded_message_id(nc_mcp_client, subject)
+
+    account_id = await _first_account_id(nc_mcp_client)
+    mailboxes = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_mailboxes", {"account_id": account_id}
+        )
+    )["results"]
+    inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+    destination = next(
+        (m for m in mailboxes if m["databaseId"] != inbox["databaseId"]), None
+    )
+    if destination is None:
+        pytest.skip("account has only INBOX; no destination mailbox to move into")
+
+    _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_move_message",
+            {
+                "message_id": message_id,
+                "destination_mailbox_id": destination["databaseId"],
+            },
+        )
+    )
+
+    _sync_mail_account(account_id)
+    remaining = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+        )
+    )["results"]
+    assert subject not in [m["subject"] for m in remaining]
+
+    moved = _tool_payload(
+        await nc_mcp_client.call_tool(
+            "nc_mail_list_messages",
+            {"mailbox_id": destination["databaseId"], "limit": 20},
+        )
+    )["results"]
+    assert subject in [m["subject"] for m in moved]

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -482,7 +482,12 @@ async def test_get_message_source_returns_headers(
 async def test_delete_message_removes_it_from_the_inbox(
     nc_mcp_client, provisioned_mail_account
 ):
-    """Delete moves the message out of INBOX (into the account's trash)."""
+    """Delete moves the message out of INBOX (into the account's trash).
+
+    Requires the account to have a trash mailbox — without one the Mail app
+    rejects the call outright, which is why provision-greenmail-account.sh
+    creates Trash rather than relying on GreenMail's INBOX-only default.
+    """
     subject = "Delete probe"
     message_id = await _seeded_message_id(nc_mcp_client, subject)
 
@@ -507,9 +512,24 @@ async def test_delete_message_removes_it_from_the_inbox(
     )["results"]
     assert message_id not in [m["databaseId"] for m in remaining]
 
+    # Trashing is a move, so it invalidates the id the same way: a retry is
+    # rejected rather than being a no-op. This is what idempotentHint=False on
+    # nc_mail_delete_message records.
+    retry = await nc_mcp_client.call_tool(
+        "nc_mail_delete_message", {"message_id": message_id}
+    )
+    assert retry.isError, "expected the stale message id to be rejected on retry"
+
 
 async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_account):
-    """Move a message out of INBOX and confirm it lands in the destination."""
+    """Move a message out of INBOX and confirm it lands in the destination.
+
+    Also pins the move's *non*-idempotency, which is what ``idempotentHint=False``
+    on the tool records: the move invalidates the source id (the message is
+    re-cached in the destination under a new one), so repeating the call with
+    the same id fails instead of being a harmless no-op. An agent that reads the
+    annotation as "safe to blindly retry" would corrupt its own error handling.
+    """
     subject = "Move probe"
     message_id = await _seeded_message_id(nc_mcp_client, subject)
 
@@ -520,11 +540,17 @@ async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_ac
         )
     )["results"]
     inbox = next(m for m in mailboxes if m["name"].upper() == "INBOX")
+    # Prefer Archive: moving into Trash would overlap with delete's semantics.
+    # provision-greenmail-account.sh creates it, so a missing destination is a
+    # provisioning failure worth failing on, not a reason to skip silently.
     destination = next(
-        (m for m in mailboxes if m["databaseId"] != inbox["databaseId"]), None
+        (m for m in mailboxes if "archive" in m.get("specialUse", [])),
+        None,
+    ) or next((m for m in mailboxes if m["databaseId"] != inbox["databaseId"]), None)
+    assert destination is not None, (
+        "account has only INBOX — provision-greenmail-account.sh should have "
+        "created Trash/Archive"
     )
-    if destination is None:
-        pytest.skip("account has only INBOX; no destination mailbox to move into")
 
     _tool_payload(
         await nc_mcp_client.call_tool(
@@ -537,17 +563,28 @@ async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_ac
     )
 
     _sync_mail_account(account_id)
+    # Assert on the id, not the subject: subjects repeat across runs against a
+    # persistent dev stack, and the id is precisely what the move invalidates.
     remaining = _tool_payload(
         await nc_mcp_client.call_tool(
-            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 20}
+            "nc_mail_list_messages", {"mailbox_id": inbox["databaseId"], "limit": 50}
         )
     )["results"]
-    assert subject not in [m["subject"] for m in remaining]
+    assert message_id not in [m["databaseId"] for m in remaining]
 
     moved = _tool_payload(
         await nc_mcp_client.call_tool(
             "nc_mail_list_messages",
-            {"mailbox_id": destination["databaseId"], "limit": 20},
+            {"mailbox_id": destination["databaseId"], "limit": 50},
         )
     )["results"]
     assert subject in [m["subject"] for m in moved]
+    # The destination copy is a different row, which is why the id is stale.
+    assert message_id not in [m["databaseId"] for m in moved]
+
+    # Retrying with the now-stale id is rejected rather than repeating the move.
+    retry = await nc_mcp_client.call_tool(
+        "nc_mail_move_message",
+        {"message_id": message_id, "destination_mailbox_id": destination["databaseId"]},
+    )
+    assert retry.isError, "expected the stale message id to be rejected on retry"

--- a/tests/server/test_annotations.py
+++ b/tests/server/test_annotations.py
@@ -80,7 +80,13 @@ async def test_delete_operations_are_idempotent(nc_mcp_client: ClientSession):
 
     # Exceptions: delete operations that require a precondition (e.g. must be
     # trashed first), so calling twice produces an error on the second call.
-    non_idempotent_deletes = {"collectives_delete_collective"}
+    #
+    # nc_mail_delete_message: trashing is implemented as an IMAP move, so the
+    # first call invalidates the message id (the message is re-cached in trash
+    # under a new one) and a retry is rejected with 403 rather than being a
+    # no-op. Verified end-to-end in tests/integration/test_mail_greenmail.py::
+    # test_delete_message_removes_it_from_the_inbox.
+    non_idempotent_deletes = {"collectives_delete_collective", "nc_mail_delete_message"}
 
     for tool in tools.tools:
         if "delete" in tool.name.lower() and tool.name not in non_idempotent_deletes:
@@ -97,7 +103,14 @@ async def test_create_operations_not_idempotent(nc_mcp_client: ClientSession):
     # Exceptions: operations that are actually idempotent
     # - calendar_create_meeting: creates or returns existing meeting
     # - nc_webdav_create_directory: MKCOL returns 405 if exists (same end state)
-    idempotent_exceptions = {"calendar_create_meeting", "nc_webdav_create_directory"}
+    # - nc_mail_create_tag: create-or-get. The Mail app has no tag-listing
+    #   route, so POST /tags is the only way to look a tag up; it returns the
+    #   existing row for a name already in use rather than creating a second.
+    idempotent_exceptions = {
+        "calendar_create_meeting",
+        "nc_webdav_create_directory",
+        "nc_mail_create_tag",
+    }
 
     for tool in tools.tools:
         if "create" in tool.name.lower() and tool.name not in idempotent_exceptions:

--- a/tests/unit/test_mail_write_tools.py
+++ b/tests/unit/test_mail_write_tools.py
@@ -1,0 +1,202 @@
+"""Server-layer tests for the Mail write tools (GH #1148 and friends).
+
+These register the Mail tools on a fresh ``FastMCP`` and invoke each tool's
+underlying function directly, mirroring ``test_webdav_tools_exclusion.py``.
+The point is the wiring the client-layer tests can't see: which flags a tool
+forwards, that a tag name is resolved to the server's own ``imapLabel`` before
+being used in a URL, and that the tools return typed ``BaseResponse`` models.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+
+from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
+from nextcloud_mcp_server.models.mail import MailActionResponse, MailTagResponse
+from nextcloud_mcp_server.server import AVAILABLE_APPS
+from nextcloud_mcp_server.server.mail import configure_mail_tools
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def basicauth_mode():
+    """Pin ``require_scopes`` to the BasicAuth pass-through path.
+
+    Same rationale as the WebDAV tool tests: these call tool functions with no
+    transport and so no verified token, and the decorator correctly denies that
+    under any OAuth-style mode.
+    """
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=SimpleNamespace(enable_login_flow=False),
+    ):
+        yield
+
+
+@pytest.fixture
+def mail_tools() -> dict:
+    """Register the Mail tools on a fresh FastMCP and return them by name."""
+    mcp = FastMCP(name="test-mail-tools")
+    configure_mail_tools(mcp)
+    return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+
+@pytest.fixture
+def fake_mail(mocker):
+    """Install a mock mail client and hand back its ``mail`` namespace."""
+    mail = AsyncMock()
+    client = SimpleNamespace(mail=mail)
+
+    async def fake_get_client(ctx):
+        return client
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.mail.get_client", side_effect=fake_get_client
+    )
+    return mail
+
+
+def _ctx() -> SimpleNamespace:
+    ctx = SimpleNamespace()
+    ctx.request_context = SimpleNamespace()
+    return ctx
+
+
+async def test_set_flags_forwards_only_the_flags_given(mail_tools, fake_mail):
+    """Omitted flags must not be sent — sending them would clobber their state."""
+    result = await mail_tools["nc_mail_set_flags"].fn(42, _ctx(), seen=True)
+
+    assert isinstance(result, MailActionResponse)
+    assert result.message_id == 42
+    fake_mail.set_flags.assert_awaited_once_with(42, {"seen": True})
+
+
+async def test_set_flags_marks_unread(mail_tools, fake_mail):
+    """GH #1148's other direction: seen=False puts a message back to unread."""
+    await mail_tools["nc_mail_set_flags"].fn(42, _ctx(), seen=False)
+
+    fake_mail.set_flags.assert_awaited_once_with(42, {"seen": False})
+
+
+async def test_set_flags_maps_junk_to_the_imap_keyword(mail_tools, fake_mail):
+    """``junk`` is a custom IMAP keyword, spelled ``$junk`` on the wire."""
+    await mail_tools["nc_mail_set_flags"].fn(
+        42, _ctx(), flagged=True, answered=False, junk=True
+    )
+
+    fake_mail.set_flags.assert_awaited_once_with(
+        42, {"flagged": True, "answered": False, "$junk": True}
+    )
+
+
+async def test_set_flags_without_any_flag_is_an_error(mail_tools, fake_mail):
+    """A no-flag call would be a silent no-op reported as success."""
+    with pytest.raises(McpError):
+        await mail_tools["nc_mail_set_flags"].fn(42, _ctx())
+
+    fake_mail.set_flags.assert_not_awaited()
+
+
+async def test_set_tag_resolves_the_label_server_side(mail_tools, fake_mail):
+    """The tag route addresses tags by ``imapLabel``, which the server derives.
+
+    Re-deriving it client-side would mean reimplementing the Mail app's
+    modified-UTF-7 encoding; instead the create-or-get response supplies it.
+    """
+    fake_mail.ensure_tag.return_value = {
+        "id": 7,
+        "displayName": "AI Index",
+        "imapLabel": "$ai_index",
+    }
+
+    result = await mail_tools["nc_mail_set_tag"].fn(42, "AI Index", _ctx())
+
+    assert isinstance(result, MailTagResponse)
+    assert result.tag.id == 7
+    assert result.tag.imap_label == "$ai_index"
+    assert result.message_id == 42
+    fake_mail.ensure_tag.assert_awaited_once_with("AI Index")
+    fake_mail.set_tag.assert_awaited_once_with(42, "$ai_index")
+
+
+async def test_remove_tag_resolves_the_same_way(mail_tools, fake_mail):
+    fake_mail.ensure_tag.return_value = {"id": 7, "imapLabel": "$ai_index"}
+
+    await mail_tools["nc_mail_remove_tag"].fn(42, "AI Index", _ctx())
+
+    fake_mail.remove_tag.assert_awaited_once_with(42, "$ai_index")
+
+
+async def test_create_tag_returns_the_id_used_by_the_tags_filter(mail_tools, fake_mail):
+    """The tag id is the only way to build a ``tags:<id>`` listing filter."""
+    fake_mail.ensure_tag.return_value = {
+        "id": 7,
+        "displayName": "AI Index",
+        "imapLabel": "$ai_index",
+        "color": "#0082c9",
+    }
+
+    result = await mail_tools["nc_mail_create_tag"].fn("AI Index", _ctx())
+
+    assert result.tag.id == 7
+    assert result.message_id is None
+
+
+async def test_move_and_delete_return_typed_responses(mail_tools, fake_mail):
+    moved = await mail_tools["nc_mail_move_message"].fn(42, 9, _ctx())
+    deleted = await mail_tools["nc_mail_delete_message"].fn(42, _ctx())
+
+    assert isinstance(moved, MailActionResponse)
+    assert isinstance(deleted, MailActionResponse)
+    fake_mail.move_message.assert_awaited_once_with(42, 9)
+    fake_mail.delete_message.assert_awaited_once_with(42)
+
+
+async def test_get_message_source_returns_raw_text(mail_tools, fake_mail):
+    fake_mail.get_message_raw.return_value = "From: a@b.com\r\nSubject: hi\r\n\r\nbody"
+
+    result = await mail_tools["nc_mail_get_message_source"].fn(42, _ctx())
+
+    assert result.message_id == 42
+    assert result.source.startswith("From: a@b.com")
+
+
+def test_write_tools_are_registered_with_the_write_scope(mail_tools):
+    """A write tool that slipped through with mail.read would be over-granted."""
+    write_tools = [
+        "nc_mail_set_flags",
+        "nc_mail_create_tag",
+        "nc_mail_set_tag",
+        "nc_mail_remove_tag",
+        "nc_mail_move_message",
+        "nc_mail_delete_message",
+    ]
+    for name in write_tools:
+        assert list(mail_tools[name].fn._required_scopes) == ["mail.write"], name
+
+
+def test_every_tool_scope_is_grantable():
+    """Every scope a tool requires must be in ALL_SUPPORTED_SCOPES.
+
+    A scope missing from that set cannot be granted through the provisioning
+    path, so the tool is unreachable in OAuth mode while still working under
+    BasicAuth (where ``require_scopes`` short-circuits) — which is how
+    ``mail.send`` stayed broken unnoticed. This walks every registered app so
+    the next omission fails here rather than in a deployment.
+    """
+    mcp = FastMCP(name="test-all-tools")
+    for configure in AVAILABLE_APPS.values():
+        configure(mcp)
+
+    required = {
+        scope
+        for tool in mcp._tool_manager.list_tools()
+        for scope in getattr(tool.fn, "_required_scopes", ())
+    }
+    assert required <= ALL_SUPPORTED_SCOPES, (
+        f"scopes used by tools but not grantable: {sorted(required - ALL_SUPPORTED_SCOPES)}"
+    )

--- a/tests/unit/test_mail_write_tools.py
+++ b/tests/unit/test_mail_write_tools.py
@@ -95,8 +95,12 @@ async def test_set_flags_maps_junk_to_the_imap_keyword(mail_tools, fake_mail):
 
 async def test_set_flags_without_any_flag_is_an_error(mail_tools, fake_mail):
     """A no-flag call would be a silent no-op reported as success."""
+    # Setup hoisted out of the with-block so only the call under test can raise
+    # (python:S5778).
+    set_flags = mail_tools["nc_mail_set_flags"].fn
+    ctx = _ctx()
     with pytest.raises(McpError):
-        await mail_tools["nc_mail_set_flags"].fn(42, _ctx())
+        await set_flags(42, ctx)
 
     fake_mail.set_flags.assert_not_awaited()
 


### PR DESCRIPTION
Closes #1148.

> **Part of stack #1189** (#1185 → #1186 → #1187), so the diff here is only the
> write tools. Merging #1185 auto-rebases and retargets this one — no manual
> retarget needed.

## What

The Mail tools were read-only: an agent that processed a message had no way to
mark it read, so mail piled up looking unhandled. This adds the write surface.

| Tool | Notes |
|---|---|
| `nc_mail_set_flags` | read/unread, star, answered, junk |
| `nc_mail_create_tag` | create-or-get |
| `nc_mail_set_tag` / `nc_mail_remove_tag` | by display name |
| `nc_mail_move_message` | |
| `nc_mail_delete_message` | `destructiveHint=True` |
| `nc_mail_get_message_source` | raw RFC 2822 |

## Notes on the design

**#1148 asked for `nc_mail_mark_as_read`; this ships `nc_mail_set_flags(seen=…)`.**
The endpoint behind it (`PUT /api/messages/{id}/flags`) takes a *map* of flag →
bool, so read/unread, star, answered and junk all cost the same diff. Only the
flags you pass are sent; omitted ones are left alone. There is no bulk endpoint
in the Mail app — its own UI loops per message — so neither do we.

**Tags resolve through create-or-get.** `MailManager::createTag` returns the
existing tag when the name resolves to the same IMAP label, and the Mail app has
**no tag-listing route at all**, so this idempotent POST is the only way to
resolve a tag's per-user id (needed for the `tags:<id>` listing filter). The tag
tools route through it so the server hands us the `imapLabel` — meaning we never
reimplement its modified-UTF-7 encoding, which Python's stdlib can't do anyway.
A side effect worth naming: `nc_mail_remove_tag` for a name never used creates an
empty tag row before removing nothing. Harmless, and it keeps one resolution path.

**The filter grammar is now documented** on `nc_mail_list_messages`. The parameter
already worked; agents just couldn't discover `is:unread`, `from:`, `tags:` etc.

## Pre-existing bug fixed here

`mail.send` was required by `nc_mail_send_message` but missing from
`ALL_SUPPORTED_SCOPES`, and **no** mail scope appeared in the DCR list — so the
mail tools were ungrantable in OAuth mode while working fine under BasicAuth
(where `require_scopes` short-circuits). That asymmetry is why it went unnoticed.

Rather than adding the missing strings, the DCR list is now *derived* from
`ALL_SUPPORTED_SCOPES` — the two were a duplicated pair that had drifted — and a
new test walks every registered app asserting each `@require_scopes` scope is
grantable. That test immediately found the same latent bug in Talk
(`talk.read`/`talk.write`), fixed here too.

## Test coverage (per the repo's API-surface gate)

- **Unit, client layer** (`tests/client/mail/test_mail_api.py`): request shape per
  method — the flags **map** body, `ensure_tag` reading a bare (not
  `data`-wrapped) response, URL-encoded IMAP labels, and that bodyless writes
  don't declare a JSON content type.
- **Unit, tool layer** (`tests/unit/test_mail_write_tools.py`, new): which flags
  are forwarded, `junk` → `$junk`, the no-flags error, tag-label resolution, and
  the scope guard above.
- **E2E** (`tests/integration/test_mail_greenmail.py`): flags round-trip through
  a real Nextcloud + GreenMail stack (mark read → re-fetch → assert `seen`, and
  that starring doesn't reset `seen`), full tag lifecycle including finding the
  message again via `tags:<id>`, raw source, and delete. This lane runs in the
  `single-user` CI job.
- **Contract (Pact)**: no change required — these tools are neither an
  `/api/v1/*` provider route nor one of the pacted consumer boundaries (gateway
  OCR, astrolabe OCS). Flagging explicitly rather than leaving the gate silent.

Full unit suite: 2668 passed. `ruff` / `ruff format` / `ty` clean.

⚠️ **I could not run the GreenMail lane locally** — another worktree's stack held
ports 8000/3306 and tearing it down wasn't mine to do. The write routes are
CSRF-gated exactly like the GETs this client already makes successfully in that
lane (the check is method-agnostic, applied per request in `SecurityMiddleware`),
so the header should exempt them the same way — but that inference is what the CI
run of the new integration tests is there to confirm. Worth a look at that job
before merging.

Deck: card #917 (board 12).

---

_This PR was generated with the help of AI, and reviewed by a Human_
