### PR TITLE
fix(security): autoescape the admin UI templates and escape IdP-derived values

### DIFF
--- a/nextcloud_mcp_server/auth/userinfo_routes.py
+++ b/nextcloud_mcp_server/auth/userinfo_routes.py
@@ -493,8 +493,18 @@ async def user_info_html(request: Request) -> HTMLResponse:
     #
     # html.escape() escapes &, <, >, " and ' -- enough for both element text
     # and the quoted attribute values these fragments interpolate into.
-    auth_mode = escape(str(user_context.get("auth_mode", "unknown")))
-    username = escape(str(user_context.get("username", "unknown")))
+    #
+    # auth_mode and username are kept in BOTH forms on purpose. The raw values
+    # go to template.render(), where user_info.html interpolates them as plain
+    # `{{ username }}` / `{{ auth_mode }}` and Jinja's now-enabled autoescape
+    # handles them exactly once; passing the pre-escaped copy there instead
+    # double-escapes, so a display name like `O'Brien & Co` renders as
+    # `O&#x27;Brien &amp; Co` in the navbar. The escaped copies are only for the
+    # f-string fragments below, which autoescape cannot reach.
+    auth_mode = str(user_context.get("auth_mode", "unknown"))
+    username = str(user_context.get("username", "unknown"))
+    auth_mode_html = escape(auth_mode)
+    username_html = escape(username)
 
     # Get logout URL dynamically for OAuth mode
     logout_url = ""
@@ -633,11 +643,11 @@ async def user_info_html(request: Request) -> HTMLResponse:
         <table>
             <tr>
                 <td><strong>Username</strong></td>
-                <td>{username}</td>
+                <td>{username_html}</td>
             </tr>
             <tr>
                 <td><strong>Authentication Mode</strong></td>
-                <td><span class="badge badge-{auth_mode}">{auth_mode}</span></td>
+                <td><span class="badge badge-{auth_mode_html}">{auth_mode_html}</span></td>
             </tr>
         </table>
 

--- a/nextcloud_mcp_server/auth/userinfo_routes.py
+++ b/nextcloud_mcp_server/auth/userinfo_routes.py
@@ -9,11 +9,12 @@ For OAuth mode: Requires browser-based OAuth login to establish session.
 
 import logging
 import traceback
+from html import escape
 from pathlib import Path
 from typing import Any
 
 from httpx import BasicAuth
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from starlette.authentication import requires
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
@@ -26,9 +27,19 @@ from ..http import nextcloud_httpx_client
 
 logger = logging.getLogger(__name__)
 
-# Setup Jinja2 environment for templates
+# Setup Jinja2 environment for templates.
+#
+# autoescape is NOT Jinja's default and its absence was a live XSS hole
+# (python:S5247): every `{{ }}` in these templates rendered raw, including
+# `{{ error_message }}` (built from exception text) and the user-derived values
+# in user_info.html. The three `|safe` fragments in user_info.html stay
+# deliberate — they are HTML this module builds — and the values interpolated
+# into them are escaped at the point they are read, below.
 _template_dir = Path(__file__).parent / "templates"
-_jinja_env = Environment(loader=FileSystemLoader(_template_dir))
+_jinja_env = Environment(
+    loader=FileSystemLoader(_template_dir),
+    autoescape=select_autoescape(["html", "xml"]),
+)
 
 
 async def _get_authenticated_client_for_userinfo(request: Request) -> NextcloudClient:
@@ -470,9 +481,20 @@ async def user_info_html(request: Request) -> HTMLResponse:
             )
         )
 
-    # Build HTML response
-    auth_mode = user_context.get("auth_mode", "unknown")
-    username = user_context.get("username", "unknown")
+    # Build HTML response.
+    #
+    # The fragments below are assembled with f-strings and handed to the
+    # template through `|safe`, so autoescaping does not reach them: every
+    # value interpolated into one is escaped here, where it is read. The
+    # sources are not trustworthy — `username` and the IdP profile are
+    # attacker-influencable claims from the identity provider, and a display
+    # name containing a <script> tag would otherwise execute in an
+    # authenticated page.
+    #
+    # html.escape() escapes &, <, >, " and ' -- enough for both element text
+    # and the quoted attribute values these fragments interpolate into.
+    auth_mode = escape(str(user_context.get("auth_mode", "unknown")))
+    username = escape(str(user_context.get("username", "unknown")))
 
     # Get logout URL dynamically for OAuth mode
     logout_url = ""
@@ -485,7 +507,7 @@ async def user_info_html(request: Request) -> HTMLResponse:
     # Build host info HTML (BasicAuth only)
     host_info_html = ""
     if auth_mode == "basic":
