### PR TITLE
feat(search): add granularity="document" to nc_semantic_search

### DIFF
--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -31,6 +31,9 @@ from nextcloud_mcp_server.api.management import (
 from nextcloud_mcp_server.config import Settings, get_settings
 from nextcloud_mcp_server.providers import get_provider
 from nextcloud_mcp_server.search import (
+    GRANULARITY_CHUNK,
+    GRANULARITY_DOCUMENT,
+    VALID_GRANULARITIES,
     BM25HybridSearchAlgorithm,
     SearchAlgorithm,
     SemanticSearchAlgorithm,
@@ -182,7 +185,11 @@ async def unified_search(request: Request) -> JSONResponse:
         "limit": 20,  // max: 100
         "offset": 0,  // pagination offset
         "include_pca": false,  // optional PCA coordinates
-        "include_chunks": true  // include text snippets
+        "include_chunks": true,  // include text snippets
+        "granularity": "chunk"  // "chunk" (default) or "document": one row
+                                // per document (its best chunk), so `limit`
+                                // counts documents. "document" requires the
+                                // bm25/hybrid algorithm.
     }
 
     Response:
@@ -279,6 +286,21 @@ async def unified_search(request: Request) -> JSONResponse:
 
         requested_algorithm = body.get("algorithm")  # None ⇒ graceful default
         fusion = body.get("fusion", "rrf")
+        # Unlike ``fusion`` (normalized to "rrf" when unrecognized), an
+        # unrecognized granularity is rejected rather than silently downgraded:
+        # a caller asking for one row per document and receiving several chunks
+        # of the same document would look like a ranking bug, not a bad request.
+        granularity = body.get("granularity", GRANULARITY_CHUNK)
+        if granularity not in VALID_GRANULARITIES:
+            return JSONResponse(
+                {
+                    "error": (
+                        f"Invalid granularity {granularity!r}. "
+                        f"Must be one of {list(VALID_GRANULARITIES)}"
+                    )
+                },
+                status_code=400,
+            )
         include_pca = body.get("include_pca", False)
         include_chunks = body.get("include_chunks", True)
         doc_types = body.get("doc_types")  # Optional filter
@@ -312,6 +334,23 @@ async def unified_search(request: Request) -> JSONResponse:
         except UnsupportedSearchType as e:
             return _unsupported_search_type_response(e)
 
+        # Only the hybrid algorithm implements grouping. The dense-only path
+        # would accept the kwarg and silently ignore it, returning several
+        # chunks of one document to a caller that asked for one row per
+        # document — indistinguishable from a ranking bug. Reject instead.
+        # Astrolabe requests "hybrid" (its default), so this combination is
+        # reachable only by an explicit opt-in to the dense algorithm.
+        if granularity == GRANULARITY_DOCUMENT and algorithm == "semantic":
+            return JSONResponse(
+                {
+                    "error": "granularity_unsupported_for_algorithm",
+                    "granularity": granularity,
+                    "algorithm": algorithm,
+                    "supported_algorithms": ["bm25", "hybrid"],
+                },
+                status_code=422,
+            )
+
         # Request extra results to handle offset
         search_limit = limit + offset
 
@@ -334,6 +373,7 @@ async def unified_search(request: Request) -> JSONResponse:
                                 doc_type=doc_type,
                                 accessible_owners=owners,
                                 shared_root_ids=roots,
+                                granularity=granularity,
                                 modified_after=modified_after,
                                 modified_before=modified_before,
                                 path_prefixes=path_prefixes,
@@ -355,6 +395,7 @@ async def unified_search(request: Request) -> JSONResponse:
                     limit=search_limit,
                     accessible_owners=owners,
                     shared_root_ids=roots,
+                    granularity=granularity,
                     modified_after=modified_after,
                     modified_before=modified_before,
                     path_prefixes=path_prefixes,

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -94,14 +94,25 @@ class SemanticSearchResponse(BaseResponse):
             "same fused query."
         ),
     )
