### PR TITLE
docs(tools): drop shell metacharacters from tool descriptions (fixes 29 tools dropped by anti-injection gateways)

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -2181,7 +2181,7 @@ def get_nextcloud_http_keepalive() -> bool:
 
     Returns:
         - False if NEXTCLOUD_HTTP_KEEPALIVE=false (fresh connection per
-          request; mitigates the poisoned-keep-alive truncation in #965).
+          request, mitigates the poisoned-keep-alive truncation in #965).
         - True otherwise (default pooled keep-alive behavior).
     """
     return get_settings().nextcloud_http_keepalive

--- a/nextcloud_mcp_server/server/collectives.py
+++ b/nextcloud_mcp_server/server/collectives.py
@@ -461,7 +461,7 @@ def configure_collectives_tools(mcp: FastMCP):
         """Move a page to trash in a Nextcloud Collective (soft delete).
 
         Trashed pages can be restored with collectives_restore_page. The
-        Collectives API does not support permanent page deletion; trashed
+        Collectives API does not support permanent page deletion. Trashed
         pages are cleaned up by Nextcloud's retention policy.
 
         Args:

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -456,7 +456,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
                 - ``fn`` (str): Formatted full name.
                 - ``email`` (str): Email address. **Update path supports plain
-                  strings only**; dict / list-form inputs are not applied — the
+                  strings only**. Dict / list-form inputs are not applied — the
                   existing EMAIL line is preserved unchanged and a warning is
                   logged. Use create_contact for multi-entry support with TYPE
                   annotations.
@@ -468,15 +468,15 @@ def configure_contacts_tools(mcp: FastMCP):
                 - ``note`` (str): Free-form note.
                 - ``nickname`` (str or list of str).
                 - ``bday`` (ISO date str ``"YYYY-MM-DD"`` or ``datetime.date``).
-                  Non-ISO strings are rejected with a warning; the existing
+                  Non-ISO strings are rejected with a warning. The existing
                   BDAY line is preserved.
                 - ``categories`` (list of str, or comma-separated str).
                 - ``url`` (str or list of str). Only the first URL is written
-                  on update; multi-URL contacts should use create_contact.
+                  on update. Multi-URL contacts should use create_contact.
 
                 Example: ``{"fn": "Jane Doe", "email": "jane.doe@example.com"}``.
             etag: Optional ETag for optimistic concurrency control. Pass the
-                value from a previous read or update; the update is rejected if
+                value from a previous read or update. The update is rejected if
                 the contact changed since.
 
         Returns:

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -812,7 +812,7 @@ def configure_deck_tools(mcp: FastMCP):
             include_users: Include the board's user list (default True). Set
                 False to reduce response size when users are not needed.
             include_labels: Include the board's label definitions (default
-                True). Set False to reduce response size; labels can still be
+                True). Set False to reduce response size. Labels can still be
                 retrieved via deck_get_labels.
         """
         client = await get_client(ctx)
@@ -851,9 +851,9 @@ def configure_deck_tools(mcp: FastMCP):
         Args:
             board_id: The ID of the board
             include_cards: Include cards inside each stack (default True). Set
-                False for a lightweight stack listing; fetch cards separately
+                False for a lightweight stack listing. Fetch cards separately
                 via deck_get_cards.
-            detail: "summary" (default) returns compact card rows; "full"
+            detail: "summary" (default) returns compact card rows. "full"
                 returns the complete card objects (the old behavior).
             status: Which cards to include — "open" (default), "done",
                 "archived", or "all". The first three partition the board
@@ -934,7 +934,7 @@ def configure_deck_tools(mcp: FastMCP):
     ) -> DeckStack:
         """Get details of a specific Nextcloud Deck stack.
 
-        Cards are returned as compact summaries by default; see
+        Cards are returned as compact summaries by default. See
         deck_get_stacks for the shared parameter semantics.
 
         Args:
@@ -943,7 +943,7 @@ def configure_deck_tools(mcp: FastMCP):
             include_cards: Include cards in the stack (default True).
             detail: "summary" (default) or "full".
             status: "open" (default), "done", "archived", or "all"
-                (non-overlapping; a done+archived card counts as "archived").
+                (non-overlapping, a done+archived card counts as "archived").
                 "archived"/"all" include archived cards, which the active
                 listing endpoint omits — this costs one extra API call.
             label: If set, only cards carrying a label with this exact title.
