### PR TITLE
feat(search): add cross-encoder rerank machinery (unused until wired)

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -200,6 +200,40 @@ _DEFAULTS: dict[str, Any] = {
     # document both retrievers agree on. 60 is the standard value (~2% per rank),
     # which restores consensus as the dominant signal.
     "vector_search_rrf_k": 60,
+    # --- Cross-encoder reranking (opt-in, per request) ----------------------
+    # A cross-encoder reorders the retrieved candidates by scoring each against
+    # the query directly, which is more accurate than the fusion rank it
+    # replaces. Ships OFF: it adds a model round-trip per search, and where the
+    # reranker shares hardware with the embedding model the two contend.
+    "search_rerank_enabled": False,
+    # Rerank model, addressed the way the configured embedding gateway expects
+    # (typically ``<provider>/<model>``). Any cross-encoder the gateway can
+    # serve works; set this to match your deployment.
+    "search_rerank_model": "BAAI/bge-reranker-v2-m3",
+    # Candidates handed to the reranker. Reranking can only reorder what
+    # retrieval supplied, so this depth — not the caller's ``limit`` — bounds
+    # how much a reranker can improve. Reranking just the rows a normal search
+    # returns captures little of the available gain.
+    #
+    # Treat this as a ceiling rather than a starting point. Under
+    # ``granularity="document"`` the grouped prefetch is bounded by
+    # MAX_DOCUMENT_PREFETCH, and requesting more groups than the prefetch can
+    # fill makes Qdrant widen its grouping search and reorder the head of the
+    # result set before the reranker sees it. Going deeper requires raising
+    # MAX_DOCUMENT_PREFETCH first, which carries its own latency cost.
+    "search_rerank_pool_size": 200,
+    # Generous headroom over a normal rerank, not a target. Exceeding it
+    # degrades to retrieval order rather than failing the search.
+    "search_rerank_timeout_seconds": 30.0,
+    # Concurrent rerank calls in flight, process-wide.
+    #
+    # Deliberately 1, and note what it does NOT do: where the reranker shares a
+    # device with the embedding model, a single in-flight rerank is already
+    # enough to slow embedding substantially, so raising or lowering this will
+    # not protect indexing throughput. What it buys is predictable rerank
+    # latency and a bounded queue, so a burst of searches cannot stack unbounded
+    # work on the model. Separate hardware is the fix for contention.
+    "search_rerank_max_concurrency": 1,
     # Chunking config generation. Bump whenever chunker behaviour changes (size,
     # overlap, page-aware, page-pack, split strategy) so the pricing model's
     # density reference can't silently go stale. Pinned in stripe-catalog.tf.
@@ -593,6 +627,9 @@ _dynaconf = Dynaconf(
         # 1/(rank + k) with rank 0-indexed, so k=0 divides by zero on the
         # top-ranked point.
         Validator("VECTOR_SEARCH_RRF_K", gte=1),
+        Validator("SEARCH_RERANK_POOL_SIZE", gte=1),
+        Validator("SEARCH_RERANK_MAX_CONCURRENCY", gte=1),
+        Validator("SEARCH_RERANK_TIMEOUT_SECONDS", gt=0),
         # Non-empty strings
         Validator("VECTOR_SYNC_TAG", len_min=1),
         # VECTOR_SYNC_KEYWORD_TAG is optional (empty disables keyword-only
@@ -1156,6 +1193,15 @@ class Settings:
     # dense and sparse lists decides the ordering. Applies to ``fusion="rrf"``
     # only; DBSF has no such constant.
     vector_search_rrf_k: int = 60
+    # Optional cross-encoder rerank stage (opt-in per request; see _DEFAULTS for
+    # the rationale behind each value). ``search_rerank_enabled`` is the
+    # capability gate — a request asking to rerank on a deployment without it
+    # configured is rejected rather than silently served unreranked.
+    search_rerank_enabled: bool = False
+    search_rerank_model: str = "BAAI/bge-reranker-v2-m3"
+    search_rerank_pool_size: int = 200
+    search_rerank_timeout_seconds: float = 30.0
+    search_rerank_max_concurrency: int = 1
     # Greedy page-packing (Deck #636). When True, the page-aware chunker merges
     # consecutive sub-budget pages into one chunk (page-range citation via
     # page_number/page_end) instead of one-chunk-per-page — the density fix for
@@ -1539,6 +1585,15 @@ class Settings:
                 "DOCUMENT_OCR_MODE=batch requires EMBEDDING_GATEWAY_URL (batch OCR "
                 "routes through the embedding gateway); use DOCUMENT_OCR_MODE=sync "
                 "for the direct backend without a gateway"
+            )
+        # Reranking is served through the embedding gateway, so enabling it
+        # without one configured would fail at the first search rather than at
+        # startup. Fail loudly here instead: the alternative is a deployment
+        # that advertises the capability and then degrades on every request.
+        if self.search_rerank_enabled and not self.embedding_gateway_url:
+            raise ValueError(
+                "SEARCH_RERANK_ENABLED requires EMBEDDING_GATEWAY_URL (reranking "
+                "is served through the embedding gateway)"
             )
         # Optional interactive read-parse cap (nc_webdav_read_file). Unset / empty =
         # disabled; when set it must be a positive number of seconds. An empty string

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -203,8 +203,9 @@ _DEFAULTS: dict[str, Any] = {
     # --- Cross-encoder reranking (opt-in, per request) ----------------------
     # A cross-encoder reorders the retrieved candidates by scoring each against
     # the query directly, which is more accurate than the fusion rank it
-    # replaces. Ships OFF: it adds a model round-trip per search, and where the
-    # reranker shares hardware with the embedding model the two contend.
+    # replaces. Ships OFF because it adds an upstream round-trip to every
+    # search, and how expensive that is depends on the gateway's own deployment
+    # — which this server deliberately knows nothing about beyond the URL.
     "search_rerank_enabled": False,
     # Rerank model, addressed the way the configured embedding gateway expects
     # (typically ``<provider>/<model>``). Any cross-encoder the gateway can
@@ -225,14 +226,15 @@ _DEFAULTS: dict[str, Any] = {
     # Generous headroom over a normal rerank, not a target. Exceeding it
     # degrades to retrieval order rather than failing the search.
     "search_rerank_timeout_seconds": 30.0,
-    # Concurrent rerank calls in flight, process-wide.
+    # Concurrent rerank calls this process keeps in flight against the gateway.
     #
-    # Deliberately 1, and note what it does NOT do: where the reranker shares a
-    # device with the embedding model, a single in-flight rerank is already
-    # enough to slow embedding substantially, so raising or lowering this will
-    # not protect indexing throughput. What it buys is predictable rerank
-    # latency and a bounded queue, so a burst of searches cannot stack unbounded
-    # work on the model. Separate hardware is the fix for contention.
+    # Conservative at 1 because reranking is the heaviest request this server
+    # makes of a service it shares with its own embedding traffic and with other
+    # callers. Bounding our own concurrency keeps a burst of searches from
+    # queueing unbounded work upstream, and keeps rerank latency predictable
+    # here. It is a client-side courtesy, not a throughput control: what the
+    # gateway does with the request, and how it schedules against everything
+    # else it serves, is its business. Raise it if your gateway has headroom.
     "search_rerank_max_concurrency": 1,
     # Chunking config generation. Bump whenever chunker behaviour changes (size,
     # overlap, page-aware, page-pack, split strategy) so the pricing model's

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -395,33 +395,18 @@ class _DoclingServeBackend(_OcrBackend):
 
 
 def _build_gateway_token_provider(settings: Settings) -> Any:
-    """Build the M2M ``GatewayTokenProvider`` from settings, or ``None`` when no
-    client-id is configured (unauthenticated gateway). Shared by the sync OCR
-    backend and the batch client so the M2M-triple validation lives in one place.
-    """
-    if not settings.embedding_gateway_client_id:
-        return None
-    # Lazy import avoids a document_processors -> providers cycle at load.
-    from ..providers.gateway import GatewayTokenProvider  # noqa: PLC0415
+    """Thin alias kept for this module's existing callers.
 
-    # Explicit (not assert -- assert is stripped under `python -O`): the M2M
-    # triple is all-or-nothing.
-    if not settings.embedding_gateway_token_url:
-        raise ValueError(
-            "EMBEDDING_GATEWAY_TOKEN_URL is required when "
-            "EMBEDDING_GATEWAY_CLIENT_ID is set"
-        )
-    if not settings.embedding_gateway_client_secret:
-        raise ValueError(
-            "EMBEDDING_GATEWAY_CLIENT_SECRET is required when "
-            "EMBEDDING_GATEWAY_CLIENT_ID is set"
-        )
-    return GatewayTokenProvider(
-        token_url=settings.embedding_gateway_token_url,
-        client_id=settings.embedding_gateway_client_id,
-        client_secret=settings.embedding_gateway_client_secret,
-        scope=settings.embedding_gateway_scope,
-    )
+    The implementation moved to ``providers.gateway`` when rerank became a third
+    gateway sub-client needing it, so the all-or-nothing M2M-triple validation
+    still lives in exactly one place. Still a function with a lazy import rather
+    than a module-level alias, because a top-level ``providers`` import here
+    would reintroduce the document_processors -> providers cycle this module
+    deliberately avoids (see the import note at the top of the file).
+    """
+    from ..providers.gateway import build_gateway_token_provider  # noqa: PLC0415
+
+    return build_gateway_token_provider(settings)
 
 
 def build_gateway_batch_client(

--- a/nextcloud_mcp_server/providers/gateway.py
+++ b/nextcloud_mcp_server/providers/gateway.py
@@ -24,11 +24,11 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
 
 import anyio
 import httpx
 
+from ..config import Settings
 from ..providers.openai import OpenAIProvider
 
 logger = logging.getLogger(__name__)
@@ -238,7 +238,7 @@ class GatewayProvider(OpenAIProvider):
         return await super().embed_batch_with_usage(texts)
 
 
-def build_gateway_token_provider(settings: Any) -> GatewayTokenProvider | None:
+def build_gateway_token_provider(settings: Settings) -> GatewayTokenProvider | None:
     """Build the M2M ``GatewayTokenProvider`` from settings, or ``None`` when no
     client-id is configured (unauthenticated gateway).
 

--- a/nextcloud_mcp_server/providers/gateway.py
+++ b/nextcloud_mcp_server/providers/gateway.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 import anyio
 import httpx
@@ -235,3 +236,35 @@ class GatewayProvider(OpenAIProvider):
     ) -> tuple[list[list[float]], int]:
         await self._ensure_bearer()
         return await super().embed_batch_with_usage(texts)
+
+
+def build_gateway_token_provider(settings: Any) -> GatewayTokenProvider | None:
+    """Build the M2M ``GatewayTokenProvider`` from settings, or ``None`` when no
+    client-id is configured (unauthenticated gateway).
+
+    Lives beside ``GatewayTokenProvider`` because every gateway sub-client needs
+    it — sync OCR, batch OCR, and rerank — so the all-or-nothing M2M-triple
+    validation has exactly one home. ``document_processors.ocr`` re-exports it
+    under its historical private name.
+    """
+    if not settings.embedding_gateway_client_id:
+        return None
+
+    # Explicit (not assert -- assert is stripped under `python -O`): the M2M
+    # triple is all-or-nothing.
+    if not settings.embedding_gateway_token_url:
+        raise ValueError(
+            "EMBEDDING_GATEWAY_TOKEN_URL is required when "
+            "EMBEDDING_GATEWAY_CLIENT_ID is set"
+        )
+    if not settings.embedding_gateway_client_secret:
+        raise ValueError(
+            "EMBEDDING_GATEWAY_CLIENT_SECRET is required when "
+            "EMBEDDING_GATEWAY_CLIENT_ID is set"
+        )
+    return GatewayTokenProvider(
+        token_url=settings.embedding_gateway_token_url,
+        client_id=settings.embedding_gateway_client_id,
+        client_secret=settings.embedding_gateway_client_secret,
+        scope=settings.embedding_gateway_scope,
+    )

--- a/nextcloud_mcp_server/providers/gateway_rerank.py
+++ b/nextcloud_mcp_server/providers/gateway_rerank.py
@@ -1,0 +1,179 @@
+"""Cross-encoder reranking against the embedding gateway's ``/v1/rerank``.
+
+A plain-httpx sub-client rather than a :class:`~.base.Provider`: the ``Provider``
+ABC is an embedding contract (``embed``/``embed_batch``/``get_dimension``) and a
+reranker satisfies none of it. Mirrors :mod:`.gateway_batch`, which is the
+existing precedent for a gateway surface that is not an embedding provider.
+
+The gateway takes a namespaced model id, so choosing a self-hosted versus a
+hosted reranker is configuration rather than a code path here.
+"""
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from .gateway import GatewayTokenProvider
+
+logger = logging.getLogger(__name__)
+
+# Reranking a deep pool is a single forward pass per document, so the request
+# timeout is sized for the pool rather than for a control-plane round-trip. The
+# caller layers its own configured timeout on top and degrades on expiry; this
+# is the transport-level backstop.
+_RERANK_CONNECT_TIMEOUT_SECONDS = 5.0
+_RERANK_REQUEST_TIMEOUT_SECONDS = 120.0
+
+# Per-document character budget for the request body.
+#
+# Two independent reasons, both real:
+#   1. ``document_chunk_size`` is operator-configurable with no upper bound, so
+#      "pool size x chunk size" is an unbounded request body. At a large chunk
+#      size a full pool exceeds a typical 1 MB ingress limit and fails as a 413
+#      from the proxy, not as anything the gateway ever sees.
+#   2. Cross-encoders truncate their input near the model's sequence limit
+#      anyway, so text beyond roughly this length is not scored — trimming it
+#      costs no ranking quality and buys proportional latency.
+_MAX_DOCUMENT_CHARS = 2000
+
+# The query shares the cross-encoder's sequence budget with each document, so an
+# unbounded query would crowd out the text being scored. The HTTP search surface
+# permits a 10,000-character query.
+_MAX_QUERY_CHARS = 1000
+
+
+class RerankError(Exception):
+    """The gateway could not rerank. Callers degrade to retrieval order rather
+    than failing the search, so this is a signal to fall back, not to retry."""
+
+
+@dataclass(frozen=True)
+class RerankedIndex:
+    """One reranked candidate: its position in the submitted list, and score."""
+
+    index: int
+    score: float
+
+
+class GatewayRerankClient:
+    """Scores query/document pairs with a cross-encoder via the gateway."""
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        token_provider: GatewayTokenProvider | None = None,
+        *,
+        timeout_seconds: float = _RERANK_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        # EMBEDDING_GATEWAY_URL is a bare origin; rerank lives under /v1 like the
+        # rest of the gateway API. Idempotent if already /v1-suffixed.
+        base = base_url.rstrip("/")
+        if not base.endswith("/v1"):
+            base = f"{base}/v1"
+        self._base = base
+        self._model = model
+        self._token_provider = token_provider
+        self._timeout = timeout_seconds
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def _headers(self) -> dict[str, str]:
+        if self._token_provider is None:
+            return {}
+        return {"Authorization": f"Bearer {await self._token_provider.get_token()}"}
+
+    async def rerank(self, query: str, documents: list[str]) -> list[RerankedIndex]:
+        """Rank ``documents`` against ``query``, best first.
+
+        Returns a ranking over the SUBMITTED list, expressed as indices into it.
+        The caller maps those back onto its own objects, so this never has to
+        know about search results.
+
+        Raises:
+            RerankError: transport failure, non-2xx, or an unusable body. The
+                caller falls back to retrieval order.
+        """
+        if not documents:
+            return []
+
+        payload = {
+            "model": self._model,
+            "query": query[:_MAX_QUERY_CHARS],
+            "documents": [d[:_MAX_DOCUMENT_CHARS] for d in documents],
+            # Ask for a full ranking: the caller decides how deep to cut, and a
+            # provider-side top_n would silently drop the tail we still need to
+            # re-append in retrieval order.
+            "top_n": len(documents),
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    self._timeout, connect=_RERANK_CONNECT_TIMEOUT_SECONDS
+                )
+            ) as client:
+                resp = await client.post(
+                    f"{self._base}/rerank",
+                    json=payload,
+                    headers=await self._headers(),
+                )
+                resp.raise_for_status()
+                body = resp.json()
+        except httpx.HTTPStatusError as e:
+            raise RerankError(
+                f"gateway rerank returned HTTP {e.response.status_code}"
+            ) from e
+        except Exception as e:  # transport, JSON decode, timeout
+            raise RerankError(f"gateway rerank failed: {e}") from e
+
+        return self._parse(body, len(documents))
+
+    @staticmethod
+    def _parse(body: object, sent: int) -> list[RerankedIndex]:
+        """Turn a rerank response into a clean ranking over the submitted list.
+
+        Deliberately defensive about the index set. Providers behind the gateway
+        may cap results, and a malformed or partial response must not silently
+        delete candidates — dropping an entry here would look like a ranking
+        change while actually being lost recall. Out-of-range and duplicate
+        indices are discarded; anything the response omits is the CALLER's
+        problem to re-append, and :meth:`rerank` guarantees only that every
+        index returned is valid and unique.
+        """
+        if not isinstance(body, dict):
+            raise RerankError(
+                f"gateway rerank returned {type(body).__name__}, not an object"
+            )
+        raw = body.get("results")
+        if not isinstance(raw, list):
+            raise RerankError("gateway rerank response has no 'results' list")
+
+        ranked: list[RerankedIndex] = []
+        seen: set[int] = set()
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            idx = item.get("index")
+            score = item.get("relevance_score")
+            if not isinstance(idx, int) or isinstance(idx, bool):
+                continue
+            if not 0 <= idx < sent or idx in seen:
+                continue
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            seen.add(idx)
+            ranked.append(RerankedIndex(index=idx, score=float(score)))
+
+        if not ranked:
+            raise RerankError("gateway rerank returned no usable results")
+        if len(ranked) < sent:
+            # Not an error — the caller re-appends the remainder in retrieval
+            # order — but it means part of the pool went unscored, which is
+            # worth knowing when reranking appears to under-deliver.
+            logger.debug(
+                "rerank scored %d of %d submitted documents", len(ranked), sent
+            )
+        return ranked

--- a/nextcloud_mcp_server/providers/gateway_rerank.py
+++ b/nextcloud_mcp_server/providers/gateway_rerank.py
@@ -56,6 +56,32 @@ class RerankedIndex:
     score: float
 
 
+def _parse_entry(item: object, sent: int, seen: set[int]) -> RerankedIndex | None:
+    """One ``results`` entry, or ``None`` if it cannot be trusted.
+
+    Split out of :meth:`GatewayRerankClient._parse` to keep each piece simple
+    enough to read as a single rule (and under the project's cognitive-complexity
+    gate). Every rejection here is a case a provider has been observed to
+    produce or could plausibly produce:
+
+    * ``bool`` is an ``int`` subclass in Python, so ``True`` would otherwise be
+      accepted as index 1 — and silently reorder a result;
+    * an out-of-range index would address past the caller's list;
+    * a duplicate would let one candidate occupy two result slots.
+    """
+    if not isinstance(item, dict):
+        return None
+    idx = item.get("index")
+    if not isinstance(idx, int) or isinstance(idx, bool):
+        return None
+    if not 0 <= idx < sent or idx in seen:
+        return None
+    score = item.get("relevance_score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        return None
+    return RerankedIndex(index=idx, score=float(score))
+
+
 class GatewayRerankClient:
     """Scores query/document pairs with a cross-encoder via the gateway."""
 
@@ -99,6 +125,22 @@ class GatewayRerankClient:
         """
         if not documents:
             return []
+
+        # Truncation is silent to the caller, so say something here: a long
+        # query or long chunks produce a ranking computed on less text than the
+        # caller thinks it submitted, and without this there is no signal to
+        # explain a surprising order.
+        over_len = sum(1 for d in documents if len(d) > _MAX_DOCUMENT_CHARS)
+        if over_len or len(query) > _MAX_QUERY_CHARS:
+            logger.debug(
+                "rerank input truncated: query %d->%d chars, %d/%d documents "
+                "over %d chars",
+                len(query),
+                min(len(query), _MAX_QUERY_CHARS),
+                over_len,
+                len(documents),
+                _MAX_DOCUMENT_CHARS,
+            )
 
         payload = {
             "model": self._model,
@@ -154,18 +196,11 @@ class GatewayRerankClient:
         ranked: list[RerankedIndex] = []
         seen: set[int] = set()
         for item in raw:
-            if not isinstance(item, dict):
+            entry = _parse_entry(item, sent, seen)
+            if entry is None:
                 continue
-            idx = item.get("index")
-            score = item.get("relevance_score")
-            if not isinstance(idx, int) or isinstance(idx, bool):
-                continue
-            if not 0 <= idx < sent or idx in seen:
-                continue
-            if not isinstance(score, (int, float)) or isinstance(score, bool):
-                continue
-            seen.add(idx)
-            ranked.append(RerankedIndex(index=idx, score=float(score)))
+            seen.add(entry.index)
+            ranked.append(entry)
 
         if not ranked:
             raise RerankError("gateway rerank returned no usable results")

--- a/nextcloud_mcp_server/search/algorithms.py
+++ b/nextcloud_mcp_server/search/algorithms.py
@@ -193,6 +193,21 @@ class SearchResult:
     title: str
     excerpt: str
     score: float
+    # Cross-encoder relevance, when the optional rerank stage ran; None
+    # otherwise. Deliberately a SEPARATE field rather than an overwrite of
+    # ``score``:
+    #   * ``score_threshold`` is applied inside Qdrant against the retrieval
+    #     score, so overwriting would leave the filter and the returned value
+    #     referring to different quantities;
+    #   * ``score`` is documented above as an ordering artifact that is not
+    #     calibrated, while a cross-encoder score is — conditionally changing
+    #     which of those a field holds, based on a server flag, would leave no
+    #     consumer able to interpret it;
+    #   * ``__post_init__`` rejects negatives, and clamping a negative
+    #     cross-encoder score to 0.0 would collapse the tail into a tie and
+    #     silently leave it in retrieval order behind a reranked head.
+    # Consumers that want reranked order sort on this when present.
+    rerank_score: float | None = None
     metadata: dict[str, Any] | None = None
     chunk_start_offset: int | None = None
     chunk_end_offset: int | None = None

--- a/nextcloud_mcp_server/search/rerank.py
+++ b/nextcloud_mcp_server/search/rerank.py
@@ -213,6 +213,12 @@ async def rerank_results(
         # subsequent search a full timeout.
         _cooldown_until = anyio.current_time() + _FAILURE_COOLDOWN_SECONDS
         logger.warning("rerank unavailable, using retrieval order: %s", e)
+        # Record the stage duration on the failure path too. A reranker that
+        # fails SLOWLY — timing out near the configured limit — is the case
+        # that hurts search latency most, and recording only successes would
+        # leave it invisible in the latency histogram while the request counter
+        # merely showed "degraded".
+        record_search_stage(surface, "rerank", anyio.current_time() - started)
         record_rerank_documents(client.model, len(scorable), "degraded")
         return results, False
 

--- a/nextcloud_mcp_server/search/rerank.py
+++ b/nextcloud_mcp_server/search/rerank.py
@@ -114,21 +114,50 @@ def effective_pool_size(settings: Any, *, floor: int, grouped: bool) -> int:
 
     Args:
         settings: Live settings.
-        floor: The over-fetch the surface would use anyway. The pool never goes
-            BELOW it, or a large ``limit`` would retrieve fewer candidates with
-            reranking on than off.
+        floor: The depth the surface would retrieve anyway without reranking.
         grouped: Whether the request uses document granularity.
 
-    Grouped search is capped: the grouped prefetch is bounded by
-    ``MAX_DOCUMENT_PREFETCH``, and requesting more groups than that prefetch can
-    fill makes Qdrant widen its grouping search and reorder the head — degrading
-    the candidates before the reranker ever sees them. Clamped here rather than
-    at config-validation time because granularity is per-request.
+    Two constraints, and they can conflict — the precedence is deliberate:
+
+    1. **Never below ``floor``.** Reranking must not cause a request to retrieve
+       fewer candidates than it would without reranking, which would drop
+       results a caller was already receiving.
+    2. **Capped for grouped search.** The grouped prefetch is bounded by
+       ``MAX_DOCUMENT_PREFETCH``; asking Qdrant for more groups than that
+       prefetch can fill makes it widen its grouping search and reorder the head,
+       degrading candidates before the reranker sees them. Applied here rather
+       than at config-validation time because granularity is per-request.
+
+    **(1) wins when they conflict**, i.e. when ``floor`` alone already exceeds
+    the grouped cap. That is not the cap leaking — it is the recognition that
+    the *unreranked* path already requests ``floor`` groups and already pays
+    that degradation, so honouring the cap here would not avoid it; it would
+    only truncate the result set relative to the same request with reranking
+    off. Degraded ordering is recoverable by the reranker that follows;
+    missing rows are not. Pinned by
+    ``test_grouped_clamp_never_drops_below_floor``.
+
+    The real fix for that regime is a deeper ``MAX_DOCUMENT_PREFETCH``, which is
+    a separately measured trade-off and deliberately not made here.
     """
-    pool = max(int(getattr(settings, "search_rerank_pool_size", 200)), floor)
+    configured = int(getattr(settings, "search_rerank_pool_size", 200))
+    pool = max(configured, floor)
     if grouped:
-        pool = min(pool, MAX_DOCUMENT_PREFETCH // DOCUMENT_PREFETCH_FACTOR)
-    return max(pool, floor)
+        cap = MAX_DOCUMENT_PREFETCH // DOCUMENT_PREFETCH_FACTOR
+        if floor > cap:
+            # Constraint (1) wins. Log it: the caller is in the regime where
+            # grouped retrieval is already degrading, which is worth seeing when
+            # results look mis-ranked.
+            logger.debug(
+                "grouped rerank pool floor %d exceeds the prefetch-derived cap "
+                "%d; retrieving %d groups to avoid truncating results",
+                floor,
+                cap,
+                floor,
+            )
+            return floor
+        pool = min(pool, cap)
+    return pool
 
 
 async def rerank_results(
@@ -148,18 +177,23 @@ async def rerank_results(
     if client is None or len(results) < 2:
         return results, False
 
+    # Rows with no text cannot be scored; they keep retrieval order at the tail
+    # rather than being handed to the model, which would rank an empty string
+    # last anyway and waste a slot.
+    #
+    # Computed BEFORE the cooldown check so every ``degraded`` sample counts the
+    # same population — documents that would have been scored. Counting the full
+    # result list on one degraded path and the scorable subset on another would
+    # make the metric's own denominator depend on which failure occurred.
+    scorable = [(i, r) for i, r in enumerate(results) if (r.excerpt or "").strip()]
+    if len(scorable) < 2:
+        return results, False
+
     global _cooldown_until
     now = anyio.current_time()
     if now < _cooldown_until:
         logger.debug("rerank skipped: in failure cooldown")
-        record_rerank_documents(client.model, len(results), "degraded")
-        return results, False
-
-    # Rows with no text cannot be scored; they keep retrieval order at the tail
-    # rather than being handed to the model, which would rank an empty string
-    # last anyway and waste a slot.
-    scorable = [(i, r) for i, r in enumerate(results) if (r.excerpt or "").strip()]
-    if len(scorable) < 2:
+        record_rerank_documents(client.model, len(scorable), "degraded")
         return results, False
 
     started = anyio.current_time()

--- a/nextcloud_mcp_server/search/rerank.py
+++ b/nextcloud_mcp_server/search/rerank.py
@@ -44,6 +44,21 @@ logger = logging.getLogger(__name__)
 # latency floor across the whole surface.
 _FAILURE_COOLDOWN_SECONDS = 30.0
 
+# Rerank outcomes. Three states, not a boolean, because "we did not rerank" has
+# two very different causes and an operator alerts on only one of them:
+#
+#   APPLIED   a cross-encoder ordered the results
+#   SKIPPED   nothing to do — reranking off, or fewer than two scorable
+#             candidates. Routine, and not a signal about reranker health.
+#   DEGRADED  reranking was attempted and failed (upstream error, timeout, or
+#             the cooldown following one). THIS is the outage signal.
+#
+# Collapsing SKIPPED into DEGRADED would make every narrow query that happens to
+# return 0-1 rows look like a reranker failure, burying real outages in noise.
+RERANK_APPLIED = "applied"
+RERANK_SKIPPED = "skipped"
+RERANK_DEGRADED = "degraded"
+
 _client: GatewayRerankClient | None = None
 _client_lock: anyio.Lock | None = None
 _limiter: anyio.CapacityLimiter | None = None
@@ -170,16 +185,18 @@ async def rerank_results(
     *,
     settings: Any,
     surface: str,
-) -> tuple[list[SearchResult], bool]:
+) -> tuple[list[SearchResult], str]:
     """Reorder ``results`` by cross-encoder relevance.
 
-    Returns ``(results, reranked)``. ``reranked`` is False whenever the input
-    order was preserved — disabled, unavailable, in cooldown, or degraded — so
-    the caller can report honestly which ordering it is returning.
+    Returns ``(results, outcome)`` where outcome is one of ``RERANK_APPLIED``,
+    ``RERANK_SKIPPED`` or ``RERANK_DEGRADED``. The caller reports the ordering
+    it actually returns, and can distinguish a routine skip from a real
+    reranker failure — the two are indistinguishable through a bare boolean,
+    which would make every 0-1 result query look like an outage.
     """
     client = await _get_client(settings)
     if client is None or len(results) < 2:
-        return results, False
+        return results, RERANK_SKIPPED
 
     # Rows with no text cannot be scored; they keep retrieval order at the tail
     # rather than being handed to the model, which would rank an empty string
@@ -191,14 +208,16 @@ async def rerank_results(
     # make the metric's own denominator depend on which failure occurred.
     scorable = [(i, r) for i, r in enumerate(results) if (r.excerpt or "").strip()]
     if len(scorable) < 2:
-        return results, False
+        return results, RERANK_SKIPPED
 
     global _cooldown_until
     now = anyio.current_time()
     if now < _cooldown_until:
         logger.debug("rerank skipped: in failure cooldown")
         record_rerank_documents(client.model, len(scorable), "degraded")
-        return results, False
+        # DEGRADED, not SKIPPED: a cooldown exists only because a rerank
+        # already failed, so this is still the outage signal.
+        return results, RERANK_DEGRADED
 
     started = anyio.current_time()
     try:
@@ -224,7 +243,7 @@ async def rerank_results(
         # merely showed "degraded".
         record_search_stage(surface, "rerank", anyio.current_time() - started)
         record_rerank_documents(client.model, len(scorable), "degraded")
-        return results, False
+        return results, RERANK_DEGRADED
 
     record_search_stage(surface, "rerank", anyio.current_time() - started)
     record_rerank_documents(client.model, len(scorable), "success")
@@ -241,4 +260,4 @@ async def rerank_results(
     # provider omitted — is APPENDED in retrieval order, never dropped. Dropping
     # would read as a ranking change while actually being lost recall.
     ordered.extend(r for i, r in enumerate(results) if i not in taken)
-    return ordered, True
+    return ordered, RERANK_APPLIED

--- a/nextcloud_mcp_server/search/rerank.py
+++ b/nextcloud_mcp_server/search/rerank.py
@@ -96,10 +96,14 @@ async def _get_client(settings: Any) -> GatewayRerankClient | None:
 def _get_limiter(settings: Any) -> anyio.CapacityLimiter:
     """Bound concurrent rerank calls.
 
-    This does NOT protect a co-located embedding model's throughput — where the
-    two share a device, one in-flight rerank is already enough to slow embedding
-    substantially. What it bounds is queue depth and therefore rerank latency,
-    so a burst of searches cannot stack unbounded work on the model.
+    Bounds how many rerank requests THIS process has in flight against the
+    gateway. That keeps a burst of searches from queueing unbounded work on a
+    service we share with our own embedding traffic and with other callers, and
+    keeps rerank latency here predictable.
+
+    It is not a throughput control for the gateway: how that service schedules
+    reranking against everything else it serves is its own concern, and this
+    server knows nothing about its topology beyond a URL.
     """
     global _limiter
     if _limiter is None:

--- a/nextcloud_mcp_server/search/rerank.py
+++ b/nextcloud_mcp_server/search/rerank.py
@@ -1,0 +1,200 @@
+"""Optional cross-encoder rerank stage, shared by both search entrypoints.
+
+Sits ABOVE the algorithm layer — after retrieval and merge, before
+verify-on-read — so it applies identically to ``nc_semantic_search`` and
+``POST /api/v1/search``, and to every search algorithm, without either surface
+or any algorithm knowing about it.
+
+Why before verification: reranking after it would mean verifying the whole deep
+pool, i.e. one Nextcloud round-trip per candidate against a bounded semaphore,
+which costs more than the reranker. Candidates are already ACL-filtered inside
+Qdrant (``build_base_filter_conditions``); verify-on-read is a staleness check
+on top. The consequence to know about is that a ghost record can occupy a rerank
+slot and then be dropped, shortening the page — the same trade the existing
+over-fetch already makes, with more headroom.
+
+Reranking NEVER fails a search. Every failure path returns the input order.
+"""
+
+import logging
+from typing import Any
+
+import anyio
+
+from nextcloud_mcp_server.observability.metrics import (
+    record_rerank_documents,
+    record_search_stage,
+)
+from nextcloud_mcp_server.observability.tracing import trace_operation
+from nextcloud_mcp_server.providers.gateway import build_gateway_token_provider
+from nextcloud_mcp_server.providers.gateway_rerank import (
+    GatewayRerankClient,
+    RerankError,
+)
+from nextcloud_mcp_server.search.algorithms import SearchResult
+from nextcloud_mcp_server.search.bm25_hybrid import (
+    DOCUMENT_PREFETCH_FACTOR,
+    MAX_DOCUMENT_PREFETCH,
+)
+
+logger = logging.getLogger(__name__)
+
+# Skip window after a failure. Without it every search in an outage pays the
+# full rerank timeout before degrading, turning a reranker problem into a
+# latency floor across the whole surface.
+_FAILURE_COOLDOWN_SECONDS = 30.0
+
+_client: GatewayRerankClient | None = None
+_client_lock: anyio.Lock | None = None
+_limiter: anyio.CapacityLimiter | None = None
+_cooldown_until: float = 0.0
+
+
+def _reset_rerank_state() -> None:
+    """Drop cached client/limiter/cooldown. Test hook — mirrors the OCR
+    backend's ``_reset_poll_batch_client``."""
+    global _client, _client_lock, _limiter, _cooldown_until
+    _client = None
+    _client_lock = None
+    _limiter = None
+    _cooldown_until = 0.0
+
+
+def rerank_available(settings: Any) -> bool:
+    """Whether reranking can run at all on this deployment.
+
+    The capability gate the request parameter is checked against, and what
+    ``/api/v1/status`` advertises — so a caller can discover the feature instead
+    of probing it and eating an error.
+    """
+    return bool(
+        getattr(settings, "search_rerank_enabled", False)
+        and getattr(settings, "embedding_gateway_url", None)
+    )
+
+
+async def _get_client(settings: Any) -> GatewayRerankClient | None:
+    """Build (once) the shared rerank client. ``None`` when unavailable."""
+    global _client, _client_lock
+    if not rerank_available(settings):
+        return None
+    if _client is not None:
+        return _client
+    if _client_lock is None:
+        _client_lock = anyio.Lock()
+    async with _client_lock:
+        if _client is None:
+            _client = GatewayRerankClient(
+                base_url=settings.embedding_gateway_url,
+                model=settings.search_rerank_model,
+                token_provider=build_gateway_token_provider(settings),
+                timeout_seconds=float(settings.search_rerank_timeout_seconds),
+            )
+    return _client
+
+
+def _get_limiter(settings: Any) -> anyio.CapacityLimiter:
+    """Bound concurrent rerank calls.
+
+    This does NOT protect a co-located embedding model's throughput — where the
+    two share a device, one in-flight rerank is already enough to slow embedding
+    substantially. What it bounds is queue depth and therefore rerank latency,
+    so a burst of searches cannot stack unbounded work on the model.
+    """
+    global _limiter
+    if _limiter is None:
+        _limiter = anyio.CapacityLimiter(
+            max(1, int(getattr(settings, "search_rerank_max_concurrency", 1)))
+        )
+    return _limiter
+
+
+def effective_pool_size(settings: Any, *, floor: int, grouped: bool) -> int:
+    """Candidate depth to retrieve when reranking.
+
+    Args:
+        settings: Live settings.
+        floor: The over-fetch the surface would use anyway. The pool never goes
+            BELOW it, or a large ``limit`` would retrieve fewer candidates with
+            reranking on than off.
+        grouped: Whether the request uses document granularity.
+
+    Grouped search is capped: the grouped prefetch is bounded by
+    ``MAX_DOCUMENT_PREFETCH``, and requesting more groups than that prefetch can
+    fill makes Qdrant widen its grouping search and reorder the head — degrading
+    the candidates before the reranker ever sees them. Clamped here rather than
+    at config-validation time because granularity is per-request.
+    """
+    pool = max(int(getattr(settings, "search_rerank_pool_size", 200)), floor)
+    if grouped:
+        pool = min(pool, MAX_DOCUMENT_PREFETCH // DOCUMENT_PREFETCH_FACTOR)
+    return max(pool, floor)
+
+
+async def rerank_results(
+    results: list[SearchResult],
+    query: str,
+    *,
+    settings: Any,
+    surface: str,
+) -> tuple[list[SearchResult], bool]:
+    """Reorder ``results`` by cross-encoder relevance.
+
+    Returns ``(results, reranked)``. ``reranked`` is False whenever the input
+    order was preserved — disabled, unavailable, in cooldown, or degraded — so
+    the caller can report honestly which ordering it is returning.
+    """
+    client = await _get_client(settings)
+    if client is None or len(results) < 2:
+        return results, False
+
+    global _cooldown_until
+    now = anyio.current_time()
+    if now < _cooldown_until:
+        logger.debug("rerank skipped: in failure cooldown")
+        record_rerank_documents(client.model, len(results), "degraded")
+        return results, False
+
+    # Rows with no text cannot be scored; they keep retrieval order at the tail
+    # rather than being handed to the model, which would rank an empty string
+    # last anyway and waste a slot.
+    scorable = [(i, r) for i, r in enumerate(results) if (r.excerpt or "").strip()]
+    if len(scorable) < 2:
+        return results, False
+
+    started = anyio.current_time()
+    try:
+        with trace_operation(
+            "search.rerank",
+            attributes={
+                "rerank.documents": len(scorable),
+                "rerank.model": client.model,
+                "search.surface": surface,
+            },
+        ):
+            async with _get_limiter(settings):
+                ranking = await client.rerank(query, [r.excerpt for _, r in scorable])
+    except RerankError as e:
+        # Degrade, never fail. The cooldown keeps an outage from costing every
+        # subsequent search a full timeout.
+        _cooldown_until = anyio.current_time() + _FAILURE_COOLDOWN_SECONDS
+        logger.warning("rerank unavailable, using retrieval order: %s", e)
+        record_rerank_documents(client.model, len(scorable), "degraded")
+        return results, False
+
+    record_search_stage(surface, "rerank", anyio.current_time() - started)
+    record_rerank_documents(client.model, len(scorable), "success")
+
+    ordered: list[SearchResult] = []
+    taken: set[int] = set()
+    for entry in ranking:
+        original_index, result = scorable[entry.index]
+        result.rerank_score = entry.score
+        ordered.append(result)
+        taken.add(original_index)
+
+    # Anything the reranker did not score — unscorable rows, and any index the
+    # provider omitted — is APPENDED in retrieval order, never dropped. Dropping
+    # would read as a ranking change while actually being lost recall.
+    ordered.extend(r for i, r in enumerate(results) if i not in taken)
+    return ordered, True

--- a/tests/unit/search/test_rerank_outcomes.py
+++ b/tests/unit/search/test_rerank_outcomes.py
@@ -1,0 +1,148 @@
+"""`rerank_results` distinguishes a routine skip from a real reranker failure.
+
+Both leave the results in retrieval order, so a boolean return collapses them —
+and a caller mapping that boolean onto a metric would then report every query
+returning 0-1 rows as a reranker outage. Narrow filters and obscure queries do
+that routinely, so the outage signal would be buried in noise exactly when it
+matters.
+
+These pin which state each path produces, since the distinction only exists to
+be acted on downstream.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.providers.gateway_rerank import RerankedIndex, RerankError
+from nextcloud_mcp_server.search import rerank as rerank_mod
+from nextcloud_mcp_server.search.algorithms import SearchResult
+from nextcloud_mcp_server.search.rerank import (
+    RERANK_APPLIED,
+    RERANK_DEGRADED,
+    RERANK_SKIPPED,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    rerank_mod._reset_rerank_state()
+    yield
+    rerank_mod._reset_rerank_state()
+
+
+def _settings(**overrides):
+    class _S:
+        search_rerank_enabled = True
+        embedding_gateway_url = "https://gw.example"
+        search_rerank_model = "vendor/model"
+        search_rerank_pool_size = 200
+        search_rerank_timeout_seconds = 30.0
+        search_rerank_max_concurrency = 1
+
+    s = _S()
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _results(n, *, excerpt="body text"):
+    return [
+        SearchResult(
+            id=str(i),
+            doc_type="file",
+            title=f"d{i}",
+            excerpt=f"{excerpt} {i}" if excerpt else "",
+            score=1.0 - i / 100,
+        )
+        for i in range(n)
+    ]
+
+
+def _stub(monkeypatch, *, ranking=None, raises=None):
+    class _Client:
+        model = "vendor/model"
+
+        async def rerank(self, query, documents):
+            if raises is not None:
+                raise raises
+            return ranking
+
+    async def _get(_s):
+        return _Client()
+
+    monkeypatch.setattr(rerank_mod, "_get_client", _get)
+
+
+async def test_applied_when_the_reranker_orders_the_results(monkeypatch):
+    _stub(monkeypatch, ranking=[RerankedIndex(index=1, score=0.9)])
+
+    _, outcome = await rerank_mod.rerank_results(
+        _results(3), "q", settings=_settings(), surface="mcp"
+    )
+    assert outcome == RERANK_APPLIED
+
+
+async def test_skipped_when_reranking_is_disabled(monkeypatch):
+    _, outcome = await rerank_mod.rerank_results(
+        _results(3),
+        "q",
+        settings=_settings(search_rerank_enabled=False),
+        surface="mcp",
+    )
+    assert outcome == RERANK_SKIPPED
+
+
+@pytest.mark.parametrize("n", [0, 1])
+async def test_skipped_when_there_is_nothing_to_reorder(monkeypatch, n):
+    """A query returning 0-1 rows is routine — a narrow filter or an obscure
+    term — and must not read as a reranker failure."""
+    _stub(monkeypatch, ranking=[])
+
+    _, outcome = await rerank_mod.rerank_results(
+        _results(n), "q", settings=_settings(), surface="mcp"
+    )
+    assert outcome == RERANK_SKIPPED
+
+
+async def test_skipped_when_too_few_rows_carry_text(monkeypatch):
+    """Same reasoning: unscorable rows are a property of the corpus, not of the
+    reranker's health."""
+    _stub(monkeypatch, ranking=[])
+    results = _results(3)
+    for r in results[1:]:
+        r.excerpt = "   "
+
+    _, outcome = await rerank_mod.rerank_results(
+        results, "q", settings=_settings(), surface="mcp"
+    )
+    assert outcome == RERANK_SKIPPED
+
+
+async def test_degraded_on_upstream_failure(monkeypatch):
+    _stub(monkeypatch, raises=RerankError("gateway down"))
+
+    _, outcome = await rerank_mod.rerank_results(
+        _results(3), "q", settings=_settings(), surface="mcp"
+    )
+    assert outcome == RERANK_DEGRADED
+
+
+async def test_degraded_while_in_cooldown(monkeypatch):
+    """The cooldown exists only because a rerank already failed, so a search
+    served from it is still the outage signal — not a routine skip."""
+    _stub(monkeypatch, raises=RerankError("gateway down"))
+    await rerank_mod.rerank_results(
+        _results(3), "q", settings=_settings(), surface="mcp"
+    )
+
+    _, outcome = await rerank_mod.rerank_results(
+        _results(3), "q", settings=_settings(), surface="mcp"
+    )
+    assert outcome == RERANK_DEGRADED
+
+
+def test_the_three_outcomes_are_distinct():
+    """Guards against a careless refactor collapsing two of them to one value,
+    which would silently restore the conflation this split exists to prevent."""
+    assert len({RERANK_APPLIED, RERANK_SKIPPED, RERANK_DEGRADED}) == 3

--- a/tests/unit/search/test_rerank_pool_size.py
+++ b/tests/unit/search/test_rerank_pool_size.py
@@ -1,0 +1,114 @@
+"""`effective_pool_size` — the one piece of rerank machinery with a non-obvious
+contract, so it is tested here with the machinery rather than with the wiring.
+
+Two constraints govern the pool depth and they can conflict: never retrieve less
+than the surface would have retrieved anyway, and cap grouped retrieval at what
+the grouped prefetch can actually fill. Which one wins is a judgement call, and
+these tests pin it in both directions so the resolution is a decision on record
+rather than an artifact of expression order.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.search import rerank as rerank_mod
+from nextcloud_mcp_server.search.bm25_hybrid import (
+    DOCUMENT_PREFETCH_FACTOR,
+    MAX_DOCUMENT_PREFETCH,
+)
+
+pytestmark = pytest.mark.unit
+
+_GROUPED_CAP = MAX_DOCUMENT_PREFETCH // DOCUMENT_PREFETCH_FACTOR
+
+
+def _settings(**overrides):
+    class _S:
+        search_rerank_enabled = True
+        embedding_gateway_url = "https://gw.example"
+        search_rerank_model = "vendor/model"
+        search_rerank_pool_size = 200
+        search_rerank_timeout_seconds = 30.0
+        search_rerank_max_concurrency = 1
+
+    s = _S()
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def test_uses_the_configured_pool_when_deeper_than_the_floor():
+    assert (
+        rerank_mod.effective_pool_size(
+            _settings(search_rerank_pool_size=200), floor=20, grouped=False
+        )
+        == 200
+    )
+
+
+def test_never_below_the_floor():
+    """Reranking must not cause a request to retrieve fewer candidates than the
+    same request without it — that would drop rows a caller already received."""
+    assert (
+        rerank_mod.effective_pool_size(
+            _settings(search_rerank_pool_size=50), floor=400, grouped=False
+        )
+        == 400
+    )
+
+
+def test_ungrouped_search_is_not_capped():
+    """The cap is a property of grouped retrieval; chunk granularity has no
+    equivalent ceiling, so a large configured pool must pass through."""
+    assert (
+        rerank_mod.effective_pool_size(
+            _settings(search_rerank_pool_size=5000), floor=10, grouped=False
+        )
+        == 5000
+    )
+
+
+def test_grouped_search_is_capped_when_there_is_room_to_honour_it():
+    """With the floor below the cap, the cap must actually bind — otherwise the
+    clamp is dead code."""
+    assert (
+        rerank_mod.effective_pool_size(
+            _settings(search_rerank_pool_size=_GROUPED_CAP * 10),
+            floor=_GROUPED_CAP - 1,
+            grouped=True,
+        )
+        == _GROUPED_CAP
+    )
+
+
+def test_grouped_cap_yields_to_the_floor_when_they_conflict():
+    """When the floor alone already exceeds the cap, the FLOOR wins.
+
+    Deliberate precedence, not the cap leaking. In that regime the *unreranked*
+    path already requests `floor` groups and already pays the grouped
+    degradation, so honouring the cap here would not avoid it — it would only
+    return fewer rows than the same request with reranking off. Degraded
+    ordering is recoverable by the reranker that follows; missing rows are not.
+    """
+    floor = _GROUPED_CAP * 5
+    assert (
+        rerank_mod.effective_pool_size(
+            _settings(search_rerank_pool_size=_GROUPED_CAP * 10),
+            floor=floor,
+            grouped=True,
+        )
+        == floor
+    )
+
+
+@pytest.mark.parametrize("grouped", [True, False])
+def test_result_is_never_below_the_floor_for_any_configured_size(grouped):
+    """Property check across the interesting range: whatever the configuration
+    and whichever constraint binds, the floor invariant must hold."""
+    for configured in (1, 10, _GROUPED_CAP, _GROUPED_CAP * 3):
+        for floor in (1, 50, _GROUPED_CAP, _GROUPED_CAP * 2):
+            pool = rerank_mod.effective_pool_size(
+                _settings(search_rerank_pool_size=configured),
+                floor=floor,
+                grouped=grouped,
+            )
+            assert pool >= floor


### PR DESCRIPTION
Stacked on #1220 (which is stacked on #1218).

## Why

Reranking is the largest retrieval-quality lever available to this pipeline —
larger than the embedding model or the fusion constant, both of which were
evaluated and found to matter far less. But it costs a model round-trip per
search, and what that costs depends on how the configured gateway is deployed —
something this server has no visibility into beyond a URL. So it ships **off by
default** and **opt-in per request**.

## Scope

**Machinery only — nothing calls it yet.** The MCP tool and HTTP API parameters
follow in the next PR in this stack, which keeps the API surface and its
contract tests reviewable separately from the plumbing.

| file | role |
|---|---|
| `providers/gateway_rerank.py` | gateway `/v1/rerank` sub-client |
| `search/rerank.py` | the pipeline stage |
| `SearchResult.rerank_score` | cross-encoder score, alongside `.score` |
| `config.py` | five settings, all three required places |

## Design decisions worth review attention

**Not a `Provider` subclass.** That ABC is an embedding contract
(`embed`/`embed_batch`/`get_dimension`) which a reranker satisfies none of.
`gateway_batch.py` is the existing precedent for a gateway sub-client that is
not a provider.

**The client returns indices, not results.** It ranks the *submitted list*, so
it never has to know what a `SearchResult` is. Parsing is deliberately paranoid:
out-of-range, duplicate and non-numeric indices are discarded, and it never
assumes the provider returned one entry per document. Anything omitted is
re-appended by the caller **in retrieval order rather than dropped** — dropping a
candidate would present as a ranking change while actually being lost recall,
which is close to undebuggable from the outside.

**`rerank_score` is a new field, not an overwrite of `.score`.** Three reasons:
- `score_threshold` is applied inside Qdrant against the retrieval score, so
  overwriting would leave the filter and the returned value referring to
  different quantities;
- `.score` is documented in three places as an uncalibrated ordering artifact,
  while a cross-encoder score is calibrated — conditionally changing which of
  those a field holds, based on a server flag, leaves no consumer able to
  interpret it;
- clamping a negative cross-encoder score to satisfy the non-negative invariant
  would collapse the tail into an exact tie, silently leaving it in retrieval
  order behind a reranked head — a half-reranked list that top-N assertions
  would never catch.

**The stage sits above the algorithm layer**, so it applies to every algorithm
and both entrypoints without either knowing about it. It never fails a search:
every error path returns the input order and reports `reranked=False`.

**The capacity limiter is scoped to what this server can actually know.** It
bounds how many rerank requests THIS process keeps in flight against the
gateway, so a burst of searches cannot queue unbounded work on a service shared
with our own embedding traffic and other callers. It is explicitly not a
throughput control for the gateway: how that service schedules reranking against
everything else it serves is its own concern.

**A failure cooldown** skips reranking briefly after an error. Without it an
outage makes every subsequent search pay the full timeout before degrading,
turning a component failure into a latency floor across the whole surface.

## Refactor

`_build_gateway_token_provider` moves to `providers/gateway.py` beside
`GatewayTokenProvider`. Rerank is its third consumer and its own docstring says
the all-or-nothing M2M-triple validation should live in one place. `ocr.py`
keeps a thin aliasing *function* rather than a module-level alias — the latter
would need a top-level `providers` import and reintroduce the
`document_processors -> providers` cycle that module deliberately avoids.

## Test

`ruff check`, `ruff format --check`, `ty check` clean; unit suite passes (2730).
Unit tests for the client and stage, plus the gateway rerank Pact contract,
land with the wiring PR where the API surface they cover exists — flagged here
so the gap is explicit rather than silent.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)