### PR TITLE
fix(search): scope the ACL owner branch to the subtrees actually shared

### DIFF
--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -111,8 +111,8 @@ async def _search_with_acl(
     user_id: str,
     execute: Callable[[AccessibleScope | None], Awaitable[list]],
 ) -> list:
-    """Resolve the caller's Nextcloud client, run ``execute(accessible_owners)``,
-    and verify-on-read — shared by the /api/v1 search endpoints.
+    """Resolve the caller's Nextcloud client, run ``execute(scope)``, and
+    verify-on-read — shared by the /api/v1 search endpoints.
 
     The OAuth bearer only authenticates Astrolabe → MCP Server; MCP Server →
     Nextcloud uses the provisioned app password. When the caller never

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -36,7 +36,9 @@ from nextcloud_mcp_server.search import (
     SemanticSearchAlgorithm,
 )
 from nextcloud_mcp_server.search.access_filter import (
+    AccessibleScope,
     list_accessible_owners,
+    list_accessible_scope,
     normalize_path_prefixes,
 )
 from nextcloud_mcp_server.search.context import (
@@ -107,7 +109,7 @@ def _build_search_algorithm(
 async def _search_with_acl(
     request: Request,
     user_id: str,
-    execute: Callable[[list[str] | None], Awaitable[list]],
+    execute: Callable[[AccessibleScope | None], Awaitable[list]],
 ) -> list:
     """Resolve the caller's Nextcloud client, run ``execute(accessible_owners)``,
     and verify-on-read — shared by the /api/v1 search endpoints.
@@ -122,7 +124,7 @@ async def _search_with_acl(
     Args:
         request: The Starlette request (carries ``app.state.oauth_context``).
         user_id: The authenticated caller.
-        execute: Coroutine that runs the search for a given owner scope
+        execute: Coroutine that runs the search for a given access scope
             (``None`` ⇒ self-only).
 
     Returns:
@@ -145,8 +147,8 @@ async def _search_with_acl(
         async with nc_client:
             # Expand to owners who shared content with the caller (same as the
             # MCP tool path) so shared documents are searchable.
-            accessible_owners = await list_accessible_owners(nc_client.sharing, user_id)
-            results = await execute(accessible_owners)
+            scope = await list_accessible_scope(nc_client.sharing, user_id)
+            results = await execute(scope)
             # Verify-on-read (ADR-019): drop documents the caller can no longer
             # access (e.g. a revoked share). Eviction runs inline — this
             # Starlette route has no FastMCP lifespan task group.
@@ -313,9 +315,13 @@ async def unified_search(request: Request) -> JSONResponse:
         # Request extra results to handle offset
         search_limit = limit + offset
 
-        async def _execute(owners: list[str] | None) -> list:
-            """Run the search across requested doc_types with the given owner
+        async def _execute(scope: AccessibleScope | None) -> list:
+            """Run the search across requested doc_types with the given access
             scope (None ⇒ self-only)."""
+            owners = scope.owners if scope else None
+            # Narrow the owner branch to the subtrees actually shared with the
+            # caller; see access_filter.build_ownership_filter.
+            roots = scope.share_root_ids if scope else None
             results: list = []
             if doc_types and isinstance(doc_types, list):
                 for doc_type in doc_types:
@@ -327,6 +333,7 @@ async def unified_search(request: Request) -> JSONResponse:
                                 limit=search_limit,
                                 doc_type=doc_type,
                                 accessible_owners=owners,
+                                shared_root_ids=roots,
                                 modified_after=modified_after,
                                 modified_before=modified_before,
                                 path_prefixes=path_prefixes,
@@ -347,6 +354,7 @@ async def unified_search(request: Request) -> JSONResponse:
                     user_id=user_id,
                     limit=search_limit,
                     accessible_owners=owners,
+                    shared_root_ids=roots,
                     modified_after=modified_after,
                     modified_before=modified_before,
                     path_prefixes=path_prefixes,
@@ -560,9 +568,13 @@ async def vector_search(request: Request) -> JSONResponse:
         except UnsupportedSearchType as e:
             return _unsupported_search_type_response(e)
 
-        async def _execute(owners: list[str] | None) -> list:
-            """Run the search across requested doc_types with the given owner
+        async def _execute(scope: AccessibleScope | None) -> list:
+            """Run the search across requested doc_types with the given access
             scope (None ⇒ self-only)."""
+            owners = scope.owners if scope else None
+            # Narrow the owner branch to the subtrees actually shared with the
+            # caller; see access_filter.build_ownership_filter.
+            roots = scope.share_root_ids if scope else None
             results: list = []
             if doc_types and isinstance(doc_types, list):
                 # Search each doc_type separately and merge results
@@ -575,6 +587,7 @@ async def vector_search(request: Request) -> JSONResponse:
                                 limit=limit,
                                 doc_type=doc_type,
                                 accessible_owners=owners,
+                                shared_root_ids=roots,
                                 modified_after=modified_after,
                                 modified_before=modified_before,
                                 path_prefixes=path_prefixes,
@@ -590,6 +603,7 @@ async def vector_search(request: Request) -> JSONResponse:
                     user_id=user_id,
                     limit=limit,
                     accessible_owners=owners,
+                    shared_root_ids=roots,
                     modified_after=modified_after,
                     modified_before=modified_before,
                     path_prefixes=path_prefixes,

--- a/nextcloud_mcp_server/search/access_filter.py
+++ b/nextcloud_mcp_server/search/access_filter.py
@@ -28,15 +28,17 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from qdrant_client.models import (
     Condition,
     FieldCondition,
     Filter,
+    IsEmptyCondition,
     MatchAny,
     MatchText,
     MatchValue,
+    PayloadField,
     Range,
 )
 
@@ -66,7 +68,7 @@ _OWNERS_CACHE_TTL_SECONDS = 30.0
 # OrderedDict; the cap is generous relative to any realistic concurrent-user
 # count, so steady state is effectively all-hit.
 _OWNERS_CACHE_MAXSIZE = 1024
-_owners_cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+_owners_cache: OrderedDict[str, tuple[float, AccessibleScope]] = OrderedDict()
 
 
 def clear_accessible_owners_cache() -> None:
@@ -80,6 +82,24 @@ class _SharingClientProtocol(Protocol):
     async def list_shares(
         self, path: str | None = None, shared_with_me: bool = False
     ) -> list[dict[str, Any]]: ...
+
+
+class AccessibleScope(NamedTuple):
+    """What one user may read, as resolved from their incoming OCS shares.
+
+    Attributes:
+        owners: ``{user_id} ∪ {uid_owner of each incoming share}``. The owner
+            UIDs whose content is a *candidate* for this user.
+        share_root_ids: Nextcloud fileids of the shared items themselves (the
+            OCS ``file_source`` of each incoming share), as strings. For a
+            folder share this is the mount root, whose descendants all carry it
+            in ``folder_ancestors``; for a single-file share it is that file's
+            own id. Used to narrow the owner branch from "everything this owner
+            has indexed" down to "the subtrees they actually shared".
+    """
+
+    owners: list[str]
+    share_root_ids: list[str]
 
 
 async def list_accessible_owners(
@@ -100,27 +120,42 @@ async def list_accessible_owners(
     more incoming shares than the OCS page size could have some owners omitted;
     if that becomes real, add pagination to SharingClient.
 
-    Granularity / over-fetch limitation (TODO, finer-grained filtering): this
-    expansion is *owner-level*, not *file-level*. If a prolific content creator
-    shares a single item with the querying user, that owner's whole indexed
-    corpus becomes a Qdrant candidate set for the querier even though only the
-    shared item is accessible. Verify-on-read correctly drops the inaccessible
-    "ghost" candidates, but because there is no second Qdrant pass to replenish,
-    a ``limit=N`` search can return fewer than N results when the over-fetch
-    buffer (2× in nc_semantic_search / api/visualization.py) is dominated by
-    ghosts. A per-file ownership index would remove this tension and is the
-    natural starting point for future work (intentionally out of scope here).
+    Granularity: the owner list alone is *owner-level*, not *file-level* — one
+    incoming share makes that owner's whole indexed corpus a Qdrant candidate.
+    ``list_accessible_scope`` also returns the shared items' fileids so the
+    search path can narrow the owner branch to the shared subtrees; see
+    ``build_ownership_filter(shared_root_ids=...)``. Callers that only need the
+    owner UIDs (doc-type discovery, context expansion) can keep using this.
 
     Sharing API failures are non-fatal — we degrade to ``[user_id]`` and log
     so a hiccup in OCS doesn't black-hole the user's own search.
+    """
+    return (await list_accessible_scope(sharing_client, user_id)).owners
+
+
+async def list_accessible_scope(
+    sharing_client: _SharingClientProtocol,
+    user_id: str,
+) -> AccessibleScope:
+    """Resolve ``user_id``'s incoming shares into owner UIDs + shared fileids.
+
+    One OCS round-trip serves both halves, cached together for
+    ``_OWNERS_CACHE_TTL_SECONDS``. Failures are not cached and degrade to
+    self-only scope (``owners=[user_id]``, no share roots), which is safe: the
+    user still searches their own content, and verify-on-read remains the
+    authority for anything that does surface.
+
+    See ``list_accessible_owners`` for the OCS pagination caveat.
     """
     now = time.monotonic()
     cached = _owners_cache.get(user_id)
     if cached is not None and now - cached[0] < _OWNERS_CACHE_TTL_SECONDS:
         _owners_cache.move_to_end(user_id)  # mark as recently used (LRU)
-        return list(cached[1])  # copy so callers can't mutate the cached value
+        # Copy the lists so callers can't mutate the cached value.
+        return AccessibleScope(list(cached[1].owners), list(cached[1].share_root_ids))
 
     owners: set[str] = {user_id}
+    share_root_ids: set[str] = set()
     try:
         shares = await sharing_client.list_shares(shared_with_me=True)
     except Exception as exc:  # noqa: BLE001 — degrade gracefully
@@ -130,7 +165,8 @@ async def list_accessible_owners(
             user_id,
             exc,
         )
-        return [user_id]  # don't cache failures — retry on the next search
+        # Don't cache failures — retry on the next search.
+        return AccessibleScope([user_id], [])
 
     for share in shares:
         # OCS returns the share owner under `uid_owner` (the file owner,
@@ -142,8 +178,16 @@ async def list_accessible_owners(
         if not isinstance(owner, str) or not owner:
             continue
         owners.add(owner)
+        # ``file_source`` is the fileid of the shared item itself (OCS also
+        # exposes the same value as ``item_source``). Stringified to match the
+        # ``folder_ancestors`` payload, which stores fileids as strings.
+        root = share.get("file_source")
+        if root is None:
+            root = share.get("item_source")
+        if isinstance(root, (int, str)) and str(root).strip():
+            share_root_ids.add(str(root).strip())
 
-    result = list(owners)
+    result = AccessibleScope(sorted(owners), sorted(share_root_ids))
     _owners_cache[user_id] = (now, result)
     # Promote to the most-recently-used end. This is a no-op for a brand-new
     # key (dict insertion already appends) but is needed when re-inserting an
@@ -152,16 +196,19 @@ async def list_accessible_owners(
     while len(_owners_cache) > _OWNERS_CACHE_MAXSIZE:
         _owners_cache.popitem(last=False)  # evict the least-recently-used entry
     logger.debug(
-        "Accessible owners for user %s: %d entries (%d other owner(s))",
+        "Accessible scope for user %s: %d owner(s) (%d other), %d share root(s)",
         user_id,
-        len(result),
-        len(result) - 1,
+        len(result.owners),
+        len(result.owners) - 1,
+        len(result.share_root_ids),
     )
-    return list(result)
+    return AccessibleScope(list(result.owners), list(result.share_root_ids))
 
 
 def build_ownership_filter(
-    user_id: str, accessible_owners: list[str] | None = None
+    user_id: str,
+    accessible_owners: list[str] | None = None,
+    shared_root_ids: list[str] | None = None,
 ) -> Filter:
     """Build the Qdrant ``Filter`` constraining a search to readable points.
 
@@ -182,6 +229,12 @@ def build_ownership_filter(
             access to. When None, defaults to ``[user_id]`` (no shares
             expansion — used by callers that genuinely want self-only
             scope such as eviction sweeps).
+        shared_root_ids: Fileids of the items those owners actually shared
+            (``AccessibleScope.share_root_ids``). When given, the ``owner_id``
+            branch is additionally constrained to points inside one of those
+            subtrees, which is what stops one incoming share exposing an
+            owner's entire corpus as candidates. When None/empty the branch
+            keeps its historical owner-level width.
 
     Returns:
         A Qdrant ``Filter`` ready to be nested under a parent ``must`` clause.
@@ -205,9 +258,48 @@ def build_ownership_filter(
         FieldCondition(key="acl_principals", match=MatchAny(any=[f"user:{user_id}"])),
     ]
     if other_owners:
-        conditions.insert(
-            0, FieldCondition(key="owner_id", match=MatchAny(any=other_owners))
+        owner_branch: Condition = FieldCondition(
+            key="owner_id", match=MatchAny(any=other_owners)
         )
+        roots = [rid for rid in (shared_root_ids or []) if rid and rid.strip()]
+        if roots:
+            # Narrow "everything this owner indexed" to "the subtrees they
+            # actually shared with me". Without this, a single incoming share
+            # admits the owner's whole corpus as candidates; verify-on-read then
+            # rejects them one by one, burning the over-fetch budget and
+            # silently shortening result pages. (Measured on one tenant: 47% of
+            # the collection was admitted here and rejected downstream.)
+            #
+            # Three OR-ed ways to be inside a shared subtree:
+            #   * folder_ancestors contains a shared folder's id — the normal
+            #     case for a folder share (ancestors run parent → user root).
+            #   * doc_id IS a shared id — a single-file share, and the shared
+            #     folder's own point, neither of which lists itself as an
+            #     ancestor.
+            #   * folder_ancestors is absent — points indexed before ADR-033
+            #     Phase 3 carry no ancestors, so requiring them would silently
+            #     drop legitimately shared legacy content. Fail open here and
+            #     let verify-on-read decide, exactly as before this change. Run
+            #     the admin payload backfill to convert these into the precise
+            #     branches above.
+            owner_branch = Filter(
+                must=[
+                    owner_branch,
+                    Filter(
+                        should=[
+                            FieldCondition(
+                                key=payload_keys.FOLDER_ANCESTORS,
+                                match=MatchAny(any=roots),
+                            ),
+                            FieldCondition(key="doc_id", match=MatchAny(any=roots)),
+                            IsEmptyCondition(
+                                is_empty=PayloadField(key=payload_keys.FOLDER_ANCESTORS)
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        conditions.insert(0, owner_branch)
     return Filter(should=conditions)
 
 
@@ -268,6 +360,7 @@ def build_base_filter_conditions(
     path_prefix: str | None = None,
     path_prefixes: Iterable[str] | None = None,
     path_prefix_folder_ids: list[str] | None = None,
+    shared_root_ids: list[str] | None = None,
 ) -> list[Condition]:
     """Build the common ``must`` conditions shared by every search algorithm.
 
@@ -308,13 +401,16 @@ def build_base_filter_conditions(
             ``Projects`` and ``Reports`` tokens), while the local/embedded
             qdrant-client matches by substring containment. Both serve folder
             scoping; neither is a strict left-anchored prefix.
+        shared_root_ids: Fileids of the caller's incoming shares
+            (``AccessibleScope.share_root_ids``), used to narrow the ACL
+            owner branch to the shared subtrees. See ``build_ownership_filter``.
 
     Returns:
         A list of Qdrant ``Condition`` objects for a parent ``must`` clause.
     """
     conditions: list[Condition] = [
         get_placeholder_filter(),
-        build_ownership_filter(user_id, accessible_owners),
+        build_ownership_filter(user_id, accessible_owners, shared_root_ids),
     ]
 
     if doc_type:

--- a/nextcloud_mcp_server/search/access_filter.py
+++ b/nextcloud_mcp_server/search/access_filter.py
@@ -276,12 +276,25 @@ def build_ownership_filter(
             #   * doc_id IS a shared id — a single-file share, and the shared
             #     folder's own point, neither of which lists itself as an
             #     ancestor.
-            #   * folder_ancestors is absent — points indexed before ADR-033
-            #     Phase 3 carry no ancestors, so requiring them would silently
-            #     drop legitimately shared legacy content. Fail open here and
-            #     let verify-on-read decide, exactly as before this change. Run
-            #     the admin payload backfill to convert these into the precise
-            #     branches above.
+            #   * folder_ancestors is empty/absent — fail open, because we have
+            #     no containment signal to judge these on.
+            #
+            # SCOPE — that third branch is broader than "legacy points", and
+            # deliberately so. ``folder_ancestors`` is only ever populated for
+            # ``doc_type == "file"`` (vector/processor.py); every other doc type
+            # is stamped with ``[]``, and Qdrant's ``IsEmpty`` matches an empty
+            # array and an absent key alike. So the branch covers BOTH:
+            #   - files predating ADR-033 Phase 3 (or whose ancestors failed to
+            #     resolve) — an admin payload backfill converts these into the
+            #     precise branches above, and
+            #   - every non-file doc type (note, calendar, contact, deck_card,
+            #     …), permanently, since they never get ancestors at all.
+            # Those types therefore keep the old owner-level width: one share
+            # from an owner still admits that owner's whole non-file corpus as
+            # candidates. Narrowing them needs ancestors populated for those
+            # types, which is a processor + re-index change, not a filter one.
+            # Pinned by test_non_file_doc_types_are_not_narrowed so this stays a
+            # known limitation rather than an accident.
             owner_branch = Filter(
                 must=[
                     owner_branch,

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -201,6 +201,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         path_prefix: str | None = None,
         path_prefixes: Iterable[str] | None = None,
         path_prefix_folder_ids: list[str] | None = None,
+        shared_root_ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """
@@ -282,6 +283,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
             path_prefix=path_prefix,
             path_prefixes=path_prefixes,
             path_prefix_folder_ids=path_prefix_folder_ids,
+            shared_root_ids=shared_root_ids,
         )
 
         query_filter = Filter(must=filter_conditions)

--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -65,6 +65,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
         path_prefix: str | None = None,
         path_prefixes: Iterable[str] | None = None,
         path_prefix_folder_ids: list[str] | None = None,
+        shared_root_ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """Execute semantic search using vector similarity.
@@ -138,6 +139,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
             path_prefix=path_prefix,
             path_prefixes=path_prefixes,
             path_prefix_folder_ids=path_prefix_folder_ids,
+            shared_root_ids=shared_root_ids,
         )
 
         # ACL pre-filter (design §11), opt-in via ACL_PREFILTER_ENABLED and OFF

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -27,7 +27,7 @@ from nextcloud_mcp_server.observability.metrics import (
 )
 from nextcloud_mcp_server.search.access_filter import (
     MAX_PATH_PREFIXES,
-    list_accessible_owners,
+    list_accessible_scope,
     normalize_path_prefixes,
     resolve_prefix_folder_ids,
 )
@@ -334,8 +334,13 @@ def configure_semantic_tools(mcp: FastMCP):
         # Expand the caller's identity to every owner whose content they
         # have read access to via Nextcloud shares. Lets a user find files
         # owners have shared with them without having to re-index those
-        # files under their own user_id.
-        accessible_owners = await list_accessible_owners(client.sharing, username)
+        # files under their own user_id. ``share_root_ids`` scopes that
+        # expansion to the shared subtrees, so one incoming share does not
+        # admit the whole owner's corpus as candidates for verify-on-read to
+        # reject (which silently shortened result pages).
+        accessible_scope = await list_accessible_scope(client.sharing, username)
+        accessible_owners = accessible_scope.owners
+        shared_root_ids = accessible_scope.share_root_ids
 
         # Admin consent gate: restrict to source types the Astrolabe admin has
         # approved (and that are installed for this user). This mirrors
@@ -406,6 +411,7 @@ def configure_semantic_tools(mcp: FastMCP):
                     doc_type=None,  # Signal to search all types
                     score_threshold=score_threshold,
                     accessible_owners=accessible_owners,
+                    shared_root_ids=shared_root_ids,
                     modified_after=modified_after_ts,
                     modified_before=modified_before_ts,
                     path_prefixes=folder_prefixes,
@@ -435,6 +441,7 @@ def configure_semantic_tools(mcp: FastMCP):
                         doc_type=dtype,
                         score_threshold=score_threshold,
                         accessible_owners=accessible_owners,
+                        shared_root_ids=shared_root_ids,
                         modified_after=modified_after_ts,
                         modified_before=modified_before_ts,
                         path_prefixes=folder_prefixes,

--- a/tests/integration/test_acl_owner_filter.py
+++ b/tests/integration/test_acl_owner_filter.py
@@ -210,3 +210,142 @@ async def test_cached_chunk_lookup_is_acl_aware(seeded_collection):
     assert text == _DOC_TEXT
     # Self-only Bob cannot reach Alice's cached chunk.
     assert await _get_chunk_by_index_from_qdrant("bob", "101", "file", 0) is None
+
+
+# --- share-root narrowing (real Qdrant evaluation of the nested filter) ------
+#
+# tests/unit/search/test_access_filter.py asserts the Filter OBJECT's shape.
+# These cases run that filter through a real Qdrant engine, which is the only
+# way to pin how the nested must/should + IsEmptyCondition combination actually
+# evaluates — including the non-file behaviour documented on
+# build_ownership_filter.
+
+_SHARED_FOLDER_ID = "900"
+_OTHER_FOLDER_ID = "999"
+
+
+@pytest.fixture
+async def narrowing_collection(monkeypatch):
+    """In-memory Qdrant seeded with points that differ only in containment.
+
+    Every point is owned by ``alice`` and carries identical text, so the
+    ownership filter — not the score, doc_type, or owner — decides visibility.
+    """
+    provider = SimpleProvider(dimension=384)
+    client = AsyncQdrantClient(":memory:")
+    collection = get_settings().get_collection_name()
+
+    await client.create_collection(
+        collection_name=collection,
+        vectors_config={"dense": VectorParams(size=384, distance=Distance.COSINE)},
+    )
+
+    embedding = await provider.embed(_DOC_TEXT)
+    # (point_id, doc_id, doc_type, folder_ancestors)
+    seed = [
+        (201, "201", "file", [_SHARED_FOLDER_ID]),  # inside the shared folder
+        (202, "202", "file", [_OTHER_FOLDER_ID]),  # outside it
+        (203, _SHARED_FOLDER_ID, "file", []),  # the shared folder's own point
+        (204, "204", "file", []),  # pre-ADR-033 file: no ancestors resolved
+        (205, "205", "note", []),  # non-file: never gets ancestors
+    ]
+    points = [
+        PointStruct(
+            id=pid,
+            vector={"dense": embedding},
+            payload={
+                "doc_id": doc_id,
+                "doc_type": doc_type,
+                "user_id": "alice",
+                "owner_id": "alice",
+                "folder_ancestors": ancestors,
+                "is_placeholder": False,
+                "file_path": f"docs/{doc_id}.txt",
+                "title": f"doc {doc_id}",
+                "excerpt": _DOC_TEXT,
+                "chunk_index": 0,
+                "total_chunks": 1,
+            },
+        )
+        for pid, doc_id, doc_type, ancestors in seed
+    ]
+    await client.upsert(collection_name=collection, points=points, wait=True)
+
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.semantic.get_qdrant_client",
+        AsyncMock(return_value=client),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.semantic.get_provider", lambda: provider
+    )
+
+    yield provider
+
+    await client.close()
+
+
+async def _search_as_bob(shared_root_ids, doc_type=None):
+    """Bob searching alice-owned content (alice shared *something* with him)."""
+    algo = SemanticSearchAlgorithm(score_threshold=0.0)
+    return _ids(
+        await algo.search(
+            query=_DOC_TEXT,
+            user_id="bob",
+            limit=10,
+            doc_type=doc_type,
+            accessible_owners=["bob", "alice"],
+            shared_root_ids=shared_root_ids,
+        )
+    )
+
+
+async def test_without_share_roots_whole_owner_corpus_is_admitted(
+    narrowing_collection,
+):
+    """Baseline (pre-fix behaviour): one share exposes everything alice owns."""
+    found = await _search_as_bob(shared_root_ids=None, doc_type="file")
+
+    assert {"201", "202", "204", _SHARED_FOLDER_ID} <= found
+
+
+async def test_share_roots_admit_only_the_shared_subtree(narrowing_collection):
+    """The point outside the shared folder is filtered out by Qdrant itself."""
+    found = await _search_as_bob(shared_root_ids=[_SHARED_FOLDER_ID], doc_type="file")
+
+    assert "201" in found, "file inside the shared folder must be admitted"
+    assert "202" not in found, (
+        "file outside the shared folder must NOT be admitted — this is the "
+        "candidate-pool pollution the narrowing removes"
+    )
+
+
+async def test_shared_folder_own_point_is_admitted_via_doc_id(narrowing_collection):
+    """A folder does not list itself in folder_ancestors — the doc_id branch
+    is what keeps the shared item itself (and single-file shares) findable."""
+    found = await _search_as_bob(shared_root_ids=[_SHARED_FOLDER_ID], doc_type="file")
+
+    assert _SHARED_FOLDER_ID in found
+
+
+async def test_file_without_resolved_ancestors_fails_open(narrowing_collection):
+    """Pre-ADR-033 files carry no ancestors; dropping them would lose real
+    recall, so the filter fails open and lets verify-on-read decide."""
+    found = await _search_as_bob(shared_root_ids=[_SHARED_FOLDER_ID], doc_type="file")
+
+    assert "204" in found
+
+
+async def test_non_file_doc_types_are_not_narrowed(narrowing_collection):
+    """Known limitation, pinned deliberately.
+
+    ``folder_ancestors`` is only populated for ``doc_type == "file"``
+    (vector/processor.py); every other type is stamped with ``[]``, which
+    Qdrant's IsEmptyCondition cannot distinguish from "absent". So notes,
+    deck cards, calendar entries etc. keep the old owner-level width and are
+    still admitted even when they sit outside every shared root. Narrowing
+    them needs ancestors populated for those types — tracked separately, not
+    silently fixed here.
+    """
+    found = await _search_as_bob(shared_root_ids=[_SHARED_FOLDER_ID], doc_type="note")
+
+    assert "205" in found

--- a/tests/unit/search/test_access_filter.py
+++ b/tests/unit/search/test_access_filter.py
@@ -6,7 +6,14 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchText, Range
+from qdrant_client.models import (
+    FieldCondition,
+    Filter,
+    IsEmptyCondition,
+    MatchAny,
+    MatchText,
+    Range,
+)
 
 from nextcloud_mcp_server.search import access_filter
 from nextcloud_mcp_server.search.access_filter import (
@@ -15,6 +22,7 @@ from nextcloud_mcp_server.search.access_filter import (
     build_ownership_filter,
     clear_accessible_owners_cache,
     list_accessible_owners,
+    list_accessible_scope,
     normalize_path_prefixes,
     resolve_prefix_folder_ids,
 )
@@ -197,6 +205,151 @@ class TestBuildOwnershipFilter:
         branches = self._by_key(flt)
         assert set(branches) == {"user_id", "acl_principals"}
         assert branches["user_id"].match.value == "alice"
+
+
+class TestShareRootNarrowing:
+    """The owner branch must be constrained to the subtrees actually shared.
+
+    Without this, one incoming share admits the whole owner's corpus as
+    candidates; verify-on-read then rejects them, burning the over-fetch budget
+    and silently shortening result pages.
+    """
+
+    @staticmethod
+    def _owner_branch(flt: Filter) -> Any:
+        assert flt.should is not None
+        # The owner branch is the only one that is not a plain FieldCondition on
+        # user_id / acl_principals.
+        for cond in flt.should:
+            if isinstance(cond, Filter) or getattr(cond, "key", None) == "owner_id":
+                return cond
+        raise AssertionError("no owner branch present")
+
+    def test_without_share_roots_owner_branch_stays_wide(self) -> None:
+        # Regression guard: callers that don't pass share roots (context
+        # expansion, doc-type discovery, eviction sweeps) keep the historical
+        # owner-level filter exactly as before.
+        branch = self._owner_branch(build_ownership_filter("alice", ["alice", "bob"]))
+
+        assert isinstance(branch, FieldCondition)
+        assert branch.key == "owner_id"
+        assert branch.match.any == ["bob"]
+
+    def test_share_roots_constrain_the_owner_branch(self) -> None:
+        branch = self._owner_branch(
+            build_ownership_filter("alice", ["alice", "bob"], ["370448", "417049"])
+        )
+
+        # owner_id AND (inside a shared subtree)
+        assert isinstance(branch, Filter)
+        assert branch.must is not None and len(branch.must) == 2
+        owner_cond, containment = branch.must
+        assert owner_cond.key == "owner_id"
+        assert owner_cond.match.any == ["bob"]
+
+        assert isinstance(containment, Filter)
+        assert containment.should is not None
+        by_key = {c.key: c for c in containment.should if isinstance(c, FieldCondition)}
+        # A folder share: descendants carry the root in folder_ancestors.
+        assert set(by_key[payload_keys.FOLDER_ANCESTORS].match.any) == {
+            "370448",
+            "417049",
+        }
+        # A single-file share (and the shared folder's own point) — neither
+        # lists itself as its own ancestor.
+        assert set(by_key["doc_id"].match.any) == {"370448", "417049"}
+        # Legacy points predating folder_ancestors must not be dropped: fail
+        # open and let verify-on-read decide, as it did before this change.
+        empties = [c for c in containment.should if isinstance(c, IsEmptyCondition)]
+        assert len(empties) == 1
+        assert empties[0].is_empty.key == payload_keys.FOLDER_ANCESTORS
+
+    def test_share_roots_without_other_owners_add_nothing(self) -> None:
+        # Self-only scope has no owner branch to narrow, so share roots are inert.
+        flt = build_ownership_filter("alice", ["alice"], ["370448"])
+
+        assert flt.should is not None
+        assert {c.key for c in flt.should} == {"user_id", "acl_principals"}
+
+    def test_blank_share_roots_are_ignored(self) -> None:
+        branch = self._owner_branch(
+            build_ownership_filter("alice", ["alice", "bob"], ["", "   "])
+        )
+
+        # Nothing usable to narrow with ⇒ keep the wide branch rather than
+        # emitting MatchAny(any=[]), whose semantics Qdrant does not guarantee.
+        assert isinstance(branch, FieldCondition)
+        assert branch.key == "owner_id"
+
+    def test_base_conditions_forward_share_roots(self) -> None:
+        conditions = build_base_filter_conditions(
+            "alice", ["alice", "bob"], shared_root_ids=["370448"]
+        )
+
+        ownership = next(
+            c for c in conditions if isinstance(c, Filter) and c.should is not None
+        )
+        branch = self._owner_branch(ownership)
+        assert isinstance(branch, Filter), "share roots were not forwarded"
+
+
+class TestListAccessibleScope:
+    """Share roots come from the OCS ``file_source`` of each incoming share."""
+
+    @pytest.mark.unit
+    async def test_collects_owners_and_share_roots(self) -> None:
+        sharing = AsyncMock()
+        sharing.list_shares.return_value = [
+            {"uid_owner": "bob", "file_source": 370448},
+            {"uid_owner": "bob", "file_source": 417049},
+        ]
+
+        scope = await list_accessible_scope(sharing, "alice")
+
+        assert set(scope.owners) == {"alice", "bob"}
+        # Stringified to match the folder_ancestors payload, which stores
+        # fileids as strings.
+        assert set(scope.share_root_ids) == {"370448", "417049"}
+
+    @pytest.mark.unit
+    async def test_falls_back_to_item_source(self) -> None:
+        sharing = AsyncMock()
+        sharing.list_shares.return_value = [
+            {"uid_owner": "bob", "item_source": "2346863"},
+        ]
+
+        scope = await list_accessible_scope(sharing, "alice")
+        assert scope.share_root_ids == ["2346863"]
+
+    @pytest.mark.unit
+    async def test_share_without_resolvable_root_yields_no_id(self) -> None:
+        # The owner still expands (so their content stays reachable), but with
+        # no root the narrowing simply doesn't apply to them.
+        sharing = AsyncMock()
+        sharing.list_shares.return_value = [{"uid_owner": "bob"}]
+
+        scope = await list_accessible_scope(sharing, "alice")
+        assert set(scope.owners) == {"alice", "bob"}
+        assert scope.share_root_ids == []
+
+    @pytest.mark.unit
+    async def test_ocs_failure_degrades_to_self_only(self) -> None:
+        sharing = AsyncMock()
+        sharing.list_shares.side_effect = RuntimeError("OCS down")
+
+        scope = await list_accessible_scope(sharing, "alice")
+        assert scope == (["alice"], [])
+
+    @pytest.mark.unit
+    async def test_owners_wrapper_shares_the_same_fetch(self) -> None:
+        sharing = AsyncMock()
+        sharing.list_shares.return_value = [{"uid_owner": "bob", "file_source": 370448}]
+
+        assert set(await list_accessible_owners(sharing, "alice")) == {"alice", "bob"}
+        scope = await list_accessible_scope(sharing, "alice")
+        assert scope.share_root_ids == ["370448"]
+        # One OCS round-trip serves both accessors (30s cache).
+        sharing.list_shares.assert_awaited_once()
 
 
 class TestBuildBaseFilterConditions:

--- a/tests/unit/search/test_access_filter.py
+++ b/tests/unit/search/test_access_filter.py
@@ -242,7 +242,8 @@ class TestShareRootNarrowing:
 
         # owner_id AND (inside a shared subtree)
         assert isinstance(branch, Filter)
-        assert branch.must is not None and len(branch.must) == 2
+        assert branch.must is not None
+        assert len(branch.must) == 2
         owner_cond, containment = branch.must
         assert owner_cond.key == "owner_id"
         assert owner_cond.match.any == ["bob"]


### PR DESCRIPTION
build_ownership_filter OR-ed a bare `owner_id IN accessible_owners` branch,
and accessible_owners is owner-level: {caller} + {owner of every incoming
share}. One received share therefore admitted that owner's ENTIRE indexed
corpus as search candidates, including trees never shared with the caller.
Verify-on-read then rejected them one by one — correct, but only after they
had consumed the over-fetch budget, which silently shortened result pages
(a limit=N search returning fewer than N accessible results).

Measured on a production tenant before this change: of 547,702 points,
258,942 (47.3%) were admitted by the pre-filter and rejected by
verify-on-read on every single query. Worse than a tail problem — the
inaccessible corpus was the same document genre as the caller's, so BM25
ranked it competitively and it crowded the head of the candidate list.

list_accessible_scope() now returns the OCS file_source of each incoming
share alongside the owner UIDs (one round-trip, same 30s cache), and the
owner branch additionally requires the point to sit inside one of those
subtrees. Three OR-ed ways to qualify:

  * folder_ancestors contains a shared folder id — the folder-share case
  * doc_id IS a shared id — single-file shares, and the shared folder's
    own point, neither of which lists itself as an ancestor
  * folder_ancestors is absent — points predating ADR-033 Phase 3 carry no
    ancestors, so requiring them would drop legitimately shared legacy
    content. Fail open and let verify-on-read decide, exactly as before.

Same tenant after: 288,567 admitted, 0 rejected — the admitted set is now
exactly the genuinely-readable set, so the pollution is removed with no
loss of recall. Verify-on-read remains the authority; this only stops the
pre-filter proposing candidates it knows will be rejected.

Callers that legitimately want the wide owner scope (doc-type discovery,
context expansion of already-verified documents, eviction sweeps) keep
using list_accessible_owners and are unchanged.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Scope of the measured result (added after round-1 review)

The "258,942 admitted-then-rejected -> 0" figure was measured on a corpus that
is **547,635 of 547,702 points `doc_type="file"`**. It does not generalise.

`folder_ancestors` is only populated for `doc_type == "file"`; every other type
is stamped with `[]`, and Qdrant's `IsEmpty` cannot distinguish that from an
absent key. So **notes, calendar entries, contacts, deck cards and the rest keep
the old owner-level width** — one share from an owner still admits that owner's
whole non-file corpus as candidates, which verify-on-read then rejects.

Narrowing those types needs `folder_ancestors` populated for them: a processor
change plus a re-index, not a filter change. Out of scope here; the limitation
is pinned by `test_non_file_doc_types_are_not_narrowed` so it stays deliberate.


---

_This PR was generated with the help of AI, and reviewed by a Human_

