### PR TITLE
fix(ingest): stop unreadable PDFs from re-queueing forever

### DIFF
--- a/nextcloud_mcp_server/document_processors/_isolation.py
+++ b/nextcloud_mcp_server/document_processors/_isolation.py
@@ -315,7 +315,10 @@ def _parse_pdf_extract(
 
     pymupdf4llm = load_classic_pymupdf4llm()
 
-    doc = pymupdf.open(source_path)
+    # filetype="pdf": source_path is the ingest spool (``*.bin``); inferring the
+    # type from that suffix finds no MuPDF handler. Must match the parent's
+    # metadata open (pymupdf.py) or a document that opened there fails here.
+    doc = pymupdf.open(source_path, filetype="pdf")
     try:
         # Page gate (Deck #399). to_markdown is superlinear in page count, so a
         # large document burns the entire parse timeout and then dead-letters

--- a/nextcloud_mcp_server/document_processors/classifier.py
+++ b/nextcloud_mcp_server/document_processors/classifier.py
@@ -336,7 +336,10 @@ def image_coverage_per_page_from_path(source_path: str) -> list[float]:
     )
 
     cov: list[float] = []
-    with pymupdf_serialized(), pymupdf.open(source_path) as doc:
+    # filetype="pdf": the spool path is ``*.bin``, and PyMuPDF would infer the
+    # MuPDF magic from that suffix and fail to find a handler. Matches the
+    # bytes-based twin below, which already passes "pdf" explicitly.
+    with pymupdf_serialized(), pymupdf.open(source_path, filetype="pdf") as doc:
         for n in range(min(doc.page_count, MAX_SAMPLED_PAGES)):
             cov.append(_page_image_coverage(doc.load_page(n)))
     return cov

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -155,7 +155,17 @@ class PyMuPDFProcessor(DocumentProcessor):
         )
 
         with pymupdf_serialized():
-            doc = pymupdf.open(source_path)
+            # filetype="pdf" rather than letting MuPDF infer it from the path: the
+            # ingest spool is named ``nc-ingest-XXXX.bin`` (source.spool_target),
+            # and PyMuPDF derives the MuPDF magic from the suffix, so the inferred
+            # type is "bin" -- no handler, FileDataError, before any content is
+            # read. Handler selection then falls back to content sniffing, which
+            # only inspects a prefix: a PDF whose header sits behind a long run of
+            # junk (recovery-tool output) is rejected outright, even though the
+            # PDF handler's xref repair can reconstruct it. We only reach this
+            # processor because the registry matched application/pdf, so naming
+            # the type states what the caller already knows.
+            doc = pymupdf.open(source_path, filetype="pdf")
             try:
                 meta = self._extract_metadata(doc, filename)
                 meta["file_size"] = size
@@ -238,9 +248,51 @@ class PyMuPDFProcessor(DocumentProcessor):
             if progress_callback:
                 await progress_callback(0, 100, "Opening PDF document")
 
-            metadata, page_count = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-                self._read_metadata_sync, source_path, filename, source.size
-            )
+            try:
+                metadata, page_count = await anyio.to_thread.run_sync(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+                    self._read_metadata_sync, source_path, filename, source.size
+                )
+            except pymupdf.FileDataError as exc:
+                # MuPDF could not recognise the bytes as a document it can open
+                # at all -- a file named ``.pdf`` whose content is something else
+                # (or nothing: a zero-filled recovery artifact). Nextcloud derives
+                # the mime type from the extension, so such a file is served as
+                # application/pdf and routed here on a claim its bytes don't back.
+                #
+                # Fail like the fast tier does (pypdfium2_fast: success=False)
+                # rather than raising ProcessorError. A raise skips the
+                # escalate-or-dead-letter path in vector.processor entirely and
+                # lands in the generic retry handler, where _drop_reason() labels
+                # it "other" and deliberately does NOT mark the document failed --
+                # so the scanner re-queued it forever, re-downloading the whole
+                # file on every cycle. Returning the failure makes it terminal
+                # once no higher tier remains.
+                #
+                # Narrow on purpose: EmptyFileError subclasses FileDataError, so
+                # both are covered, while pymupdf's own FileNotFoundError (the
+                # spool vanished) stays an exception -- that is an infrastructure
+                # fault and must remain retryable.
+                logger.warning(
+                    "PDF %s is not a readable document (%s); failing as unreadable",
+                    filename or "<bytes>",
+                    exc,
+                    extra={
+                        "processor": self.name,
+                        "tier": self.tier,
+                        "status": "error",
+                        "reason": "unreadable",
+                    },
+                )
+                return ProcessingResult(
+                    text="",
+                    metadata={
+                        "file_size": source.size,
+                        "parse_failed_reason": "unreadable",
+                    },
+                    processor=self.name,
+                    success=False,
+                    error=f"not a readable PDF: {exc}",
+                )
 
             if progress_callback:
                 await progress_callback(10, 100, f"Extracting {page_count} pages")