@@ -1022,7 +1022,7 @@ def configure_deck_tools(mcp: FastMCP):
         This is the archived-only shortcut: it returns *only* archived cards
         in a single call. The active list tools (deck_get_cards,
         deck_get_stacks, deck_get_board_overview) also include archived cards
-        when called with status="archived"/"all"; use this tool when you want
+        when called with status="archived"/"all". Use this tool when you want
         archived cards exclusively and don't need the open ones. Typical use:
         auditing completed work archived off the active board (e.g. cards moved
         through a "Done" stack and then archived via deck_archive_card). The
@@ -1094,7 +1094,7 @@ def configure_deck_tools(mcp: FastMCP):
         Args:
             board_id: The ID of the board
             stack_id: The ID of the stack
-            detail: "summary" (default) returns compact card rows; "full"
+            detail: "summary" (default) returns compact card rows. "full"
                 returns the complete card objects.
             status: "open" (default), "done", "archived", or "all". The first
                 three partition the board (a done+archived card counts as
@@ -1165,7 +1165,7 @@ def configure_deck_tools(mcp: FastMCP):
         board" / "what's in progress" style requests on large boards — it is
         the token-efficient way to view board *state*. It intentionally omits
         the board-management fields (ACL, user list, full label objects) that
-        deck_get_board exposes; reach for deck_get_board when you need those.
+        deck_get_board exposes. Reach for deck_get_board when you need those.
 
         Args:
             board_id: The ID of the board
@@ -1625,7 +1625,7 @@ def configure_deck_tools(mcp: FastMCP):
         a card marked done keeps its done state but its done timestamp is reset
         to the time of the move.
 
-        target_stack_id must be a stack on target_board_id; the move is
+        target_stack_id must be a stack on target_board_id. The move is
         rejected otherwise.
 
         Args:
@@ -1871,7 +1871,7 @@ def configure_deck_tools(mcp: FastMCP):
             card_id: The ID of the card
             limit: Maximum number of comments to return (default 20, max 200)
             offset: Pagination offset (default 0)
-            detail: "summary" (default) returns compact comments; "full"
+            detail: "summary" (default) returns compact comments. "full"
                 returns the complete comment objects.
             message_max_length: If set, truncate each comment message to this
                 many characters.
@@ -1922,15 +1922,15 @@ def configure_deck_tools(mcp: FastMCP):
 
         Check the length before calling and pick `overflow` accordingly:
 
-        - 1000 characters or fewer: call as-is; `overflow` is ignored.
+        - 1000 characters or fewer: call as-is. `overflow` is ignored.
         - Longer, and the text is meant to be read on the card (activity
           updates, run summaries, changelogs): pass overflow="split" up front
           rather than guessing a shorter message. The text is cut at markdown
           heading, then paragraph, then line, then sentence, then word
           boundaries -- never mid-word -- each part is prefixed "(i/N)", and
           parts 2..N are posted as replies to part 1 so the card shows one
-          thread. @-mentions are never split across parts. At most 10 parts;
-          past that, write the content to a note (nc_notes_create_note) or a
+          thread. @-mentions are never split across parts. At most 10 parts.
+          Past that, write the content to a note (nc_notes_create_note) or a
           file (nc_webdav_write_file), attach it with deck_attach_note /
           deck_attach_file, and post a short pointer comment instead.
         - Longer, and you would rather shorten it yourself: leave the default
@@ -1951,7 +1951,7 @@ def configure_deck_tools(mcp: FastMCP):
                 splitting, part 1 replies to this comment and parts 2..N reply
                 to part 1.
             overflow: What to do when the message exceeds 1000 characters.
-                "error" (the default) posts nothing and explains the overage;
+                "error" (the default) posts nothing and explains the overage.
                 "split" posts the message as multiple threaded comments.
 
         Returns:
@@ -2000,7 +2000,7 @@ def configure_deck_tools(mcp: FastMCP):
         follow-up comment with deck_create_card_comment instead of growing an
         existing one past the limit.
 
-        Only the comment's author can update it; the server returns 403
+        Only the comment's author can update it. The server returns 403
         otherwise.
 
         Args:
@@ -2045,7 +2045,7 @@ def configure_deck_tools(mcp: FastMCP):
     ) -> CardCommentOperationResponse:
         """Delete a Nextcloud Deck card comment
 
-        Only the comment's author can delete it; the server returns 403 otherwise.
+        Only the comment's author can delete it. The server returns 403 otherwise.
 
         Args:
             card_id: The ID of the card the comment belongs to
@@ -2087,8 +2087,8 @@ def configure_deck_tools(mcp: FastMCP):
         """Attach an existing Nextcloud file to a Deck card without copying.
 
         Creates a share of ``path`` with the card (``shareType=12``,
-        ``shareWith=<card_id>``). The file stays in its original location;
-        clicking the attachment in the Deck UI opens the file in place.
+        ``shareWith=<card_id>``). The file stays in its original location.
+        Clicking the attachment in the Deck UI opens the file in place.
 
         Generic over the user's Files: works for any file the caller can
         read — markdown notes, PDFs, images, spreadsheets, etc. Use