+    granularity: str = Field(
+        default="chunk",
+        description=(
+            "Result granularity actually applied: 'chunk' (each row is a "
+            "passage; one document may occupy several rows) or 'document' "
+            "(each row is a distinct document, represented by its "
+            "best-matching chunk). Echoed so a stored or forwarded response "
+            "is self-describing without its originating request."
+        ),
+    )
     verified_chunk_count: int = Field(
         default=0,
         description=(
-            "Number of search result chunks that passed verify-on-read "
-            "access checks (ADR-019). Equals len(verified_results) before "
-            "trimming to limit. Sized in chunks (result rows), NOT in "
-            "unique documents — see dropped_document_count for the "
-            "per-document counterpart."
+            "Number of result rows that passed verify-on-read access checks "
+            "(ADR-019). Equals len(verified_results) before trimming to "
+            "limit. Counts rows, which are passages at granularity='chunk' "
+            "and distinct documents at granularity='document' — so it equals "
+            "the document count only in the latter. See "
+            "dropped_document_count, which is always sized in documents."
         ),
     )
     dropped_document_count: int = Field(

--- a/nextcloud_mcp_server/search/__init__.py
+++ b/nextcloud_mcp_server/search/__init__.py
@@ -14,7 +14,12 @@ from nextcloud_mcp_server.search.algorithms import (
     SearchResult,
     get_indexed_doc_types,
 )
-from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
+from nextcloud_mcp_server.search.bm25_hybrid import (
+    GRANULARITY_CHUNK,
+    GRANULARITY_DOCUMENT,
+    VALID_GRANULARITIES,
+    BM25HybridSearchAlgorithm,
+)
 from nextcloud_mcp_server.search.semantic import SemanticSearchAlgorithm
 
 __all__ = [
@@ -24,4 +29,7 @@ __all__ = [
     "get_indexed_doc_types",
     "SemanticSearchAlgorithm",
     "BM25HybridSearchAlgorithm",
+    "GRANULARITY_CHUNK",
+    "GRANULARITY_DOCUMENT",
+    "VALID_GRANULARITIES",
 ]

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -24,6 +24,39 @@ from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
 logger = logging.getLogger(__name__)
 
+# Result granularity (ADR-027 follow-up, Deck #83). "chunk" is the historical
+# behaviour and stays the default everywhere; "document" collapses each document
+# to its single best-scoring chunk via Qdrant's native grouping.
+GRANULARITY_CHUNK = "chunk"
+GRANULARITY_DOCUMENT = "document"
+VALID_GRANULARITIES = (GRANULARITY_CHUNK, GRANULARITY_DOCUMENT)
+
+# Extra prefetch depth applied on top of the usual budget when grouping. Chunks
+# concentrate hard in the head of the ranking — one document can legitimately own
+# a double-digit run of consecutive chunks — so filling N *distinct* documents
+# needs materially more candidates than filling N chunks. Measured on a
+# 550k-chunk corpus: a 400-chunk prefetch yielded ~300 distinct documents.
+DOCUMENT_PREFETCH_FACTOR = 4
+
+
+class _FlattenedGroups:
+    """Adapt a grouped Qdrant response to the ungrouped ``.points`` shape.
+
+    Grouping is a retrieval concern, not a result-shape concern: every caller
+    downstream (dedup, SearchResult construction, verification, context
+    expansion) already works on a flat list of scored points. Flattening each
+    group to its best hit here keeps that whole path granularity-agnostic
+    instead of forking it.
+    """
+
+    __slots__ = ("points",)
+
+    def __init__(self, groups):
+        # ``hits`` is ordered best-first within a group, so hits[0] is the
+        # document's strongest chunk. Empty groups cannot occur in practice
+        # (a group exists because a point matched) but are skipped defensively.
+        self.points = [g.hits[0] for g in groups if g.hits]
+
 
 class BM25HybridSearchAlgorithm(SearchAlgorithm):
     """
@@ -149,37 +182,75 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         query_filter: Filter,
         limit: int,
         score_threshold: float,
+        granularity: str = GRANULARITY_CHUNK,
     ) -> Any:
         """Execute the Qdrant query: dense + sparse prefetches merged by native
         fusion (RRF or DBSF).
 
         Keyword-only documents (``keyword-index`` tag) carry no dense vector, so
         the dense prefetch never returns them; they surface via the sparse
-        prefetch and are merged in by fusion. No mode branch is needed.
+        prefetch and are merged in by fusion. No mode branch is needed for that.
+
+        ``granularity="document"`` runs the same prefetch + fusion through
+        Qdrant's native grouping so each document contributes exactly one row
+        (its best chunk) instead of competing for slots chunk-by-chunk. The
+        prefetch is deepened by ``DOCUMENT_PREFETCH_FACTOR`` because filling N
+        distinct documents needs more candidates than filling N chunks.
         """
         collection_name = settings.get_collection_name()
+        grouped = granularity == GRANULARITY_DOCUMENT
+        # Both paths over-fetch 2x for the dedup/verification budget.
+        prefetch_limit = limit * 2 * (DOCUMENT_PREFETCH_FACTOR if grouped else 1)
+        prefetches = [
+            # Dense semantic search
+            models.Prefetch(
+                query=dense_embedding,
+                using="dense",
+                limit=prefetch_limit,
+                filter=query_filter,
+            ),
+            # Sparse BM25 search
+            models.Prefetch(
+                query=sparse_query,
+                using="sparse",
+                limit=prefetch_limit,
+                filter=query_filter,
+            ),
+        ]
         with trace_operation(
             "search.qdrant_query",
-            attributes={"query.limit": limit * 2, "query.fusion": self.fusion_name},
+            attributes={
+                "query.limit": limit * 2,
+                "query.fusion": self.fusion_name,
+                "query.granularity": granularity,
+            },
         ):
+            if grouped:
+                response = await qdrant_client.query_points_groups(
+                    collection_name=collection_name,
+                    prefetch=prefetches,
+                    query=self._build_fusion_query(settings),
+                    # doc_id is the per-document key. Caveat: it is NOT unique
+                    # across doc_types (a note 42 and a file 42 are distinct
+                    # documents sharing an id), so a cross-app grouped search
+                    # can collapse two such documents into one group. Qdrant
+                    # groups on a single payload field, so avoiding this needs a
+                    # composite key written at index time. The tool layer's
+                    # per-doc_type loop is unaffected; only doc_types=None is.
+                    group_by="doc_id",
+                    # One row per document: the caller asked for documents, and
+                    # the extra hits would just re-introduce the chunk-level
+                    # concentration this mode exists to remove.
+                    group_size=1,
+                    limit=limit * 2,  # groups, not chunks
+                    score_threshold=score_threshold,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+                return _FlattenedGroups(response.groups)
             return await qdrant_client.query_points(
                 collection_name=collection_name,
-                prefetch=[
-                    # Dense semantic search
-                    models.Prefetch(
-                        query=dense_embedding,
-                        using="dense",
-                        limit=limit * 2,  # Get extra for deduplication
-                        filter=query_filter,
-                    ),
-                    # Sparse BM25 search
-                    models.Prefetch(
-                        query=sparse_query,
-                        using="sparse",
-                        limit=limit * 2,  # Get extra for deduplication
-                        filter=query_filter,
-                    ),
-                ],
+                prefetch=prefetches,
                 # Fusion query (RRF or DBSF based on initialization)
                 query=self._build_fusion_query(settings),
                 limit=limit * 2,  # Get extra for deduplication
@@ -202,6 +273,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         path_prefixes: Iterable[str] | None = None,
         path_prefix_folder_ids: list[str] | None = None,
         shared_root_ids: list[str] | None = None,
+        granularity: str = GRANULARITY_CHUNK,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """
@@ -232,6 +304,13 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
             path_prefixes: Folder/path filters on ``file_path`` (files only),
                 OR-ed together; ``None``/empty ⇒ no path filter (ADR-027
                 Phase 2).
+            granularity: ``"chunk"`` (default) returns the best-matching
+                passages, so one document may occupy several rows. ``"document"``
+                returns one row per document — its best chunk — which is the
+                right shape for "which files mention X". Note this changes what
+                ``limit`` counts (documents, not chunks); it does NOT deepen
+                recall, since a document whose best chunk misses the prefetch is
+                absent either way.
             **kwargs: Additional parameters (score_threshold override)
 
         Returns:
@@ -240,6 +319,16 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         Raises:
             McpError: If vector sync is not enabled or search fails
         """
+        if granularity not in VALID_GRANULARITIES:
+            # Validated here rather than only at the tool boundary so every
+            # surface (MCP tool, /api/v1) gets the same contract, and an
+            # unrecognised value fails loudly instead of silently falling back
+            # to chunk granularity.
+            raise ValueError(
+                f"Invalid granularity {granularity!r}. "
+                f"Must be one of {VALID_GRANULARITIES}"
+            )
+
         settings = get_settings()
         score_threshold = kwargs.get("score_threshold", self.score_threshold)
 
@@ -305,6 +394,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
                 query_filter=query_filter,
                 limit=limit,
                 score_threshold=score_threshold,
+                granularity=granularity,
             )
             record_qdrant_operation("search", "success")
         except Exception:

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -38,6 +38,21 @@ VALID_GRANULARITIES = (GRANULARITY_CHUNK, GRANULARITY_DOCUMENT)
 # 550k-chunk corpus: a 400-chunk prefetch yielded ~300 distinct documents.
 DOCUMENT_PREFETCH_FACTOR = 4
 
+# Ceiling on the per-branch prefetch when grouping. The multipliers compound —
+# the tool layer over-fetches 2x for verification headroom, _run_qdrant_query
+# doubles again for dedup, and DOCUMENT_PREFETCH_FACTOR stacks on top — so an
+# uncapped limit=100 asks Qdrant for 1600 candidates per branch, per doc_type.
+# Measured on a 550k-chunk collection, same query and result count:
+#
+#   chunk    limit=100 (prefetch  400)   412 ms
+#   document limit=100 (prefetch 1600)  4275 ms
+#   document limit=100 (prefetch  800)   302 ms   <- identical 200 groups
+#
+# The extra depth past ~800 buys no additional documents and costs ~10x
+# latency, so cap it. Only bites above limit=50; below that the computed
+# budget is already under the ceiling.
+MAX_DOCUMENT_PREFETCH = 800
+
 
 class _FlattenedGroups:
     """Adapt a grouped Qdrant response to the ungrouped ``.points`` shape.
@@ -199,8 +214,14 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         """
         collection_name = settings.get_collection_name()
         grouped = granularity == GRANULARITY_DOCUMENT
-        # Both paths over-fetch 2x for the dedup/verification budget.
-        prefetch_limit = limit * 2 * (DOCUMENT_PREFETCH_FACTOR if grouped else 1)
+        # Both paths over-fetch 2x for the dedup/verification budget; grouping
+        # deepens it further, bounded by MAX_DOCUMENT_PREFETCH so the compounding
+        # multipliers can't produce a pathological query at a high ``limit``.
+        prefetch_limit = limit * 2
+        if grouped:
+            prefetch_limit = min(
+                prefetch_limit * DOCUMENT_PREFETCH_FACTOR, MAX_DOCUMENT_PREFETCH
+            )
         prefetches = [
             # Dense semantic search
             models.Prefetch(

--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -16,6 +16,7 @@ from nextcloud_mcp_server.search.algorithms import (
     SearchResult,
     build_search_result_from_point,
 )
+from nextcloud_mcp_server.search.bm25_hybrid import GRANULARITY_CHUNK
 from nextcloud_mcp_server.vector.payload_keys import ACL_HASH
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
@@ -66,6 +67,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
         path_prefixes: Iterable[str] | None = None,
         path_prefix_folder_ids: list[str] | None = None,
         shared_root_ids: list[str] | None = None,
+        granularity: str = GRANULARITY_CHUNK,
         **kwargs: Any,
     ) -> list[SearchResult]:
         """Execute semantic search using vector similarity.
@@ -104,6 +106,19 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
         Raises:
             McpError: If vector sync is not enabled or search fails
         """
+        if granularity != GRANULARITY_CHUNK:
+            # Declared explicitly rather than swallowed by **kwargs, matching
+            # the convention on accessible_owners/modified_at: a value this
+            # algorithm cannot honour must fail loudly, not silently return
+            # chunk-granularity rows to a caller that asked for documents.
+            # Grouping is implemented only by BM25HybridSearchAlgorithm; the
+            # /api/v1 layer rejects the combination with a 422 before reaching
+            # here, so this is the defence-in-depth backstop for direct callers.
+            raise ValueError(
+                f"granularity={granularity!r} is not supported by the dense-only "
+                f"{self.name!r} algorithm; use the bm25/hybrid algorithm."
+            )
+
         settings = get_settings()
         score_threshold = kwargs.get("score_threshold", self.score_threshold)
 

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -1,7 +1,7 @@
 """Semantic search MCP tools using vector database."""
 
 import logging
-from typing import Annotated
+from typing import Annotated, Literal
 
 import anyio
 from httpx import RequestError
@@ -148,7 +148,7 @@ def configure_semantic_tools(mcp: FastMCP):
         score_threshold: Annotated[float, Field(ge=0.0)] = 0.0,
         fusion: str = "rrf",
         granularity: Annotated[
-            str,
+            Literal["chunk", "document"],
             Field(
                 description=(
                     "Result granularity. 'chunk' (default) returns the "

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -147,6 +147,24 @@ def configure_semantic_tools(mcp: FastMCP):
         doc_types: list[str] | None = None,
         score_threshold: Annotated[float, Field(ge=0.0)] = 0.0,
         fusion: str = "rrf",
+        granularity: Annotated[
+            str,
+            Field(
+                description=(
+                    "Result granularity. 'chunk' (default) returns the "
+                    "best-matching passages, so a long document can occupy "
+                    "several result slots. 'document' returns one row per "
+                    "document (its best-matching chunk), which is the right "
+                    "shape for 'which files mention X' / 'list documents "
+                    "about Y' — `limit` then counts documents rather than "
+                    "passages. Use 'chunk' when you want the passage text to "
+                    "answer from, 'document' when you want to enumerate "
+                    "sources. Note 'document' improves result diversity, not "
+                    "recall: a document whose best chunk ranks too low to be "
+                    "retrieved is absent under both settings."
+                ),
+            ),
+        ] = "chunk",
         include_context: bool = False,
         context_chars: Annotated[int, Field(ge=0)] = 300,
         modified_after: Annotated[
@@ -412,6 +430,7 @@ def configure_semantic_tools(mcp: FastMCP):
                     score_threshold=score_threshold,
                     accessible_owners=accessible_owners,
                     shared_root_ids=shared_root_ids,
+                    granularity=granularity,
                     modified_after=modified_after_ts,
                     modified_before=modified_before_ts,
                     path_prefixes=folder_prefixes,
@@ -442,6 +461,7 @@ def configure_semantic_tools(mcp: FastMCP):
                         score_threshold=score_threshold,
                         accessible_owners=accessible_owners,
                         shared_root_ids=shared_root_ids,
+                        granularity=granularity,
                         modified_after=modified_after_ts,
                         modified_before=modified_before_ts,
                         path_prefixes=folder_prefixes,

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -161,7 +161,12 @@ def configure_semantic_tools(mcp: FastMCP):
                     "answer from, 'document' when you want to enumerate "
                     "sources. Note 'document' improves result diversity, not "
                     "recall: a document whose best chunk ranks too low to be "
-                    "retrieved is absent under both settings."
+                    "retrieved is absent under both settings. Caveat when "
+                    "combined with the default doc_types=None (search all "
+                    "types): grouping keys on the numeric document id, which "
+                    "is not unique across types, so a note and a file that "
+                    "happen to share an id can be merged into one result. "
+                    "Pass an explicit doc_types (e.g. ['file']) to avoid this."
                 ),
             ),
         ] = "chunk",
@@ -387,6 +392,7 @@ def configure_semantic_tools(mcp: FastMCP):
                     query=query,
                     total_found=0,
                     search_method=search_method,
+                    granularity=granularity,
                     verified_chunk_count=0,
                     dropped_document_count=0,
                 )
@@ -713,6 +719,7 @@ def configure_semantic_tools(mcp: FastMCP):
                 query=query,
                 total_found=len(results),
                 search_method=search_method,
+                granularity=granularity,
                 verified_chunk_count=verified_chunk_count,
                 dropped_document_count=dropped_count,
             )

--- a/tests/integration/test_search_granularity.py
+++ b/tests/integration/test_search_granularity.py
@@ -1,0 +1,221 @@
+"""Result granularity — real Qdrant grouping through the hybrid algorithm.
+
+``tests/unit/search/test_bm25_hybrid.py::TestGranularity`` asserts the *query
+shape* sent to Qdrant (group_by, group_size, prefetch depth) against a mock.
+That cannot show whether grouping actually changes what a caller receives, so
+this exercises ``BM25HybridSearchAlgorithm.search()`` end to end against an
+in-memory Qdrant holding a corpus deliberately shaped like the production one:
+a chunk-heavy document that monopolises chunk-level results, plus several
+single-chunk documents that it crowds out.
+
+No Nextcloud, no verification layer, no background sync — fast and
+deterministic.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import (
+    Distance,
+    PointStruct,
+    SparseVector,
+    SparseVectorParams,
+    VectorParams,
+)
+
+from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
+
+pytestmark = pytest.mark.integration
+
+_COLLECTION = "granularity_test"
+_DIM = 4
+
+# One "bundle" document with many chunks (the shape that monopolises a
+# chunk-ranked result page) and four single-chunk documents.
+_BUNDLE_CHUNKS = 6
+_SINGLE_DOCS = ["single-1", "single-2", "single-3", "single-4"]
+
+
+_QUERY_VEC = [1.0, 0.0, 0.0, 0.0]
+
+
+def _bundle_vec(chunk_index: int) -> list[float]:
+    """Bundle chunks sit closest to the query, so they legitimately win the
+    chunk-level ranking — the production shape this mode addresses."""
+    return [1.0, 0.01 * chunk_index, 0.0, 0.0]
+
+
+def _single_vec(i: int) -> list[float]:
+    """Single-chunk documents are relevant but rank below every bundle chunk."""
+    return [1.0, 0.5 + (0.1 * i), 0.0, 0.0]
+
+
+@pytest.fixture
+async def granularity_collection(monkeypatch):
+    client = AsyncQdrantClient(":memory:")
+    await client.create_collection(
+        collection_name=_COLLECTION,
+        vectors_config={"dense": VectorParams(size=_DIM, distance=Distance.COSINE)},
+        sparse_vectors_config={"sparse": SparseVectorParams()},
+    )
+
+    points: list[PointStruct] = []
+    pid = 0
+    for chunk_index in range(_BUNDLE_CHUNKS):
+        points.append(
+            _point(
+                pid,
+                "bundle",
+                chunk_index,
+                _BUNDLE_CHUNKS,
+                _bundle_vec(chunk_index),
+                sparse_weight=1.0,
+            )
+        )
+        pid += 1
+    for i, doc_id in enumerate(_SINGLE_DOCS):
+        points.append(_point(pid, doc_id, 0, 1, _single_vec(i), sparse_weight=0.5))
+        pid += 1
+    await client.upsert(collection_name=_COLLECTION, points=points, wait=True)
+
+    settings = MagicMock()
+    settings.get_collection_name.return_value = _COLLECTION
+    settings.get_embedding_provider_family.return_value = "test"
+    settings.vector_search_rrf_k = 60
+    settings.acl_prefilter_enabled = False
+
+    provider = MagicMock()
+    provider.embed_with_usage = AsyncMock(return_value=(_QUERY_VEC, 3))
+    bm25 = MagicMock()
+    bm25.encode_async = AsyncMock(return_value={"indices": [1], "values": [1.0]})
+
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+        AsyncMock(return_value=client),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.bm25_hybrid.get_provider", lambda: provider
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.bm25_hybrid.get_bm25_service",
+        AsyncMock(return_value=bm25),
+    )
+    monkeypatch.setattr(
+        "nextcloud_mcp_server.search.bm25_hybrid.get_settings", lambda: settings
+    )
+
+    yield client
+
+    await client.close()
+
+
+def _point(
+    pid: int,
+    doc_id: str,
+    chunk_index: int,
+    total: int,
+    dense: list[float],
+    *,
+    sparse_weight: float,
+) -> PointStruct:
+    return PointStruct(
+        id=pid,
+        vector={
+            "dense": dense,
+            "sparse": SparseVector(indices=[1], values=[sparse_weight]),
+        },
+        payload={
+            "doc_id": doc_id,
+            "doc_type": "file",
+            "user_id": "alice",
+            "owner_id": "alice",
+            "is_placeholder": False,
+            "title": f"{doc_id}.pdf",
+            "excerpt": f"chunk {chunk_index} of {doc_id}",
+            "file_path": f"docs/{doc_id}.pdf",
+            "chunk_index": chunk_index,
+            "total_chunks": total,
+            # Distinct offsets matter: search() deduplicates on
+            # (doc_id, doc_type, chunk_start_offset, chunk_end_offset), so
+            # leaving these unset would collapse every chunk of a document into
+            # one row and hide the very concentration this suite is about.
+            "chunk_start_offset": chunk_index * 1000,
+            "chunk_end_offset": (chunk_index + 1) * 1000,
+        },
+    )
+
+
+async def _search(granularity: str, limit: int = 5) -> list:
+    return await BM25HybridSearchAlgorithm().search(
+        query="anything",
+        user_id="alice",
+        limit=limit,
+        doc_type="file",
+        granularity=granularity,
+    )
+
+
+async def test_chunk_granularity_lets_one_document_monopolise(
+    granularity_collection,
+):
+    """Baseline: the pre-existing behaviour this mode exists to offer an
+    alternative to. The bundle's chunks crowd out the other documents."""
+    results = await _search("chunk", limit=5)
+
+    doc_ids = [r.id for r in results]
+    assert doc_ids.count("bundle") > 1, (
+        "chunk granularity is expected to return several chunks of the same "
+        f"document — got {doc_ids}"
+    )
+    assert len(set(doc_ids)) < len(doc_ids), "expected duplicate documents"
+
+
+async def test_document_granularity_returns_one_row_per_document(
+    granularity_collection,
+):
+    results = await _search("document", limit=5)
+
+    doc_ids = [r.id for r in results]
+    assert len(doc_ids) == len(set(doc_ids)), (
+        f"every document must appear at most once — got {doc_ids}"
+    )
+    assert doc_ids.count("bundle") == 1
+
+
+async def test_document_granularity_surfaces_crowded_out_documents(
+    granularity_collection,
+):
+    """The payoff: documents the bundle displaced now fit on the page."""
+    chunk_docs = {r.id for r in await _search("chunk", limit=5)}
+    document_docs = {r.id for r in await _search("document", limit=5)}
+
+    assert len(document_docs) > len(chunk_docs)
+    recovered = document_docs - chunk_docs
+    assert recovered, "expected at least one previously-crowded-out document"
+    assert recovered <= set(_SINGLE_DOCS)
+
+
+async def test_document_granularity_returns_the_documents_best_chunk(
+    granularity_collection,
+):
+    """The row that represents a document must be its top-scoring chunk, not an
+    arbitrary one — the excerpt is what the caller reads."""
+    grouped_bundle = next(
+        r for r in await _search("document", limit=5) if r.id == "bundle"
+    )
+    # Rather than hard-coding which chunk "should" win (that would just restate
+    # the fixture's vectors), assert the invariant: the representative is the
+    # same chunk that ranks highest for this document at chunk granularity.
+    best_ranked = next(r for r in await _search("chunk", limit=10) if r.id == "bundle")
+
+    assert grouped_bundle.chunk_index == best_ranked.chunk_index
+    assert grouped_bundle.excerpt == best_ranked.excerpt
+
+
+async def test_limit_counts_documents_not_chunks(granularity_collection):
+    """With 5 documents indexed, limit=3 must yield 3 documents."""
+    results = await _search("document", limit=3)
+
+    assert len(results) == 3
+    assert len({r.id for r in results}) == 3

--- a/tests/unit/api/test_search_granularity_api.py
+++ b/tests/unit/api/test_search_granularity_api.py
@@ -1,0 +1,107 @@
+"""`granularity` on POST /api/v1/search — the surface Astrolabe consumes.
+
+The MCP tool's granularity behaviour is covered in
+``tests/unit/search/test_bm25_hybrid.py`` and
+``tests/integration/test_search_granularity.py``. These drive the real
+Starlette handler so the HTTP contract itself is pinned: the default, the
+pass-through to the algorithm, and the two rejection paths.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from nextcloud_mcp_server.api.visualization import unified_search
+from nextcloud_mcp_server.vector.oauth_sync import NotProvisionedError
+
+pytestmark = pytest.mark.unit
+
+
+def _settings() -> MagicMock:
+    settings = MagicMock()
+    settings.vector_sync_enabled = True
+    return settings
+
+
+def _app() -> Starlette:
+    app = Starlette(routes=[Route("/api/v1/search", unified_search, methods=["POST"])])
+    # _search_with_acl reads the configured Nextcloud host from here.
+    app.state.oauth_context = {"config": {"nextcloud_host": "https://nc.example"}}
+    return app
+
+
+def _post(body: dict, *, search_spy=None):
+    algo = MagicMock()
+    algo.search = search_spy or AsyncMock(return_value=[])
+    algo.query_token_count = 0
+    with (
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+            new=AsyncMock(return_value=("alice", {})),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.BM25HybridSearchAlgorithm",
+            return_value=algo,
+        ),
+        # Let _search_with_acl actually run: an unprovisioned caller takes the
+        # execute(None) path, so the real _execute closure runs and we can
+        # observe the kwargs it forwards to the algorithm.
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_user_client_basic_auth",
+            new=AsyncMock(side_effect=NotProvisionedError("not provisioned")),
+        ),
+    ):
+        return TestClient(_app()).post("/api/v1/search", json=body), algo
+
+
+def test_invalid_granularity_is_rejected_with_400():
+    """Rejected rather than normalised: silently downgrading a 'document'
+    request to chunks would surface as a ranking bug, not a bad request."""
+    resp, _ = _post({"query": "anything", "granularity": "documnet"})
+
+    assert resp.status_code == 400
+    assert "Invalid granularity" in resp.json()["error"]
+
+
+def test_document_granularity_with_semantic_algorithm_returns_422():
+    """The dense-only algorithm has no grouping and would ignore the kwarg."""
+    resp, _ = _post(
+        {"query": "anything", "algorithm": "semantic", "granularity": "document"}
+    )
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"] == "granularity_unsupported_for_algorithm"
+    assert body["algorithm"] == "semantic"
+    assert body["supported_algorithms"] == ["bm25", "hybrid"]
+
+
+@pytest.mark.parametrize("algorithm", ["bm25", "hybrid"])
+def test_document_granularity_reaches_the_algorithm(algorithm: str):
+    """Accepted *and* forwarded — a 200 alone would not prove the wiring."""
+    spy = AsyncMock(return_value=[])
+    resp, _ = _post(
+        {"query": "anything", "algorithm": algorithm, "granularity": "document"},
+        search_spy=spy,
+    )
+
+    assert resp.status_code == 200
+    spy.assert_awaited()
+    assert spy.await_args.kwargs["granularity"] == "document"
+
+
+def test_default_granularity_is_chunk():
+    """Omitting the field must leave existing callers on today's behaviour."""
+    spy = AsyncMock(return_value=[])
+    resp, _ = _post({"query": "anything"}, search_spy=spy)
+
+    assert resp.status_code == 200
+    spy.assert_awaited()
+    assert spy.await_args.kwargs["granularity"] == "chunk"

--- a/tests/unit/search/test_bm25_hybrid.py
+++ b/tests/unit/search/test_bm25_hybrid.py
@@ -391,7 +391,10 @@ class TestGranularity:
     @pytest.mark.unit
     async def test_invalid_granularity_raises(self, patched_search):
         """Fails loudly rather than silently degrading to chunk granularity."""
+        # Constructed outside the raises block so only one call inside it can
+        # throw (python:S5778) — otherwise a constructor regression would pass
+        # as if it were the validation firing.
+        algo = BM25HybridSearchAlgorithm()
+
         with pytest.raises(ValueError, match="Invalid granularity"):
-            await BM25HybridSearchAlgorithm().search(
-                query="hello", user_id="alice", granularity="documnet"
-            )
+            await algo.search(query="hello", user_id="alice", granularity="documnet")

--- a/tests/unit/search/test_bm25_hybrid.py
+++ b/tests/unit/search/test_bm25_hybrid.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from qdrant_client import models
 
-from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
+from nextcloud_mcp_server.search.bm25_hybrid import (
+    DOCUMENT_PREFETCH_FACTOR,
+    MAX_DOCUMENT_PREFETCH,
+    BM25HybridSearchAlgorithm,
+)
 
 
 @pytest.mark.unit
@@ -315,6 +319,33 @@ class TestGranularity:
         assert len(prefetch) == 2, "still dense + sparse"
         # 10 * 2 (over-fetch) * DOCUMENT_PREFETCH_FACTOR
         assert [p.limit for p in prefetch] == [80, 80]
+
+    @pytest.mark.unit
+    async def test_document_prefetch_is_capped(self, patched_search, monkeypatch):
+        """The multipliers compound (tool 2x * dedup 2x * factor 4x), so an
+        uncapped limit=100 would ask Qdrant for 1600 candidates per branch and
+        measured ~10x the latency for identical results. Cap it."""
+        qdrant = MagicMock()
+        grouped = MagicMock()
+        grouped.groups = []
+        qdrant.query_points_groups = AsyncMock(return_value=grouped)
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        # The tool layer passes limit*2, so limit=200 is the real high-end call.
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", limit=200, granularity="document"
+        )
+
+        prefetch = qdrant.query_points_groups.await_args.kwargs["prefetch"]
+        uncapped = 200 * 2 * DOCUMENT_PREFETCH_FACTOR
+        assert uncapped > MAX_DOCUMENT_PREFETCH, "fixture no longer exercises the cap"
+        assert [p.limit for p in prefetch] == [
+            MAX_DOCUMENT_PREFETCH,
+            MAX_DOCUMENT_PREFETCH,
+        ]
 
     @pytest.mark.unit
     async def test_groups_are_flattened_to_best_chunk_per_document(

--- a/tests/unit/search/test_bm25_hybrid.py
+++ b/tests/unit/search/test_bm25_hybrid.py
@@ -235,3 +235,132 @@ class TestFusionRankingConstant:
 
         assert isinstance(query, models.FusionQuery)
         assert query.fusion == models.Fusion.DBSF
+
+
+class TestGranularity:
+    """`granularity="document"` routes through Qdrant's native grouping.
+
+    The point of the mode is that one document occupies one result row instead
+    of competing chunk-by-chunk, so these assert the *query shape* sent to
+    Qdrant — group_by/group_size/prefetch depth — not just that a call happened.
+    """
+
+    @pytest.mark.unit
+    async def test_chunk_granularity_is_the_default_and_ungrouped(
+        self, patched_search, monkeypatch
+    ):
+        qdrant = MagicMock()
+        empty = MagicMock()
+        empty.points = []
+        qdrant.query_points = AsyncMock(return_value=empty)
+        qdrant.query_points_groups = AsyncMock()
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        await BM25HybridSearchAlgorithm().search(query="hello", user_id="alice")
+
+        qdrant.query_points.assert_awaited_once()
+        qdrant.query_points_groups.assert_not_awaited()
+
+    @pytest.mark.unit
+    async def test_document_granularity_groups_by_doc_id(
+        self, patched_search, monkeypatch
+    ):
+        qdrant = MagicMock()
+        grouped = MagicMock()
+        grouped.groups = []
+        qdrant.query_points = AsyncMock()
+        qdrant.query_points_groups = AsyncMock(return_value=grouped)
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", limit=10, granularity="document"
+        )
+
+        qdrant.query_points.assert_not_awaited()
+        kwargs = qdrant.query_points_groups.await_args.kwargs
+        assert kwargs["group_by"] == "doc_id"
+        # One row per document — extra hits would reintroduce the very
+        # concentration this mode removes.
+        assert kwargs["group_size"] == 1
+        # limit counts groups (documents), carrying the same 2x over-fetch.
+        assert kwargs["limit"] == 20
+        # Fusion is unchanged: still the explicit-k RRF query.
+        assert isinstance(kwargs["query"], models.RrfQuery)
+
+    @pytest.mark.unit
+    async def test_document_granularity_deepens_the_prefetch(
+        self, patched_search, monkeypatch
+    ):
+        """Filling N distinct documents needs more candidates than N chunks."""
+        qdrant = MagicMock()
+        grouped = MagicMock()
+        grouped.groups = []
+        qdrant.query_points_groups = AsyncMock(return_value=grouped)
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", limit=10, granularity="document"
+        )
+
+        prefetch = qdrant.query_points_groups.await_args.kwargs["prefetch"]
+        assert len(prefetch) == 2, "still dense + sparse"
+        # 10 * 2 (over-fetch) * DOCUMENT_PREFETCH_FACTOR
+        assert [p.limit for p in prefetch] == [80, 80]
+
+    @pytest.mark.unit
+    async def test_groups_are_flattened_to_best_chunk_per_document(
+        self, patched_search, monkeypatch
+    ):
+        """Each group collapses to its top hit, preserving the flat result shape
+        every downstream stage (dedup, verification, context) already expects."""
+        best = MagicMock(score=0.9)
+        worse = MagicMock(score=0.1)
+        group = MagicMock()
+        group.hits = [best, worse]
+        empty_group = MagicMock()
+        empty_group.hits = []
+
+        grouped = MagicMock()
+        grouped.groups = [group, empty_group]
+        qdrant = MagicMock()
+        qdrant.query_points_groups = AsyncMock(return_value=grouped)
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        captured = []
+
+        def fake_build(point, metadata_extras):
+            captured.append(point)
+            return None  # skip SearchResult construction; we only assert routing
+
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.build_search_result_from_point",
+            fake_build,
+        )
+
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", granularity="document"
+        )
+
+        # Only the best hit of the non-empty group; the empty group is skipped
+        # rather than raising an IndexError.
+        assert captured == [best]
+
+    @pytest.mark.unit
+    async def test_invalid_granularity_raises(self, patched_search):
+        """Fails loudly rather than silently degrading to chunk granularity."""
+        with pytest.raises(ValueError, match="Invalid granularity"):
+            await BM25HybridSearchAlgorithm().search(
+                query="hello", user_id="alice", granularity="documnet"
+            )

