### PR TITLE
feat(observability): measure both semantic-search entrypoints equally

### DIFF
--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -70,6 +70,23 @@ logger = logging.getLogger(__name__)
 _NEXTCLOUD_HOST_NOT_CONFIGURED = "Nextcloud host not configured"
 
 
+def _search_algorithm_label(algorithm: str, fusion: str) -> str:
+    """The ``algorithm`` label for search metrics.
+
+    Shared by every ``record_search_request`` call site so success and error
+    samples land on the SAME series. Normalising in one place and using the raw
+    value in another fragments ``astrolabe_search_requests_total`` into
+    non-comparable series and quietly breaks "error rate by algorithm" — exactly
+    the surface drift these metrics exist to prevent.
+
+    Matches the MCP tool's ``search_method`` convention
+    (``bm25_hybrid_<fusion>``) so the two entrypoints stay comparable.
+    """
+    if algorithm == "semantic":
+        return algorithm
+    return f"bm25_hybrid_{fusion}"
+
+
 def _unsupported_search_type_response(e: UnsupportedSearchType) -> JSONResponse:
     """Uniform 422 for an explicit unsupported search algorithm.
 
@@ -524,7 +541,7 @@ async def unified_search(request: Request) -> JSONResponse:
 
         record_search_request(
             surface="http",
-            algorithm=f"bm25_hybrid_{fusion}" if algorithm != "semantic" else algorithm,
+            algorithm=_search_algorithm_label(algorithm, fusion),
             granularity=granularity,
             reranked="false",
             status="success",
@@ -554,7 +571,7 @@ async def unified_search(request: Request) -> JSONResponse:
         logger.exception("Error in unified search")
         record_search_request(
             surface="http",
-            algorithm=algorithm,
+            algorithm=_search_algorithm_label(algorithm, fusion),
             granularity=granularity,
             reranked="false",
             status="error",
@@ -711,7 +728,7 @@ async def vector_search(request: Request) -> JSONResponse:
                 )
             return results
 
-        all_results, _dropped = await _search_with_acl(request, user_id, _execute)
+        all_results, dropped_count = await _search_with_acl(request, user_id, _execute)
 
         # Format results for PHP client
         formatted_results = []
@@ -770,6 +787,29 @@ async def vector_search(request: Request) -> JSONResponse:
             # Not enough results for PCA
             response_data["coordinates_3d"] = []
             response_data["query_coords"] = []
+
+        # The third search entrypoint, and it embeds a query exactly like the
+        # other two — so omitting metering here would recreate the very ledger
+        # blind spot this change closes on /api/v1/search. Its own surface label
+        # keeps the visualization route from being conflated with the search
+        # route in dashboards.
+        record_search_request(
+            surface="http_viz",
+            algorithm=_search_algorithm_label(algorithm, fusion),
+            granularity=GRANULARITY_CHUNK,
+            reranked="false",
+            status="success",
+            results_returned=len(formatted_results),
+            verification_dropped=dropped_count,
+        )
+        await record_search_usage(
+            enabled=settings.usage_metering_enabled,
+            user_id=user_id,
+            fusion=fusion,
+            doc_types=doc_types if isinstance(doc_types, list) else None,
+            token_count=search_algo.query_token_count,
+            surface="http_viz",
+        )
 
         return JSONResponse(response_data)
 

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -543,6 +543,7 @@ async def unified_search(request: Request) -> JSONResponse:
             fusion=fusion,
             doc_types=doc_types if isinstance(doc_types, list) else None,
             token_count=search_algo.query_token_count,
+            surface="http",
         )
 
         return JSONResponse(response_data)

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -622,6 +622,11 @@ async def vector_search(request: Request) -> JSONResponse:
             status_code=401,
         )
 
+    # Bound before the try so the error-path metric can label the request even
+    # when parsing is what failed — same reason as unified_search.
+    algorithm = "unknown"
+    fusion = "rrf"
+
     try:
         # Parse request body
         body = await request.json()
@@ -817,6 +822,17 @@ async def vector_search(request: Request) -> JSONResponse:
         # The client only ever sees a sanitized message, so without this the
         # traceback is lost entirely and a 500 leaves no trace anywhere.
         logger.exception("Error in vector search")
+        # Without this sample the visualization surface drops out of "error rate
+        # by surface" entirely — it would report successes and nothing else,
+        # which reads as a perfectly healthy endpoint no matter how often it
+        # fails.
+        record_search_request(
+            surface="http_viz",
+            algorithm=_search_algorithm_label(algorithm, fusion),
+            granularity=GRANULARITY_CHUNK,
+            reranked="false",
+            status="error",
+        )
         error_msg = _sanitize_error_for_client(e, "vector_search")
         return JSONResponse(
             {"error": error_msg},

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import anyio
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
@@ -29,6 +30,10 @@ from nextcloud_mcp_server.api.management import (
     validate_token_and_get_user,
 )
 from nextcloud_mcp_server.config import Settings, get_settings
+from nextcloud_mcp_server.observability.metrics import (
+    record_search_request,
+    record_search_stage,
+)
 from nextcloud_mcp_server.providers import get_provider
 from nextcloud_mcp_server.search import (
     GRANULARITY_CHUNK,
@@ -49,6 +54,7 @@ from nextcloud_mcp_server.search.context import (
     get_chunk_with_context,
 )
 from nextcloud_mcp_server.search.verification import verify_search_results
+from nextcloud_mcp_server.usage.search import record_search_usage
 from nextcloud_mcp_server.utils.validation import (
     is_valid_nextcloud_doc_id,
     parse_modified_timestamp,
@@ -113,7 +119,7 @@ async def _search_with_acl(
     request: Request,
     user_id: str,
     execute: Callable[[AccessibleScope | None], Awaitable[list]],
-) -> list:
+) -> tuple[list, int]:
     """Resolve the caller's Nextcloud client, run ``execute(scope)``, and
     verify-on-read — shared by the /api/v1 search endpoints.
 