@@ -2134,7 +2134,7 @@ def configure_deck_tools(mcp: FastMCP):
         Convenience wrapper: looks up the note's filesystem path from the
         Notes app settings + note metadata, then shares the file with the
         card (same mechanism as :func:`deck_attach_file`). The note remains
-        editable in the Notes app; the card just shows a clickable link to
+        editable in the Notes app. The card just shows a clickable link to
         it.
 
         Path is reconstructed as ``<notes_folder>/<category>/<title>.md``.
@@ -2202,7 +2202,7 @@ def configure_deck_tools(mcp: FastMCP):
         """Delete an attachment from a Nextcloud Deck card.
 
         For ``type="file"`` attachments this removes the share linking the
-        file to the card; the underlying file in the user's Files is left
+        file to the card. The underlying file in the user's Files is left
         untouched. For ``type="deck_file"`` blobs the binary is deleted from
         Deck's storage.
 

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -135,7 +135,7 @@ def configure_mail_tools(mcp: FastMCP):
     ) -> ListMessagesResponse:
         """List message envelopes in a mailbox, newest first (requires mail.read scope).
 
-        Reads cached envelope metadata (fast); does not fetch bodies. Use
+        Reads cached envelope metadata (fast). Does not fetch bodies. Use
         nc_mail_get_message to fetch a full body.
 
         Args:
@@ -148,7 +148,7 @@ def configure_mail_tools(mcp: FastMCP):
             ListMessagesResponse with message summaries. ``has_more`` is a
             heuristic (true when exactly ``limit`` messages were returned), so it
             can be a false positive when a mailbox holds exactly ``limit``
-            messages; page with ``cursor`` and stop on an empty result.
+            messages. Page with ``cursor`` and stop on an empty result.
         """
         client = await get_client(ctx)
         # Clamp to the same window the client/OCS API enforce so the has_more
@@ -325,7 +325,7 @@ def configure_mail_tools(mcp: FastMCP):
 
         Returns:
             GetAttachmentResponse with name, mime, size, and content. ``content``
-            is the attachment body base64-encoded; large attachments produce a
+            is the attachment body base64-encoded. Large attachments produce a
             correspondingly large response, so prefer the ``size`` from the
             message's attachment list before fetching.
         """

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -213,7 +213,7 @@ def configure_semantic_tools(mcp: FastMCP):
         similarity, natural language) and BM25 sparse vectors (precise
         keyword/acronym matching), fused in the database for optimal relevance.
         Documents indexed keyword-only (``keyword-index`` tag) carry no dense
-        vector and so contribute via the BM25 sparse side only; they appear in the
+        vector and so contribute via the BM25 sparse side only. They appear in the
         same unified result set.
 
         Requires VECTOR_SYNC_ENABLED=true. Supports indexing of notes, files,
@@ -230,13 +230,13 @@ def configure_semantic_tools(mcp: FastMCP):
             include_context: Whether to expand results with surrounding context (default: False)
             context_chars: Number of characters to include before/after matched chunk (default: 300)
             modified_after: Only return documents whose last-modified time is at or after this