--- a/tests/unit/search/test_semantic.py
+++ b/tests/unit/search/test_semantic.py
@@ -27,3 +27,29 @@ def test_semantic_initialization_explicit_threshold():
 
     assert algo.score_threshold == 0.5
     assert algo.requires_vector_db is True
+
+
+@pytest.mark.unit
+async def test_dense_algorithm_rejects_document_granularity():
+    """The dense-only algorithm has no grouping, so it must fail loudly rather
+    than swallow the kwarg via **kwargs and silently return chunk rows to a
+    caller that asked for one row per document.
+
+    The /api/v1 layer already rejects this combination with a 422; this is the
+    backstop for direct callers.
+    """
+    algo = SemanticSearchAlgorithm()
+
+    with pytest.raises(ValueError, match="not supported by the dense-only"):
+        await algo.search(query="hello", user_id="alice", granularity="document")
+
+
+@pytest.mark.unit
+def test_dense_algorithm_defaults_to_chunk_granularity():
+    """Regression guard: the default must stay the value the algorithm can
+    actually honour, so existing callers are unaffected."""
+    import inspect
+
+    sig = inspect.signature(SemanticSearchAlgorithm.search)
+
+    assert sig.parameters["granularity"].default == "chunk"


### PR DESCRIPTION
## Problem

