### PR TITLE
fix(search): request exact group count in grouped hybrid search

### DIFF
--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -214,9 +214,11 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         """
         collection_name = settings.get_collection_name()
         grouped = granularity == GRANULARITY_DOCUMENT
-        # Both paths over-fetch 2x for the dedup/verification budget; grouping
-        # deepens it further, bounded by MAX_DOCUMENT_PREFETCH so the compounding
-        # multipliers can't produce a pathological query at a high ``limit``.
+        # Both paths deepen the PREFETCH 2x (grouping deepens it further, bounded
+        # by MAX_DOCUMENT_PREFETCH so the compounding multipliers can't produce a
+        # pathological query at a high ``limit``). Note this is the prefetch
+        # depth only -- the grouped branch's own ``limit`` must stay exact; see
+        # the comment on that call.
         prefetch_limit = limit * 2
         if grouped:
             prefetch_limit = min(
@@ -263,7 +265,18 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
                     # the extra hits would just re-introduce the chunk-level
                     # concentration this mode exists to remove.
                     group_size=1,
-                    limit=limit * 2,  # groups, not chunks
+                    # Groups, not chunks -- and deliberately NOT ``limit * 2``.
+                    # The chunk path over-fetches 2x because chunks from one
+                    # document collapse during dedup, so it needs spares;
+                    # ``group_size=1`` already yields one row per document, so
+                    # there is nothing here for spares to replace. Worse, asking
+                    # for more groups than the prefetch can fill makes Qdrant
+                    # widen its grouping search and REORDER the head rather than
+                    # simply appending weaker tail results, so an over-request
+                    # measurably degrades the top of the result set. The damage
+                    # grows as the requested group count approaches the prefetch
+                    # depth, which is why this must track ``limit`` exactly.
+                    limit=limit,
                     score_threshold=score_threshold,
                     with_payload=True,
                     with_vectors=False,

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -243,7 +243,13 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         with trace_operation(
             "search.qdrant_query",
             attributes={
-                "query.limit": limit * 2,
+                # Must track what is actually requested below: the grouped
+                # branch asks for exactly ``limit`` groups while the chunk
+                # branch over-fetches 2x. A single hardcoded value here would
+                # misreport one of them to anyone debugging limit/prefetch
+                # behaviour from traces — which is precisely the kind of
+                # investigation this span exists for.
+                "query.limit": limit if grouped else limit * 2,
                 "query.fusion": self.fusion_name,
                 "query.granularity": granularity,
             },

--- a/tests/unit/search/test_bm25_hybrid.py
+++ b/tests/unit/search/test_bm25_hybrid.py
@@ -292,10 +292,47 @@ class TestGranularity:
         # One row per document — extra hits would reintroduce the very
         # concentration this mode removes.
         assert kwargs["group_size"] == 1
-        # limit counts groups (documents), carrying the same 2x over-fetch.
-        assert kwargs["limit"] == 20
+        # limit counts groups (documents), and is EXACT — see
+        # test_grouped_limit_is_not_over_requested.
+        assert kwargs["limit"] == 10
         # Fusion is unchanged: still the explicit-k RRF query.
         assert isinstance(kwargs["query"], models.RrfQuery)
+
+    @pytest.mark.unit
+    async def test_grouped_limit_is_not_over_requested(
+        self, patched_search, monkeypatch
+    ):
+        """Regression: the grouped branch must ask for exactly ``limit`` groups.
+
+        The chunk path over-fetches 2x because chunks from one document collapse
+        during dedup and it needs spares. ``group_size=1`` already returns one
+        row per document, so spares buy nothing here — and asking for more
+        groups than the prefetch can fill makes Qdrant widen its grouping search
+        and reorder the head, measurably degrading the top of the result set
+        rather than merely appending weaker tail entries.
+
+        The chunk path keeps its 2x, so this pins the asymmetry rather than the
+        constant.
+        """
+        qdrant = MagicMock()
+        grouped = MagicMock()
+        grouped.groups = []
+        qdrant.query_points_groups = AsyncMock(return_value=grouped)
+        qdrant.query_points = AsyncMock()
+        monkeypatch.setattr(
+            "nextcloud_mcp_server.search.bm25_hybrid.get_qdrant_client",
+            AsyncMock(return_value=qdrant),
+        )
+
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", limit=37, granularity="document"
+        )
+        assert qdrant.query_points_groups.await_args.kwargs["limit"] == 37
+
+        await BM25HybridSearchAlgorithm().search(
+            query="hello", user_id="alice", limit=37, granularity="chunk"
+        )
+        assert qdrant.query_points.await_args.kwargs["limit"] == 74
 
     @pytest.mark.unit
     async def test_document_granularity_deepens_the_prefetch(


### PR DESCRIPTION
## What

`_run_qdrant_query` asked Qdrant for `limit * 2` **groups** in the
`granularity="document"` branch, where `limit` is already `user_limit * 2`
from the tool layer — a **4x over-request** on every grouped query.

## Why it was wrong

The `* 2` is correct on the chunk path immediately below: chunks from one
document collapse during deduplication, so that path genuinely needs spares.
With `group_size=1` each group is already exactly one document, so spares buy
nothing here.

Worse, asking Qdrant for more groups than the prefetch can fill makes it widen
its grouping search and **reorder the head** of the result set — it is not
merely a harmless tail of extra candidates.

## Impact

Measured against the enumeration and OHR-Bench evaluation sets (paired
bootstrap over the query set):

- **Enumeration recall improves significantly** with the exact group count
  (p < 0.05). These are the "which documents mention X" queries that spread
  across many documents.
- **Complete-set recall** and **single-answer retrieval** are unaffected at the
  shipped limits, because the requested group count there is well within what
  the prefetch can supply.

Severity scales with how close the requested group count is to the prefetch
depth, so today's defaults sit at the mild end. That makes this a routine fix
rather than a hotfix — but the effect grows sharply for any future feature that
retrieves a deeper candidate pool.

## Test

The regression test pins the **asymmetry** between the two paths rather than the
constant — one `search()` at `limit=37` with `granularity="document"` must
request exactly 37 groups, and the same call with `granularity="chunk"` must
request 74. A future change that "tidies up" the inconsistency by making them
match will fail.

An existing assertion expected the inflated value (`limit == 20`) and was
pinning the bug in place; it is corrected here. That is why this survived
review originally.

`ruff check`, `ruff format --check`, `ty check` clean; full unit suite passes.

## Scope

No API surface changes (no new/modified MCP tool, HTTP route, or cross-service
boundary), so no e2e/Pact additions are required by the repo's coverage gate.
Behaviour change is confined to the number of groups requested from Qdrant.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)