@@ -131,7 +137,11 @@ async def _search_with_acl(
             (``None`` ⇒ self-only).
 
     Returns:
-        The result list (verified for provisioned callers).
+        ``(results, dropped)`` — the result list (verified for provisioned
+        callers) and the number of documents verify-on-read removed. ``dropped``
+        is always 0 on the unprovisioned path, where no verification runs; the
+        caller records it as a metric, so the two search surfaces report the
+        same ghost-record signal.
 
     Raises:
         ValueError: If the Nextcloud host is not configured.
@@ -141,21 +151,33 @@ async def _search_with_acl(
     if not nextcloud_host:
         raise ValueError(_NEXTCLOUD_HOST_NOT_CONFIGURED)
 
+    # Stage timings are recorded here rather than around this whole call so
+    # "retrieve" means embed+Qdrant and "verify" means the Nextcloud round-trips
+    # — timing the wrapper would conflate them into one unattributable number.
+    dropped = 0
     try:
         nc_client = await get_user_client_basic_auth(user_id, nextcloud_host)
     except NotProvisionedError:
         logger.debug("User %s not provisioned; self-only unverified search", user_id)
+        retrieve_start = anyio.current_time()
         results = await execute(None)
+        record_search_stage("http", "retrieve", anyio.current_time() - retrieve_start)
     else:
         async with nc_client:
             # Expand to owners who shared content with the caller (same as the
             # MCP tool path) so shared documents are searchable.
             scope = await list_accessible_scope(nc_client.sharing, user_id)
+            retrieve_start = anyio.current_time()
             results = await execute(scope)
+            record_search_stage(
+                "http", "retrieve", anyio.current_time() - retrieve_start
+            )
             # Verify-on-read (ADR-019): drop documents the caller can no longer
             # access (e.g. a revoked share). Eviction runs inline — this
             # Starlette route has no FastMCP lifespan task group.
-            results, _dropped = await verify_search_results(nc_client, results)
+            verify_start = anyio.current_time()
+            results, dropped = await verify_search_results(nc_client, results)
+            record_search_stage("http", "verify", anyio.current_time() - verify_start)
 
     # Safe to log titles now: provisioned callers passed verify-on-read;
     # non-provisioned ran self-only (unverified titles are never logged — see
@@ -168,7 +190,7 @@ async def _search_with_acl(
                 for r in results[:5]
             ),
         )
-    return results
+    return results, dropped
 
 
 async def unified_search(request: Request) -> JSONResponse:
@@ -229,6 +251,13 @@ async def unified_search(request: Request) -> JSONResponse:
             },
             status_code=401,
         )
+
+    # Bound before the try so the error-path metric can label the request even
+    # when parsing is what failed. Reading them out of locals() in the handler
+    # would silently mislabel as "unknown" the moment either name moves.
+    algorithm = "unknown"
+    granularity = GRANULARITY_CHUNK
+    fusion = "rrf"
 
     try:
         # Parse request body
@@ -402,7 +431,7 @@ async def unified_search(request: Request) -> JSONResponse:
                 )
             return results
 
-        all_results = await _search_with_acl(request, user_id, _execute)
+        all_results, dropped_count = await _search_with_acl(request, user_id, _execute)
 
         # Sort results by score (no deduplication - show all chunks)
         sorted_results = sorted(all_results, key=lambda r: r.score, reverse=True)
@@ -493,12 +522,42 @@ async def unified_search(request: Request) -> JSONResponse:
             except Exception as e:
                 logger.warning("Failed to compute PCA for unified search: %s", e)
 
+        record_search_request(
+            surface="http",
+            algorithm=f"bm25_hybrid_{fusion}" if algorithm != "semantic" else algorithm,
+            granularity=granularity,
+            reranked="false",
+            status="success",
+            results_returned=len(formatted_results),
+            verification_dropped=dropped_count,
+        )
+        # Usage metering parity with nc_semantic_search. This endpoint embeds a
+        # query — a real, billable provider cost — and until now recorded no
+        # usage event at all, so Astrolabe-driven search (most traffic) was
+        # invisible to the ledger while MCP-driven search was billed. Recording
+        # it here makes the two entrypoints consistent; expect a step change in
+        # tokens_embedded rather than a new charge.
+        await record_search_usage(
+            enabled=settings.usage_metering_enabled,
+            user_id=user_id,
+            fusion=fusion,
+            doc_types=doc_types if isinstance(doc_types, list) else None,
+            token_count=search_algo.query_token_count,
+        )
+
         return JSONResponse(response_data)
 
     except Exception as e:
         # exception() over error(): keeps the traceback and satisfies Sonar
         # python:S8572 (logging.error with the exception object in an except).
         logger.exception("Error in unified search")