-                instant. Accepts an RFC 3339 / ISO 8601 datetime (e.g. "2026-01-01T00:00:00Z";
+                instant. Accepts an RFC 3339 / ISO 8601 datetime (e.g. "2026-01-01T00:00:00Z",
                 a naive datetime is treated as UTC) or Unix seconds. None = no lower bound
                 (default).
             modified_before: Only return documents whose last-modified time is at or before this
                 instant. Same formats as modified_after. None = no upper bound (default). Must be
                 >= modified_after when both are supplied.
-            path_prefix: Deprecated single-folder filter; prefer path_prefixes. Restrict to files
+            path_prefix: Deprecated single-folder filter. Prefer path_prefixes. Restrict to files
                 under this folder/path (e.g. "/Projects/Reports"). Folded into path_prefixes.
             path_prefixes: Restrict to files under any of these folders/paths (OR-ed), e.g.
                 ["/Projects/Reports", "/Shared/Specs"]. Matches the file_path of indexed files
@@ -248,7 +248,7 @@ def configure_semantic_tools(mcp: FastMCP):
 
             Verification fields (ADR-019 verify-on-read):
             - verified_chunk_count: chunk rows that passed access checks
-              (sized in chunks; counted before trimming to ``limit``, so it
+              (sized in chunks, counted before trimming to ``limit``, so it
               can exceed ``len(results)`` when a doc has multiple matching
               chunks).
             - dropped_document_count: unique ``(doc_id, doc_type)`` pairs
@@ -782,7 +782,7 @@ def configure_semantic_tools(mcp: FastMCP):
         the full note body via ``client.notes.get_note`` after upstream
         verify-on-read has already round-tripped to the same endpoint as a
         race guard (ADR-019). Expect one additional Nextcloud round-trip per
-        note result; raising ``limit`` above the default of 5 amplifies this
+        note result. Raising ``limit`` above the default of 5 amplifies this
         cost roughly linearly. File / news / deck results do not pay this
         cost — they reuse the verified excerpt.
         """

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -168,7 +168,7 @@ def configure_sharing_tools(mcp: FastMCP):
             minute precision: a link expires at 00:00:00 on ``expireDate`` in
             the owner's timezone (i.e. the end of the day before ``expireDate``).
             The requested window is rounded up so the link stays valid at least
-            that long; ``expires_at`` reports the precise requested instant, but
+            that long. ``expires_at`` reports the precise requested instant, but
             the link may remain valid until the end of that day server-side. To
             revoke earlier, call ``nc_share_delete`` with the returned
             ``share_id``.

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -56,7 +56,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         """List the user's Talk conversations (rooms).
 
         Args:
-            modified_since: Optional Unix timestamp; only conversations
+            modified_since: Optional Unix timestamp. Only conversations
                 modified after this time are returned.
             include_status: Whether to include user-status info for
                 one-to-one conversations.
@@ -102,13 +102,13 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         """Read chat history for a Talk conversation.
 
         Returns the most recent messages (older first when paginated).
-        Does not move the user's read marker; call
+        Does not move the user's read marker. Call
         ``talk_mark_as_read`` separately if desired.
 
         Args:
             token: Conversation token.
             limit: Max messages per page. Valid range is 1-200 (spreed
-                caps server-side at 200); values outside this range are
+                caps server-side at 200). Values outside this range are
                 clamped. Default 50.
             last_known_message_id: Pagination cursor — pass the
                 ``last_known_message_id`` from the previous response to

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -227,7 +227,7 @@ def configure_webdav_tools(mcp: FastMCP):
                   scanned one escalates to OCR when the server has OCR enabled.
                 - ``"markdown"``: additionally reconstruct structure (headings,
                   tables) rather than returning a flat text layer. Costs a
-                  second, slower parse and is bounded by a page ceiling; when it
+                  second, slower parse and is bounded by a page ceiling, when it
                   cannot be honoured the response says so instead of pretending.
                 - ``"raw"``: do not parse. Text files are decoded, anything else
                   comes back base64-encoded.
@@ -422,10 +422,10 @@ def configure_webdav_tools(mcp: FastMCP):
         overwritten. What happens depends on ``if_match`` (see below).
 
         Raises ``ToolError`` when ``EXCLUDED_TAGS`` is configured and the
-        target path (or an ancestor folder) carries an excluded system tag;
-        when the decoded content exceeds ``WEBDAV_WRITE_MAX_MB``; when the
+        target path (or an ancestor folder) carries an excluded system tag,
+        when the decoded content exceeds ``WEBDAV_WRITE_MAX_MB``, when the
         write conflicts with a concurrent edit or an existing/missing file
-        (412); or when the file is locked by another client (423) -- see
+        (412), or when the file is locked by another client (423) -- see
         ``if_match`` below.
 
         Args:
@@ -438,7 +438,7 @@ def configure_webdav_tools(mcp: FastMCP):
                   existing file you must first read it with
                   ``nc_webdav_read_file`` and pass the etag it returned.
                 - Pass that **etag** to overwrite the file only if it has not
-                  changed since you read it; if someone edited it in the
+                  changed since you read it. If someone edited it in the
                   meantime (e.g. in the Nextcloud web UI) the write fails --
                   re-read and retry deliberately rather than looping.
                 - Pass the literal ``"*"`` to **force-overwrite** an existing
@@ -446,13 +446,13 @@ def configure_webdav_tools(mcp: FastMCP):
 
         Returns:
             ``WriteFileResponse`` with ``path``, ``status_code``, ``size``,
-            ``created`` (True when a new file was created, i.e. HTTP 201; False
+            ``created`` (True when a new file was created, i.e. HTTP 201, False
             when an existing file was overwritten, i.e. HTTP 204) and ``etag``.
 
             ``etag`` is the file as just written — pass it straight back as
             ``if_match`` on the next write to chain edits without an intervening
             read. It is ``None`` when the server did not return one (some
-            proxies strip it); re-read the file to obtain it in that case.
+            proxies strip it). Re-read the file to obtain it in that case.
         """
         client = await get_client(ctx)
 
@@ -597,7 +597,7 @@ def configure_webdav_tools(mcp: FastMCP):
                 nc_webdav_read_file or nc_webdav_write_file). The move then
                 replaces the destination only if it is still that exact version,
                 so ``overwrite=True`` cannot clobber a file someone else changed
-                in the meantime. Requires ``overwrite=True``; ``"*"`` is not
+                in the meantime. Requires ``overwrite=True``. ``"*"`` is not
                 accepted. Files only — a directory destination always fails the
                 check with 412.
 
@@ -668,7 +668,7 @@ def configure_webdav_tools(mcp: FastMCP):
                 nc_webdav_read_file or nc_webdav_write_file). The copy then
                 replaces the destination only if it is still that exact version,
                 so ``overwrite=True`` cannot clobber a file someone else changed