-        nextcloud_host = user_context.get("nextcloud_host", "unknown")
+        nextcloud_host = escape(str(user_context.get("nextcloud_host", "unknown")))
         host_info_html = f"""
         <h2>Connection</h2>
         <table>
@@ -499,17 +521,21 @@ async def user_info_html(request: Request) -> HTMLResponse:
     # Build session info HTML (OAuth only)
     session_info_html = ""
     if auth_mode == "oauth" and "session_id" in user_context:
-        session_id = user_context.get("session_id", "unknown")
+        session_id = escape(str(user_context.get("session_id", "unknown")))
         background_access_granted = user_context.get("background_access_granted", False)
         background_details = user_context.get("background_access_details")
 
         # Build background access section
         background_html = ""
         if background_access_granted and background_details:
-            flow_type = background_details.get("flow_type", "unknown")
-            provisioned_at = background_details.get("provisioned_at", "unknown")
-            scopes = background_details.get("scopes", "N/A")
-            token_audience = background_details.get("token_audience", "unknown")
+            flow_type = escape(str(background_details.get("flow_type", "unknown")))
+            provisioned_at = escape(
+                str(background_details.get("provisioned_at", "unknown"))
+            )
+            scopes = escape(str(background_details.get("scopes", "N/A")))
+            token_audience = escape(
+                str(background_details.get("token_audience", "unknown"))
+            )
 
             background_html = f"""
             <tr>
@@ -554,7 +580,7 @@ async def user_info_html(request: Request) -> HTMLResponse:
 
         # Add revoke button if background access is granted
         if background_access_granted:
-            revoke_url = str(request.url_for("revoke_session_endpoint"))
+            revoke_url = escape(str(request.url_for("revoke_session_endpoint")))
             session_info_html += f"""
             <div style="margin-top: 15px;">
                 <form method="post" action="{revoke_url}" onsubmit="return confirm('Are you sure you want to revoke background access? This will delete the refresh token.');">
@@ -587,17 +613,18 @@ async def user_info_html(request: Request) -> HTMLResponse:
                 value_str = ", ".join(str(v) for v in value)
             else:
                 value_str = str(value)
+            # Both the claim names and their values come straight from the IdP.
             idp_profile_html += f"""
             <tr>
-                <td><strong>{key}</strong></td>
-                <td>{value_str}</td>
+                <td><strong>{escape(str(key))}</strong></td>
+                <td>{escape(value_str)}</td>
             </tr>
             """
         idp_profile_html += "</table>"
     elif "idp_profile_error" in user_context:
         idp_profile_html = f"""
         <h2>Identity Provider Profile</h2>