+        record_search_request(
+            surface="http",
+            algorithm=algorithm,
+            granularity=granularity,
+            reranked="false",
+            status="error",
+        )
         return JSONResponse(
             {
                 "error": "Internal error",
@@ -651,7 +710,7 @@ async def vector_search(request: Request) -> JSONResponse:
                 )
             return results
 
-        all_results = await _search_with_acl(request, user_id, _execute)
+        all_results, _dropped = await _search_with_acl(request, user_id, _execute)
 
         # Format results for PHP client
         formatted_results = []

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -49,6 +49,7 @@ from nextcloud_mcp_server.search.access_filter import (
     list_accessible_scope,
     normalize_path_prefixes,
 )
+from nextcloud_mcp_server.search.bm25_hybrid import search_method_label
 from nextcloud_mcp_server.search.context import (
     get_chunk_bbox_and_page_from_qdrant,
     get_chunk_with_context,
@@ -84,7 +85,9 @@ def _search_algorithm_label(algorithm: str, fusion: str) -> str:
     """
     if algorithm == "semantic":
         return algorithm
-    return f"bm25_hybrid_{fusion}"
+    # Shared helper: clamps an unrecognised fusion so a caller-supplied string
+    # can never reach a Prometheus label from either surface.
+    return search_method_label(fusion)
 
 
 def _unsupported_search_type_response(e: UnsupportedSearchType) -> JSONResponse:

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -678,6 +678,71 @@ document_download_truncated_total = Counter(
 )
 
 # =============================================================================
+# Astrolabe Search Metrics
+# =============================================================================
+#
+# Semantic search has TWO entrypoints — the ``nc_semantic_search`` MCP tool and
+# ``POST /api/v1/search`` (what Astrolabe calls) — and before these existed each
+# was visible only through its transport's generic counters
+# (``mcp_tool_calls_total`` / ``mcp_http_requests_total``). Neither reported what
+# search actually did: how many results came back, how many the ACL check
+# dropped, which granularity ran, or where the time went.
+#
+# Every metric here carries ``surface`` so the two entrypoints are directly
+# comparable on one dashboard, and all of them are recorded from
+# ``record_search_request`` / ``record_search_stage`` below so the surfaces
+# cannot drift apart as one of them gains a feature.
+
+search_requests_total = Counter(
+    "astrolabe_search_requests_total",
+    "Total semantic searches, by entrypoint and configuration",
+    # surface: mcp | http — algorithm: bm25_hybrid_rrf | bm25_hybrid_dbsf | semantic
+    # granularity: chunk | document — reranked: true | false | unavailable
+    # status: success | error
+    ["surface", "algorithm", "granularity", "reranked", "status"],
+)
+
+# Per-stage latency, so a slow search can be attributed without a trace.
+# stage: retrieve (embed + Qdrant) | rerank (cross-encoder) | verify (verify-on-read).
+# Buckets run to 30s because rerank over a deep pool is seconds, not milliseconds,
+# and verify-on-read is bounded by Nextcloud round-trips rather than by us.
+search_stage_duration_seconds = Histogram(
+    "astrolabe_search_stage_duration_seconds",
+    "Semantic search stage duration in seconds",
+    ["surface", "stage"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+
+# Results actually returned to the caller (post-verification, post-trim). A
+# distribution that collapses toward zero is the signal that the corpus, the
+# filters, or verify-on-read is starving callers — invisible in a request count.
+search_results_returned = Histogram(
+    "astrolabe_search_results_returned",
+    "Results returned to the caller per search",
+    ["surface"],
+    buckets=(0, 1, 2, 5, 10, 20, 50, 100),
+)
+
+# Documents dropped by verify-on-read (ADR-019 ghost records). Sustained
+# non-zero means the index is drifting from Nextcloud faster than webhooks
+# reconcile it, which degrades recall silently because the over-fetch absorbs it.
+search_verification_dropped_total = Counter(
+    "astrolabe_search_verification_dropped_total",
+    "Documents dropped by verify-on-read during search",
+    ["surface"],
+)
+
+# Documents scored by the cross-encoder. This is the honest cost unit for
+# reranking — there is no natural token unit — and the one to watch against GPU
+# saturation, since reranking and query-embedding contend for the same device.
+search_rerank_documents_total = Counter(
+    "astrolabe_search_rerank_documents_total",
+    "Documents scored by the reranker",
+    ["model", "outcome"],  # outcome: success | degraded
+)
+
+
+# =============================================================================
 # Database Metrics
 # =============================================================================
 
@@ -1301,6 +1366,71 @@ def record_embedding_tokens(provider: str, operation: str, tokens: int) -> None:
         embedding_tokens_total.labels(provider=provider, operation=operation).inc(
             tokens
         )
+
+
+def record_search_request(
+    *,
+    surface: str,
+    algorithm: str,
+    granularity: str,
+    reranked: str,
+    status: str,
+    results_returned: int | None = None,
+    verification_dropped: int = 0,
+) -> None:
+    """Record one semantic search from either entrypoint.
+
+    Both ``nc_semantic_search`` (surface ``"mcp"``) and ``POST /api/v1/search``
+    (surface ``"http"``) call this, so the two are comparable on one dashboard
+    and cannot drift as either gains a feature.
+
+    Args:
+        surface: ``"mcp"`` or ``"http"``.
+        algorithm: Search method label, e.g. ``bm25_hybrid_rrf`` or ``semantic``.
+        granularity: ``chunk`` or ``document``.
+        reranked: ``"true"`` when the reranker ordered the results,
+            ``"false"`` when it was not requested, ``"unavailable"`` when it was
+            requested but degraded to retrieval order. Kept as a string label
+            because those are three distinct states, not a boolean.
+        status: ``success`` or ``error``.
+        results_returned: Results handed to the caller. ``None`` on the error
+            path, where the count is not meaningful.
+        verification_dropped: Documents removed by verify-on-read.
+    """
+    search_requests_total.labels(
+        surface=surface,
+        algorithm=algorithm,
+        granularity=granularity,
+        reranked=reranked,
+        status=status,
+    ).inc()
+    if results_returned is not None:
+        search_results_returned.labels(surface=surface).observe(results_returned)
+    if verification_dropped > 0:
+        search_verification_dropped_total.labels(surface=surface).inc(
+            verification_dropped
+        )
+
+
+def record_search_stage(surface: str, stage: str, seconds: float) -> None:
+    """Record the duration of one search stage (retrieve | rerank | verify)."""
+    if seconds >= 0:
+        search_stage_duration_seconds.labels(surface=surface, stage=stage).observe(
+            seconds
+        )
+
+
+def record_rerank_documents(model: str, count: int, outcome: str) -> None:
+    """Record documents scored by the reranker.
+
+    Documents-scored is the honest cost unit: reranking has no natural token
+    unit, and this is what contends with query embedding for the GPU.
+    ``outcome`` is ``"success"`` or ``"degraded"`` — the degraded count records
+    what the reranker *would* have scored, so a reranker outage is visible as a
+    shift between outcomes rather than as a silent gap in the series.
+    """
+    if count > 0:
+        search_rerank_documents_total.labels(model=model, outcome=outcome).inc(count)
 
 
 def record_document_chunks(doc_type: str, count: int) -> None:

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -733,8 +733,9 @@ search_verification_dropped_total = Counter(
 )
 
 # Documents scored by the cross-encoder. This is the honest cost unit for
-# reranking — there is no natural token unit — and the one to watch against GPU
-# saturation, since reranking and query-embedding contend for the same device.
+# reranking — there is no natural token unit — and the series to correlate
+# against the gateway's own saturation signals when reranking gets slow. How
+# that service is deployed is not something this server knows or should encode.
 search_rerank_documents_total = Counter(
     "astrolabe_search_rerank_documents_total",
     "Documents scored by the reranker",
@@ -1424,7 +1425,8 @@ def record_rerank_documents(model: str, count: int, outcome: str) -> None:
     """Record documents scored by the reranker.
 
     Documents-scored is the honest cost unit: reranking has no natural token
-    unit, and this is what contends with query embedding for the GPU.
+    unit, and document count is what drives the work a rerank request asks of
+    the gateway.
     ``outcome`` is ``"success"`` or ``"degraded"`` — the degraded count records
     what the reranker *would* have scored, so a reranker outage is visible as a
     shift between outcomes rather than as a silent gap in the series.

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 # Result granularity (ADR-027 follow-up, Deck #83). "chunk" is the historical
 # behaviour and stays the default everywhere; "document" collapses each document
 # to its single best-scoring chunk via Qdrant's native grouping.
+# The only fusion modes Qdrant is asked for. Exported so every surface derives
+# its metric label from the SAME bounded set — a caller-supplied fusion string
+# that reached a Prometheus label would mint a permanent time series per distinct
+# value, which is a cardinality-explosion vector rather than a cosmetic issue.
+VALID_FUSIONS = ("rrf", "dbsf")
+
 GRANULARITY_CHUNK = "chunk"
 GRANULARITY_DOCUMENT = "document"
 VALID_GRANULARITIES = (GRANULARITY_CHUNK, GRANULARITY_DOCUMENT)
@@ -52,6 +58,19 @@ DOCUMENT_PREFETCH_FACTOR = 4
 # latency, so cap it. Only bites above limit=50; below that the computed
 # budget is already under the ceiling.
 MAX_DOCUMENT_PREFETCH = 800
+
+
+def search_method_label(fusion: str) -> str:
+    """The bounded ``search_method`` / metric label for a hybrid search.
+
+    Clamps an unrecognised ``fusion`` to the default rather than interpolating
+    it, so a caller-controlled string can never become a metric label. Callers
+    that also CONSTRUCT the algorithm still pass the raw value, which continues
+    to raise on an invalid mode — this only bounds what gets reported, it does
+    not make a bad request succeed.
+    """
+    safe = fusion if fusion in VALID_FUSIONS else VALID_FUSIONS[0]
+    return f"bm25_hybrid_{safe}"
 
 
 class _FlattenedGroups:
@@ -110,7 +129,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
         Raises:
             ValueError: If fusion is not "rrf" or "dbsf"
         """
-        if fusion not in ("rrf", "dbsf"):
+        if fusion not in VALID_FUSIONS:
             raise ValueError(
                 f"Invalid fusion algorithm '{fusion}'. Must be 'rrf' or 'dbsf'"
             )

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -33,7 +33,10 @@ from nextcloud_mcp_server.search.access_filter import (
     normalize_path_prefixes,
     resolve_prefix_folder_ids,
 )
-from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
+from nextcloud_mcp_server.search.bm25_hybrid import (
+    BM25HybridSearchAlgorithm,
+    search_method_label,
+)
 from nextcloud_mcp_server.search.context import get_chunk_with_context
 from nextcloud_mcp_server.search.verification import verify_search_results
 from nextcloud_mcp_server.usage.search import record_search_usage
@@ -219,7 +222,14 @@ def configure_semantic_tools(mcp: FastMCP):
         # Self-describing method label, mirroring BM25HybridSearchAlgorithm: the
         # query always fuses dense + sparse prefetches (keyword-only documents
         # contribute via the sparse side), so the label is always the fusion one.
-        search_method = f"bm25_hybrid_{fusion}"
+        # Derived from the BOUNDED label helper, not by interpolating the raw
+        # parameter. `fusion` is caller-controlled and is not validated until
+        # the algorithm is constructed inside the try below — but this value
+        # becomes a Prometheus label on every exit path including the error one,
+        # so an arbitrary string here would mint a permanent time series per
+        # distinct value. An invalid mode still raises when the algorithm is
+        # built; this only bounds what gets reported.
+        search_method = search_method_label(fusion)
 
         logger.info(
             "%s: query=%r, user=%s, limit=%d, score_threshold=%s, fusion=%s",

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -24,6 +24,8 @@ from nextcloud_mcp_server.models.semantic import (
 )
 from nextcloud_mcp_server.observability.metrics import (
     instrument_tool,
+    record_search_request,
+    record_search_stage,
 )
 from nextcloud_mcp_server.search.access_filter import (
     MAX_PATH_PREFIXES,
@@ -34,7 +36,7 @@ from nextcloud_mcp_server.search.access_filter import (
 from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
 from nextcloud_mcp_server.search.context import get_chunk_with_context
 from nextcloud_mcp_server.search.verification import verify_search_results
-from nextcloud_mcp_server.usage import UsageEventStore
+from nextcloud_mcp_server.usage.search import record_search_usage
 from nextcloud_mcp_server.utils.validation import parse_modified_timestamp
 from nextcloud_mcp_server.vector.metrics_publisher import (
     count_indexed,
@@ -43,15 +45,6 @@ from nextcloud_mcp_server.vector.metrics_publisher import (
 from nextcloud_mcp_server.vector.qdrant_client import get_qdrant_client
 
 logger = logging.getLogger(__name__)
-
-# Cap how many doc_types we copy into a usage-metering metadata row. doc_types
-# is caller-supplied and (unlike path_prefixes) has no max_length on the tool
-# signature, so an adversarial caller could pass a huge list. The CP rollup
-# ignores metadata for billing (GROUP BY day, metric) and the value is bound
-# parameterized, so this is not a billing/injection risk — the cap just keeps
-# a single JSONB row from ballooning. 16 is generous headroom over the handful
-# of real indexed doc types.
-_USAGE_METADATA_MAX_DOC_TYPES = 16
 
 
 def _consent_narrowed_doc_types(
@@ -71,61 +64,6 @@ def _consent_narrowed_doc_types(
     if doc_types is None:
         return sorted(allowed)
     return [dt for dt in doc_types if dt in allowed]
-
-
-async def record_search_usage(
-    *,
-    enabled: bool,
-    user_id: str,
-    fusion: str,
-    doc_types: list[str] | None,
-    token_count: int | None,
-) -> None:
-    """Record the billable ``tokens_embedded`` event for one semantic search.
-
-    The value is the query embedding's token count (provider-reported or
-    estimated) — the unit upstream providers bill on, and the same metric the
-    indexing path records for chunk embeddings (Deck #67). ``nc_semantic_search``
-    flows through here — do not add a second hook.
-
-    Best-effort and flag-gated: a metering failure is logged and never breaks
-    the search. Unlike the indexing path's chunk-count guard, a 0-token query is
-    still recorded (the query embedding ran); a zero-value row is a no-op at the
-    Stripe ``sum`` aggregation.
-
-    Privacy note: ``user_id`` stays tenant-local — the CP rollup aggregates
-    GROUP BY (day, metric) into ``usage_daily`` (no metadata column), so nothing
-    here propagates to Stripe; it is retained only to keep Deck #67's future
-    per-user attribution derivable from app-DB metadata without a re-migration.
-    """
-    if not enabled:
-        return
-    try:
-        store = await UsageEventStore.shared()
-        await store.record_usage_event(
-            metric="tokens_embedded",
-            value=token_count or 0,
-            metadata={
-                "user_id": user_id,
-                "fusion": fusion,
-                # Bounded copy — see _USAGE_METADATA_MAX_DOC_TYPES. Both None and
-                # [] normalize to null so a future metadata->'doc_types' IS NULL
-                # query counts the all-types case consistently.
-                "doc_types": (
-                    doc_types[:_USAGE_METADATA_MAX_DOC_TYPES] if doc_types else None
-                ),
-            },
-            # The caller already confirmed the flag, so pass enabled=True
-            # directly — the store then skips a second uncached Settings build on
-            # this hot query path (ADR-024).
-            enabled=True,
-        )
-    except Exception:
-        # Reached only when shared()/store construction itself raises
-        # (record_usage_event swallows its own write failures). Metering is on,
-        # so warn — a silent DEBUG line would hide "operator enabled metering
-        # but gets no data".
-        logger.warning("usage metering hook (tokens_embedded) skipped")
 
 
 def configure_semantic_tools(mcp: FastMCP):
@@ -387,6 +325,17 @@ def configure_semantic_tools(mcp: FastMCP):
                     "doc_type is admin-approved for semantic search",
                     username,
                 )
+                # A short-circuit is a successful search that found nothing, not
+                # an error — recording it keeps the zero-result distribution
+                # honest about how often consent narrowing is the cause.
+                record_search_request(
+                    surface="mcp",
+                    algorithm=search_method,
+                    granularity=granularity,
+                    reranked="false",
+                    status="success",
+                    results_returned=0,
+                )
                 return SemanticSearchResponse(
                     results=[],
                     query=query,
@@ -396,6 +345,15 @@ def configure_semantic_tools(mcp: FastMCP):
                     verified_chunk_count=0,
                     dropped_document_count=0,
                 )
+
+        # Search-metric state, recorded in the ``finally`` below so every exit —
+        # success, McpError, or an unexpected raise — lands exactly one
+        # ``astrolabe_search_requests_total`` sample. Defaults describe the
+        # failure case; the success path overwrites them.
+        metric_status = "error"
+        metric_results: int | None = None
+        metric_dropped = 0
+        metric_reranked = "false"
 
         try:
             # The nc_semantic_search tool deliberately uses BM25-hybrid (dense +
@@ -407,6 +365,8 @@ def configure_semantic_tools(mcp: FastMCP):
             search_algo = BM25HybridSearchAlgorithm(
                 score_threshold=score_threshold, fusion=fusion
             )
+
+            retrieve_start = anyio.current_time()
 
             # Execute search across requested document types
             # If doc_types is None, search all indexed types (cross-app search)
@@ -483,6 +443,13 @@ def configure_semantic_tools(mcp: FastMCP):
                 all_results.sort(key=lambda r: r.score, reverse=True)
                 all_results = all_results[: limit * 2]
 
+            # Covers query embedding + Qdrant across every branch above, so the
+            # per-doc_type loop's higher cost is visible rather than averaged
+            # away against the single-query branch.
+            record_search_stage(
+                "mcp", "retrieve", anyio.current_time() - retrieve_start
+            )
+
             # ADR-019: Verify-on-read. The vector index is a recall layer;
             # Nextcloud is the source of truth for access. Filter out ghost
             # records (deleted/unshared docs not yet reconciled by webhooks)
@@ -508,6 +475,9 @@ def configure_semantic_tools(mcp: FastMCP):
                 client,
                 all_results,
                 eviction_task_group=eviction_task_group,
+            )
+            record_search_stage(
+                "mcp", "verify", anyio.current_time() - verification_start
             )
             verified_chunk_count = len(verified_results)
             logger.debug(
@@ -712,7 +682,12 @@ def configure_semantic_tools(mcp: FastMCP):
                 fusion=fusion,
                 doc_types=doc_types,
                 token_count=search_algo.query_token_count,
+                surface="mcp",
             )
+
+            metric_status = "success"
+            metric_results = len(results)
+            metric_dropped = dropped_count
 
             return SemanticSearchResponse(
                 results=results,
@@ -748,6 +723,19 @@ def configure_semantic_tools(mcp: FastMCP):
             # the stack here (logger.exception) for triage.
             logger.exception("Search error: %s", e)
             raise McpError(ErrorData(code=-1, message=f"Search failed: {str(e)}"))
+        finally:
+            # One sample per search, on every exit path. Paired with the
+            # identical call in api/visualization.py so the MCP and HTTP
+            # entrypoints are directly comparable on one dashboard.
+            record_search_request(
+                surface="mcp",
+                algorithm=search_method,
+                granularity=granularity,
+                reranked=metric_reranked,
+                status=metric_status,
+                results_returned=metric_results,
+                verification_dropped=metric_dropped,
+            )
 
     @mcp.tool(
         title="Check Indexing Status",

--- a/nextcloud_mcp_server/usage/search.py
+++ b/nextcloud_mcp_server/usage/search.py
@@ -1,0 +1,95 @@
+"""Usage metering for semantic search.
+
+Lives here rather than in ``server/semantic.py`` because semantic search has TWO
+entrypoints — the ``nc_semantic_search`` MCP tool and ``POST /api/v1/search`` —
+and ``api/`` must not import from ``server/``. ``server.semantic`` re-exports
+``record_search_usage`` so existing callers and tests keep working.
+"""
+
+import logging
+
+from nextcloud_mcp_server.usage.store import UsageEventStore
+
+logger = logging.getLogger(__name__)
+
+# Cap how many doc_types we copy into a usage-metering metadata row. doc_types
+# is caller-supplied and (unlike path_prefixes) has no max_length on the tool
+# signature, so an adversarial caller could pass a huge list. The CP rollup
+# ignores metadata for billing (GROUP BY day, metric) and the value is bound
+# parameterized, so this is not a billing/injection risk — the cap just keeps
+# a single JSONB row from ballooning. 16 is generous headroom over the handful
+# of real indexed doc types.
+_USAGE_METADATA_MAX_DOC_TYPES = 16
+
+
+async def record_search_usage(
+    *,
+    enabled: bool,
+    user_id: str,
+    fusion: str,
+    doc_types: list[str] | None,
+    token_count: int | None,
+    surface: str = "mcp",
+) -> None:
+    """Record the billable ``tokens_embedded`` event for one semantic search.
+
+    The value is the query embedding's token count (provider-reported or
+    estimated) — the unit upstream providers bill on, and the same metric the
+    indexing path records for chunk embeddings (Deck #67).
+
+    Called once per search from each entrypoint: ``nc_semantic_search``
+    (``surface="mcp"``) and ``POST /api/v1/search`` (``surface="http"``). Do not
+    add a second hook *within* either path — the guard is against double-counting
+    one search, not against a second entrypoint.
+
+    Best-effort and flag-gated: a metering failure is logged and never breaks
+    the search. Unlike the indexing path's chunk-count guard, a 0-token query is
+    still recorded (the query embedding ran); a zero-value row is a no-op at the
+    Stripe ``sum`` aggregation.
+
+    Privacy note: ``user_id`` stays tenant-local — the CP rollup aggregates
+    GROUP BY (day, metric) into ``usage_daily`` (no metadata column), so nothing
+    here propagates to Stripe; it is retained only to keep Deck #67's future
+    per-user attribution derivable from app-DB metadata without a re-migration.
+
+    Args:
+        enabled: ``USAGE_METERING_ENABLED``; when false this is a no-op.
+        user_id: The authenticated caller (tenant-local, see privacy note).
+        fusion: Fusion mode label (``rrf`` | ``dbsf``).
+        doc_types: Requested doc_type filter, or ``None`` for all types.
+        token_count: Query-embedding tokens; ``None`` is recorded as 0.
+        surface: Which entrypoint recorded this — ``"mcp"`` or ``"http"``. Kept
+            in metadata so the two can be separated in the rollup; the HTTP
+            surface began recording later than the MCP one, so a step change in
+            ``tokens_embedded`` is expected at that point rather than a
+            regression.
+    """
+    if not enabled:
+        return
+    try:
+        store = await UsageEventStore.shared()
+        await store.record_usage_event(
+            metric="tokens_embedded",
+            value=token_count or 0,
+            metadata={
+                "user_id": user_id,
+                "fusion": fusion,
+                "surface": surface,
+                # Bounded copy — see _USAGE_METADATA_MAX_DOC_TYPES. Both None and
+                # [] normalize to null so a future metadata->'doc_types' IS NULL
+                # query counts the all-types case consistently.
+                "doc_types": (
+                    doc_types[:_USAGE_METADATA_MAX_DOC_TYPES] if doc_types else None
+                ),
+            },
+            # The caller already confirmed the flag, so pass enabled=True
+            # directly — the store then skips a second uncached Settings build on
+            # this hot query path (ADR-024).
+            enabled=True,
+        )
+    except Exception:
+        # Reached only when shared()/store construction itself raises
+        # (record_usage_event swallows its own write failures). Metering is on,
+        # so warn — a silent DEBUG line would hide "operator enabled metering
+        # but gets no data".
+        logger.warning("usage metering hook (tokens_embedded) skipped")

--- a/tests/unit/api/test_search_usage_metering.py
+++ b/tests/unit/api/test_search_usage_metering.py
@@ -109,3 +109,90 @@ def test_non_list_doc_types_normalize_to_none():
 
     assert resp.status_code == 200
     assert usage.await_args.kwargs["doc_types"] is None
+
+
+def _post_metrics(body, *, algo_raises=None):
+    """Same harness, but spying on `record_search_request` instead."""
+    settings = MagicMock()
+    settings.vector_sync_enabled = True
+    settings.usage_metering_enabled = False
+    settings.search_rerank_enabled = False
+    settings.embedding_gateway_url = ""
+
+    algo = MagicMock()
+    algo.search = (
+        AsyncMock(side_effect=algo_raises)
+        if algo_raises
+        else AsyncMock(return_value=[])
+    )
+    algo.query_token_count = 0
+    algo.query_embedding = None
+
+    spy = MagicMock()
+    with (
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_settings",
+            return_value=settings,
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+            new=AsyncMock(return_value=("alice", {})),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.BM25HybridSearchAlgorithm",
+            return_value=algo,
+        ),
+        # `algorithm="semantic"` resolves to the dense-only class, so both must
+        # be stubbed or that parametrisation reaches a real search.
+        patch(
+            "nextcloud_mcp_server.api.visualization.SemanticSearchAlgorithm",
+            return_value=algo,
+        ),
+        patch("nextcloud_mcp_server.api.visualization.record_search_request", new=spy),
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_user_client_basic_auth",
+            new=AsyncMock(side_effect=NotProvisionedError("not provisioned")),
+        ),
+    ):
+        return TestClient(_app()).post("/api/v1/search", json=body), spy
+
+
+def test_algorithm_label_is_identical_on_success_and_error():
+    """Success and error samples must land on the SAME series.
+
+    Normalising the label on one path and passing the raw value on the other
+    fragments `astrolabe_search_requests_total` into non-comparable series and
+    breaks "error rate by algorithm" — which is precisely the cross-surface
+    drift these metrics exist to detect.
+    """
+    ok, ok_spy = _post_metrics({"query": "q", "algorithm": "hybrid", "fusion": "rrf"})
+    assert ok.status_code == 200
+    ok_label = ok_spy.call_args.kwargs["algorithm"]
+
+    bad, bad_spy = _post_metrics(
+        {"query": "q", "algorithm": "hybrid", "fusion": "rrf"},
+        algo_raises=RuntimeError("qdrant exploded"),
+    )
+    assert bad.status_code == 500
+    err_label = bad_spy.call_args.kwargs["algorithm"]
+
+    assert ok_label == err_label == "bm25_hybrid_rrf"
+
+
+def test_semantic_algorithm_label_is_not_rewritten():
+    """The dense-only algorithm has no fusion, so its label must pass through
+    rather than being decorated with a fusion it never used."""
+    resp, spy = _post_metrics({"query": "q", "algorithm": "semantic"})
+
+    assert resp.status_code == 200
+    assert spy.call_args.kwargs["algorithm"] == "semantic"
+
+
+def test_error_path_still_records_a_sample():
+    """An error must not simply vanish from the request counter."""
+    resp, spy = _post_metrics(
+        {"query": "q"}, algo_raises=RuntimeError("qdrant exploded")
+    )
+
+    assert resp.status_code == 500
+    assert spy.call_args.kwargs["status"] == "error"

--- a/tests/unit/api/test_search_usage_metering.py
+++ b/tests/unit/api/test_search_usage_metering.py
@@ -1,0 +1,111 @@
+"""Usage metering on POST /api/v1/search.
+
+This endpoint embeds a query — a real billable provider cost — and for a long
+time recorded no usage event at all, so Astrolabe-driven search was invisible to
+the ledger while MCP-driven search was billed.
+
+The `surface` assertion is the point of this file. `record_search_usage`
+defaults `surface="mcp"`, so a call site that simply forgets to pass it produces
+events that look *plausible* — they land in the ledger, with a surface field, at
+the right volume — while attributing all HTTP traffic to MCP. Nothing downstream
+can detect that; only an assertion at the call site can.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from nextcloud_mcp_server.api.visualization import unified_search
+from nextcloud_mcp_server.vector.oauth_sync import NotProvisionedError
+
+pytestmark = pytest.mark.unit
+
+
+def _app() -> Starlette:
+    app = Starlette(routes=[Route("/api/v1/search", unified_search, methods=["POST"])])
+    app.state.oauth_context = {"config": {"nextcloud_host": "https://nc.example"}}
+    return app
+
+
+def _post(body, *, metering_enabled=True, token_count=42):
+    settings = MagicMock()
+    settings.vector_sync_enabled = True
+    settings.usage_metering_enabled = metering_enabled
+    settings.search_rerank_enabled = False
+    settings.embedding_gateway_url = ""
+
+    algo = MagicMock()
+    algo.search = AsyncMock(return_value=[])
+    algo.query_token_count = token_count
+    algo.query_embedding = None
+
+    usage = AsyncMock()
+    with (
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_settings",
+            return_value=settings,
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.validate_token_and_get_user",
+            new=AsyncMock(return_value=("alice", {})),
+        ),
+        patch(
+            "nextcloud_mcp_server.api.visualization.BM25HybridSearchAlgorithm",
+            return_value=algo,
+        ),
+        patch("nextcloud_mcp_server.api.visualization.record_search_usage", new=usage),
+        patch(
+            "nextcloud_mcp_server.api.visualization.get_user_client_basic_auth",
+            new=AsyncMock(side_effect=NotProvisionedError("not provisioned")),
+        ),
+    ):
+        return TestClient(_app()).post("/api/v1/search", json=body), usage
+
+
+def test_http_search_is_metered_as_the_http_surface():
+    """The whole point of the surface field: MCP and HTTP must be separable in
+    the rollup. `record_search_usage` defaults to "mcp", so omitting this
+    argument silently attributes every Astrolabe search to the MCP tool."""
+    resp, usage = _post({"query": "anything"})
+
+    assert resp.status_code == 200
+    usage.assert_awaited_once()
+    assert usage.await_args.kwargs["surface"] == "http"
+
+
+def test_records_the_query_token_count():
+    """Tokens are the billed unit; the value must be the query embedding's
+    count, not a placeholder."""
+    resp, usage = _post({"query": "anything"}, token_count=137)
+
+    assert resp.status_code == 200
+    assert usage.await_args.kwargs["token_count"] == 137
+
+
+def test_metering_flag_is_forwarded_not_assumed():
+    """The helper is flag-gated internally, so the endpoint must pass the real
+    setting rather than hardcoding it on."""
+    resp, usage = _post({"query": "anything"}, metering_enabled=False)
+
+    assert resp.status_code == 200
+    assert usage.await_args.kwargs["enabled"] is False
+
+
+def test_doc_types_filter_is_recorded_when_a_list():
+    resp, usage = _post({"query": "anything", "doc_types": ["file", "note"]})
+
+    assert resp.status_code == 200
+    assert usage.await_args.kwargs["doc_types"] == ["file", "note"]
+
+
+def test_non_list_doc_types_normalize_to_none():
+    """Both None and a malformed value must land as null so a future
+    `metadata->'doc_types' IS NULL` query counts the all-types case
+    consistently."""
+    resp, usage = _post({"query": "anything", "doc_types": "file"})
+
+    assert resp.status_code == 200
+    assert usage.await_args.kwargs["doc_types"] is None

--- a/tests/unit/server/test_semantic_metering.py
+++ b/tests/unit/server/test_semantic_metering.py
@@ -3,8 +3,14 @@
 ``record_search_usage`` records the billable ``tokens_embedded`` event for a
 semantic search. These pin the value mapping (query token count), the flag-off
 no-op, the doc_types metadata bounding, and the best-effort failure path —
-covering the server-tool metering wiring without standing up the full
-``nc_semantic_search`` tool.
+covering the metering wiring without standing up the full ``nc_semantic_search``
+tool.
+
+The helper lives in ``nextcloud_mcp_server.usage.search`` because BOTH search
+entrypoints record through it (``nc_semantic_search`` and ``POST
+/api/v1/search``), and ``api/`` must not import from ``server/``. It is still
+re-exported as ``server.semantic.record_search_usage``, which is what these
+tests call — the monkeypatch target, however, must be the defining module.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -12,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nextcloud_mcp_server.server import semantic
+from nextcloud_mcp_server.usage import search as usage_search
 
 
 @pytest.fixture
@@ -20,7 +27,7 @@ def store_spy(monkeypatch):
     store = MagicMock()
     store.record_usage_event = AsyncMock()
     monkeypatch.setattr(
-        semantic.UsageEventStore, "shared", AsyncMock(return_value=store)
+        usage_search.UsageEventStore, "shared", AsyncMock(return_value=store)
     )
     return store
 
@@ -102,14 +109,14 @@ async def test_doc_types_metadata_is_bounded(store_spy):
         token_count=5,
     )
     recorded = store_spy.record_usage_event.await_args.kwargs["metadata"]["doc_types"]
