### PR TITLE
fix(calendar): expand VTODO recurrences client-side

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -137,3 +137,30 @@ await nc_calendar_complete_todo(
 
 Not idempotent: a second call without an explicit `completed` restamps the
 timestamp.
+
+## Recurring todos
+
+CalDAV does not expand VTODO recurrences: a `calendar-query` returns only the
+master component, whose `DTSTART`/`DUE` describe the **first** instance of the
+series. A chore created in 2023 that repeats every June therefore keeps
+reporting `due: "2023-06-15"` forever, which reads as "three years overdue" even
+though the current instance ran a few weeks ago.
+
+`nc_calendar_list_todos` and `nc_calendar_search_todos` expand the recurrence
+set client-side and add four fields to recurring todos:
+
+| Field | Meaning |
+|-------|---------|
+| `recurring` | `true` when the todo has an `RRULE` |
+| `recurrence_rule` | The RFC 5545 rule, e.g. `FREQ=YEARLY` |
+| `current_dtstart` | Start of the currently relevant occurrence |
+| `current_due` | Due date of the currently relevant occurrence |
+
+"Currently relevant" is the most recent occurrence that has already started, or
+the first upcoming one if the series has not started yet.
+
+`dtstart`/`due` are deliberately left as stored, so updates keep addressing the
+series rather than a single instance. **When judging whether a recurring todo is
+overdue, read `current_due`, not `due`.** If the occurrence cannot be resolved
+(no `DTSTART` to anchor the rule, or an unexpandable rule) the `current_*`
+fields are omitted rather than guessed.

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -147,20 +147,33 @@ reporting `due: "2023-06-15"` forever, which reads as "three years overdue" even
 though the current instance ran a few weeks ago.
 
 `nc_calendar_list_todos` and `nc_calendar_search_todos` expand the recurrence
-set client-side and add four fields to recurring todos:
+set client-side and describe the **unfinished backlog** of the series:
 
 | Field | Meaning |
 |-------|---------|
 | `recurring` | `true` when the todo has an `RRULE` |
-| `recurrence_rule` | The RFC 5545 rule, e.g. `FREQ=YEARLY` |
-| `current_dtstart` | Start of the currently relevant occurrence |
-| `current_due` | Due date of the currently relevant occurrence |
+| `recurrence_rule` | The RFC 5545 rule, e.g. `FREQ=MONTHLY;BYMONTHDAY=28` |
+| `pending_count` | How many occurrences have started and are not done (`0` = up to date) |
+| `oldest_pending_dtstart` / `oldest_pending_due` | The oldest unfinished occurrence — how far the backlog reaches back |
+| `current_dtstart` / `current_due` | The most recent unfinished occurrence — the one to work on now |
 
-"Currently relevant" is the most recent occurrence that has already started, or
-the first upcoming one if the series has not started yet.
+An occurrence is **pending** when it has started (`DTSTART <= now`) and is not
+done. Expansion applies `EXDATE` and `RECURRENCE-ID` overrides, which is what
+makes per-instance completion visible: clients that materialise recurrences
+(jtx Board via DAVx5, for one) write one override per instance and mark
+finished ones `STATUS:COMPLETED`. `PERCENT-COMPLETE:100` counts as done too,
+since some clients set only that. The result therefore matches the open items
+such an app shows for the same series.
 
-`dtstart`/`due` are deliberately left as stored, so updates keep addressing the
-series rather than a single instance. **When judging whether a recurring todo is
-overdue, read `current_due`, not `due`.** If the occurrence cannot be resolved
-(no `DTSTART` to anchor the rule, or an unexpandable rule) the `current_*`
-fields are omitted rather than guessed.
+For a series with no overrides at all, every started occurrence counts as
+pending — there is nothing recording that any of them were done.
+
+**When judging whether a recurring todo is overdue, read `current_due` (or
+`oldest_pending_due`), never `due`.** `dtstart`/`due` are deliberately left as
+stored so that updates keep addressing the series rather than a single
+instance.
+
+Two bounds worth knowing: the backlog is searched over the last three years, so
+`pending_count` is a lower bound for a long-abandoned series; and if the
+recurrence cannot be resolved at all (no `DTSTART` to anchor the rule, or an
+unexpandable rule) every field above is omitted rather than guessed.

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -37,19 +37,12 @@ async def _maybe_await(result: Any) -> Any:
     return result
 
 
-# Rough length of one repetition per FREQ, used to size the window that the
-# currently relevant occurrence of a recurring VTODO is searched in.
-_RECURRENCE_BASE_PERIOD = {
-    "SECONDLY": dt.timedelta(seconds=1),
-    "MINUTELY": dt.timedelta(minutes=1),
-    "HOURLY": dt.timedelta(hours=1),
-    "DAILY": dt.timedelta(days=1),
-    "WEEKLY": dt.timedelta(weeks=1),
-    "MONTHLY": dt.timedelta(days=31),
-    "YEARLY": dt.timedelta(days=366),
-}
-_RECURRENCE_MIN_WINDOW = dt.timedelta(days=1)
-_RECURRENCE_MAX_WINDOW = dt.timedelta(days=366 * 6)
+# How far back a recurring todo's unfinished backlog is searched. Bounded so an
+# abandoned daily series cannot turn a single todo into thousands of expansions.
+_PENDING_MAX_LOOKBACK = dt.timedelta(days=366 * 3)
+
+# An occurrence in one of these states is finished and not part of the backlog.
+_TODO_DONE_STATUSES = frozenset({"COMPLETED", "CANCELLED"})
 
 
 def _rrule_to_string(rrule: Any) -> str:
@@ -71,20 +64,21 @@ def _rrule_to_string(rrule: Any) -> str:
         return str(rrule)
 
 
-def _recurrence_window(rrule: Any) -> dt.timedelta:
-    """Pick a search window wide enough to contain neighbouring occurrences."""
-    freq, interval = "DAILY", 1
-    if isinstance(rrule, list):
-        rrule = rrule[0] if rrule else None
-    if rrule is not None:
-        try:
-            freq = str(rrule.get("FREQ", ["DAILY"])[0]).upper()
-            interval = int(rrule.get("INTERVAL", [1])[0])
-        except (AttributeError, IndexError, TypeError, ValueError):
-            pass
+def _occurrence_is_done(component: Any) -> bool:
+    """True when a VTODO occurrence is finished.
 
-    window = _RECURRENCE_BASE_PERIOD.get(freq, dt.timedelta(days=1)) * max(interval, 1)
-    return max(_RECURRENCE_MIN_WINDOW, min(window * 2, _RECURRENCE_MAX_WINDOW))
+    Clients that materialise recurrences (jtx Board via DAVx5, for one) mark a
+    completed instance by writing an override with ``STATUS:COMPLETED``. Some
+    leave ``STATUS`` alone and only set ``PERCENT-COMPLETE:100``, so both are
+    treated as done.
+    """
+    status = str(component.get("status") or "").upper()
+    if status in _TODO_DONE_STATUSES:
+        return True
+    try:
+        return int(component.get("percent-complete", 0)) >= 100
+    except (TypeError, ValueError):
+        return False
 
 
 def _as_utc_datetime(value: dt.date) -> dt.datetime:
@@ -1678,32 +1672,41 @@ class CalendarClient:
                 return component
         return components[0] if components else None
 
-    def _current_todo_occurrence(
+    def _pending_todo_occurrences(
         self, cal: Any, master: Any, now: dt.datetime | None = None
-    ) -> dict[str, str]:
-        """Return the currently relevant occurrence of a recurring VTODO.
+    ) -> dict[str, Any]:
+        """Summarise the unfinished occurrences of a recurring VTODO.
 
         CalDAV never expands VTODO recurrences: a ``calendar-query`` hands back
-        only the master component, whose DTSTART/DUE describe the *first*
-        instance. Reporting those verbatim makes a live yearly series look years
-        overdue, so the recurrence set is expanded client-side — the same
-        approach :meth:`_expand_event_occurrences` already takes for VEVENT.
+        the whole resource, and the master component's DTSTART/DUE describe the
+        *first* instance of the series. Reporting those verbatim makes a live
+        monthly chore from 2023 look years overdue, so the recurrence set is
+        expanded client-side — the same approach
+        :meth:`_expand_event_occurrences` already takes for VEVENT.
 
-        "Currently relevant" is the most recent occurrence that has already
-        started, or the first upcoming one if the series has not started yet.
-        Returns an empty dict when the occurrence cannot be determined, leaving
+        Expansion applies EXDATE and RECURRENCE-ID overrides, which is what
+        makes per-instance completion visible: clients that materialise
+        recurrences write a ``STATUS:COMPLETED`` override per finished instance.
+        An occurrence counts as pending when it has started
+        (``DTSTART <= now``) and is not done — the same rule task apps use to
+        decide what to show, so the result matches what the user sees there.
+
+        Returns ``pending_count`` plus the oldest and newest pending occurrence.
+        An empty dict means the recurrence could not be resolved at all, leaving
         the master's DTSTART/DUE as the only answer.
         """
-        rrule = master.get("rrule")
-        if not rrule or not master.get("dtstart"):
+        dtstart = master.get("dtstart")
+        if not master.get("rrule") or not dtstart:
             return {}
 
         now = now or dt.datetime.now(dt.UTC)
-        window = _recurrence_window(rrule)
+        # `between` returns occurrences overlapping the window, so an instance
+        # that has started but is not yet due is included.
+        window_start = max(_as_utc_datetime(dtstart.dt), now - _PENDING_MAX_LOOKBACK)
 
         try:
             occurrences = recurring_ical_events.of(cal, components=["VTODO"]).between(
-                now - window, now + window
+                window_start, now
             )
         except Exception as e:
             logger.warning(
@@ -1713,22 +1716,28 @@ class CalendarClient:
             )
             return {}
 
-        occurrences = sorted(
-            (occ for occ in occurrences if occ.get("dtstart")),
+        pending = sorted(
+            (
+                occ
+                for occ in occurrences
+                if occ.get("dtstart") and not _occurrence_is_done(occ)
+            ),
             key=lambda occ: _as_utc_datetime(occ.get("dtstart").dt),
         )
-        if not occurrences:
-            return {}
+        if not pending:
+            # Every started occurrence is done — the series is up to date.
+            return {"pending_count": 0}
 
-        started = [
-            occ for occ in occurrences if _as_utc_datetime(occ.get("dtstart").dt) <= now
-        ]
-        current = started[-1] if started else occurrences[0]
-
-        occurrence_data = {"current_dtstart": current.get("dtstart").dt.isoformat()}
-        current_due = current.get("due")
-        if current_due:
-            occurrence_data["current_due"] = current_due.dt.isoformat()
+        oldest, newest = pending[0], pending[-1]
+        occurrence_data: dict[str, Any] = {
+            "pending_count": len(pending),
+            "oldest_pending_dtstart": oldest.get("dtstart").dt.isoformat(),
+            "current_dtstart": newest.get("dtstart").dt.isoformat(),
+        }
+        if oldest.get("due"):
+            occurrence_data["oldest_pending_due"] = oldest.get("due").dt.isoformat()
+        if newest.get("due"):
+            occurrence_data["current_due"] = newest.get("due").dt.isoformat()
         return occurrence_data
 
     def _parse_ical_todo(
@@ -1775,13 +1784,13 @@ class CalendarClient:
                 todo_data["categories"] = self._extract_categories(categories)
 
             # Handle recurrence. DTSTART/DUE stay as stored so that updates keep
-            # addressing the series, while current_* carries the instance a
-            # caller should reason about today.
+            # addressing the series, while the pending_* / current_* fields
+            # describe the instances a caller should reason about today.
             rrule = component.get("rrule")
             if rrule:
                 todo_data["recurring"] = True
                 todo_data["recurrence_rule"] = _rrule_to_string(rrule)
-                todo_data.update(self._current_todo_occurrence(cal, component, now))
+                todo_data.update(self._pending_todo_occurrences(cal, component, now))
 
             return todo_data
 

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1703,6 +1703,11 @@ class CalendarClient:
         # `between` returns occurrences overlapping the window, so an instance
         # that has started but is not yet due is included.
         window_start = max(_as_utc_datetime(dtstart.dt), now - _PENDING_MAX_LOOKBACK)
+        if window_start >= now:
+            # The series only begins in the future, so nothing has started and
+            # there is no backlog. Querying this span would ask for a window
+            # that ends before it starts, which the expander rejects.
+            return {"pending_count": 0}
 
         try:
             occurrences = recurring_ical_events.of(cal, components=["VTODO"]).between(

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -37,6 +37,63 @@ async def _maybe_await(result: Any) -> Any:
     return result
 
 
+# Rough length of one repetition per FREQ, used to size the window that the
+# currently relevant occurrence of a recurring VTODO is searched in.
+_RECURRENCE_BASE_PERIOD = {
+    "SECONDLY": dt.timedelta(seconds=1),
+    "MINUTELY": dt.timedelta(minutes=1),
+    "HOURLY": dt.timedelta(hours=1),
+    "DAILY": dt.timedelta(days=1),
+    "WEEKLY": dt.timedelta(weeks=1),
+    "MONTHLY": dt.timedelta(days=31),
+    "YEARLY": dt.timedelta(days=366),
+}
+_RECURRENCE_MIN_WINDOW = dt.timedelta(days=1)
+_RECURRENCE_MAX_WINDOW = dt.timedelta(days=366 * 6)
+
+
+def _rrule_to_string(rrule: Any) -> str:
+    """Render an icalendar ``vRecur`` as an RFC 5545 RRULE value.
+
+    ``str(vRecur)`` yields a Python repr (``vRecur({'FREQ': ['YEARLY']})``),
+    which is not a valid RRULE and cannot be fed back into
+    ``vRecur.from_ical()`` when a caller round-trips the value into an update.
+    """
+    if rrule is None:
+        return ""
+    if isinstance(rrule, list):
+        if not rrule:
+            return ""
+        rrule = rrule[0]
+    try:
+        return rrule.to_ical().decode("utf-8")
+    except AttributeError:
+        return str(rrule)
+
+
+def _recurrence_window(rrule: Any) -> dt.timedelta:
+    """Pick a search window wide enough to contain neighbouring occurrences."""
+    freq, interval = "DAILY", 1
+    if isinstance(rrule, list):
+        rrule = rrule[0] if rrule else None
+    if rrule is not None:
+        try:
+            freq = str(rrule.get("FREQ", ["DAILY"])[0]).upper()
+            interval = int(rrule.get("INTERVAL", [1])[0])
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+
+    window = _RECURRENCE_BASE_PERIOD.get(freq, dt.timedelta(days=1)) * max(interval, 1)
+    return max(_RECURRENCE_MIN_WINDOW, min(window * 2, _RECURRENCE_MAX_WINDOW))
+
+
+def _as_utc_datetime(value: dt.date) -> dt.datetime:
+    """Normalize a date or datetime to an aware UTC datetime for ordering."""
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo else value.replace(tzinfo=dt.UTC)
+    return dt.datetime(value.year, value.month, value.day, tzinfo=dt.UTC)
+
+
 class CalendarClient:
     """Client for Nextcloud CalDAV calendar and task operations."""
 
@@ -1232,7 +1289,7 @@ class CalendarClient:
         rrule = component.get("rrule")
         if rrule:
             event_data["recurring"] = True
-            event_data["recurrence_rule"] = str(rrule)
+            event_data["recurrence_rule"] = _rrule_to_string(rrule)
 
         # Handle attendees
         attendees = []
@@ -1606,44 +1663,127 @@ class CalendarClient:
         cal.add_component(todo)
         return cal.to_ical().decode("utf-8")
 
-    def _parse_ical_todo(self, ical_text: str) -> dict[str, Any] | None:
-        """Parse iCalendar text and extract todo data."""
+    @staticmethod
+    def _select_master_vtodo(cal: Any) -> Any | None:
+        """Pick the master VTODO from a resource.
+
+        A recurring todo may carry its modified instances in the same resource,
+        each tagged with a RECURRENCE-ID. Taking the first component in document
+        order would let such an override shadow the series, so prefer the
+        component without a RECURRENCE-ID.
+        """
+        components = list(cal.walk("VTODO"))
+        for component in components:
+            if "recurrence-id" not in component:
+                return component
+        return components[0] if components else None
+
+    def _current_todo_occurrence(
+        self, cal: Any, master: Any, now: dt.datetime | None = None
+    ) -> dict[str, str]:
+        """Return the currently relevant occurrence of a recurring VTODO.
+
+        CalDAV never expands VTODO recurrences: a ``calendar-query`` hands back
+        only the master component, whose DTSTART/DUE describe the *first*
+        instance. Reporting those verbatim makes a live yearly series look years
+        overdue, so the recurrence set is expanded client-side — the same
+        approach :meth:`_expand_event_occurrences` already takes for VEVENT.
+
+        "Currently relevant" is the most recent occurrence that has already
+        started, or the first upcoming one if the series has not started yet.
+        Returns an empty dict when the occurrence cannot be determined, leaving
+        the master's DTSTART/DUE as the only answer.
+        """
+        rrule = master.get("rrule")
+        if not rrule or not master.get("dtstart"):
+            return {}
+
+        now = now or dt.datetime.now(dt.UTC)
+        window = _recurrence_window(rrule)
+
+        try:
+            occurrences = recurring_ical_events.of(cal, components=["VTODO"]).between(
+                now - window, now + window
+            )
+        except Exception as e:
+            logger.warning(
+                "Client-side VTODO recurrence expansion failed (%s); "
+                "falling back to the master DTSTART/DUE",
+                e,
+            )
+            return {}
+
+        occurrences = sorted(
+            (occ for occ in occurrences if occ.get("dtstart")),
+            key=lambda occ: _as_utc_datetime(occ.get("dtstart").dt),
+        )
+        if not occurrences:
+            return {}
+
+        started = [
+            occ for occ in occurrences if _as_utc_datetime(occ.get("dtstart").dt) <= now
+        ]
+        current = started[-1] if started else occurrences[0]
+
+        occurrence_data = {"current_dtstart": current.get("dtstart").dt.isoformat()}
+        current_due = current.get("due")
+        if current_due:
+            occurrence_data["current_due"] = current_due.dt.isoformat()
+        return occurrence_data
+
+    def _parse_ical_todo(
+        self, ical_text: str, now: dt.datetime | None = None
+    ) -> dict[str, Any] | None:
+        """Parse iCalendar text and extract todo data.
+
+        ``now`` overrides the reference instant used to resolve which occurrence
+        of a recurring todo is the current one (injected by tests).
+        """
         try:
             cal = Calendar.from_ical(ical_text)
-            for component in cal.walk():
-                if component.name == "VTODO":
-                    todo_data = {
-                        "uid": str(component.get("uid", "")),
-                        "summary": str(component.get("summary", "")),
-                        "description": str(component.get("description", "")),
-                        "status": str(component.get("status", "NEEDS-ACTION")),
-                        "priority": int(component.get("priority", 0)),
-                        "percent_complete": int(component.get("percent-complete", 0)),
-                    }
+            component = self._select_master_vtodo(cal)
+            if component is None:
+                return None
 
-                    # Handle due date
-                    due = component.get("due")
-                    if due:
-                        todo_data["due"] = due.dt.isoformat()
+            todo_data = {
+                "uid": str(component.get("uid", "")),
+                "summary": str(component.get("summary", "")),
+                "description": str(component.get("description", "")),
+                "status": str(component.get("status", "NEEDS-ACTION")),
+                "priority": int(component.get("priority", 0)),
+                "percent_complete": int(component.get("percent-complete", 0)),
+            }
 
-                    # Handle start date
-                    dtstart = component.get("dtstart")
-                    if dtstart:
-                        todo_data["dtstart"] = dtstart.dt.isoformat()
+            # Handle due date
+            due = component.get("due")
+            if due:
+                todo_data["due"] = due.dt.isoformat()
 
-                    # Handle completed date
-                    completed = component.get("completed")
-                    if completed:
-                        todo_data["completed"] = completed.dt.isoformat()
+            # Handle start date
+            dtstart = component.get("dtstart")
+            if dtstart:
+                todo_data["dtstart"] = dtstart.dt.isoformat()
 
-                    # Handle categories
-                    categories = component.get("categories")
-                    if categories:
-                        todo_data["categories"] = self._extract_categories(categories)
+            # Handle completed date
+            completed = component.get("completed")
+            if completed:
+                todo_data["completed"] = completed.dt.isoformat()
 
-                    return todo_data
+            # Handle categories
+            categories = component.get("categories")
+            if categories:
+                todo_data["categories"] = self._extract_categories(categories)
 
-            return None
+            # Handle recurrence. DTSTART/DUE stay as stored so that updates keep
+            # addressing the series, while current_* carries the instance a
+            # caller should reason about today.
+            rrule = component.get("rrule")
+            if rrule:
+                todo_data["recurring"] = True
+                todo_data["recurrence_rule"] = _rrule_to_string(rrule)
+                todo_data.update(self._current_todo_occurrence(cal, component, now))
+
+            return todo_data
 
         except Exception as e:
             logger.error("Error parsing iCalendar todo: %s", e)

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -241,6 +241,28 @@ class Todo(BaseModel):
         None, description="Completion timestamp (ISO format)"
     )
     categories: str = Field(default="", description="Comma-separated categories")
+    recurring: bool = Field(
+        default=False, description="Whether this todo recurs (i.e. has an RRULE)"
+    )
+    recurrence_rule: str = Field(
+        default="", description="RFC 5545 RRULE value, e.g. 'FREQ=YEARLY;INTERVAL=1'"
+    )
+    current_dtstart: Optional[str] = Field(
+        None,
+        description=(
+            "Recurring todos only: start of the currently relevant occurrence "
+            "(ISO format). Prefer this over 'dtstart', which describes the "
+            "first instance of the series and may be years in the past."
+        ),
+    )
+    current_due: Optional[str] = Field(
+        None,
+        description=(
+            "Recurring todos only: due date of the currently relevant "
+            "occurrence (ISO format). Prefer this over 'due' when judging "
+            "whether a recurring todo is overdue."
+        ),
+    )
     href: str = Field(default="", description="CalDAV href")
     etag: str = Field(default="", description="ETag for versioning")
     calendar_name: Optional[str] = Field(

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -247,18 +247,41 @@ class Todo(BaseModel):
     recurrence_rule: str = Field(
         default="", description="RFC 5545 RRULE value, e.g. 'FREQ=YEARLY;INTERVAL=1'"
     )
+    pending_count: Optional[int] = Field(
+        None,
+        description=(
+            "Recurring todos only: how many occurrences have started and are "
+            "not yet done. 0 means the series is up to date. Bounded by a "
+            "three-year lookback, so treat it as a lower bound."
+        ),
+    )
+    oldest_pending_dtstart: Optional[str] = Field(
+        None,
+        description=(
+            "Recurring todos only: start of the oldest unfinished occurrence "
+            "(ISO format) — how far the backlog reaches back."
+        ),
+    )
+    oldest_pending_due: Optional[str] = Field(
+        None,
+        description=(
+            "Recurring todos only: due date of the oldest unfinished "
+            "occurrence (ISO format). Use this to say since when a recurring "
+            "todo has been overdue."
+        ),
+    )
     current_dtstart: Optional[str] = Field(
         None,
         description=(
-            "Recurring todos only: start of the currently relevant occurrence "
-            "(ISO format). Prefer this over 'dtstart', which describes the "
-            "first instance of the series and may be years in the past."
+            "Recurring todos only: start of the most recent unfinished "
+            "occurrence (ISO format). Prefer this over 'dtstart', which "
+            "describes the first instance of the series and may be years old."
         ),
     )
     current_due: Optional[str] = Field(
         None,
         description=(
-            "Recurring todos only: due date of the currently relevant "
+            "Recurring todos only: due date of the most recent unfinished "
             "occurrence (ISO format). Prefer this over 'due' when judging "
             "whether a recurring todo is overdue."
         ),

--- a/tests/unit/client/test_calendar_todo_recurrence.py
+++ b/tests/unit/client/test_calendar_todo_recurrence.py
@@ -68,7 +68,7 @@ def _monthly_series(done_through: tuple[int, int] = (2026, 4)) -> str:
         """
 BEGIN:VTODO
 UID:monthly
-SUMMARY:Geldabrechnung
+SUMMARY:Monthly reconciliation
 DTSTART:20240128T130000
 DUE:20240203T130000
 RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=28
@@ -90,7 +90,7 @@ END:VTODO
             parts.append(f"""
 BEGIN:VTODO
 UID:monthly
-SUMMARY:Geldabrechnung
+SUMMARY:Monthly reconciliation
 DTSTART:{start:%Y%m%dT%H%M%S}
 RECURRENCE-ID:{start:%Y%m%dT%H%M%S}
 DUE:{due:%Y%m%dT%H%M%S}
@@ -132,7 +132,7 @@ def test_series_starting_in_the_future_has_no_backlog():
     future = """
 BEGIN:VTODO
 UID:colonoscopy
-SUMMARY:Termin Darmspiegelung ausmachen
+SUMMARY:Schedule five-yearly checkup
 DTSTART;VALUE=DATE:20261001
 DUE;VALUE=DATE:20261127
 RRULE:FREQ=YEARLY;COUNT=-1;INTERVAL=5
@@ -151,7 +151,7 @@ def test_percent_complete_counts_as_done_without_status():
         """
 BEGIN:VTODO
 UID:weekly
-SUMMARY:Kaffeemaschine
+SUMMARY:Clean the coffee machine
 DTSTART:20260704T090000
 DUE:20260704T170000
 RRULE:FREQ=WEEKLY;BYDAY=SA;UNTIL=20260726T090000
@@ -161,7 +161,7 @@ END:VTODO
         """
 BEGIN:VTODO
 UID:weekly
-SUMMARY:Kaffeemaschine
+SUMMARY:Clean the coffee machine
 DTSTART:20260725T090000
 RECURRENCE-ID:20260725T090000
 DUE:20260725T170000
@@ -171,7 +171,7 @@ END:VTODO
     )
     todo = _client()._parse_ical_todo(ics, now=NOW)
 
-    # 04.07., 11.07. and 18.07. stay open; 25.07. is done via PERCENT-COMPLETE.
+    # 04, 11 and 18 July stay open; 25 July is done via PERCENT-COMPLETE.
     assert todo["pending_count"] == 3
     assert todo["current_dtstart"] == "2026-07-18T09:00:00"
 

--- a/tests/unit/client/test_calendar_todo_recurrence.py
+++ b/tests/unit/client/test_calendar_todo_recurrence.py
@@ -123,6 +123,28 @@ def test_fully_completed_series_reports_zero_pending():
     assert "oldest_pending_due" not in todo
 
 
+def test_series_starting_in_the_future_has_no_backlog():
+    """Nothing has started yet, so the backlog is empty rather than unresolved.
+
+    The naive query would span from the series start back to now — a window
+    ending before it begins, which the expander rejects outright.
+    """
+    future = """
+BEGIN:VTODO
+UID:colonoscopy
+SUMMARY:Termin Darmspiegelung ausmachen
+DTSTART;VALUE=DATE:20261001
+DUE;VALUE=DATE:20261127
+RRULE:FREQ=YEARLY;COUNT=-1;INTERVAL=5
+PRIORITY:3
+END:VTODO
+"""
+    todo = _client()._parse_ical_todo(_ical(future), now=NOW)
+
+    assert todo["pending_count"] == 0
+    assert "current_due" not in todo
+
+
 def test_percent_complete_counts_as_done_without_status():
     """Some clients only set PERCENT-COMPLETE on a finished instance."""
     ics = _ical(

--- a/tests/unit/client/test_calendar_todo_recurrence.py
+++ b/tests/unit/client/test_calendar_todo_recurrence.py
@@ -1,10 +1,14 @@
 """Unit tests for client-side VTODO recurrence expansion.
 
-CalDAV hands back only the master VTODO of a recurring task, whose DTSTART/DUE
-describe the *first* instance. Without expansion a yearly chore created in 2023
-is reported as due 2023-06-15 forever, which reads as "years overdue" to any
-consumer. These tests pin that the currently relevant occurrence is surfaced
-instead, and that it survives the Pydantic mapping the server layer performs.
+CalDAV hands back the whole resource but never expands VTODO recurrences, and
+the master component's DTSTART/DUE describe the *first* instance. Without
+expansion a monthly chore created in 2024 is reported as due 2024-02-03
+forever, which reads as "years overdue" to any consumer.
+
+Clients that materialise recurrences (jtx Board via DAVx5) write one
+RECURRENCE-ID override per instance and mark finished ones COMPLETED, so the
+unfinished backlog is recoverable from the resource. These tests pin that it is
+recovered, and that it survives the Pydantic mapping the server layer performs.
 """
 
 import datetime as dt
@@ -16,7 +20,7 @@ from nextcloud_mcp_server.models.calendar import Todo
 
 pytestmark = pytest.mark.unit
 
-# 2026-07-30: past the 2026 instance (Jun 1-15) of the yearly series below.
+# 2026-07-30: inside the 2026-07-28 window of the monthly series below.
 NOW = dt.datetime(2026, 7, 30, 12, 0, tzinfo=dt.UTC)
 
 
@@ -54,11 +58,113 @@ END:VTODO
 """
 
 
-def test_recurring_todo_reports_current_occurrence():
-    """The 2026 instance is surfaced; the master dates stay untouched."""
+def _monthly_series(done_through: tuple[int, int] = (2026, 4)) -> str:
+    """A materialised monthly series, finished up to and including ``done_through``.
+
+    Mirrors what jtx Board writes: a master carrying the RRULE plus one
+    RECURRENCE-ID override per instance, finished ones marked COMPLETED.
+    """
+    parts = [
+        """
+BEGIN:VTODO
+UID:monthly
+SUMMARY:Geldabrechnung
+DTSTART:20240128T130000
+DUE:20240203T130000
+RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=28
+PRIORITY:4
+END:VTODO
+"""
+    ]
+    for year in (2024, 2025, 2026):
+        for month in range(1, 13):
+            if (year, month) > (2026, 7):
+                continue
+            start = dt.datetime(year, month, 28, 13, 0)
+            due = start + dt.timedelta(days=6)
+            status = (
+                "STATUS:COMPLETED\nPERCENT-COMPLETE:100\nCOMPLETED:20260517T180549Z"
+                if (year, month) <= done_through
+                else "STATUS:NEEDS-ACTION"
+            )
+            parts.append(f"""
+BEGIN:VTODO
+UID:monthly
+SUMMARY:Geldabrechnung
+DTSTART:{start:%Y%m%dT%H%M%S}
+RECURRENCE-ID:{start:%Y%m%dT%H%M%S}
+DUE:{due:%Y%m%dT%H%M%S}
+PRIORITY:4
+{status}
+END:VTODO
+""")
+    return _ical(*parts)
+
+
+def test_backlog_reports_only_unfinished_started_occurrences():
+    """The three open instances are found; the completed ones are not."""
+    todo = _client()._parse_ical_todo(_monthly_series(), now=NOW)
+
+    assert todo["pending_count"] == 3
+    # Oldest still-open instance — "overdue since".
+    assert todo["oldest_pending_dtstart"] == "2026-05-28T13:00:00"
+    assert todo["oldest_pending_due"] == "2026-06-03T13:00:00"
+    # Newest, i.e. the one currently inside its window.
+    assert todo["current_dtstart"] == "2026-07-28T13:00:00"
+    assert todo["current_due"] == "2026-08-03T13:00:00"
+
+
+def test_fully_completed_series_reports_zero_pending():
+    """A series whose started occurrences are all done is up to date."""
+    todo = _client()._parse_ical_todo(_monthly_series(done_through=(2026, 12)), now=NOW)
+
+    assert todo["pending_count"] == 0
+    assert "current_due" not in todo
+    assert "oldest_pending_due" not in todo
+
+
+def test_percent_complete_counts_as_done_without_status():
+    """Some clients only set PERCENT-COMPLETE on a finished instance."""
+    ics = _ical(
+        """
+BEGIN:VTODO
+UID:weekly
+SUMMARY:Kaffeemaschine
+DTSTART:20260704T090000
+DUE:20260704T170000
+RRULE:FREQ=WEEKLY;BYDAY=SA;UNTIL=20260726T090000
+PRIORITY:3
+END:VTODO
+""",
+        """
+BEGIN:VTODO
+UID:weekly
+SUMMARY:Kaffeemaschine
+DTSTART:20260725T090000
+RECURRENCE-ID:20260725T090000
+DUE:20260725T170000
+PERCENT-COMPLETE:100
+END:VTODO
+""",
+    )
+    todo = _client()._parse_ical_todo(ics, now=NOW)
+
+    # 04.07., 11.07. and 18.07. stay open; 25.07. is done via PERCENT-COMPLETE.
+    assert todo["pending_count"] == 3
+    assert todo["current_dtstart"] == "2026-07-18T09:00:00"
+
+
+def test_unmaterialised_series_still_reports_the_backlog():
+    """Without overrides every started occurrence counts as pending.
+
+    Also pins the three-year lookback: the series starts in 2023 but only the
+    2024, 2025 and 2026 instances fall inside the window, so ``pending_count``
+    is a lower bound rather than the true backlog depth.
+    """
     todo = _client()._parse_ical_todo(_ical(YEARLY_TODO), now=NOW)
 
-    assert todo["current_dtstart"] == "2026-06-01"
+    assert todo["pending_count"] == 3
+    assert todo["oldest_pending_due"] == "2024-06-15"
     assert todo["current_due"] == "2026-06-15"
     # The master keeps addressing the series, so updates still target it.
     assert todo["dtstart"] == "2023-06-01"
@@ -78,17 +184,8 @@ def test_non_recurring_todo_has_no_recurrence_fields():
     todo = _client()._parse_ical_todo(_ical(PLAIN_TODO), now=NOW)
 
     assert "recurring" not in todo
-    assert "current_dtstart" not in todo
+    assert "pending_count" not in todo
     assert todo["due"] == "2023-06-15"
-
-
-def test_series_not_yet_started_reports_first_occurrence():
-    """Before the series begins there is no started occurrence to pick."""
-    todo = _client()._parse_ical_todo(
-        _ical(YEARLY_TODO), now=dt.datetime(2023, 1, 5, tzinfo=dt.UTC)
-    )
-
-    assert todo["current_dtstart"] == "2023-06-01"
 
 
 def test_recurrence_id_override_does_not_shadow_master():
@@ -110,7 +207,7 @@ END:VTODO
 
 
 def test_recurring_todo_without_dtstart_falls_back_to_master_dates():
-    """An RRULE has no anchor without DTSTART, so no occurrence can be resolved.
+    """An RRULE has no anchor without DTSTART, so nothing can be resolved.
     The todo must still be returned with its stored DUE rather than dropped."""
     anchorless = """
 BEGIN:VTODO
@@ -126,18 +223,17 @@ END:VTODO
     assert todo is not None
     assert todo["recurring"] is True
     assert todo["due"] == "2023-06-15"
-    assert "current_dtstart" not in todo
-    assert "current_due" not in todo
+    assert "pending_count" not in todo
 
 
 def test_todo_model_round_trip_preserves_recurrence_fields():
     """Mirrors the server's ``Todo(**todo_data)`` mapping — an unmodelled field
     would be dropped there and never reach the caller."""
-    todo_data = _client()._parse_ical_todo(_ical(YEARLY_TODO), now=NOW)
+    todo_data = _client()._parse_ical_todo(_monthly_series(), now=NOW)
 
     todo = Todo(**todo_data)
 
     assert todo.recurring is True
-    assert todo.recurrence_rule == "FREQ=YEARLY"
-    assert todo.current_dtstart == "2026-06-01"
-    assert todo.current_due == "2026-06-15"
+    assert todo.pending_count == 3
+    assert todo.oldest_pending_due == "2026-06-03T13:00:00"
+    assert todo.current_due == "2026-08-03T13:00:00"

--- a/tests/unit/client/test_calendar_todo_recurrence.py
+++ b/tests/unit/client/test_calendar_todo_recurrence.py
@@ -1,0 +1,143 @@
+"""Unit tests for client-side VTODO recurrence expansion.
+
+CalDAV hands back only the master VTODO of a recurring task, whose DTSTART/DUE
+describe the *first* instance. Without expansion a yearly chore created in 2023
+is reported as due 2023-06-15 forever, which reads as "years overdue" to any
+consumer. These tests pin that the currently relevant occurrence is surfaced
+instead, and that it survives the Pydantic mapping the server layer performs.
+"""
+
+import datetime as dt
+
+import pytest
+
+from nextcloud_mcp_server.client.calendar import CalendarClient
+from nextcloud_mcp_server.models.calendar import Todo
+
+pytestmark = pytest.mark.unit
+
+# 2026-07-30: past the 2026 instance (Jun 1-15) of the yearly series below.
+NOW = dt.datetime(2026, 7, 30, 12, 0, tzinfo=dt.UTC)
+
+
+def _client() -> CalendarClient:
+    """A client for pure-parsing tests; the constructor needs credentials."""
+    return CalendarClient.__new__(CalendarClient)
+
+
+def _ical(*vtodos: str) -> str:
+    body = "\n".join(vtodo.strip() for vtodo in vtodos)
+    return f"BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//test//EN\n{body}\nEND:VCALENDAR\n"
+
+
+YEARLY_TODO = """
+BEGIN:VTODO
+UID:backup-check
+SUMMARY:Check backups
+DTSTART;VALUE=DATE:20230601
+DUE;VALUE=DATE:20230615
+STATUS:NEEDS-ACTION
+PRIORITY:2
+CATEGORIES:IT
+RRULE:FREQ=YEARLY
+END:VTODO
+"""
+
+PLAIN_TODO = """
+BEGIN:VTODO
+UID:one-off
+SUMMARY:Renew passport
+DTSTART;VALUE=DATE:20230601
+DUE;VALUE=DATE:20230615
+STATUS:NEEDS-ACTION
+END:VTODO
+"""
+
+
+def test_recurring_todo_reports_current_occurrence():
+    """The 2026 instance is surfaced; the master dates stay untouched."""
+    todo = _client()._parse_ical_todo(_ical(YEARLY_TODO), now=NOW)
+
+    assert todo["current_dtstart"] == "2026-06-01"
+    assert todo["current_due"] == "2026-06-15"
+    # The master keeps addressing the series, so updates still target it.
+    assert todo["dtstart"] == "2023-06-01"
+    assert todo["due"] == "2023-06-15"
+    assert todo["recurring"] is True
+
+
+def test_recurrence_rule_is_rfc5545_not_python_repr():
+    """``str(vRecur)`` would yield ``vRecur({'FREQ': ['YEARLY']})``, which no
+    caller can feed back into ``vRecur.from_ical()``."""
+    todo = _client()._parse_ical_todo(_ical(YEARLY_TODO), now=NOW)
+
+    assert todo["recurrence_rule"] == "FREQ=YEARLY"
+
+
+def test_non_recurring_todo_has_no_recurrence_fields():
+    todo = _client()._parse_ical_todo(_ical(PLAIN_TODO), now=NOW)
+
+    assert "recurring" not in todo
+    assert "current_dtstart" not in todo
+    assert todo["due"] == "2023-06-15"
+
+
+def test_series_not_yet_started_reports_first_occurrence():
+    """Before the series begins there is no started occurrence to pick."""
+    todo = _client()._parse_ical_todo(
+        _ical(YEARLY_TODO), now=dt.datetime(2023, 1, 5, tzinfo=dt.UTC)
+    )
+
+    assert todo["current_dtstart"] == "2023-06-01"
+
+
+def test_recurrence_id_override_does_not_shadow_master():
+    """An override stored ahead of the master must not be mistaken for it."""
+    override = """
+BEGIN:VTODO
+UID:backup-check
+RECURRENCE-ID;VALUE=DATE:20240601
+SUMMARY:Check backups (moved)
+DTSTART;VALUE=DATE:20240701
+DUE;VALUE=DATE:20240715
+STATUS:NEEDS-ACTION
+END:VTODO
+"""
+    todo = _client()._parse_ical_todo(_ical(override, YEARLY_TODO), now=NOW)
+
+    assert todo["summary"] == "Check backups"
+    assert todo["recurrence_rule"] == "FREQ=YEARLY"
+
+
+def test_recurring_todo_without_dtstart_falls_back_to_master_dates():
+    """An RRULE has no anchor without DTSTART, so no occurrence can be resolved.
+    The todo must still be returned with its stored DUE rather than dropped."""
+    anchorless = """
+BEGIN:VTODO
+UID:no-anchor
+SUMMARY:Water the plants
+DUE;VALUE=DATE:20230615
+STATUS:NEEDS-ACTION
+RRULE:FREQ=WEEKLY
+END:VTODO
+"""
+    todo = _client()._parse_ical_todo(_ical(anchorless), now=NOW)
+
+    assert todo is not None
+    assert todo["recurring"] is True
+    assert todo["due"] == "2023-06-15"
+    assert "current_dtstart" not in todo
+    assert "current_due" not in todo
+
+
+def test_todo_model_round_trip_preserves_recurrence_fields():
+    """Mirrors the server's ``Todo(**todo_data)`` mapping — an unmodelled field
+    would be dropped there and never reach the caller."""
+    todo_data = _client()._parse_ical_todo(_ical(YEARLY_TODO), now=NOW)
+
+    todo = Todo(**todo_data)
+
+    assert todo.recurring is True
+    assert todo.recurrence_rule == "FREQ=YEARLY"
+    assert todo.current_dtstart == "2026-06-01"
+    assert todo.current_due == "2026-06-15"


### PR DESCRIPTION
## Problem

CalDAV does not expand VTODO recurrences — a `calendar-query` returns only the master component, whose `DTSTART`/`DUE` describe the **first** instance of the series. `_parse_ical_todo` reported those verbatim and never read the `RRULE` at all.

A chore created in 2023 that repeats every June therefore keeps reporting:

```json
{"summary": "Check backups", "dtstart": "2023-06-01", "due": "2023-06-15", "status": "NEEDS-ACTION"}
```

There is nothing in that payload to distinguish a live series from a task that has been rotting for three years. An LLM consuming `nc_calendar_list_todos` reasonably concludes "overdue since 2023" — which is how I ran into this: a daily briefing agent reported a user's routine chores as years overdue, while their task app (jtx Board) correctly showed the current instance. jtx Board reconstructs an ical4j `VToDo` from the stored recurrence properties and calls `calculateRecurrenceSet()`; the data was on the server all along, this client just dropped it.

## Change

Expand the recurrence set client-side with `recurring_ical_events`. The dependency is already used for VEVENT in `_expand_event_occurrences`, and its `components=` argument covers VTODO — so this is the same approach the event path already takes, applied to todos.

Crucially, expansion applies `EXDATE` and `RECURRENCE-ID` overrides, which is what makes **per-instance completion** visible. Clients that materialise recurrences (jtx Board via DAVx5) write one override per instance and mark finished ones `STATUS:COMPLETED`, so the unfinished backlog is fully recoverable from the resource — it was simply being discarded.

Recurring todos gain five fields:

| Field | Meaning |
|-------|---------|
| `recurring` | `true` when the todo has an `RRULE` |
| `recurrence_rule` | The RFC 5545 rule, e.g. `FREQ=MONTHLY;BYMONTHDAY=28` |
| `pending_count` | How many occurrences have started and are not done (`0` = up to date) |
| `oldest_pending_dtstart` / `oldest_pending_due` | The oldest unfinished occurrence |
| `current_dtstart` / `current_due` | The most recent unfinished occurrence |

An occurrence is pending when it has started (`DTSTART <= now`) and is not done — `STATUS:COMPLETED`/`CANCELLED` or `PERCENT-COMPLETE:100`, since some clients set only the latter. That is the same rule task apps use to decide what to show, so the output matches what a user sees for the same series. Verified against a real jtx-written resource: a monthly series running since 2023 with a completed override per instance yields exactly the three open occurrences the app displays.

`dtstart`/`due` are deliberately left as stored, so updates keep addressing the series rather than a single instance, and no existing consumer changes meaning. The backlog search is bounded to three years (a daily series over that span expands in ~40 ms), making `pending_count` a lower bound for a long-abandoned series. If the recurrence cannot be resolved at all (no `DTSTART` to anchor the rule, or an unexpandable rule) the fields are omitted rather than guessed.

### Also fixed

- **A modified instance could shadow the series.** `_parse_ical_todo` returned the first VTODO in document order. When a recurring todo ships its overrides in the same resource, an override stored ahead of the master would be returned as if it were the whole todo. Now the component without a `RECURRENCE-ID` is selected.

- **`recurrence_rule` was a Python repr, not an RRULE.** `str(vRecur)` yields `vRecur({'FREQ': ['YEARLY']})`, which is not valid RFC 5545 and cannot be fed back into `vRecur.from_ical()` — so round-tripping `recurrence_rule` from `nc_calendar_get_event` into `nc_calendar_update_event` was broken. Now rendered via `to_ical()`. **This affected events too and is fixed on both paths.** Existing tests assert `"WEEKLY" in recurrence_rule`, which holds for both forms, so nothing was pinning the old behaviour.

- **The new fields are added to the `Todo` model.** The server maps dicts through `Todo(**todo_data)`, which would otherwise drop them silently.

## Tests

Nine unit tests in `tests/unit/client/test_calendar_todo_recurrence.py`, covering a materialised series with a completed override per instance, a fully-completed series, `PERCENT-COMPLETE` without `STATUS`, a series with no overrides at all, and the three-year lookback boundary — plus a model round-trip test that pins the Pydantic mapping (the failure mode that would otherwise make this change a silent no-op at the tool boundary).

`tests/unit/client` + `tests/unit/server`: 265 passed. Full unit suite: 2335 passed; the 4 failures in my environment are a missing optional `procrastinate` dependency and are unrelated. `ruff format --diff` and `ruff check` clean on the locked 0.15.22.

## Noted but not addressed

- A malformed `RRULE` (e.g. `UNTIL=nonsense`) makes `Calendar.from_ical()` itself raise, so the todo disappears from the list entirely rather than degrading to its stored dates. That is a pre-existing parse-level issue independent of recurrence — happy to address separately if you want it in scope.
- `_merge_ical_todo_properties` has the same "first VTODO wins" pattern on the write path. Changing write behaviour for series with exceptions felt out of scope for a read fix.
