### PR TITLE
feat(mail): index only tagged messages via MAIL_INDEX_TAG

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,6 +346,44 @@ OLLAMA_BASE_URL=http://ollama:11434
 
 > **Note:** In multi-user modes (Login Flow v2, Multi-User BasicAuth), enabling `ENABLE_SEMANTIC_SEARCH` automatically enables background operations and refresh token storage. You don't need to set `ENABLE_BACKGROUND_OPERATIONS` separately!
 
+### Indexing a subset of mail — `MAIL_INDEX_TAG`
+
+Mail is indexed for semantic search whenever vector sync is on. By default that
+means **every message in every mailbox** (up to 100 per mailbox — the Mail API's
+per-request maximum). `MAIL_INDEX_TAG` narrows it to the messages a user has
+tagged, the mail analogue of `VECTOR_SYNC_TAG` for files.
+
+| Value | Behaviour |
+|-------|-----------|
+| `""` (default) | Index every message. Unchanged from before this setting existed. |
+| a tag display name | Index only messages carrying that Mail tag. |
+
+```dotenv
+MAIL_INDEX_TAG=vector-index
+```
+
+The tag is created for each user automatically on the first scan, so it shows up
+in their Mail tag picker — applying it there **is** the opt-in. Tag names
+normalise (`"AI Index"`, `"ai index"` and `"ai_index"` are one tag), and tagging
+follows a message's `Message-ID`, so it applies to copies in other mailboxes too.
+
+Notes:
+
+- **Turning it on makes untagged mail unsearchable immediately.** Verify-on-read
+  drops untagged results on the next query; the index storage is reclaimed within
+  a couple of scan cycles by the usual grace-period eviction. No purge needed.
+- **Turning it off is lossy.** Messages indexed *because* they were tagged but
+  older than the unfiltered 100-message window fall out of discovery and are
+  evicted, then re-embedded if they come back. "Just unset it" is not free.
+- **The cap becomes 100 *tagged* messages per mailbox**, which reaches much
+  further back in a mailbox than the unfiltered window does — that coverage is
+  the main win, beyond simply indexing less. Exceeding it logs a warning naming
+  the mailbox.
+- If the tag can't be resolved (Mail app down), the mail scan is skipped for that
+  cycle rather than falling back to indexing everything, and search keeps
+  returning already-indexed mail unverified.
+- Max 128 characters (validated at startup — the Mail app rejects longer names).
+
 ### Per-document keyword vs hybrid indexing — `VECTOR_SYNC_KEYWORD_TAG`
 
 Documents are indexed **hybrid** (dense semantic + BM25 sparse) or

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -98,6 +98,15 @@ covers up to 100 messages per mailbox (the Mail API's per-request maximum;
 paging beyond it is not implemented yet), and a message's sent timestamp is used
 for change detection, since mail is immutable.
 