-    assert recorded == many[: semantic._USAGE_METADATA_MAX_DOC_TYPES]
+    assert recorded == many[: usage_search._USAGE_METADATA_MAX_DOC_TYPES]
 
 
 @pytest.mark.unit
 async def test_store_failure_is_swallowed(monkeypatch):
     """A store-construction failure is logged, never raised into the search."""
     monkeypatch.setattr(
-        semantic.UsageEventStore,
+        usage_search.UsageEventStore,
         "shared",
         AsyncMock(side_effect=RuntimeError("boom")),
     )

--- a/tests/unit/server/test_semantic_search_metrics.py
+++ b/tests/unit/server/test_semantic_search_metrics.py
@@ -163,3 +163,38 @@ def test_reranked_label_is_false_when_not_requested():
     spy, _ = _run()
 
     assert spy.call_args.kwargs["reranked"] == "false"
+
+
+def test_arbitrary_fusion_cannot_reach_the_metric_label():
+    """`fusion` is caller-controlled and is not validated until the algorithm is
+    constructed — which happens AFTER the label is computed, and inside the try
+    whose `finally` records the sample regardless.
+
+    So an unrecognised value must clamp rather than interpolate. Otherwise every
+    distinct string a caller sends mints a permanent Prometheus series, which
+    any holder of `semantic.read` could exploit without even completing a
+    search.
+    """
+    spy, _ = _run(fusion="../../etc/passwd\n\nrandom-unique-value")
+
+    assert spy.call_count == 1
+    assert spy.call_args.kwargs["algorithm"] == "bm25_hybrid_rrf"
+
+    # This harness stubs BM25HybridSearchAlgorithm, so it cannot show that the
+    # bad mode still fails the request — asserting that here would only be
+    # testing the mock. The real rejection is pinned one layer down, below.
+
+
+def test_the_real_algorithm_still_rejects_an_invalid_fusion():
+    """Bounding the LABEL must not make an invalid request succeed."""
+    from nextcloud_mcp_server.search.bm25_hybrid import BM25HybridSearchAlgorithm
+
+    with pytest.raises(ValueError, match="Invalid fusion"):
+        BM25HybridSearchAlgorithm(fusion="not-a-mode")
+
+
+def test_valid_fusion_is_reported_verbatim():
+    """Clamping must not flatten the modes that genuinely differ."""
+    spy, _ = _run(fusion="dbsf")
+
+    assert spy.call_args.kwargs["algorithm"] == "bm25_hybrid_dbsf"