--- a/nextcloud_mcp_server/document_processors/pymupdf.py
+++ b/nextcloud_mcp_server/document_processors/pymupdf.py
@@ -25,6 +25,10 @@ from .source import DocumentSource, MemoryDocumentSource, resolve_path
 
 logger = logging.getLogger(__name__)
 
+# Stand-in for the filename in log lines when the document came from bytes (a
+# note attachment, a deck card) and so has no path to name.
+_UNNAMED = "<bytes>"
+
 
 def _record_parse_mode(
     metadata: dict[str, Any], page_count: int, settings: Any
@@ -274,7 +278,7 @@ class PyMuPDFProcessor(DocumentProcessor):
                 # fault and must remain retryable.
                 logger.warning(
                     "PDF %s is not a readable document (%s); failing as unreadable",
-                    filename or "<bytes>",
+                    filename or _UNNAMED,
                     exc,
                     extra={
                         "processor": self.name,
@@ -325,7 +329,7 @@ class PyMuPDFProcessor(DocumentProcessor):
             except PdfParseFailed as exc:
                 logger.warning(
                     "Isolated PDF parse failed for %s (reason=%s): %s",
-                    filename or "<bytes>",
+                    filename or _UNNAMED,
                     exc.reason,
                     exc,
                     extra={
@@ -370,7 +374,7 @@ class PyMuPDFProcessor(DocumentProcessor):
 
             logger.info(
                 "Successfully processed PDF %s: %s pages, %s chars, %s images",
-                filename or "<bytes>",
+                filename or _UNNAMED,
                 metadata["page_count"],
                 len(md_text),
                 metadata.get("image_count", 0),

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -391,7 +391,7 @@ document_escalation_suppressed_total = Counter(
 document_parse_failed_total = Counter(
     "astrolabe_document_parse_failed_total",
     "Document parses that failed in the isolated worker (process killed)",
-    ["reason"],  # reason: timeout | oom | error
+    ["reason"],  # reason: timeout | oom | error | unreadable
 )
 
 # Documents dead-lettered after a terminal parse failure: the failing tier had
@@ -405,7 +405,7 @@ document_parse_failed_total = Counter(
 document_dead_lettered_total = Counter(
     "astrolabe_document_dead_lettered_total",
     "Documents dead-lettered after a terminal parse failure (no escalation tier)",
-    ["reason"],  # reason: timeout | oom | error | oversize
+    ["reason"],  # reason: timeout | oom | error | oversize | unreadable
 )
 
 # Documents dropped after exhausting in-process indexing retries (the scanner

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1161,7 +1161,11 @@ def record_document_parse_failed(reason: str) -> None:
     """Record a hard parse failure from the isolated worker.
 
     Args:
-        reason: ``timeout`` | ``oom`` | ``error``
+        reason: ``timeout`` | ``oom`` | ``error`` (from the isolated worker), or
+            ``unreadable`` -- the engine could not open the bytes as a document
+            at all, i.e. the file's content does not match the mime type its
+            extension claimed. Distinguished from ``error`` on purpose: it means
+            corrupt input, not a failure of ours, so it should not page anyone.
     """
     document_parse_failed_total.labels(reason=reason).inc()
 
@@ -1211,8 +1215,10 @@ def record_document_dead_lettered(reason: str) -> None:
 
     Args:
         reason: ``timeout`` | ``oom`` | ``error`` (the terminal parse failure
-            reason carried from the isolated worker) or ``oversize`` (rejected by
-            the pre-parse size guard, which no tier can ever parse).
+            reason carried from the isolated worker), ``oversize`` (rejected by
+            the pre-parse size guard, which no tier can ever parse), or
+            ``unreadable`` (the bytes are not a document the engine can open --
+            no tier will do better, so it is terminal on the first attempt).
     """
     document_dead_lettered_total.labels(reason=reason).inc()
 

--- a/nextcloud_mcp_server/search/pdf_highlighter.py
+++ b/nextcloud_mcp_server/search/pdf_highlighter.py
@@ -920,7 +920,9 @@ class PDFHighlighter:
                 return results
             window = page_window if page_window and page_window > 0 else len(pages)
             for start in range(0, len(pages), window):
-                doc = pymupdf.open(source_path)
+                # filetype="pdf": source_path is the ingest spool (``*.bin``), so
+                # letting MuPDF infer the type from the suffix finds no handler.
+                doc = pymupdf.open(source_path, filetype="pdf")
                 try:
                     for page_num in pages[start : start + window]:
                         page = doc[page_num - 1]

--- a/tests/unit/search/test_pdf_highlighter_bbox.py
+++ b/tests/unit/search/test_pdf_highlighter_bbox.py
@@ -537,3 +537,44 @@ def test_no_resolvable_pages_returns_empty_without_error(window, caplog):
 
     assert results == {}
     assert "Error computing chunk bboxes" not in caplog.text
+
+
+@pytest.mark.unit
+def test_compute_chunk_bboxes_from_a_bin_spool_path(tmp_path, caplog):
+    """Bbox extraction must read the ingest spool, whose name ends in ``.bin``.
+
+    ``vector.processor`` passes ``pdf_path=source.path()`` -- the spool file, named
+    ``nc-ingest-XXXX.bin``. PyMuPDF derives the MuPDF magic from that suffix, so
+    without an explicit ``filetype`` there is no handler and the open raises. This
+    path swallows every exception (returning ``{}`` after logging), so the failure
+    is silent: chunks simply get no bboxes and nothing surfaces as broken.
+
+    The junk prefix is what makes the suffix load-bearing rather than cosmetic --
+    it pushes ``%PDF-`` past MuPDF's content-sniffing window, so the type cannot be
+    recovered by inspecting the bytes. Mirrors the ingest-side coverage in
+    tests/unit/test_pdf_ladder_source.py.
+    """
+    pages = [
+        "Chapter 1: Introduction. Nextcloud is a self-hosted collaboration platform "
+        "covering installation, configuration and maintenance topics.",
+    ]
+    boundaries, full_text = _page_boundaries(pages)
+    spool = tmp_path / "nc-ingest-abcd1234.bin"
+    spool.write_bytes(b"\0" * (8 * 1024 * 1024) + _make_pdf(pages))
+
+    caplog.set_level(
+        logging.ERROR, logger="nextcloud_mcp_server.search.pdf_highlighter"
+    )
+    results = PDFHighlighter.compute_chunk_bboxes_batch(
+        pdf_bytes=None,
+        chunks=[(0, 0, len(pages[0]), 1, pages[0])],
+        page_boundaries=boundaries,
+        full_text=full_text,
+        pdf_path=spool,
+    )
+
+    assert "Error computing chunk bboxes" not in caplog.text
+    assert set(results) == {0}
+    rects, page = results[0]
+    assert page == 1
+    assert len(rects) >= 1

--- a/tests/unit/test_doc_classifier.py
+++ b/tests/unit/test_doc_classifier.py
@@ -316,6 +316,27 @@ def test_image_coverage_per_page():
     assert len(digital) == 2 and all(c < 0.1 for c in digital)
 
 
+def test_image_coverage_from_a_bin_spool_path(tmp_path):
+    """Scan detection reads the ingest spool, whose name ends in ``.bin``.
+
+    ``registry`` calls this with ``str(source.path())`` -- the spool file, named
+    ``nc-ingest-XXXX.bin``. PyMuPDF derives the MuPDF magic from that suffix, so
+    without an explicit ``filetype`` the open finds no handler and raises. The
+    caller wraps this in a bare ``except Exception`` and downgrades to text-only
+    signals, so a regression here is silent: scanned PDFs quietly stop being
+    detected as scans.
+
+    The junk prefix pushes ``%PDF-`` past MuPDF's content-sniffing window, which
+    is what makes the explicit type load-bearing rather than cosmetic.
+    """
+    spool = tmp_path / "nc-ingest-abcd1234.bin"
+    spool.write_bytes(b"\0" * (8 * 1024 * 1024) + _full_page_image_pdf(pages=2))
+
+    coverage = clf.image_coverage_per_page_from_path(str(spool))
+
+    assert len(coverage) == 2 and all(c >= 0.8 for c in coverage)
+
+
 def test_scan_coverage_shorter_than_pages_aligns_without_crash():
     # image_coverage shorter than the boundaries (the MAX_SAMPLED_PAGES cap):
     # the single entry aligns to page 0; later pages get no coverage entry. With

--- a/tests/unit/test_pdf_ladder_source.py
+++ b/tests/unit/test_pdf_ladder_source.py
@@ -17,6 +17,7 @@ import pymupdf
 import pytest
 
 from nextcloud_mcp_server.document_processors import get_registry
+from nextcloud_mcp_server.document_processors.pymupdf import PyMuPDFProcessor
 from nextcloud_mcp_server.document_processors.source import (
     MemoryDocumentSource,
     SpooledDocumentSource,
@@ -200,3 +201,66 @@ async def test_in_memory_source_still_works(settings):
 
     assert result.success is True
     assert result.metadata["pipeline_tier"] == "fast"
+
+
+async def test_unreadable_file_fails_gracefully_instead_of_raising(spooled, settings):
+    """A file named ``.pdf`` whose bytes are not a document must not raise.
+
+    Nextcloud derives the mime type from the extension, so a zero-filled recovery
+    artifact named ``.pdf`` is served as application/pdf and routed to the PDF
+    ladder. The structured tier used to raise ``ProcessorError`` here, which skips
+    ``vector.processor``'s escalate-or-dead-letter path entirely: the failure was
+    labelled ``other``, the document was deliberately NOT marked failed, and the
+    scanner re-queued it forever -- re-downloading the whole file every cycle.
+
+    Returning ``success=False`` puts it on the terminal path instead.
+
+    This case is unreachable-by-content: a pure zero-fill has nothing for MuPDF's
+    xref repair to reconstruct, so it fails even with ``filetype="pdf"`` -- which
+    is why the graceful-failure branch is needed on top of the type hint that
+    ``test_pdf_behind_a_junk_prefix_is_still_read`` covers.
+    """
+    settings()
+
+    result = await PyMuPDFProcessor().process_source(
+        spooled(b"\0" * 4096, name="nc-ingest-zeroes.bin")
+    )
+
+    assert result.success is False
+    assert result.metadata["parse_failed_reason"] == "unreadable"
+    assert "not a readable PDF" in (result.error or "")
+
+
+async def test_valid_pdf_parses_from_a_bin_suffixed_spool(spooled, settings):
+    """The spool's ``.bin`` suffix must stay irrelevant to a real PDF."""
+    settings()
+
+    result = await PyMuPDFProcessor().process_source(
+        spooled(_digital_pdf(), name="nc-ingest-valid.bin")
+    )
+
+    assert result.success is True
+    assert "Ladder source test page" in result.text
+
+
+async def test_pdf_behind_a_junk_prefix_is_still_read(spooled, settings):
+    """A PDF whose header sits past MuPDF's sniffing window must still parse.
+
+    This is the case that makes ``filetype="pdf"`` load-bearing rather than
+    cosmetic. Handler selection from the ``.bin`` spool suffix finds no handler, so
+    MuPDF falls back to sniffing a prefix only; with megabytes of junk in front of
+    ``%PDF-`` -- what recovery tools emit -- the sniff misses it and the document
+    is rejected outright, even though the PDF handler's xref repair reconstructs it
+    fine. Naming the type skips the guess and lets repair run.
+
+    Uses 8 MB of padding to clear the sniffing window by a wide margin, matching
+    the real document that surfaced this (content began ~7 MB in).
+    """
+    settings()
+
+    result = await PyMuPDFProcessor().process_source(
+        spooled(b"\0" * (8 * 1024 * 1024) + _digital_pdf(), name="nc-ingest-junk.bin")
+    )
+
+    assert result.success is True
+    assert "Ladder source test page" in result.text


### PR DESCRIPTION
## Problem

A document the PDF engine cannot open was **re-queued by the scanner indefinitely**
instead of being dead-lettered. In one dev tenant, 85 documents from a bulk
data-recovery import were each retried roughly every 30 minutes for hours —
~170 failed index attempts per hour — and every cycle re-downloaded the whole
file **twice** (fast tier, then structured after escalation). For the largest
member (825 MB) that is ~1.6 GB of WebDAV traffic and ~80 s of worker time per
cycle, in perpetuity, for a document that yields no text.

The visible symptom was a confusing log line naming the spool file rather than
the document:

```
Failed to index file_<id> after 1 retries (other): ProcessorError(
  "Failed to process PDF <path>: Failed to open file '/tmp/nc-ingest-XXXXXXXX.bin' as type bin.")
```

## Root cause — two independent defects

### 1. The spool suffix hid the document's type from MuPDF

Ingest streams every document to `nc-ingest-XXXX.bin` (`document_processors/source.py`)
and called `pymupdf.open(path)` with no `filetype=`. PyMuPDF derives the MuPDF magic
from the path suffix, so MuPDF was asked for a handler for type `bin`, found none, and
failed **before reading any content**. Handler selection then falls back to sniffing a
prefix only — so a PDF whose header sits behind a long run of junk (what recovery tools
emit) was rejected outright, even though the PDF handler's xref repair reconstructs it.

Measured on the real document (pymupdf 1.28.0 / mupdf 1.29.0, the pinned pair):

| open call | result |
|---|---|
| `open("spool.bin")` | `FileDataError: … as type bin.` ← the production error |
| `open("spool.bin", filetype="pdf")` | **opens** |
| `open("spool.pdf")` | opens |

The bytes-based call sites already passed `"pdf"` explicitly; only the four path-based
ones were missing it. **Two of the four fail silently**, which is how this hid: scan
detection (`classifier.image_coverage_per_page_from_path`) is wrapped in a bare
`except Exception` that downgrades to text-only signals, and bbox extraction
(`pdf_highlighter.compute_chunk_bboxes_batch`) logs and returns `{}`. So for any
junk-prefixed PDF, scans quietly stopped being detected and chunks quietly got no
bboxes.

Two further sites write a temp file they name `pdf.pdf` themselves and are correctly
left alone (they also carry a warning that renaming them changes markdown offsets).

### 2. An unopenable document was not terminal, so it looped

The two PDF tiers disagreed about how to fail:

| Tier | On an unopenable document | Consequence |
|---|---|---|
| fast (`pypdfium2_fast`) | returns `success=False` | graceful → escalates |
| structured (`pymupdf`) | **raised `ProcessorError`** | see below |

The raise bypasses the whole `if not result.success` block in `vector/processor.py` —
no `record_document_parse_failed`, no `mark_dead_letter`, no failed mark. It lands in
the generic retry handler, where `_drop_reason()` has no branch for it and returns
`"other"`. On that path the document is *deliberately* not marked failed (so the next
scan re-picks it, for the transient-infra case that reason exists for), and the scanner
re-queued it once the placeholder aged past `scan_interval * 5`.

Both fixes are needed: (1) alone still leaves genuinely unopenable documents looping —
a pure zero-fill fails even with `filetype="pdf"`; (2) alone leaves repairable PDFs
unnecessarily rejected.

## Changes

- Pass `filetype="pdf"` at the four path-based opens (`pymupdf.py`, `_isolation.py`,
  `classifier.py`, `search/pdf_highlighter.py`).
- `PyMuPDFProcessor.process_source` returns `success=False` with
  `parse_failed_reason="unreadable"` instead of raising, so the document flows into the
  existing escalate-or-dead-letter path that `oversize` and isolated-worker OOM/timeout
  already use. Caught narrowly — `EmptyFileError` subclasses `FileDataError` so both are
  covered, while pymupdf's own `FileNotFoundError` (the spool vanished) keeps raising,
  since that is an infrastructure fault and must stay retryable.
- Document the new `unreadable` reason on the two metric helpers that carry it.

## Deliberately not done

- **No magic-byte / offset-0 content gate.** It would reject exactly the junk-prefixed
  PDFs that xref repair recovers. The engines' own content recognition is the better
  test; the fix is to make its verdict terminal.
- **No change to the spool suffix.** `.bin` is correct — the spool is format-agnostic
  and shared with non-PDF documents. Naming the type at the call site is narrower.
- **No mime-dispatch rework.** Dispatch is already mime-driven (the registry gates the
  PDF ladder on `application/pdf`; each processor declares `supported_mime_types`),
  which is how other formats will slot in. Worth noting for future work: the mime type
  Nextcloud serves is derived from the **filename extension**, so a corrupt document
  named `.pdf` is announced as `application/pdf` — the claimed type restates the
  filename and is not an observation of the bytes.
- **`unreadable` is not short-circuited to terminal** the way `oversize` is, so it still
  escalates to OCR where OCR is enabled. That matches the existing `error` behavior;
  revisiting it is separate work.

## Testing

Every fix has a regression test **verified to fail without it**:

| Test | Guards |
|---|---|
| `test_unreadable_file_fails_gracefully_instead_of_raising` | defect 2 — returns instead of raising |
| `test_pdf_behind_a_junk_prefix_is_still_read` | defect 1 — reproduces the exact production error message when reverted |
| `test_valid_pdf_parses_from_a_bin_suffixed_spool` | the normal path |
| `test_image_coverage_from_a_bin_spool_path` | defect 1, silent site (scan detection) |
| `test_compute_chunk_bboxes_from_a_bin_spool_path` | defect 1, silent site (bbox extraction) |

Also verified end to end against the real 825 MB document in the exact production shape
(`.bin` spool path + `application/pdf` mime): raised before, now returns
`success=False` → terminal → dead-lettered.

Full unit suite: **2660 passed**. `ruff`, `ruff format`, `ty` clean; secrets scan clean.

**API surface:** none added or changed — no MCP tool, no `/api/v1/*` route, no
cross-service provider/consumer boundary. Per the repo's e2e + contract gate, no new
Pact or integration coverage is owed for this change; the fix is entirely inside the
document-processor layer and is covered at the unit tier.

## Remaining, outside this PR

The 85 affected documents will still produce no text — the largest opens with 0 pages
even once the type is named. They will now dead-letter once instead of looping. Separately,
the tenant sets `DOCUMENT_MAX_PDF_SIZE_MB = 2048`, which is why an 825 MB file cleared
the pre-flight size gate at all; that is a config decision to revisit, not a bug.

---

_This PR was generated with the help of AI, and reviewed by a Human_
