### PR TITLE
fix(observability): guard span status read on non-recording spans

### DIFF
--- a/nextcloud_mcp_server/observability/tracing.py
+++ b/nextcloud_mcp_server/observability/tracing.py
@@ -173,7 +173,12 @@ def trace_server_request(
             # block — a handler that catches its own exception and returns a
             # 500 never raises here — and an unconditional OK would overwrite
             # that, leaving the failure invisible to `status=error` queries.
-            if span.status.status_code is StatusCode.UNSET:  # ty: ignore[unresolved-attribute]  # OTel API Span type omits .status; the runtime SDK span provides it
+            # `is_recording()` first: an unsampled request yields a
+            # `NonRecordingSpan`, which has no `.status` at all — reading it
+            # raised AttributeError out of the middleware and turned every
+            # unsampled request into a 500 (seen on /oauth/token, breaking
+            # client connect). Non-recording spans discard status anyway.
+            if span.is_recording() and span.status.status_code is StatusCode.UNSET:  # ty: ignore[unresolved-attribute]  # OTel API Span type omits .status; the runtime SDK span provides it
                 span.set_status(Status(StatusCode.OK))
         except Exception as e:
             span.record_exception(e)

--- a/tests/unit/test_observability_trace_propagation.py
+++ b/tests/unit/test_observability_trace_propagation.py
@@ -100,6 +100,22 @@ def test_request_without_traceparent_starts_its_own_trace(client, exporter):
     assert span.get_span_context().trace_id != int(UPSTREAM_TRACE_ID, 16)
 
 
+def test_unsampled_traceparent_does_not_fail_the_request(client, exporter):
+    """A caller that opts out of sampling must still get its response.
+
+    ParentBased sampling hands back a `NonRecordingSpan`, which has no
+    `.status`; reading it unconditionally turned every unsampled request into
+    a 500 — including `POST /oauth/token`, which broke client connect.
+    """
+    response = client.get(
+        "/api/v1/status",
+        headers={"traceparent": f"00-{UPSTREAM_TRACE_ID}-{UPSTREAM_SPAN_ID}-00"},
+    )
+
+    assert response.status_code == 200
+    assert exporter.get_finished_spans() == ()
+
+
 def test_malformed_traceparent_is_ignored(client, exporter):
     """A garbage header must not fail the request or the span."""
     response = client.get(


### PR DESCRIPTION
## Problem

Any request whose inbound `traceparent` carries the **not-sampled** flag (`-00`) gets a **500** from the MCP server.

OpenTelemetry's ParentBased sampler returns a `NonRecordingSpan` for those. `trace_server_request` reads `span.status.status_code` unconditionally on exit — `NonRecordingSpan` has no `.status`, so it raises `AttributeError` out of `ObservabilityMiddleware.dispatch` *after* the handler has already produced its response.

Observed in `cloudfleet/dev` on two tenants (15 occurrences in 24h), on `POST /oauth/token` and `POST /mcp`. Every failing log line carries `otelTraceSampled: false`:

```
[INFO]  auth.oauth_routes: AS proxy token: Returning Nextcloud token for client …
[ERROR] observability.middleware: Request failed: POST /oauth/token
  File "nextcloud_mcp_server/observability/tracing.py", line 176, in trace_server_request
    if span.status.status_code is StatusCode.UNSET:
AttributeError: 'NonRecordingSpan' object has no attribute 'status'
```

**User impact:** third-party MCP clients fail at the auth step. The OAuth code exchange *succeeds* server-side, then the middleware crashes and the client sees a 500 with no useful error. It is intermittent because it depends on the caller's sampling decision — the same client succeeds on a retry whose trace happens to be sampled.

Regression from 0378f4c6 (2026-07-19, "mark handler-caught 5xx responses as error spans"), present since 0.153.x.

## Fix

Guard on `span.is_recording()` before reading `.status`. Non-recording spans discard status anyway, so nothing observable is lost — and `set_status` on them was already a safe no-op, so the 5xx-marking path in the middleware is unaffected.

## Test coverage

Added `test_unsampled_traceparent_does_not_fail_the_request` to `tests/unit/test_observability_trace_propagation.py`: a request with `traceparent` flags `-00` must return 200 and emit no span. Verified it fails with `assert 500 == 200` against the unpatched code and passes with the fix.

No API surface is added or changed, so the e2e + contract gate does not apply.

Deck: board 12, card #923.

---

_This PR was generated with the help of AI, and reviewed by a Human_