+**To index only some of your mail**, set `MAIL_INDEX_TAG` to a tag name — see
+[configuration.md](configuration.md#indexing-a-subset-of-mail--mail_index_tag).
+Only messages carrying that tag are then indexed, and the 100-per-mailbox cap
+applies to *tagged* messages, so it reaches much further back in the mailbox.
+The tools above are how an agent participates in that: `nc_mail_create_tag` to
+set the tag up, `nc_mail_set_tag` to mark a message for indexing, and
+`nc_mail_remove_tag` to take it back out (which removes it from search on the
+next query).
+
 ### Implementation notes
 
 The Mail app publishes only a small OCS API; most of what these tools need lives

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -143,6 +143,12 @@ _DEFAULTS: dict[str, Any] = {
     # embedding cost) into the SAME collection as hybrid files; ``vector-index``
     # wins if a file carries both. Set empty to disable the second tag entirely.
     "vector_sync_keyword_tag": "keyword-index",
+    # Mail tag (an IMAP keyword) restricting which messages are indexed. Empty
+    # (the default) indexes every message in every mailbox, which is the
+    # behaviour before this setting existed. Set it to a tag display name and
+    # only messages carrying that tag are indexed — the mail analogue of
+    # ``vector_sync_tag`` for files.
+    "mail_index_tag": "",
     # Fail-safe against a flaky/empty tag-discovery read: number of *consecutive*
     # scan cycles for which a given index mode's tag discovery must return zero
     # files (while Qdrant still holds indexed points for that mode) before the
@@ -591,6 +597,10 @@ _dynaconf = Dynaconf(
         Validator("VECTOR_SYNC_TAG", len_min=1),
         # VECTOR_SYNC_KEYWORD_TAG is optional (empty disables keyword-only
         # discovery), so no len_min — but when set it must be a usable tag name.
+        # MAIL_INDEX_TAG is likewise optional (empty indexes all mail), but the
+        # Mail app rejects display names over 128 characters — catch that at
+        # startup instead of failing every mail scan with an HTTP 400.
+        Validator("MAIL_INDEX_TAG", len_max=128),
         # WEBHOOK_SECRET is optional (None disables webhooks — GHSA-8vh3-g2qg-2h2c),
         # but when set it must be long enough to resist guessing. Surfaces a
         # weak/placeholder secret at startup rather than in a later audit.
@@ -1071,6 +1081,15 @@ class Settings:
     # embedding). ``vector-index`` takes precedence when a file carries both tags.
     # Set empty to disable the second tag entirely.
     vector_sync_keyword_tag: str = "keyword-index"
+
+    # Mail tag (an IMAP keyword) restricting which messages are indexed — the
+    # mail analogue of ``vector_sync_tag``. Empty (default) indexes every
+    # message in every mailbox. Set to a tag display name and the scanner
+    # resolves it to that user's tag id and lists only messages carrying it;
+    # verify-on-read applies the same filter, so untagging a message drops it
+    # out of search on the next query. Max 128 characters (the Mail app rejects
+    # longer display names).
+    mail_index_tag: str = ""
 
     # Fail-safe against a flaky/empty tag-discovery read. Number of *consecutive*
     # scan cycles for which an index mode's tag discovery must return zero files

--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -53,7 +53,10 @@ from nextcloud_mcp_server.search.algorithms import (
 )
 from nextcloud_mcp_server.utils.validation import is_valid_nextcloud_doc_id
 from nextcloud_mcp_server.vector.eviction import delete_document_points
-from nextcloud_mcp_server.vector.mail_content import list_index_window
+from nextcloud_mcp_server.vector.mail_content import (
+    list_index_window,
+    mail_index_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -510,10 +513,15 @@ async def _verify_mail_messages(
     is present in that listing — by construction the *same* window the scanner
     indexes, so anything aged out of the window is being evicted anyway.
 
+    When ``MAIL_INDEX_TAG`` is set the listing carries the same tag filter the
+    scanner indexed with, so untagging a message drops it from search on the
+    next query (and evicts it) — the mail equivalent of untagging a file.
+
     Failure policy mirrors ``_verify_news_items``: a definitive 403/404 for a
     mailbox drops all its results (eviction reclaims); transient errors keep
     them (fail-open). Results with no/!numeric ``mailbox_id`` or a non-numeric
-    ``doc_id`` are kept (fail-open; verification can't batch them).
+    ``doc_id`` are kept (fail-open; verification can't batch them), as are all
+    results when the tag filter itself can't be resolved.
     """
     # safe: cooperative concurrency, no lock needed (see verify_search_results)
     accessible: set[str] = set()
@@ -545,10 +553,28 @@ async def _verify_mail_messages(
             continue
         by_mailbox.setdefault(mailbox_int, []).append(r)
 
+    # Resolve the include-tag filter once, before the fan-out, so every mailbox
+    # is checked against the same window the scanner indexed. If it can't be
+    # resolved, keep every result unverified rather than listing unfiltered:
+    # unfiltered is a *narrower* window for old tagged mail, so falling back
+    # would drop and hard-evict messages that are legitimately indexed.
+    try:
+        index_filter = await mail_index_filter(client.mail)
+    except Exception as e:
+        logger.warning(
+            "Could not resolve the mail index filter (%s); keeping all %d mail "
+            "result(s) unverified this query",
+            e,
+            len(results),
+        )
+        return {r.id for r in results}
+
     async def check_mailbox(mailbox_id: int, mb_results: list[SearchResult]) -> None:
         async with semaphore:
             try:
-                messages = await list_index_window(client.mail, mailbox_id)
+                messages = await list_index_window(
+                    client.mail, mailbox_id, index_filter
+                )
             except HTTPStatusError as e:
                 if _is_definitive_404_or_403(e):
                     # Mailbox/account gone — all its results are inaccessible.

--- a/nextcloud_mcp_server/vector/mail_content.py
+++ b/nextcloud_mcp_server/vector/mail_content.py
@@ -13,6 +13,7 @@ Two things live here, both because *two* call sites must agree exactly:
 from typing import Any
 
 from nextcloud_mcp_server.client.mail import MailClient
+from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.vector.html_processor import html_to_markdown
 
 # Messages indexed (and verified) per mailbox. This equals the Mail API's
@@ -24,6 +25,38 @@ from nextcloud_mcp_server.vector.html_processor import html_to_markdown
 # Which end of the mailbox this window covers is the *user's* Mail ``sort-order``
 # preference, not ours: newest-first by default, oldest-first if they changed it.
 MAIL_SCAN_MAX_PER_MAILBOX = 100
+
+
+async def mail_index_filter(mail_client: MailClient) -> str | None:
+    """Resolve ``MAIL_INDEX_TAG`` into a Mail listing filter for this user.
+
+    Returns ``None`` when the setting is empty, meaning "index every message" —
+    the behaviour before the setting existed. Otherwise returns ``tags:<id>``,
+    where the id is *this user's* tag row: tag ids are per-user, so the filter
+    has to be resolved per user rather than configured as a literal.
+
+    Resolution goes through the create-or-get ``POST /api/tags``, which is the
+    only way to look a tag up (the Mail app has no tag-listing route) and has
+    the useful side effect of making the tag appear in the user's Mail tag
+    picker — that picker *is* the opt-in UI for indexing.
+
+    Deliberately not cached. One extra request per user per scan is noise next
+    to the per-account/per-mailbox listing calls, and a cache would turn the one
+    failure that matters — a user deleting and re-creating the tag, leaving a
+    stale id that returns an empty listing rather than an error — from
+    self-healing on the next tick into permanent until restart.
+
+    Raises:
+        Whatever the client raises. Callers **must not** fall back to an
+        unfiltered listing: unfiltered is a *narrower* window for old tagged
+        mail (the newest-N cap applies after the filter), so falling back would
+        hard-evict messages that were legitimately indexed.
+    """
+    tag_name = get_settings().mail_index_tag
+    if not tag_name:
+        return None
+    tag = await mail_client.ensure_tag(tag_name)
+    return f"tags:{tag['id']}"
 
 
 async def list_index_window(

--- a/nextcloud_mcp_server/vector/mail_content.py
+++ b/nextcloud_mcp_server/vector/mail_content.py
@@ -84,8 +84,8 @@ async def list_index_window(
             concretely so a signature change in ``MailClient.list_messages``
             fails type-checking here rather than silently drifting the window.
         mailbox_id: Mailbox database ID to list.
-        index_filter: Optional Mail search-filter string (e.g. ``tags:7``);
-            ``None`` lists every message.
+        index_filter: Optional Mail search-filter string, as resolved by
+            :func:`mail_index_filter`; ``None`` lists every message.
 
     Returns:
         Message summary dicts, at most ``MAIL_SCAN_MAX_PER_MAILBOX``.

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -44,6 +44,7 @@ from nextcloud_mcp_server.vector.dead_letter import is_dead_lettered
 from nextcloud_mcp_server.vector.mail_content import (
     MAIL_SCAN_MAX_PER_MAILBOX,
     list_index_window,
+    mail_index_filter,
 )
 from nextcloud_mcp_server.vector.placeholder import (
     query_document_metadata,
@@ -1910,7 +1911,10 @@ async def scan_mail_messages(
 
     Enumerates accounts → mailboxes → ``list_index_window`` per mailbox (at most
     ``MAIL_SCAN_MAX_PER_MAILBOX`` messages, the same call the search-time
-    verifier makes). Email is immutable, so a message's ``dateInt`` (sent
+    verifier makes). With ``MAIL_INDEX_TAG`` set, that window covers only
+    messages carrying the tag — so the cap then bounds *tagged* mail, which
+    reaches much further back than the unfiltered window does. Email is
+    immutable, so a message's ``dateInt`` (sent
     timestamp) is used as the change-detection ``modified_at`` — a message is
     indexed once and not re-sent. Messages that drop out of the window (or are
     deleted) are evicted via the deletion-tracking pass, keeping the index
@@ -1953,7 +1957,14 @@ async def scan_mail_messages(
             "Found %s indexed mail messages in Qdrant", len(indexed_message_ids)
         )
 
-    # Enumerate accounts → mailboxes → newest-N messages.
+    # Resolve the include-tag filter once per scan (None = index everything).
+    # Deliberately *not* wrapped: a failure here must abort the whole mail scan
+    # before the deletion pass below, so a tags endpoint returning 500 can
+    # neither enrol the user's entire mailbox (fail-open) nor evict what is
+    # already indexed. The caller logs and moves on to the next source.
+    index_filter = await mail_index_filter(nc_client.mail)
+
+    # Enumerate accounts → mailboxes → the index window per mailbox.
     accounts = await nc_client.mail.list_accounts()
     nextcloud_message_ids: set[str] = set()
     message_count = 0
@@ -1984,7 +1995,9 @@ async def scan_mail_messages(
             if mailbox_id is None:
                 continue
             try:
-                messages = await list_index_window(nc_client.mail, mailbox_id)
+                messages = await list_index_window(
+                    nc_client.mail, mailbox_id, index_filter
+                )
             except Exception as e:
                 listing_failed = True
                 logger.warning(
@@ -1998,15 +2011,31 @@ async def scan_mail_messages(
             if len(messages) >= MAIL_SCAN_MAX_PER_MAILBOX and _mark_mail_cap_logged(
                 (user_id, mailbox_id)
             ):
-                logger.info(
-                    "[SCAN-%s] Mailbox %s contains more than %s messages; only "
-                    "the newest %s are indexed (cursor pagination not yet "
-                    "implemented)",
-                    scan_id,
-                    mailbox_id,
-                    MAIL_SCAN_MAX_PER_MAILBOX,
-                    MAIL_SCAN_MAX_PER_MAILBOX,
-                )
+                # Unfiltered, hitting the cap is expected for any real mailbox.
+                # Filtered, it means the user deliberately marked more messages
+                # than we can index and some are being dropped — actionable, so
+                # it gets a warning.
+                if index_filter:
+                    logger.warning(
+                        "[SCAN-%s] Mailbox %s holds more than %s messages "
+                        "matching %s; only %s are indexed (cursor pagination "
+                        "not yet implemented)",
+                        scan_id,
+                        mailbox_id,
+                        MAIL_SCAN_MAX_PER_MAILBOX,
+                        index_filter,
+                        MAIL_SCAN_MAX_PER_MAILBOX,
+                    )
+                else:
+                    logger.info(
+                        "[SCAN-%s] Mailbox %s contains more than %s messages; "
+                        "only %s are indexed (cursor pagination not yet "
+                        "implemented)",
+                        scan_id,
+                        mailbox_id,
+                        MAIL_SCAN_MAX_PER_MAILBOX,
+                        MAIL_SCAN_MAX_PER_MAILBOX,
+                    )
 
             for message in messages:
                 msg_db_id = message.get("databaseId")

--- a/tests/unit/search/test_verification.py
+++ b/tests/unit/search/test_verification.py
@@ -1392,3 +1392,47 @@ async def test_apply_display_paths_noop_without_file_results(mocker):
     )
     await verification._apply_user_display_paths("bob", [_make_result(1, "note")])
     shared.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_verify_mail_applies_the_same_filter_the_scanner_indexed(mocker):
+    """The verifier must use the scanner's window, filter included.
+
+    Listing unfiltered here would be a *narrower* window for old tagged mail —
+    it would drop and hard-evict messages the scanner legitimately indexed.
+    """
+    mocker.patch.object(
+        verification, "mail_index_filter", new=AsyncMock(return_value="tags:7")
+    )
+    list_messages = mocker.AsyncMock(return_value=[{"databaseId": 10}])
+    client = SimpleNamespace(
+        mail=SimpleNamespace(list_messages=list_messages), username="alice"
+    )
+
+    result = await _verify_mail_messages(client, [_mail_result(10)], _sem())
+
+    assert result == {"10"}
+    list_messages.assert_awaited_once_with(
+        10, limit=MAIL_SCAN_MAX_PER_MAILBOX, search_filter="tags:7", view="singleton"
+    )
+
+
+@pytest.mark.unit
+async def test_verify_mail_keeps_results_when_the_filter_cannot_resolve(mocker):
+    """Fail-open on resolution failure — and crucially, don't list unfiltered."""
+    mocker.patch.object(
+        verification,
+        "mail_index_filter",
+        new=AsyncMock(side_effect=RuntimeError("tags endpoint down")),
+    )
+    list_messages = mocker.AsyncMock(return_value=[])
+    client = SimpleNamespace(
+        mail=SimpleNamespace(list_messages=list_messages), username="alice"
+    )
+
+    result = await _verify_mail_messages(
+        client, [_mail_result(10), _mail_result(20)], _sem()
+    )
+
+    assert result == {"10", "20"}
+    list_messages.assert_not_awaited()

--- a/tests/unit/vector/test_mail_content.py
+++ b/tests/unit/vector/test_mail_content.py
@@ -6,6 +6,7 @@ separators or header order can't silently misalign every indexed message.
 ``list_index_window`` is the equivalent for the scanner/verifier listing.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -15,6 +16,7 @@ from nextcloud_mcp_server.vector.mail_content import (
     build_mail_content,
     format_mail_addresses,
     list_index_window,
+    mail_index_filter,
 )
 
 pytestmark = pytest.mark.unit
@@ -47,6 +49,48 @@ async def test_list_index_window_passes_filter_through():
     await list_index_window(mail_client, 10, "tags:7")
 
     assert mail_client.list_messages.await_args.kwargs["search_filter"] == "tags:7"
+
+
+async def test_mail_index_filter_is_none_when_unset(mocker):
+    """Empty MAIL_INDEX_TAG means index everything — the pre-existing behaviour."""
+    mocker.patch(
+        "nextcloud_mcp_server.vector.mail_content.get_settings",
+        return_value=SimpleNamespace(mail_index_tag=""),
+    )
+    mail_client = AsyncMock()
+
+    assert await mail_index_filter(mail_client) is None
+    mail_client.ensure_tag.assert_not_awaited()
+
+
+async def test_mail_index_filter_resolves_the_tag_per_user(mocker):
+    """Tag ids are per-user, so the filter is resolved per user, not configured."""
+    mocker.patch(
+        "nextcloud_mcp_server.vector.mail_content.get_settings",
+        return_value=SimpleNamespace(mail_index_tag="AI Index"),
+    )
+    mail_client = AsyncMock()
+    mail_client.ensure_tag.return_value = {"id": 7, "imapLabel": "$ai_index"}
+
+    assert await mail_index_filter(mail_client) == "tags:7"
+    mail_client.ensure_tag.assert_awaited_once_with("AI Index")
+
+
+async def test_mail_index_filter_propagates_failures(mocker):
+    """Resolution failure must raise, never degrade to an unfiltered listing.
+
+    An unfiltered listing is a *narrower* window for old tagged mail, so a
+    silent fallback would evict messages that were legitimately indexed.
+    """
+    mocker.patch(
+        "nextcloud_mcp_server.vector.mail_content.get_settings",
+        return_value=SimpleNamespace(mail_index_tag="AI Index"),
+    )
+    mail_client = AsyncMock()
+    mail_client.ensure_tag.side_effect = RuntimeError("tags endpoint down")
+
+    with pytest.raises(RuntimeError):
+        await mail_index_filter(mail_client)
 
 
 def test_format_addresses_variants():

--- a/tests/unit/vector/test_scanner_mail.py
+++ b/tests/unit/vector/test_scanner_mail.py
@@ -374,3 +374,59 @@ async def test_grace_key_isolated_by_doc_type(mocker):
 
     # The note's grace entry is untouched by the mail scan (no cross-type stomp).
     assert ("alice", "42", "note") in scanner_module._potentially_deleted
+
+
+async def test_filtered_scan_uses_the_resolved_tag_filter(mocker):
+    """With MAIL_INDEX_TAG set, only tagged messages are listed."""
+    _patch_incremental(mocker, indexed_ids=[], existing_metadata=None)
+    mocker.patch.object(
+        scanner_module,
+        "mail_index_filter",
+        new=AsyncMock(return_value="tags:7"),
+    )
+    nc_client = _single_message_client([{"databaseId": 100, "dateInt": 1700000000}])
+
+    stream = _CollectingStream()
+    await scan_mail_messages(
+        user_id="alice",
+        send_stream=stream,
+        nc_client=nc_client,
+        initial_sync=False,
+        scan_id=1,
+    )
+
+    nc_client.mail.list_messages.assert_awaited_once_with(
+        10,
+        limit=scanner_module.MAIL_SCAN_MAX_PER_MAILBOX,
+        search_filter="tags:7",
+        view="singleton",
+    )
+
+
+async def test_filter_resolution_failure_aborts_before_the_deletion_pass(mocker):
+    """Fail-closed: a tags-endpoint failure must not evict, nor index everything.
+
+    Fail-open here would enrol the user's whole mailbox on a transient 500; the
+    raise happens before the deletion pass, so nothing is evicted either.
+    """
+    _patch_incremental(mocker, indexed_ids=["999"], existing_metadata=None)
+    scanner_module._potentially_deleted[("alice", "999", "mail_message")] = 0.0
+    mocker.patch.object(
+        scanner_module,
+        "mail_index_filter",
+        new=AsyncMock(side_effect=RuntimeError("tags endpoint down")),
+    )
+    nc_client = _single_message_client([{"databaseId": 100, "dateInt": 1700000000}])
+
+    stream = _CollectingStream()
+    with pytest.raises(RuntimeError):
+        await scan_mail_messages(
+            user_id="alice",
+            send_stream=stream,
+            nc_client=nc_client,
+            initial_sync=False,
+            scan_id=1,
+        )
+
+    assert stream.tasks == []
+    nc_client.mail.list_messages.assert_not_awaited()

--- a/tests/unit/vector/test_scanner_mail.py
+++ b/tests/unit/vector/test_scanner_mail.py
@@ -430,3 +430,48 @@ async def test_filter_resolution_failure_aborts_before_the_deletion_pass(mocker)
 
     assert stream.tasks == []
     nc_client.mail.list_messages.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_level", "expected_fragment"),
+    [
+        # Unfiltered: a big mailbox is routine, and the cap is a documented
+        # limitation rather than something the user can act on.
+        (None, "INFO", "contains more than"),
+        # Filtered: the user deliberately tagged more than fits, and messages
+        # they asked for are being dropped -- actionable, so it escalates.
+        ("index-me", "WARNING", "matching tags:7"),
+    ],
+)
+async def test_cap_log_level_depends_on_whether_a_filter_is_set(
+    mocker, caplog, tag, expected_level, expected_fragment
+):
+    """The cap message escalates to a warning only when it hides tagged mail."""
+    _patch_incremental(mocker, indexed_ids=[], existing_metadata=None)
+    mocker.patch.object(
+        scanner_module,
+        "mail_index_filter",
+        new=AsyncMock(return_value="tags:7" if tag else None),
+    )
+    # A full window is what trips the cap branch.
+    nc_client = _single_message_client(
+        [
+            {"databaseId": i, "dateInt": 1700000000}
+            for i in range(scanner_module.MAIL_SCAN_MAX_PER_MAILBOX)
+        ]
+    )
+
+    stream = _CollectingStream()
+    with caplog.at_level("INFO", logger=scanner_module.logger.name):
+        await scan_mail_messages(
+            user_id="alice",
+            send_stream=stream,
+            nc_client=nc_client,
+            initial_sync=False,
+            scan_id=1,
+        )
+
+    cap_records = [r for r in caplog.records if "are indexed" in r.getMessage()]
+    assert len(cap_records) == 1, "expected exactly one cap message"
+    assert cap_records[0].levelname == expected_level
+    assert expected_fragment in cap_records[0].getMessage()


### PR DESCRIPTION
> **Top of stack #1189** (#1185 → #1186 → #1187), so the diff here is only the
> indexing filter. Merging the PRs below auto-rebases and retargets this one.

## What

Mail indexing is all-or-nothing today: every account × every mailbox × every
message up to the per-mailbox cap, whether or not the user wants their mail in a
vector index. `MAIL_INDEX_TAG` narrows it to messages carrying a Mail tag — the
analogue of `VECTOR_SYNC_TAG` for files.

```dotenv
MAIL_INDEX_TAG=""             # default: index all mail (unchanged behaviour)
MAIL_INDEX_TAG=vector-index   # index only messages carrying that tag
```

Non-breaking: empty default preserves exactly what runs today.

## How the tag resolves

Tag ids are **per-user**, so the filter can't be a configured literal — it's
resolved per user into `tags:<id>`. `POST /api/tags` is create-or-get, which is
both the only way to look a tag up (the Mail app has **no** tag-listing route)
and the thing that puts the tag in the user's Mail tag picker. That picker is the
opt-in UI: applying the tag there is how a user says "index this".

**Deliberately uncached.** One request per user per scan is noise next to the
per-account/per-mailbox listings already made. The reason to actively avoid a
cache is the failure mode: a user deleting and re-creating the tag leaves a stale
id that doesn't error — it returns an *empty listing*, indistinguishable from
"nothing tagged", which would drive mass eviction. Uncached that self-heals on
the next tick; cached it's permanent until restart.

## The two sides fail in opposite directions, on purpose

- **Scanner fails closed.** The raise propagates and aborts the mail scan *before*
  the deletion pass, so a 500 from the tags endpoint can neither enrol a user's
  entire mailbox (fail-open) nor evict what's already indexed.
- **Verifier fails open**, keeping mail results unverified. Critically it must
  **not** fall back to an unfiltered listing — unfiltered is a *narrower* window
  for old tagged mail (the cap applies after the filter), so the intuitively-safe
  fallback would drop and hard-evict messages the scanner legitimately indexed.
  There's a comment and a test on that, because it's the trap here.

## Behaviour worth knowing (documented, not coded around)

- **Turning it on** makes untagged mail unsearchable on the *next query* via
  verify-on-read; storage is reclaimed within a couple of scan cycles by the
  normal grace-period eviction. No purge tool needed.
- **Turning it off is lossy**: messages indexed *because* they were tagged but
  older than the unfiltered window fall out of discovery and get evicted, then
  re-embedded if they return.
- **The cap now bounds *tagged* messages**, which reaches much further back into a
  mailbox than the unfiltered window — that coverage gain is the main win, more
  than the volume reduction. Hitting the cap while filtered logs a **warning**
  (the user tagged more than we can index — actionable) rather than the routine
  info line.
- Enabling this makes a background scanner write a tag row into each user's Mail
  account. That's a mutation from a sync loop; it's also the opt-in surface.

## Test coverage

- `test_mail_content.py` — filter is `None` when unset (and doesn't call the tags
  endpoint at all), resolves to `tags:<id>` when set, and *raises* rather than
  degrading on failure.
- `test_scanner_mail.py` — the filtered listing is what the scanner requests;
  resolution failure aborts before the deletion pass, queueing nothing.
- `test_verification.py` — the verifier requests the **same** filter + view +
  limit as the scanner, and on resolution failure keeps everything without
  listing unfiltered.

The filtered path would otherwise be silently untested, since the default is
empty and every existing fake would keep passing.

Full unit suite: 2675 passed. `ruff` / `ruff format` / `ty` clean.

Docs: new section in `docs/configuration.md`, plus the semantic-search section of
the new `docs/mail.md` explaining how the tag tools from #1186 drive it.

Deck: card #917 (board 12).

---

_This PR was generated with the help of AI, and reviewed by a Human_
