### PR TITLE
ci(sonar): exclude vendored submodules and tests from analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,14 @@
+# SonarCloud Automatic Analysis scope (sonar.autoscan.enabled=true).
+#
+# Automatic Analysis clones the repo *with* submodules, so without this file it
+# analyses third_party/{astrolabe,notes,oidc} -- 64,886 ncloc, 38% of the
+# project -- as if we wrote it. That accounted for 99 of 127 vulnerabilities,
+# 10 of 41 bugs and 8,251 of ~9,900 duplicated lines, and is why master failed
+# the quality gate while every PR passed: a PR gate only measures its own
+# changed lines, and nobody ever changes a vendored line.
+#
+# tests/** is excluded because the rules that fire there are test-shaped, not
+# defect-shaped (python:S5779 on the assert/except pairs our fixtures use
+# deliberately, python:S5863 on self-comparing assertions). Coverage is not
+# uploaded from Automatic Analysis, so nothing else is lost by excluding them.
+sonar.exclusions=third_party/**,tests/**


### PR DESCRIPTION
## Why master fails the quality gate and PRs don't

SonarCloud runs **Automatic Analysis** on this project (`sonar.autoscan.enabled=true`),
and there is no analysis config in the repo — the only exclusion is the inherited
`**/build-wrapper-dump.json`. Automatic Analysis clones the repo **with submodules**, so
`third_party/{astrolabe,notes,oidc}` is analysed as if we wrote it:

| | third_party | ours |
|---|---|---|
| Open vulnerabilities | **99** | 28 |
| Open bugs | **10** | 31 |
| Duplicated lines | **8,251** | ~1,663 |
| ncloc | **64,886** (38% of project) | — |

A PR quality gate only measures the lines that PR changed, and nobody ever changes a
vendored line — so every PR passes while master carries the whole pile.

`tests/**` is excluded for a different reason: the rules that fire there are test-shaped,
not defect-shaped — `python:S5779` on the deliberate assert/except pairs our fixtures use,
`python:S5863` on self-comparing assertions. That is 15 of the 31 bugs attributed to our
code. Coverage is not uploaded from Automatic Analysis, so nothing else is lost.

## Expected effect on the next master analysis

- vulnerabilities 127 → ~28
- bugs 41 → ~16
- new duplicated lines density 5.3% → under the 3% threshold

Ratings stay red until the rest of the stack lands; this PR only stops us grading
ourselves on other people's code.

## Verification

`.sonarcloud.properties` is the file Automatic Analysis reads for scope. If the next
master analysis does not show the drop, the same exclusion has to be set server-side
under Administration → Analysis Scope instead — I'll check the analysis after merge and
follow up if so.

---

_This PR was generated with the help of AI, and reviewed by a Human_
