### PR TITLE
refactor(config): derive the field→env map from Settings

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -8,7 +8,7 @@ import re
 import socket
 import ssl
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
@@ -53,7 +53,7 @@ _DEFAULTS: dict[str, Any] = {
     "qdrant_init_backoff_base": 1.0,
     "qdrant_init_backoff_max": 10.0,
     # Keys must uppercase to the env var dynaconf reads (ignore_unknown_envvars):
-    # NEXTCLOUD_OIDC_TOKEN_TYPE / NEXTCLOUD_OIDC_SCOPES, matching _field_map.
+    # NEXTCLOUD_OIDC_TOKEN_TYPE / NEXTCLOUD_OIDC_SCOPES, matching _ENV_OVERRIDE.
     "nextcloud_oidc_token_type": "Bearer",
     "nextcloud_oidc_scopes": "",
     "port": 8000,
@@ -1752,6 +1752,49 @@ class Settings:
         return self.enable_offline_access
 
 
+# ---------------------------------------------------------------------------
+# Field → env-var mapping, derived from ``Settings`` rather than restated.
+#
+# Every setting used to be written three times: once in ``_DEFAULTS`` (the
+# dynaconf key schema), once as a ``Settings`` field, and once in a literal
+# field→env map. The map was 145 entries of which 140 were exactly
+# ``field.upper()``, so it is now computed and only the genuine exceptions are
+# spelled out below.
+# ---------------------------------------------------------------------------
+
+# Fields whose env var is NOT simply the upper-cased field name.
+_ENV_OVERRIDE = {
+    "deployment_mode": "MCP_DEPLOYMENT_MODE",
+    "oidc_client_id": "NEXTCLOUD_OIDC_CLIENT_ID",
+    "oidc_client_secret": "NEXTCLOUD_OIDC_CLIENT_SECRET",
+    "oidc_token_type": "NEXTCLOUD_OIDC_TOKEN_TYPE",
+    "oidc_scopes": "NEXTCLOUD_OIDC_SCOPES",
+}
+
+# Fields ``_build_settings`` computes and assigns explicitly (from the
+# ENABLE_SEMANTIC_SEARCH / ENABLE_BACKGROUND_OPERATIONS resolution and the
+# deployment mode), so they must NOT be filled in from a same-named env var.
+_COMPUTED_FIELDS = frozenset(
+    {
+        "vector_sync_enabled",
+        "enable_offline_access",
+        "enable_login_flow",
+        "enable_multi_user_basic_auth",
+    }
+)
+
+
+def _env_key(field_name: str) -> str:
+    """Return the dynaconf/env key a ``Settings`` field is read from."""
+    return _ENV_OVERRIDE.get(field_name, field_name.upper())
+
+
+# Settings field name -> dynaconf key. Computed fields are excluded.
+_FIELD_MAP = {
+    f.name: _env_key(f.name) for f in fields(Settings) if f.name not in _COMPUTED_FIELDS
+}
+
+
 def _get_semantic_search_enabled() -> bool:
     """Get semantic search enabled status, supporting both old and new variable names.
 
@@ -1940,187 +1983,11 @@ def _build_settings() -> Settings:
     enable_semantic_search = _get_semantic_search_enabled()
     enable_background_operations = _get_background_operations_enabled()
 
-    # Mapping from Settings field name to dynaconf key
-    _field_map = {
-        # Deployment mode (ADR-021)
-        "deployment_mode": "MCP_DEPLOYMENT_MODE",
-        # OAuth/OIDC settings
-        "oidc_discovery_url": "OIDC_DISCOVERY_URL",
-        "oidc_client_id": "NEXTCLOUD_OIDC_CLIENT_ID",
-        "oidc_client_secret": "NEXTCLOUD_OIDC_CLIENT_SECRET",
-        "oidc_issuer": "OIDC_ISSUER",
-        "oidc_resource_server_id": "OIDC_RESOURCE_SERVER_ID",
-        "oidc_token_type": "NEXTCLOUD_OIDC_TOKEN_TYPE",
-        "oidc_scopes": "NEXTCLOUD_OIDC_SCOPES",
-        "oidc_discovery_max_attempts": "OIDC_DISCOVERY_MAX_ATTEMPTS",
-        "oidc_discovery_backoff_base": "OIDC_DISCOVERY_BACKOFF_BASE",
-        "oidc_discovery_backoff_max": "OIDC_DISCOVERY_BACKOFF_MAX",
-        "qdrant_init_max_attempts": "QDRANT_INIT_MAX_ATTEMPTS",
-        "qdrant_init_backoff_base": "QDRANT_INIT_BACKOFF_BASE",
-        "qdrant_init_backoff_max": "QDRANT_INIT_BACKOFF_MAX",
-        "port": "PORT",
-        # Nextcloud settings
-        "nextcloud_host": "NEXTCLOUD_HOST",
-        "nextcloud_username": "NEXTCLOUD_USERNAME",
-        "nextcloud_password": "NEXTCLOUD_PASSWORD",
-        "nextcloud_app_password": "NEXTCLOUD_APP_PASSWORD",
-        "nextcloud_public_issuer_url": "NEXTCLOUD_PUBLIC_ISSUER_URL",
-        "nextcloud_public_url": "NEXTCLOUD_PUBLIC_URL",
-        "cookie_secure": "COOKIE_SECURE",
-        # Nextcloud SSL/TLS settings
-        "nextcloud_verify_ssl": "NEXTCLOUD_VERIFY_SSL",
-        "nextcloud_ca_bundle": "NEXTCLOUD_CA_BUNDLE",
-        "nextcloud_http_keepalive": "NEXTCLOUD_HTTP_KEEPALIVE",
-        # Postgres backend pool sizing (ADR-026)
-        "database_pool_size": "DATABASE_POOL_SIZE",
-        "database_max_overflow": "DATABASE_MAX_OVERFLOW",
-        # ADR-005: Token Audience Validation
-        "nextcloud_mcp_server_url": "NEXTCLOUD_MCP_SERVER_URL",
-        "nextcloud_resource_uri": "NEXTCLOUD_RESOURCE_URI",
-        # Token verification endpoints
-        "jwks_uri": "JWKS_URI",
-        "introspection_uri": "INTROSPECTION_URI",
-        "userinfo_uri": "USERINFO_URI",
-        # NOTE: `enable_multi_user_basic_auth` and `enable_login_flow` no
-        # longer have env-var aliases — both are derived from the resolved
-        # MCP_DEPLOYMENT_MODE in detect_auth_mode() so users only configure
-        # the mode (ADR-022 follow-up).
-        # Token and webhook storage settings
-        "token_encryption_key": "TOKEN_ENCRYPTION_KEY",
-        "token_storage_db": "TOKEN_STORAGE_DB",
-        # Webhook auth (ADR-010)
-        "webhook_secret": "WEBHOOK_SECRET",
-        "webhook_internal_url": "WEBHOOK_INTERNAL_URL",
-        # Vector sync settings (ADR-007)
-        "vector_sync_scan_interval": "VECTOR_SYNC_SCAN_INTERVAL",
-        "vector_sync_processor_workers": "VECTOR_SYNC_PROCESSOR_WORKERS",
-        "vector_sync_fast_concurrency": "VECTOR_SYNC_FAST_CONCURRENCY",
-        "vector_sync_structured_concurrency": "VECTOR_SYNC_STRUCTURED_CONCURRENCY",
-        "vector_sync_queue_max_size": "VECTOR_SYNC_QUEUE_MAX_SIZE",
-        "vector_sync_metrics_refresh_interval": "VECTOR_SYNC_METRICS_REFRESH_INTERVAL",
-        "vector_density_snapshot_enabled": "VECTOR_DENSITY_SNAPSHOT_ENABLED",
-        "vector_density_snapshot_interval": "VECTOR_DENSITY_SNAPSHOT_INTERVAL",
-        "vector_density_snapshot_max_documents": "VECTOR_DENSITY_SNAPSHOT_MAX_DOCUMENTS",
-        "vector_ram_hnsw_overhead_factor": "VECTOR_RAM_HNSW_OVERHEAD_FACTOR",
-        "vector_sync_user_poll_interval": "VECTOR_SYNC_USER_POLL_INTERVAL",
-        "vector_sync_orphan_sweep_enabled": "VECTOR_SYNC_ORPHAN_SWEEP_ENABLED",
-        "health_ready_refresh_interval": "HEALTH_READY_REFRESH_INTERVAL",
-        "vector_sync_tag": "VECTOR_SYNC_TAG",
-        "vector_sync_keyword_tag": "VECTOR_SYNC_KEYWORD_TAG",
-        "vector_sync_empty_discovery_delete_threshold": "VECTOR_SYNC_EMPTY_DISCOVERY_DELETE_THRESHOLD",
-        # Verify-on-read (ADR-019)
-        "verification_concurrency": "VERIFICATION_CONCURRENCY",
-        # Qdrant settings
-        "qdrant_url": "QDRANT_URL",
-        "qdrant_location": "QDRANT_LOCATION",
-        "qdrant_api_key": "QDRANT_API_KEY",
-        "qdrant_collection": "QDRANT_COLLECTION",
-        # Ollama settings
-        "ollama_base_url": "OLLAMA_BASE_URL",
-        "ollama_embedding_model": "OLLAMA_EMBEDDING_MODEL",
-        "ollama_verify_ssl": "OLLAMA_VERIFY_SSL",
-        # OpenAI settings
-        "openai_api_key": "OPENAI_API_KEY",
-        "openai_base_url": "OPENAI_BASE_URL",
-        "openai_embedding_model": "OPENAI_EMBEDDING_MODEL",
-        # Bedrock (AWS) settings
-        "aws_region": "AWS_REGION",
-        "aws_access_key_id": "AWS_ACCESS_KEY_ID",
-        "aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",
-        "bedrock_embedding_model": "BEDROCK_EMBEDDING_MODEL",
-        # Mistral settings
-        "mistral_api_key": "MISTRAL_API_KEY",
-        "mistral_embedding_model": "MISTRAL_EMBEDDING_MODEL",
-        "mistral_base_url": "MISTRAL_BASE_URL",
-        # Simple provider
-        "simple_embedding_dimension": "SIMPLE_EMBEDDING_DIMENSION",
-        # Document chunking settings
-        "document_chunk_size": "DOCUMENT_CHUNK_SIZE",
-        "document_chunk_overlap": "DOCUMENT_CHUNK_OVERLAP",
-        "document_chunk_page_aware": "DOCUMENT_CHUNK_PAGE_AWARE",
-        "document_chunk_page_pack": "DOCUMENT_CHUNK_PAGE_PACK",
-        "chunking_config_version": "CHUNKING_CONFIG_VERSION",
-        "document_pdf_graphics_limit": "DOCUMENT_PDF_GRAPHICS_LIMIT",
-        "document_parse_timeout_seconds": "DOCUMENT_PARSE_TIMEOUT_SECONDS",
-        "document_read_timeout_seconds": "DOCUMENT_READ_TIMEOUT_SECONDS",
-        "document_max_pdf_size_mb": "DOCUMENT_MAX_PDF_SIZE_MB",
-        "webdav_write_max_mb": "WEBDAV_WRITE_MAX_MB",
-        "mcp_dns_rebinding_protection": "MCP_DNS_REBINDING_PROTECTION",
-        "mcp_allowed_hosts": "MCP_ALLOWED_HOSTS",
-        "mcp_allowed_origins": "MCP_ALLOWED_ORIGINS",
-        "cors_allow_origins": "CORS_ALLOW_ORIGINS",
-        "document_markdown_max_pages": "DOCUMENT_MARKDOWN_MAX_PAGES",
-        "pymupdf_extract_images": "PYMUPDF_EXTRACT_IMAGES",
-        "pymupdf_image_dir": "PYMUPDF_IMAGE_DIR",
-        "document_parse_mem_limit_mb": "DOCUMENT_PARSE_MEM_LIMIT_MB",
-        "document_parse_page_window": "DOCUMENT_PARSE_PAGE_WINDOW",
-        "document_parse_process_slots": "DOCUMENT_PARSE_PROCESS_SLOTS",
-        "document_stream_download_enabled": "DOCUMENT_STREAM_DOWNLOAD_ENABLED",
-        "document_spool_dir": "DOCUMENT_SPOOL_DIR",
-        "document_classify_enabled": "DOCUMENT_CLASSIFY_ENABLED",
-        "document_tier1_engine": "DOCUMENT_TIER1_ENGINE",
-        "document_ocr_enabled": "DOCUMENT_OCR_ENABLED",
-        "document_ocr_provider": "DOCUMENT_OCR_PROVIDER",
-        "document_ocr_model": "DOCUMENT_OCR_MODEL",
-        "document_ocr_timeout_seconds": "DOCUMENT_OCR_TIMEOUT_SECONDS",
-        "document_ocr_mode": "DOCUMENT_OCR_MODE",
-        "document_ocr_batch_poll_seconds": "DOCUMENT_OCR_BATCH_POLL_SECONDS",
-        "document_ocr_min_text_quality": "DOCUMENT_OCR_MIN_TEXT_QUALITY",
-        "document_ocr_page_fraction": "DOCUMENT_OCR_PAGE_FRACTION",
-        "document_ocr_min_page_chars": "DOCUMENT_OCR_MIN_PAGE_CHARS",
-        "document_ocr_detect_scanned": "DOCUMENT_OCR_DETECT_SCANNED",
-        "document_glyph_corruption_ratio": "DOCUMENT_GLYPH_CORRUPTION_RATIO",
-        # Docling backend (shared by the OCR backend + images processor). Note:
-        # DOCLING_DO_OCR is intentionally NOT here -- it's read via dynaconf for the
-        # image processor only (the OCR backend always OCRs), like the unstructured_* keys.
-        "docling_api_url": "DOCLING_API_URL",
-        "docling_ocr_lang": "DOCLING_OCR_LANG",
-        "docling_pipeline": "DOCLING_PIPELINE",
-        "docling_vlm_preset": "DOCLING_VLM_PRESET",
-        # Observability settings
-        "metrics_enabled": "METRICS_ENABLED",
-        "metrics_port": "METRICS_PORT",
-        "otel_exporter_otlp_endpoint": "OTEL_EXPORTER_OTLP_ENDPOINT",
-        "otel_exporter_verify_ssl": "OTEL_EXPORTER_VERIFY_SSL",
-        "otel_service_name": "OTEL_SERVICE_NAME",
-        "otel_traces_sampler": "OTEL_TRACES_SAMPLER",
-        "otel_traces_sampler_arg": "OTEL_TRACES_SAMPLER_ARG",
-        "pyroscope_enabled": "PYROSCOPE_ENABLED",
-        "pyroscope_server_address": "PYROSCOPE_SERVER_ADDRESS",
-        "pod_namespace": "POD_NAMESPACE",
-        "pod_name": "POD_NAME",
-        "log_format": "LOG_FORMAT",
-        "log_level": "LOG_LEVEL",
-        "log_include_trace_context": "LOG_INCLUDE_TRACE_CONTEXT",
-        "excluded_tags": "EXCLUDED_TAGS",
-        # MCP decomposition hook points (design §10)
-        "embedding_provider": "EMBEDDING_PROVIDER",
-        "ingest_queue": "INGEST_QUEUE",
-        "mcp_role": "MCP_ROLE",
-        "ingest_stalled_job_seconds": "INGEST_STALLED_JOB_SECONDS",
-        "ingest_doing_max_seconds": "INGEST_DOING_MAX_SECONDS",
-        "ingest_delete_succeeded_jobs": "INGEST_DELETE_SUCCEEDED_JOBS",
-        "ingest_listen_notify": "INGEST_LISTEN_NOTIFY",
-        "ingest_escalation_enabled": "INGEST_ESCALATION_ENABLED",
-        "ingest_transient_max_attempts": "INGEST_TRANSIENT_MAX_ATTEMPTS",
-        "ingest_reclaim_retry_delay_seconds": "INGEST_RECLAIM_RETRY_DELAY_SECONDS",
-        "collection_metadata_source": "COLLECTION_METADATA_SOURCE",
-        "collection_metadata_api_url": "COLLECTION_METADATA_API_URL",
-        "embedding_gateway_url": "EMBEDDING_GATEWAY_URL",
-        "embedding_gateway_model": "EMBEDDING_GATEWAY_MODEL",
-        "embedding_gateway_token_url": "EMBEDDING_GATEWAY_TOKEN_URL",
-        "embedding_gateway_client_id": "EMBEDDING_GATEWAY_CLIENT_ID",
-        "embedding_gateway_client_secret": "EMBEDDING_GATEWAY_CLIENT_SECRET",
-        "embedding_gateway_scope": "EMBEDDING_GATEWAY_SCOPE",
-        "acl_prefilter_enabled": "ACL_PREFILTER_ENABLED",
-        "usage_metering_enabled": "USAGE_METERING_ENABLED",
-    }
-
     # Only pass values that dynaconf actually has; omit unset keys so
     # the Settings dataclass defaults apply.
     kwargs = {
         field: val
-        for field, key in _field_map.items()
+        for field, key in _FIELD_MAP.items()
         if (val := _dget(key)) is not _UNSET
     }
 

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -1771,9 +1771,18 @@ _ENV_OVERRIDE = {
     "oidc_scopes": "NEXTCLOUD_OIDC_SCOPES",
 }
 
-# Fields ``_build_settings`` computes and assigns explicitly (from the
-# ENABLE_SEMANTIC_SEARCH / ENABLE_BACKGROUND_OPERATIONS resolution and the
-# deployment mode), so they must NOT be filled in from a same-named env var.
+# Derived fields with no env var of their own, so there is nothing to map:
+# ``vector_sync_enabled``/``enable_offline_access`` come from the
+# ENABLE_SEMANTIC_SEARCH / ENABLE_BACKGROUND_OPERATIONS resolution, and
+# ``enable_login_flow``/``enable_multi_user_basic_auth`` from the deployment
+# mode (the latter two aren't even dynaconf keys — see ``_DEFAULTS``).
+#
+# Excluding them is currently belt-and-braces rather than load-bearing: both
+# assignment sites are unconditional (``_build_settings`` overwrites the two
+# resolution-derived fields right after the comprehension, and
+# ``__post_init__`` recomputes the two mode-derived ones), so an entry here
+# would be inert rather than unsafe. It becomes load-bearing the moment
+# either site is made conditional — keep the derivation the only writer.
 _COMPUTED_FIELDS = frozenset(
     {
         "vector_sync_enabled",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -158,7 +158,7 @@ class TestGetSettings:
         """DOCUMENT_OCR_MODE / batch tuning must reach settings (regression).
 
         These were added to _DEFAULTS + the Settings dataclass but initially
-        omitted from _field_map, so dynaconf silently ignored the env vars and
+        omitted from _FIELD_MAP, so dynaconf silently ignored the env vars and
         batch mode could never be enabled in production (Deck #332).
         """
         _reload_config()
@@ -174,7 +174,7 @@ class TestGetSettings:
     def test_get_settings_empty_discovery_threshold_from_env(self):
         """VECTOR_SYNC_EMPTY_DISCOVERY_DELETE_THRESHOLD must reach settings.
 
-        Guards against the _DEFAULTS / _field_map omission that has silently
+        Guards against the _DEFAULTS / _FIELD_MAP omission that has silently
         dropped env vars before (cf. OCR batch mode #332): the setting is added
         in all three places (defaults, dataclass, field map).
         """
@@ -200,7 +200,7 @@ class TestGetSettings:
     def test_get_settings_pyroscope_from_env(self):
         """PYROSCOPE_ENABLED / _SERVER_ADDRESS must reach settings (Deck #655).
 
-        Guards against the _DEFAULTS / _field_map omission that has silently
+        Guards against the _DEFAULTS / _FIELD_MAP omission that has silently
         dropped other observability env vars before (cf. OCR batch mode, #332).
         """
         _reload_config()
@@ -217,7 +217,7 @@ class TestGetSettings:
         """POD_NAMESPACE / POD_NAME must reach settings (Deck #48).
 
         Same guard as the pyroscope pair above: these are what tag profiles and
-        make a tenant's profiles separable, and a missing _DEFAULTS / _field_map
+        make a tenant's profiles separable, and a missing _DEFAULTS / _FIELD_MAP
         entry would silently drop them with no other test noticing.
         """
         _reload_config()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,11 +2,19 @@
 
 import logging
 import os
+from dataclasses import fields
 from unittest.mock import patch
 
 import pytest
 
-from nextcloud_mcp_server.config import Settings, _reload_config, get_settings
+from nextcloud_mcp_server.config import (
+    _COMPUTED_FIELDS,
+    _ENV_OVERRIDE,
+    _FIELD_MAP,
+    Settings,
+    _reload_config,
+    get_settings,
+)
 
 
 class TestQdrantConfigValidation:
@@ -855,3 +863,40 @@ class TestNextcloudBrowserUrl:
         """Returns None when no Nextcloud URL is configured at all."""
         settings = Settings()
         assert settings.nextcloud_browser_url is None
+
+
+class TestFieldMapDerivation:
+    """``_FIELD_MAP`` is derived from ``Settings`` rather than restated.
+
+    These guard the derivation that replaced a 145-entry literal. The failure
+    they exist to catch is silent: add a ``Settings`` field whose env var is not
+    ``FIELD.upper()`` and forget ``_ENV_OVERRIDE``, and the field simply never
+    picks up its env var — no error, just a setting that ignores configuration.
+    """
+
+    def test_covers_every_non_computed_field(self):
+        """Every Settings field is mapped unless it is explicitly computed."""
+        expected = {f.name for f in fields(Settings)} - _COMPUTED_FIELDS
+        assert set(_FIELD_MAP) == expected
+
+    def test_computed_fields_are_never_mapped(self):
+        """Computed fields must not be fillable from a same-named env var.
+
+        ``_build_settings`` assigns these from the semantic-search /
+        background-operations resolution; a mapping entry would let a stray env
+        var win over that logic.
+        """
+        assert _COMPUTED_FIELDS.isdisjoint(_FIELD_MAP)
+
+    def test_overrides_are_the_only_non_identity_mappings(self):
+        """Anything not in _ENV_OVERRIDE maps to the upper-cased field name."""
+        non_identity = {f: k for f, k in _FIELD_MAP.items() if k != f.upper()}
+        assert non_identity == _ENV_OVERRIDE
+
+    def test_every_override_names_a_real_field(self):
+        """A renamed or deleted field must not leave a stale override behind."""
+        assert set(_ENV_OVERRIDE) <= {f.name for f in fields(Settings)}
+
+    def test_every_computed_field_is_a_real_field(self):
+        """Same for the computed-field exclusions."""
+        assert _COMPUTED_FIELDS <= {f.name for f in fields(Settings)}


### PR DESCRIPTION
## Context

PR **4 of 5** in the over-engineering sweep (Deck card #914, board 12), part of
stack #1191.

Every setting was written three times: once in `_DEFAULTS` (the dynaconf key
schema), once as a `Settings` dataclass field, and once in a literal field→env
map inside `_build_settings`. That map had **145 entries, 140 of them exactly
`field.upper()`**.

## What changed

The map is now computed from `dataclasses.fields(Settings)`. Only the genuine
exceptions are written down:

- **`_ENV_OVERRIDE`** — the five fields whose env var is not the upper-cased
  field name (`deployment_mode` → `MCP_DEPLOYMENT_MODE`, plus the four
  `NEXTCLOUD_OIDC_*`).
- **`_COMPUTED_FIELDS`** — the four fields `_build_settings` assigns itself from
  the semantic-search / background-operations resolution. These must stay
  unmapped: an entry would let a stray same-named env var win over that logic,
  which is why two of them are not declared to dynaconf at all.

**Verified byte-identical before deleting the literal** — all 145 keys and
values matched, so this is pure de-duplication with no behaviour change.

## The guard tests

`TestFieldMapDerivation` exists because the failure mode is silent: add a field
whose env var isn't `FIELD.upper()`, forget `_ENV_OVERRIDE`, and the setting
just quietly ignores its env var — no error, no log.

I checked the guards fail on a *real* mistake rather than passing vacuously: a
stale override naming a deleted field trips two of them; a harmless new
identity-mapped field trips none.

## Scope: this does not close #870 on its own

`_DEFAULTS` still restates the 147 defaults the dataclass already carries (I
diffed them: 147 agree, 0 mismatches, 2 deliberately absent). Collapsing that
too needs a structural change — `_DEFAULTS` is consumed by the module-level
`Dynaconf(...)` call, which runs *before* `Settings` exists — so it wants either
a `Settings` extraction into its own module or a lazily-built `_dynaconf`. That
is deliberately left out rather than bundled into a de-duplication PR.

Three items from the audit that I dropped after checking them properly, all
worth their own decision:

- **`DOCUMENT_TIER1_ENGINE` is live**, not dead — read at
  `document_processors/registry.py:353` and `escalation.py:84`. My original
  detection was wrong.
- **`NEXTCLOUD_APP_PASSWORD` is unread but advertised** in
  `settings.toml.example` and ADR-022, and the dataclass comments it as
  "preferred over `nextcloud_password`". That preference is not implemented
  anywhere — a likely bug, not dead config, so deleting it would silently break
  a published setting.
- **`OTEL_TRACES_SAMPLER`**: the OTel SDK reads this env var natively, but it
  *warns and defaults* on a bad value where our `Validator` hard-fails at
  startup. The validator is a real guard, so it stays.

## Verification

- `ruff check`, `ruff format --check`, `ty check` — clean
- `pytest tests/unit/` — 2647 passed
- `sonar analyze secrets` — clean

No API surface changes.

---

_This PR was generated with the help of AI, and reviewed by a Human_

> **CI coverage note.** While this PR targets a feature branch rather than
> `master`, the unit/integration/pact workflows are gated on
> `pull_request: branches: [master]` and **do not run on it** — it receives only
> the always-on checks (SonarCloud, claude-review, CLA). Treat it as untested by
> CI until it reaches trunk; the verification above is from local runs.