--- a/tests/unit/server/test_semantic_search_metrics.py
+++ b/tests/unit/server/test_semantic_search_metrics.py
@@ -78,7 +78,18 @@ def _run(
     scope.share_root_ids = []
 
     mod = "nextcloud_mcp_server.server.semantic"
+    # `@require_scopes` consults its OWN module's settings, not the tool's. With
+    # that left ambient the scope check followed whatever deployment mode the
+    # environment implied — passing locally under BasicAuth-like config and
+    # denying under login-flow config in CI. Pinning it here keeps these tests
+    # about metrics rather than about which .env the runner happened to have.
+    scope_settings = MagicMock()
+    scope_settings.enable_login_flow = False
     with (
+        patch(
+            "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+            return_value=scope_settings,
+        ),
         patch(f"{mod}.get_settings", return_value=_settings(vector_sync)),
         patch(f"{mod}.get_client", new=AsyncMock(return_value=client)),
         patch(f"{mod}.list_accessible_scope", new=AsyncMock(return_value=scope)),

--- a/tests/unit/server/test_semantic_search_metrics.py
+++ b/tests/unit/server/test_semantic_search_metrics.py
@@ -1,0 +1,154 @@
+"""`nc_semantic_search` records exactly one search metric per exit path.
+
+The MCP tool records its request metric in a `finally`, which is what makes the
+guarantee hold for success, `McpError`, and unexpected raises alike. That is a
+claim about control flow, so it is only worth anything if something exercises
+each path — a `finally` that was accidentally moved inside the `try`, or an
+early `return` added above it, would still pass every other test in the suite.
+
+Mirrors the spy pattern in tests/unit/api/test_search_usage_metering.py so the
+two entrypoints are held to the same standard.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.shared.exceptions import McpError
+
+pytestmark = pytest.mark.unit
+
+
+def _build_tool():
+    """Register the tools against a stub FastMCP and return `nc_semantic_search`."""
+    from nextcloud_mcp_server.server.semantic import configure_semantic_tools
+
+    captured = {}
+
+    class _Mcp:
+        def tool(self, **kwargs):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+
+            return deco
+
+    configure_semantic_tools(_Mcp())
+    return captured["nc_semantic_search"]
+
+
+def _ctx():
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.eviction_task_group = None
+    return ctx
+
+
+def _settings(vector_sync=True):
+    s = MagicMock()
+    s.vector_sync_enabled = vector_sync
+    s.usage_metering_enabled = False
+    s.search_rerank_enabled = False
+    s.embedding_gateway_url = ""
+    return s
+
+
+def _run(
+    *,
+    allowed=None,
+    search_side_effect=None,
+    search_return=None,
+    vector_sync=True,
+    **tool_kwargs,
+):
+    """Call the tool with everything below it stubbed; return the metric spy."""
+    spy = MagicMock()
+    algo = MagicMock()
+    algo.search = (
+        AsyncMock(side_effect=search_side_effect)
+        if search_side_effect
+        else AsyncMock(return_value=search_return or [])
+    )
+    algo.query_token_count = 0
+    algo.query_embedding = None
+
+    client = MagicMock()
+    client.sharing = MagicMock()
+
+    scope = MagicMock()
+    scope.owners = ["alice"]
+    scope.share_root_ids = []
+
+    mod = "nextcloud_mcp_server.server.semantic"
+    with (
+        patch(f"{mod}.get_settings", return_value=_settings(vector_sync)),
+        patch(f"{mod}.get_client", new=AsyncMock(return_value=client)),
+        patch(f"{mod}.list_accessible_scope", new=AsyncMock(return_value=scope)),
+        patch(f"{mod}.allowed_doc_types", new=AsyncMock(return_value=allowed)),
+        patch(f"{mod}.normalize_path_prefixes", return_value=[]),
+        patch(f"{mod}.resolve_prefix_folder_ids", new=AsyncMock(return_value=[])),
+        patch(f"{mod}.BM25HybridSearchAlgorithm", return_value=algo),
+        patch(f"{mod}.verify_search_results", new=AsyncMock(return_value=([], 0))),
+        patch(f"{mod}.record_search_usage", new=AsyncMock()),
+        patch(f"{mod}.record_search_request", new=spy),
+    ):
+        tool = _build_tool()
+        import anyio
+
+        async def _go():
+            return await tool(query="q", ctx=_ctx(), **tool_kwargs)
+
+        try:
+            result = anyio.run(_go)
+        except McpError as e:
+            return spy, e
+        return spy, result
+
+
+def test_success_records_exactly_one_sample():
+    spy, _ = _run()
+
+    assert spy.call_count == 1
+    kwargs = spy.call_args.kwargs
+    assert kwargs["surface"] == "mcp"
+    assert kwargs["status"] == "success"
+
+
+def test_unexpected_exception_records_an_error_sample():
+    """The `finally` is what makes this hold — a raise from deep inside the
+    search must not simply vanish from the request counter."""
+    spy, err = _run(search_side_effect=RuntimeError("qdrant exploded"))
+
+    assert isinstance(err, McpError)
+    assert spy.call_count == 1
+    assert spy.call_args.kwargs["status"] == "error"
+
+
+def test_mcp_error_path_records_an_error_sample():
+    """A client-facing McpError is still a failed search."""
+    spy, err = _run(search_side_effect=ValueError("No embedding provider configured"))
+
+    assert isinstance(err, McpError)
+    assert spy.call_count == 1
+    assert spy.call_args.kwargs["status"] == "error"
+
+
+def test_consent_short_circuit_records_a_zero_result_success():
+    """Not an error, and not nothing: recording it keeps the zero-result
+    distribution honest about how often admin consent is the cause."""
+    spy, _ = _run(allowed=frozenset(), doc_types=["file"])
+
+    assert spy.call_count == 1
+    kwargs = spy.call_args.kwargs
+    assert kwargs["status"] == "success"
+    assert kwargs["results_returned"] == 0
+
+
+def test_granularity_is_reported_as_requested():
+    spy, _ = _run(granularity="document")
+
+    assert spy.call_args.kwargs["granularity"] == "document"
+
+
+def test_reranked_label_is_false_when_not_requested():
+    spy, _ = _run()
+
+    assert spy.call_args.kwargs["reranked"] == "false"


### PR DESCRIPTION
Stacked on #1218.

## Problem

Semantic search has **two** entrypoints — the `nc_semantic_search` MCP tool and
`POST /api/v1/search` (what Astrolabe calls) — and neither reported anything
search-specific. Each was visible only through its transport's generic counters
(`mcp_tool_calls_total` / `mcp_http_requests_total`), so **result counts,
verify-on-read drops, granularity mix, and per-stage latency were unobservable
on both**.

## What this adds

One set of metrics, recorded through a shared helper pair so the two surfaces
cannot drift apart as either gains a feature:

| metric | labels |
|---|---|
| `astrolabe_search_requests_total` | surface, algorithm, granularity, reranked, status |
| `astrolabe_search_stage_duration_seconds` | surface, stage (retrieve\|rerank\|verify) |
| `astrolabe_search_results_returned` | surface |
| `astrolabe_search_verification_dropped_total` | surface |
| `astrolabe_search_rerank_documents_total` | model, outcome |

On the MCP path the request metric is recorded in a `finally`, so success,
`McpError`, and unexpected raises each land exactly one sample — no exit path
can silently skip it. The consent short-circuit records a *success with zero
results* rather than nothing, which keeps the zero-result distribution honest
about how often admin consent is the cause.

Stage timings are recorded inside `_search_with_acl` rather than around it, so
"retrieve" means embed+Qdrant and "verify" means the Nextcloud round-trips —
timing the wrapper would conflate them into one unattributable number.

## Two bugs this surfaced

**`_search_with_acl` discarded the verify-on-read drop count** (`results,
_dropped = ...`). Ghost-record drops were computed and thrown away on the HTTP
path, so the signal ADR-019 exists to expose was unobservable there. It now
returns `(results, dropped)`.

**`POST /api/v1/search` recorded no usage event at all.** It embeds a query — a
real billable provider cost — so Astrolabe-driven search (most traffic) was
invisible to the ledger while MCP-driven search was billed. Both now record
through the same helper.

## Behaviour change worth calling out

Adding metering to the HTTP path means previously-unrecorded searches start
appearing in the usage ledger. **Expect a step change in `tokens_embedded`**
where HTTP traffic dominates. This is the under-count being corrected, not a new
charge — and all tenants are currently in dev and not billed. A `surface` field
in the metadata keeps the two entrypoints separable in the rollup.

## Refactor

`record_search_usage` moves from `server/semantic.py` to `usage/search.py`:
`api/` needs it and there is no existing `api -> server` import anywhere, so
adding one would be the wrong direction. `server.semantic` re-exports it, so
existing callers are unchanged; `tests/unit/server/test_semantic_metering.py`
needed only its monkeypatch target updated to the defining module.

## Note on the rerank labels

`reranked` and `astrolabe_search_rerank_documents_total` are defined here but
unused until the rerank stage lands on top of this stack. Defining the metric
surface in one place keeps it reviewable as a whole rather than in fragments.

## Test

`ruff check`, `ruff format --check`, `ty check` clean; full unit suite passes
(2730). No new API surface, so no e2e/Pact additions are required by the
coverage gate — the changed surface is Prometheus metrics and an internal
helper signature.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)