-        <div class="warning">{user_context["idp_profile_error"]}</div>
+        <div class="warning">{escape(str(user_context["idp_profile_error"]))}</div>
         """
 
     # Build user info tab content

--- a/tests/server/auth/test_userinfo_routes.py
+++ b/tests/server/auth/test_userinfo_routes.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from nextcloud_mcp_server.auth.userinfo_routes import _jinja_env, _query_idp_userinfo
+from nextcloud_mcp_server.auth.userinfo_routes import (
+    _jinja_env,
+    _query_idp_userinfo,
+    user_info_html,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -95,3 +99,42 @@ def test_user_info_safe_fragments_are_still_raw():
     )
 
     assert "<td>marker-cell</td>" in rendered
+
+
+async def test_user_info_html_escapes_username_exactly_once(mocker):
+    """A username with HTML-special characters is escaped once, not twice.
+
+    `username` feeds two different sinks: the hand-built `|safe` fragment (which
+    autoescape cannot reach, so it needs a pre-escaped copy) and the plain
+    `{{ username }}` in the navbar (which autoescape handles itself). Passing
+    the pre-escaped copy to both renders `O'Brien & Co` as
+    `O&amp;#x27;Brien &amp;amp; Co`. This drives the real handler rather than
+    the template, because rendering the template directly is exactly what missed
+    the bug.
+    """
+    mocker.patch(
+        "nextcloud_mcp_server.auth.userinfo_routes._get_user_info",
+        return_value={"auth_mode": "basic", "username": "O'Brien & <Co>"},
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.auth.userinfo_routes._get_processing_status",
+        return_value=None,
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.auth.userinfo_routes._get_authenticated_client_for_userinfo",
+        side_effect=RuntimeError("not needed"),
+    )
+
+    request = Mock()
+    request.app.state = Mock(spec=[])  # no oauth_context -> BasicAuth rendering
+
+    # __wrapped__ skips the @requires('authenticated') gate, which asserts a
+    # real starlette Request; the subject here is the escaping, not the gate.
+    response = await user_info_html.__wrapped__(request)
+    body = response.body.decode()
+
+    # Escaped exactly once: the raw text and the double-escaped form are absent.
+    assert "O&#x27;Brien &amp; &lt;Co&gt;" in body
+    assert "&amp;#x27;" not in body
+    assert "&amp;amp;" not in body
+    assert "<Co>" not in body

--- a/tests/server/auth/test_userinfo_routes.py
+++ b/tests/server/auth/test_userinfo_routes.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from nextcloud_mcp_server.auth.userinfo_routes import _query_idp_userinfo
+from nextcloud_mcp_server.auth.userinfo_routes import _jinja_env, _query_idp_userinfo
 
 pytestmark = pytest.mark.unit
 
@@ -61,3 +61,37 @@ async def test_query_idp_userinfo_failure(mocker):
     result = await _query_idp_userinfo("test_token", "https://example.com/userinfo")
 
     assert result is None
+
+
+def test_templates_autoescape():
+    """The Jinja environment must autoescape.
+
+    Jinja does not do this by default, and without it `{{ error_message }}` --
+    built from exception text -- renders raw into an authenticated page.
+    """
+    rendered = _jinja_env.get_template("error.html").render(
+        error_message="<script>alert(1)</script>",
+        error_title="<img src=x onerror=alert(1)>",
+    )
+
+    assert "<script>alert(1)</script>" not in rendered
+    assert "&lt;script&gt;" in rendered
+    assert "onerror=alert(1)>" not in rendered
+
+
+def test_user_info_safe_fragments_are_still_raw():
+    """The three `|safe` fragments must keep passing HTML through.
+
+    Autoescaping them would double-escape markup this module builds itself; the
+    values *inside* those fragments are escaped where they are read instead.
+    """
+    rendered = _jinja_env.get_template("user_info.html").render(
+        user_info_tab_html="<table><tr><td>marker-cell</td></tr></table>",
+        vector_sync_tab_html="",
+        webhooks_tab_html="",
+        show_vector_sync_tab=False,
+        show_webhooks_tab=False,
+        logout_url=None,
+    )
+
+    assert "<td>marker-cell</td>" in rendered


### PR DESCRIPTION
Top of the SonarCloud gate stack. `new_security_hotspots_reviewed` has to be 100% for the
gate to pass, so all 20 open hotspots were reviewed. Four of them — the HIGH-probability
xss ones on the user-info page — turned out to be a **live XSS hole**, not a false
positive. That is what this PR fixes; the remainder are marked Safe/Accepted on SonarCloud
with the reasoning recorded there (summary at the bottom).

## The hole

`jinja2.Environment` does not autoescape by default, and this one did not turn it on. So
every `{{ }}` in the admin templates rendered raw — including `{{ error_message }}` in
`error.html`, which is built from exception text, and `{{ redirect_url }}` in
`success.html`.

The three `|safe` fragments in `user_info.html` are deliberate — they are HTML this module
assembles — but the values interpolated into *them* were not escaped either. Those values
are not trustworthy:

- `username` — an identity-provider claim
- every key and value of the IdP profile table (`idp_profile`), rendered verbatim
- session id, flow type, provisioned-at, scopes, token audience

A display name of `<script>…</script>` executed in an authenticated page.

## The fix

- `autoescape=select_autoescape(["html", "xml"])` on the environment, so every `{{ }}` is
  escaped by default and `|safe` becomes a deliberate opt-out rather than the ambient
  behaviour.
- Every value interpolated into the hand-built fragments is escaped where it is read, with
  `html.escape` from the standard library — `markupsafe` is only a transitive dependency
  of jinja2 here and is not declared, so importing it directly would be a latent break.

Tests cover both halves: a script payload renders escaped, and the `|safe` fragments still
pass HTML through (so the fix cannot be "improved" into double-escaping later).

## Reviewed and marked on SonarCloud, not changed here

- `python:S5332` ×11 (LOW), three different reasons — each marked individually, not in
  bulk:
  - `client/calendar.py`, `client/webdav.py` — CalDAV/WebDAV XML **namespace URIs**.
    Identifiers, never fetched. False positive.
  - `auth/elicitation.py:59` — the literal is inside `startswith(("http://", "https://"))`,
    i.e. the validation itself. False positive.
  - `config.py:314` (`http://unstructured:8000`), `auth/webhook_routes.py:124`
    (`http://<service>:<port>/webhooks/nextcloud`) — container-to-container URLs on an
    internal network, never leaving the cluster. Accepted with that rationale rather
    than called a false positive.
- `python:S2245` (`vector/scanner.py`) — `random` used for jitter, not for anything secret.
- `python:S4790` (`providers/simple.py`) — hashing for a deterministic fallback embedding,
  not for security.
- `docker:S6470`/`S6471` — reviewed individually; see the SonarCloud comments.

`terraform:S6258` on `infra/terraform/nextcloud-mcp-server/alb.tf:55` is **not** being
marked safe: it flags the ALB having no access logging, which is a real gap and a cost/infra
decision rather than something to wave through. Left open and raised on the card.

## Known gap, not fixed here

`auth/browser_oauth_routes.py` and `auth/provision_routes.py` also assemble HTML with
f-strings. Sonar did not flag them and auditing them is a bigger job than this stack;
tracked on the Deck card instead of being silently left.

---

_This PR was generated with the help of AI, and reviewed by a Human_
