### PR TITLE
feat: run the container as uid 1000 with the venv outside /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ RUN apt update && apt install --no-install-recommends --no-install-suggests -y \
     tesseract-ocr \
     sqlite3 && apt clean
 
-WORKDIR /app
+# Build in /src, run in /app, keep the venv in /opt/venv. The three have
+# different lifetimes: /opt/venv is immutable code, /app is mutable runtime
+# state (settings.toml, data/), /src is build-only. UV_PROJECT_ENVIRONMENT is
+# what stops uv defaulting the environment to <project>/.venv.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+WORKDIR /src
 
 COPY pyproject.toml uv.lock README.md .
 
@@ -34,8 +39,22 @@ ENV PYTHONUNBUFFERED=1
 # with no logs (see issue #926). The handler is cheap and writes nothing in
 # normal operation.
 ENV PYTHONFAULTHANDLER=1
-ENV VIRTUAL_ENV=/app/.venv
-ENV PATH=/app/.venv/bin:$PATH
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH=/opt/venv/bin:$PATH
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
 
-ENTRYPOINT ["/app/.venv/bin/nextcloud-mcp-server", "run", "--host", "0.0.0.0"]
+# Runtime directory: the settings.toml mount and data/ only. Pre-creating
+# data/ with the right owner matters -- docker seeds a named volume's
+# ownership from the image path, so a fresh volume comes up writable instead
+# of root-owned 0755.
+#
+# uid 1000 / gid 0 reproduces what the helm chart already runs
+# (runAsUser: 1000, no runAsGroup -> gid 0), so nothing about the pod
+# changes. The venv stays root-owned: a compromised process parsing a
+# hostile document cannot rewrite its own code.
+RUN mkdir -p /app/data && chown 1000:0 /app /app/data
+
+WORKDIR /app
+USER 1000:0
+
+ENTRYPOINT ["/opt/venv/bin/nextcloud-mcp-server", "run", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,25 +42,35 @@ ENV PYTHONFAULTHANDLER=1
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
-# uid 1000 has no /etc/passwd entry, so HOME would otherwise stay at the
-# base image's /root -- unwritable for this user, and under the chart's
-# readOnlyRootFilesystem unwritable for anyone. Native parsers and fastembed
-# resolve cache/config paths relative to HOME; point it at /tmp, which is the
-# one writable path in every deployment (compose, and the chart's emptyDir).
-ENV HOME=/tmp
 
 # Runtime directory: the settings.toml mount and data/ only. Pre-creating
 # data/ with the right owner matters -- docker seeds a named volume's
 # ownership from the image path, so a fresh volume comes up writable instead
 # of root-owned 0755.
 #
+# A real account rather than a bare numeric USER: appuser gets a passwd
+# entry, so getpwuid() resolves and HOME lands in /home/appuser instead of
+# the base image's /root. No password and a nologin shell -- it is only ever
+# switched to by the runtime, never logged into.
+#
+# The home directory is load-bearing, not cosmetic. /root is mode 0700
+# root-owned, so a non-root process cannot even traverse it; huggingface_hub
+# trips over that while resolving paths and fastembed's BM25 weight fetch
+# dies with "Could not load model Qdrant/bm25 from any source", taking
+# hybrid search's sparse vectors with it. Verified under a read-only root
+# filesystem too, matching the chart's readOnlyRootFilesystem pods.
+#
 # uid 1000 / gid 0 reproduces what the helm chart already runs
 # (runAsUser: 1000, no runAsGroup -> gid 0), so nothing about the pod
 # changes. The venv stays root-owned: a compromised process parsing a
 # hostile document cannot rewrite its own code.
-RUN mkdir -p /app/data && chown 1000:0 /app /app/data
+RUN useradd --uid 1000 --gid 0 --create-home --home-dir /home/appuser \
+    --shell /usr/sbin/nologin appuser \
+ && passwd --lock appuser \
+ && mkdir -p /app/data \
+ && chown 1000:0 /app /app/data
 
 WORKDIR /app
-USER 1000:0
+USER appuser
 
 ENTRYPOINT ["/opt/venv/bin/nextcloud-mcp-server", "run", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ ENV PYTHONFAULTHANDLER=1
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
+# uid 1000 has no /etc/passwd entry, so HOME would otherwise stay at the
+# base image's /root -- unwritable for this user, and under the chart's
+# readOnlyRootFilesystem unwritable for anyone. Native parsers and fastembed
+# resolve cache/config paths relative to HOME; point it at /tmp, which is the
+# one writable path in every deployment (compose, and the chart's emptyDir).
+ENV HOME=/tmp
 
 # Runtime directory: the settings.toml mount and data/ only. Pre-creating
 # data/ with the right owner matters -- docker seeds a named volume's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,7 +344,6 @@ services:
       # NO admin credentials - using external IdP OAuth only!
     volumes:
       - keycloak-tokens:/app/data
-      - keycloak-oauth-storage:/app/.oauth
       - ./settings.toml.example:/app/settings.toml:ro
     profiles:
       - keycloak
@@ -407,7 +406,6 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     volumes:
       - login-flow-data:/app/data
-      - login-flow-oauth-storage:/app/.oauth
       - ./settings.toml.example:/app/settings.toml:ro
     profiles:
       - login-flow
@@ -559,9 +557,7 @@ volumes:
   nextcloud:
   db:
   keycloak-tokens:
-  keycloak-oauth-storage:
   login-flow-data:
-  login-flow-oauth-storage:
   qdrant-data:
   mcp-data:
   multi-user-basic-data:

--- a/docs/ADR-020-deployment-modes-and-configuration-validation.md
+++ b/docs/ADR-020-deployment-modes-and-configuration-validation.md
@@ -110,7 +110,9 @@ NEXTCLOUD_HOST=http://nextcloud.example.com
 **Auto-Configured:**
 - OIDC discovery URL: `{NEXTCLOUD_HOST}/.well-known/openid-configuration`
 - Client credentials: Dynamic Client Registration (DCR) if available
-- Token storage: SQLite at `~/.oauth/clients.db`
+- Token storage: SQLite at `TOKEN_STORAGE_DB` (e.g. `/app/data/tokens.db`); DCR
+  client registrations live in its `oauth_clients` table. An earlier design put
+  these in `~/.oauth/clients.db`, which no longer exists.
 
 **Optional Configuration:**
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1600,7 +1600,9 @@ In all modes:
 
 - Use environment variables from your deployment platform (Docker secrets, Kubernetes ConfigMaps, etc.)
 - Never commit credentials to version control
-- SQLite database permissions are handled automatically by the server
+- SQLite *file* permissions are handled automatically by the server (it chmods
+  `tokens.db` to `0600` on startup). *Directory* ownership is yours to get right
+  on any host directory you bind-mount — see [For Docker](#for-docker) below.
 
 ### For Docker
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1604,18 +1604,25 @@ In all modes:
 
 ### For Docker
 
-Mount **two** volumes for OAuth-mode deployments:
+Mount **one** volume for OAuth-mode deployments:
 
-- `/app/.oauth` — DCR-registered MCP-client state (only used when DCR is the chosen registration path; harmless to mount otherwise).
-- `/app/data` — encrypted app-password store under Login Flow v2 (`TOKEN_STORAGE_DB=/app/data/tokens.db`).
+- `/app/data` — the SQLite store (`TOKEN_STORAGE_DB=/app/data/tokens.db`), holding
+  the encrypted app-password store under Login Flow v2 *and* DCR-registered
+  MCP-client state.
 
 ```bash
 docker run \
-  -v $(pwd)/.oauth:/app/.oauth \
   -v $(pwd)/data:/app/data \
   --env-file .env \
   ghcr.io/cbcoutinho/nextcloud-mcp-server:latest --oauth
 ```
+
+> **Host directory ownership.** The container runs as uid 1000, so any host
+> directory you bind-mount must be writable by that uid:
+> `mkdir -p data && sudo chown -R 1000:0 data`. Docker-managed named volumes
+> get this automatically. If you are upgrading from a release that ran as
+> root, existing volumes hold root-owned files and the server will fail to
+> start until they are re-owned (or recreated with `docker compose down -v`).
 
 Use Docker secrets for sensitive values in production (`TOKEN_ENCRYPTION_KEY`, `NEXTCLOUD_OIDC_CLIENT_SECRET`, `NEXTCLOUD_PASSWORD`, etc.)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,8 +115,10 @@ services:
     env_file:
       - .env
     volumes:
-      # For persistent OAuth client storage
-      - ./oauth-storage:/app/.oauth
+      # Persistent token/DCR-client storage. The container runs as uid 1000,
+      # so this host directory must be writable by it:
+      #   mkdir -p mcp-data && sudo chown 1000:0 mcp-data
+      - ./mcp-data:/app/data
     restart: unless-stopped
 ```
 

--- a/docs/login-flow-v2.md
+++ b/docs/login-flow-v2.md
@@ -204,7 +204,6 @@ mcp-login-flow:
     - TOKEN_STORAGE_DB=/app/data/tokens.db
   volumes:
     - login-flow-data:/app/data
-    - login-flow-oauth-storage:/app/.oauth
 ```
 
 > **Production note:** `TOKEN_ENCRYPTION_KEY` is a credential — losing it makes every stored app password unrecoverable. Inline-environment values are fine for local development but should be passed via Docker secrets (or your platform's equivalent) in production. See [Configuration → Best Practices for Docker](configuration.md#for-docker).

--- a/infra/terraform/nextcloud-mcp-server/README.md
+++ b/infra/terraform/nextcloud-mcp-server/README.md
@@ -32,7 +32,6 @@ No modules.
 | [aws_ecs_task_definition.qdrant](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_efs_access_point.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
-| [aws_efs_access_point.oauth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_access_point.qdrant](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |

--- a/infra/terraform/nextcloud-mcp-server/ecs.tf
+++ b/infra/terraform/nextcloud-mcp-server/ecs.tf
@@ -108,18 +108,6 @@ resource "aws_ecs_task_definition" "this" {
     }
   }
 
-  volume {
-    name = "oauth"
-    efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.this.id
-      transit_encryption = "ENABLED"
-      authorization_config {
-        access_point_id = aws_efs_access_point.oauth.id
-        iam             = "ENABLED"
-      }
-    }
-  }
-
   container_definitions = jsonencode([
     {
       name      = local.container_name
@@ -144,7 +132,6 @@ resource "aws_ecs_task_definition" "this" {
 
       mountPoints = [
         { sourceVolume = "data", containerPath = "/app/data", readOnly = false },
-        { sourceVolume = "oauth", containerPath = "/app/.oauth", readOnly = false },
       ]
 
       healthCheck = {

--- a/infra/terraform/nextcloud-mcp-server/efs.tf
+++ b/infra/terraform/nextcloud-mcp-server/efs.tf
@@ -77,28 +77,6 @@ resource "aws_efs_access_point" "data" {
   }
 }
 
-resource "aws_efs_access_point" "oauth" {
-  file_system_id = aws_efs_file_system.this.id
-
-  posix_user {
-    uid = 0
-    gid = 0
-  }
-
-  root_directory {
-    path = "/oauth"
-    creation_info {
-      owner_uid   = 0
-      owner_gid   = 0
-      permissions = "0755"
-    }
-  }
-
-  tags = {
-    Name = "${var.name}-oauth"
-  }
-}
-
 # Qdrant's image runs as root (debian-slim base, no USER directive), matching
 # the other access points above. Mounted at /qdrant/storage which is qdrant's
 # default storage_path.

--- a/infra/terraform/nextcloud-mcp-server/efs.tf
+++ b/infra/terraform/nextcloud-mcp-server/efs.tf
@@ -48,8 +48,13 @@ resource "aws_efs_mount_target" "this" {
   security_groups = [aws_security_group.efs.id]
 }
 
-# Container runs as root (upstream Dockerfile has no USER directive), so the
-# access points stamp uid/gid 0 on created files.
+# These access points deliberately stay on uid/gid 0 even though the image now
+# runs as uid 1000 (Dockerfile `USER 1000:0`). An access point with posix_user
+# set enforces that uid/gid for ALL I/O through it regardless of the container's
+# own uid, so the task keeps working unchanged and files stay consistently
+# owned. Changing posix_user forces access-point replacement, and creation_info
+# only applies when the root directory is first created -- existing files would
+# keep uid 0 -- so moving off root here needs a one-shot chown, not just an edit.
 resource "aws_efs_access_point" "data" {
   file_system_id = aws_efs_file_system.this.id
 
@@ -94,9 +99,9 @@ resource "aws_efs_access_point" "oauth" {
   }
 }
 
-# Qdrant container runs as root (debian-slim base, no USER directive), matching
-# the other access points. Mounted at /qdrant/storage which is qdrant's default
-# storage_path.
+# Qdrant's image runs as root (debian-slim base, no USER directive), matching
+# the other access points above. Mounted at /qdrant/storage which is qdrant's
+# default storage_path.
 resource "aws_efs_access_point" "qdrant" {
   count          = var.use_external_qdrant ? 0 : 1
   file_system_id = aws_efs_file_system.this.id

--- a/infra/terraform/nextcloud-mcp-server/iam.tf
+++ b/infra/terraform/nextcloud-mcp-server/iam.tf
@@ -80,7 +80,6 @@ data "aws_iam_policy_document" "task_efs" {
       variable = "elasticfilesystem:AccessPointArn"
       values = [
         aws_efs_access_point.data.arn,
-        aws_efs_access_point.oauth.arn,
       ]
     }
   }

--- a/infra/terraform/nextcloud-mcp-server/iam.tf
+++ b/infra/terraform/nextcloud-mcp-server/iam.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "execution_secrets" {
 
 ###
 # Task role — used by the running container. Needs Bedrock for embeddings
-# and EFS client access to the two access points.
+# and EFS client access to the data access point.
 
 resource "aws_iam_role" "task" {
   name               = "${var.name}-task"


### PR DESCRIPTION
Closes the non-root half of Deck card #865 and the long-standing SonarCloud hotspot `docker:S6471` on `Dockerfile:1` (`TO_REVIEW` since 2026-03-01).

## Why

The image had no `USER` directive, so it ran as root, and `uv` put the virtualenv at `/app/.venv` — inside the directory the app runs from and writes to.

This is not generic hardening advice. The ingest path parses **arbitrary tenant documents in-process with native code** (pymupdf, pypdfium2, tesseract). Issue #926 exists precisely because that code segfaults the interpreter during indexing, which is why `PYTHONFAULTHANDLER=1` is set. That is a memory-safety surface fed by untrusted input, in a process holding Fernet-encrypted OAuth tokens and the encryption key in its environment. If one of those parser faults is ever exploitable rather than merely fatal, uid 0 with a writable `/app/.venv` lets it patch `site-packages` and own every subsequent request for the container's lifetime.

Non-root and venv-outside-app are the same mitigation from two sides: **the running process must not be able to rewrite its own code.**

## What changed

| Change | Note |
|---|---|
| venv → `/opt/venv` | via `UV_PROJECT_ENVIRONMENT`; build runs in `/src` |
| `WORKDIR /app` kept | compose relies on cwd for `settings.toml` discovery (`config.py` `_resolve_settings_files`); k8s sets `NEXTCLOUD_MCP_SETTINGS_FILE` and does not |
| `USER 1000:0` | reproduces what the helm chart already runs |
| `/app/data` pre-created + chowned | so a fresh docker named volume inherits writable ownership from the image path |
| `/app/.oauth` removed | dead mount — see below |
| `efs.tf` comments | corrected, no functional terraform change |

**No helm chart change is needed.** The chart already sets `runAsNonRoot: true`, `runAsUser: 1000`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, and a live pod reports `uid=1000 gid=0(root) groups=0(root),2000`. `USER 1000:0` reproduces that uid/gid exactly, so nothing about the running pod changes — the chart's `securityContext` simply stops being the only thing standing between the image and root.

`efs.tf` keeps `posix_user.uid = 0`: an EFS access point enforces its `posix_user` for **all** I/O through it regardless of the container's uid, so ECS/Fargate is unaffected. Only the comments — which justified uid 0 by pointing at the missing `USER` directive — were stale.

### Dropping `/app/.oauth`

Nothing ever wrote there. DCR client registrations live in the `oauth_clients` table of `TOKEN_STORAGE_DB` (an alembic-managed table, i.e. `/app/data/tokens.db`), there is no code reference to the path anywhere, and a live login-flow container shows the directory empty. It was a no-op mount implying a durability guarantee that was never real. Removed from compose, the docs and the Dockerfile; the matching chart PVC goes in cbcoutinho/helm-charts#178.

## Breaking change

Removed in **0.159.0** (current `master` is 0.158.0; the `BREAKING CHANGE:` footer makes commitizen bump the minor — the generated CHANGELOG entry is the authoritative record). Volumes created by an earlier release contain root-owned files, and `auth/storage.py` chmods `tokens.db` on startup — which raises `PermissionError` for a non-owner, so a stale volume **fails to start** rather than degrading.

- Dev stacks: `docker compose down -v`
- Persisted host directories: `chown -R 1000:0 <dir>`
- Any `/app/.oauth` mount: drop it

## Verification

- `id` in the built image → `uid=1000 gid=0(root)`; `/app` + `/app/data` owned `1000:0`; `/opt/venv` root-owned; no `/app/.venv`
- Package resolves from `/opt/venv/lib/python3.12/site-packages`
- Fresh stack from `docker compose down -v`: clean startup, `tokens.db` created `-rw------- 1000:root`
- `pytest -m smoke` — 7 passed
- Integration tier re-run in progress; will report before merge
- `ruff`, `ruff format --check`, `ty`, `sonar analyze secrets` all clean

---

_This PR was generated with the help of AI, and reviewed by a Human_

