### PR TITLE
fix(search): drop the dense-search score_threshold default to 0.0

### DIFF
--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -29,11 +29,17 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
     768-dimensional embeddings and cosine distance.
     """
 
-    def __init__(self, score_threshold: float = 0.7):
+    def __init__(self, score_threshold: float = 0.0):
         """Initialize semantic search algorithm.
 
         Args:
-            score_threshold: Minimum similarity score (0-1, default: 0.7)
+            score_threshold: Minimum cosine similarity (0-1, default: 0.0 =
+                no cut). Matches ``BM25HybridSearchAlgorithm``'s default and the
+                0.0 the API layer already passes explicitly. The previous 0.7
+                default was inherited from the removed sampling tool, where it
+                silently returned zero results for questions the corpus answered
+                almost verbatim; no caller relied on it, so it survived only as
+                a footgun for the next bare instantiation.
         """
         super().__init__()
         self.score_threshold = score_threshold

--- a/tests/unit/search/test_semantic.py
+++ b/tests/unit/search/test_semantic.py
@@ -1,0 +1,29 @@
+"""Unit tests for the dense-only semantic search algorithm."""
+
+import pytest
+
+from nextcloud_mcp_server.search.semantic import SemanticSearchAlgorithm
+
+
+@pytest.mark.unit
+def test_semantic_initialization_default():
+    """The default threshold must stay 0.0 (no cut).
+
+    Regression guard: this default was 0.7, inherited from the removed MCP
+    sampling tool, where it silently returned zero results for questions the
+    corpus answered almost verbatim. Mirrors the equivalent assertion for
+    BM25HybridSearchAlgorithm in test_bm25_hybrid.py.
+    """
+    algo = SemanticSearchAlgorithm()
+
+    assert algo.score_threshold == 0.0
+    assert algo.name == "semantic"
+
+
+@pytest.mark.unit
+def test_semantic_initialization_explicit_threshold():
+    """An explicitly passed threshold still wins — the API layer relies on this."""
+    algo = SemanticSearchAlgorithm(score_threshold=0.5)
+
+    assert algo.score_threshold == 0.5
+    assert algo.requires_vector_db is True


### PR DESCRIPTION
SemanticSearchAlgorithm defaulted score_threshold to 0.7. That value was
inherited from the MCP-sampling answer tool, which has since been removed
along with sampling itself. While it was live it silently returned zero
results for questions the corpus answered almost verbatim, because the
threshold was applied to fusion scores it was never calibrated against.

No caller relies on the default today — the only construction site
(api/visualization.py) always passes an explicit value, which already
defaults to 0.0 at the request-parsing layer. The 0.7 therefore survived
purely as a footgun for the next bare instantiation, and now matches
BM25HybridSearchAlgorithm's 0.0.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

_This PR was generated with the help of AI, and reviewed by a Human_