Ranking is per-chunk, so a document gets as many result slots as it has matching chunks. A long document can take most of a result page and crowd out other documents that also match. That is correct for *"answer this from a passage"* and wrong for *"which files mention X"*.

Measured on a 550k-chunk corpus, one query, same slot count — distinct documents returned:

| `limit` | `chunk` (today) | `document` (new) |
|---|---|---|
| 10 | 7 | **10** |
| 25 | 13 | **20** |
| 50 | 15 | **41** |
| 100 | 27 | **72** |

At `limit=10` a single document was taking 3 of 10 slots.

## Change

An opt-in `granularity` argument on `nc_semantic_search`:

- **`chunk`** — the default, byte-identical to current behaviour.
- **`document`** — the same dense+sparse prefetch and RRF fusion, run through Qdrant's native grouping (`group_by="doc_id"`, `group_size=1`). One row per document (its best chunk); `limit` counts documents.

It is a per-query argument rather than a server setting, so a caller picks the shape that fits the question it is asking.

Grouped responses are flattened to the existing `.points` shape, so dedup, verification and context expansion stay granularity-agnostic rather than forking.

## What this does NOT do

**It improves diversity, not recall.** A document whose best chunk ranks below the prefetch window is absent under both settings. On the corpus above, the document that motivated this work still does not surface: it sits at BM25 rank 182 with no dense-side match, and at document granularity it ranks ~175th. Grouping cannot promote what retrieval never returned — that needs reranking.

The tool docstring says this explicitly, so callers do not read `document` as an exhaustive *"list every file containing X"*.

## Known limitation

`group_by` takes a single payload field, so a cross-app grouped search (`doc_types=None`) can collapse a note and a file that share a numeric `doc_id`. The per-`doc_type` loop is unaffected. Documented at the call site; avoiding it needs a composite key written at index time.

## Testing

- `tests/unit/search/test_bm25_hybrid.py::TestGranularity` — query shape sent to Qdrant: `group_by`, `group_size`, deepened prefetch, fusion unchanged, group flattening, invalid-value rejection.
- `tests/integration/test_search_granularity.py` — real in-memory Qdrant with a deliberately chunk-heavy document: asserts the monopolisation baseline, one-row-per-document, that crowded-out documents are recovered, that the representative row is the document's best-ranked chunk, and that `limit` counts documents.

2691 tests pass; `ruff` and `ty` green.

---

_This PR was generated with the help of AI, and reviewed by a Human_