-                in the meantime. Requires ``overwrite=True``; ``"*"`` is not
+                in the meantime. Requires ``overwrite=True``. ``"*"`` is not
                 accepted. Files only — a directory destination always fails the
                 check with 412.
 

--- a/tests/test_tool_description_metacharacters.py
+++ b/tests/test_tool_description_metacharacters.py
@@ -1,0 +1,94 @@
+"""Guard against shell metacharacters in MCP tool descriptions.
+
+Anti-injection MCP gateways (e.g. IBM mcp-context-forge) refuse to expose a tool
+whose description contains shell metacharacters. The tool is silently dropped
+from ``tools/list``: the server starts fine, the gateway reports no error, and
+the tool simply never reaches the client.
+
+Semicolons used as ordinary English punctuation are enough to trigger this. See
+https://github.com/cbcoutinho/nextcloud-mcp-server/issues/1183, where 29 of 162
+tools were dropped this way -- including ``nc_webdav_read_file``, without which
+the server has little use.
+
+Because docstrings are the descriptions, this is a documentation-style rule and
+a static check over the source is enough: it needs no Nextcloud instance.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+METACHARACTERS = ("&&", ";", "||", "$(", "> ", "< ")
+
+# Tools whose description legitimately contains a metacharacter inside a quoted
+# literal, where removing it would document invalid syntax. These stay dropped
+# by strict gateways -- a deliberate trade-off, not an oversight.
+ALLOWED_TOOLS = {
+    "nc_calendar_create_event",  # RFC 5545: ``DTSTART;TZID=`` and ``FREQ=...;BYDAY=``
+    "nc_webdav_write_file",  # MIME: ``'type;base64'``
+}
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent / "nextcloud_mcp_server"
+
+
+def _iter_tool_docstrings():
+    """Yield (tool_name, docstring, path) for every ``@mcp.tool``-decorated function."""
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - defensive
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not any("tool" in ast.dump(d) for d in node.decorator_list):
+                continue
+            docstring = ast.get_docstring(node)
+            if docstring:
+                yield node.name, docstring, path
+
+
+def test_tool_descriptions_have_no_shell_metacharacters():
+    offenders = []
+    for name, docstring, path in _iter_tool_docstrings():
+        if name in ALLOWED_TOOLS:
+            continue
+        found = sorted({m for m in METACHARACTERS if m in docstring})
+        if found:
+            offenders.append(f"{path.name}::{name} contains {found}")
+
+    assert not offenders, (
+        "Tool descriptions must not contain shell metacharacters, or "
+        "anti-injection gateways will silently drop these tools:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nUse ordinary punctuation instead (a period or a comma rather than "
+        "a semicolon). If the character is required syntax that cannot be "
+        "reworded, add the tool to ALLOWED_TOOLS with a comment explaining why."
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """An allowlisted tool that no longer needs it should leave the allowlist."""
+    names = {name for name, _, _ in _iter_tool_docstrings()}
+    unknown = ALLOWED_TOOLS - names
+    assert not unknown, f"ALLOWED_TOOLS references unknown tools: {sorted(unknown)}"
+
+    still_needed = {
+        name
+        for name, docstring, _ in _iter_tool_docstrings()
+        if name in ALLOWED_TOOLS
+        and any(m in docstring for m in METACHARACTERS)
+    }
+    obsolete = ALLOWED_TOOLS - still_needed
+    assert not obsolete, (
+        f"These tools no longer contain metacharacters and should be removed "
+        f"from ALLOWED_TOOLS: {sorted(obsolete)}"
+    )
+
+
+@pytest.mark.parametrize("metacharacter", METACHARACTERS)
+def test_detector_catches_each_metacharacter(metacharacter):
+    """Positive control: the rule must actually fire on each metacharacter."""
+    docstring = f"Does a thing{metacharacter}then another thing."
+    assert any(m in docstring for m in METACHARACTERS)

--- a/tests/test_tool_description_metacharacters.py
+++ b/tests/test_tool_description_metacharacters.py
@@ -77,8 +77,7 @@ def test_allowlist_has_no_stale_entries():
     still_needed = {
         name
         for name, docstring, _ in _iter_tool_docstrings()
-        if name in ALLOWED_TOOLS
-        and any(m in docstring for m in METACHARACTERS)
+        if name in ALLOWED_TOOLS and any(m in docstring for m in METACHARACTERS)
     }
     obsolete = ALLOWED_TOOLS - still_needed
     assert not obsolete, (


### PR DESCRIPTION
Fixes the dropped-tools problem reported in #1183.

## The problem

Anti-injection MCP gateways (IBM `mcp-context-forge`, and others applying the same heuristic) refuse to expose a tool whose **description** contains a shell metacharacter. The tool is dropped from `tools/list` *without an error*: the server starts fine, the gateway reports nothing, and the tool simply never reaches the client.

Semicolons used as ordinary English punctuation are enough to trigger it. On `0.154.1`, **29 of 162 tools** are affected — including `nc_webdav_read_file`, without which the server has little use (you can list files but not read them).

It is not a one-off: the count grew from **26 to 29 between 0.154.0 and 0.154.1**. Every new docstring written in the same (perfectly good) English style adds another dropped tool.

## What this PR changes

**45 semicolons** rewritten as a period or a comma, across 9 files — whichever the sentence calls for:

- a **period** when the following clause stands on its own — `…compact summaries by default. See …`
- a **comma** when it is part of an enumeration or sits inside parentheses — `…system tag, when the decoded content exceeds …, (412), or when the file is locked …`

Splitting those enumerations into sentences would have produced fragments like *"When the decoded content exceeds `WEBDAV_WRITE_MAX_MB`."* or *"Or when the file is locked by another client (423)"*, so the distinction is deliberate rather than mechanical.

## Three semicolons are deliberately left in place

They are **required syntax, not punctuation** — rewriting them would document values that do not work:

| Tool | Literal | Why |
|---|---|---|
| `nc_calendar_create_event` | ``DTSTART;TZID=…`` and `"FREQ=WEEKLY;BYDAY=MO,WE,FR"` | RFC 5545 |
| `nc_webdav_write_file` | `'type;base64'` | MIME |

Those two tools therefore **remain dropped by strict gateways**. That is a trade-off in favour of correct documentation, and it is recorded in the test's `ALLOWED_TOOLS` with the reason. Happy to revisit if you would rather reword the examples.

## The test

`tests/test_tool_description_metacharacters.py` walks the tool docstrings with `ast`, so it needs **no Nextcloud instance and no network** — it is a documentation-style rule, checked statically.

It also fails when an allowlist entry becomes *obsolete*, so an exemption cannot outlive its reason.

Verified both ways: the test **passes on this branch**, and **fails on `main`** listing each offending tool — so it is a real guard, not a green light.

```
E    config.py::get_nextcloud_http_keepalive contains [';']
E    collectives.py::collectives_trash_page contains [';']
E    contacts.py::nc_contacts_update_contact contains [';']
E    deck.py::deck_get_board contains [';']
    …
```

No existing test pins a tool description, so nothing else is affected. Only docstrings change — no behaviour, no signatures.
