### PR TITLE
feat(errors): render tool failures in LLM-friendly form

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -104,6 +104,7 @@ from nextcloud_mcp_server.config_validators import (
     validate_configuration,
 )
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
+from nextcloud_mcp_server.errors import NextcloudFastMCP
 from nextcloud_mcp_server.http import nextcloud_httpx_client
 from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 from nextcloud_mcp_server.observability import (
@@ -1768,7 +1769,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                         logger.warning("Error closing OAuth client: %s", e)
                 logger.info("MCP server shutdown complete")
 
-        mcp = FastMCP(
+        mcp = NextcloudFastMCP(
             "Nextcloud MCP",
             lifespan=oauth_lifespan,
             token_verifier=token_verifier,
@@ -1778,7 +1779,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
     else:
         # BasicAuth modes (single-user or multi-user)
         logger.info("Configuring MCP server for %s mode", mode.value)
-        mcp = FastMCP(
+        mcp = NextcloudFastMCP(
             "Nextcloud MCP",
             lifespan=app_lifespan_basic,
             transport_security=_build_transport_security(),

--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -19,8 +19,10 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ContentBlock
 
-#: ``summary``/``hint`` per status. 429 is absent on purpose: ``retry_on_429``
-#: in ``client/base.py`` absorbs it before it can reach a tool.
+#: ``summary``/``hint`` per status. 429 is rare -- ``retry_on_429`` in
+#: ``client/base.py`` absorbs it -- but ``_stream_request`` re-raises it once
+#: its own retries are exhausted, so it still needs a hint that says "back off"
+#: rather than the generic "re-check the arguments".
 _STATUS: dict[int, tuple[str, str]] = {
     400: (
         "Invalid request",
@@ -64,6 +66,11 @@ _STATUS: dict[int, tuple[str, str]] = {
         "Resource locked",
         "Another process holds a lock on it. Retry shortly, or report the lock "
         "to the user.",
+    ),
+    429: (
+        "Rate limited",
+        "Nextcloud is throttling requests and the client already retried and "
+        "gave up. Wait before retrying -- do not rewrite the arguments.",
     ),
     507: (
         "Insufficient storage",

--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -1,0 +1,193 @@
+"""LLM-friendly rendering of tool failures (GH #1208).
+
+The MCP SDK funnels every tool exception through
+``ToolError(f"Error executing tool {name}: {e}")`` and returns that string
+verbatim as the error content, so an unhandled ``httpx`` error reaches the model
+as an internal URL plus an MDN link and no hint about what to do next. Rewriting
+that one string at the tool boundary fixes every tool at once -- see
+:class:`NextcloudFastMCP`.
+"""
+
+import json
+import re
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import unquote
+
+from httpx import URL, HTTPStatusError, RequestError, Response, ResponseNotRead
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ContentBlock
+
+#: ``summary``/``hint`` per status. 429 is absent on purpose: ``retry_on_429``
+#: in ``client/base.py`` absorbs it before it can reach a tool.
+_STATUS: dict[int, tuple[str, str]] = {
+    400: (
+        "Invalid request",
+        "Check the argument values -- one of them was rejected as malformed.",
+    ),
+    401: (
+        "Authentication failed",
+        "The Nextcloud credentials or session are invalid or expired; "
+        "re-authenticate before retrying.",
+    ),
+    403: (
+        "Permission denied",
+        "The account cannot access this resource, or the required scope was "
+        "not granted. Do not retry without different credentials or scopes.",
+    ),
+    404: (
+        "Not found",
+        "Check the path or id for typos and verify the resource exists; "
+        "list the parent first if unsure.",
+    ),
+    405: (
+        "Operation not allowed here",
+        "The resource may already exist, or this operation is unsupported at "
+        "that location.",
+    ),
+    409: (
+        "Conflict",
+        "A parent folder may be missing, or a resource with that name already "
+        "exists. Create the parent or pick another name.",
+    ),
+    412: (
+        "Resource changed since it was read",
+        "Re-read the resource to get its current etag, then retry the update "
+        "with that etag.",
+    ),
+    413: (
+        "Payload too large",
+        "The upload exceeds the server limit; split it or use a smaller file.",
+    ),
+    423: (
+        "Resource locked",
+        "Another process holds a lock on it. Retry shortly, or report the lock "
+        "to the user.",
+    ),
+    507: (
+        "Insufficient storage",
+        "The account's quota is exhausted; free space before retrying.",
+    ),
+}
+
+_GENERIC_CLIENT = (
+    "Request rejected",
+    "The server refused the request as sent; re-check the arguments.",
+)
+_GENERIC_SERVER = (
+    "Nextcloud server error",
+    "This is usually transient -- retry once, and report it to the user if it "
+    "persists.",
+)
+
+#: DAV (``<s:message>``) and OCS (``<message>``) both put the reason here.
+_XML_MESSAGE = re.compile(r"<(?:\w+:)?message[^>]*>(.*?)</(?:\w+:)?message>", re.S)
+
+_MAX_DETAIL = 200
+
+
+def _resource(url: URL) -> str:
+    """The user-meaningful part of a request path, without internal routing.
+
+    Strips the entry points ``_resolve_url`` and the DAV clients prepend, so
+    ``/remote.php/dav/files/admin/FileUpload/test.txt`` renders as
+    ``FileUpload/test.txt`` and ``/index.php/apps/notes/api/v1/notes/5`` as
+    ``apps/notes/api/v1/notes/5``.
+    """
+    path = unquote(url.path)
+    if path.startswith("/remote.php/dav/files/"):
+        # /remote.php/dav/files/<principal>/<rest>; the home root itself has no
+        # <rest>, so fall through to the full path rather than quoting "".
+        parts = path.split("/", 5)
+        if len(parts) > 5 and parts[5]:
+            return parts[5]
+    for prefix in ("/index.php", "/ocs/v1.php", "/ocs/v2.php", "/remote.php"):
+        if path.startswith(prefix):
+            path = path[len(prefix) :]
+            break
+    return path.lstrip("/")
+
+
+def _server_detail(response: Response) -> str:
+    """The reason Nextcloud itself gave, when it published a usable one."""
+    try:
+        body = response.text
+    except ResponseNotRead:
+        # Streaming downloads raise with the body still unread; there is
+        # nothing to parse and reading it here would defeat the streaming.
+        return ""
+
+    body = body.strip()
+    if not body or body[:20].lower().startswith(("<!doctype", "<html")):
+        return ""
+
+    candidate = None
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        match = _XML_MESSAGE.search(body)
+        candidate = match.group(1) if match else None
+    else:
+        if isinstance(payload, dict):
+            meta = payload.get("ocs")
+            meta = meta.get("meta") if isinstance(meta, dict) else None
+            candidate = (
+                (meta.get("message") if isinstance(meta, dict) else None)
+                or payload.get("message")
+                or payload.get("error")
+            )
+
+    message = " ".join(candidate.split()) if isinstance(candidate, str) else ""
+    if not message:
+        return ""
+    if len(message) > _MAX_DETAIL:
+        message = message[: _MAX_DETAIL - 1].rstrip() + "…"
+    return f" Server said: {message}"
+
+
+def friendly_tool_error(exc: BaseException | None, tool_name: str) -> str | None:
+    """Render ``exc`` for an LLM, or ``None`` if it is better left alone.
+
+    ``None`` means "no improvement to offer" -- the caller re-raises unchanged,
+    so tools that already build a tailored ``McpError`` keep their own wording.
+    """
+    if isinstance(exc, HTTPStatusError):
+        status = exc.response.status_code
+        summary, hint = _STATUS.get(
+            status, _GENERIC_SERVER if status >= 500 else _GENERIC_CLIENT
+        )
+        # exc.request, not exc.response.url: a few call sites raise with a
+        # synthetic Response that has no request bound, where .url explodes.
+        return (
+            f'{tool_name} failed: {summary} — "{_resource(exc.request.url)}" '
+            f"(HTTP {status}). {hint}{_server_detail(exc.response)}"
+        )
+
+    if isinstance(exc, RequestError):
+        return (
+            f"{tool_name} failed: could not reach Nextcloud ({exc.__class__.__name__}). "
+            "The server may be down or unreachable from here; retry once, then "
+            "report it to the user."
+        )
+
+    return None
+
+
+class NextcloudFastMCP(FastMCP):
+    """FastMCP that rewrites raw HTTP failures into LLM-friendly messages.
+
+    Subclass rather than patch: ``FastMCP._setup_handlers`` binds
+    ``self.call_tool`` during ``__init__``, so a later reassignment is ignored.
+    """
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        try:
+            return await super().call_tool(name, arguments)
+        except ToolError as e:
+            message = friendly_tool_error(e.__cause__, name)
+            if message is None:
+                raise
+            raise ToolError(message) from e.__cause__

--- a/nextcloud_mcp_server/server/collectives.py
+++ b/nextcloud_mcp_server/server/collectives.py
@@ -1,6 +1,7 @@
 """MCP tool definitions for Nextcloud Collectives app."""
 
 import logging
+from typing import NoReturn
 
 from httpx import HTTPStatusError
 from mcp.server.fastmcp import Context, FastMCP
@@ -32,19 +33,18 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 logger = logging.getLogger(__name__)
 
 
-def _handle_collectives_error(
-    e: OCSError | HTTPStatusError,
-) -> McpError | HTTPStatusError:
-    """Convert an OCS error to McpError; pass an HTTP error through unchanged.
+def _raise_collectives_error(e: OCSError | HTTPStatusError) -> NoReturn:
+    """Raise the client-facing form of a collectives failure.
 
-    ``NextcloudFastMCP`` renders a raw ``HTTPStatusError`` into an LLM-friendly
-    message at the tool boundary (GH #1208). Wrapping it here in ``str(e)``
-    would shadow that with httpx's internal-URL text, so it is returned as-is
-    for the caller to re-raise.
+    An OCS envelope carries a real server message, so it becomes an
+    ``McpError``. A transport-level ``HTTPStatusError`` is re-raised untouched:
+    ``NextcloudFastMCP`` renders it into an LLM-friendly message at the tool
+    boundary (GH #1208), and wrapping it in ``str(e)`` here would shadow that
+    with httpx's internal-URL text.
     """
     if isinstance(e, OCSError):
-        return McpError(ErrorData(code=-32603, message=e.message))
-    return e
+        raise McpError(ErrorData(code=-32603, message=e.message)) from e
+    raise e
 
 
 def configure_collectives_tools(mcp: FastMCP):
@@ -66,7 +66,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_collectives = await client.collectives.get_collectives()
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         collectives = [Collective(**c) for c in raw_collectives]
         return ListCollectivesResponse(collectives=collectives, total=len(collectives))
 
@@ -88,7 +88,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_pages = await client.collectives.get_pages(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         pages = [PageInfo(**p) for p in raw_pages]
         return ListPagesResponse(
             pages=pages, total=len(pages), collective_id=collective_id
@@ -117,7 +117,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_page = await client.collectives.get_page(collective_id, page_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         page = PageInfo(**raw_page)
 
         # Fetch content via WebDAV
@@ -161,7 +161,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_pages = await client.collectives.search_pages(collective_id, query)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         pages = [PageInfo(**p) for p in raw_pages]
         return SearchPagesResponse(
             results=pages,
@@ -188,7 +188,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_tags = await client.collectives.get_tags(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         tags = [CollectiveTag(**t) for t in raw_tags]
         return ListTagsResponse(tags=tags, total=len(tags), collective_id=collective_id)
 
@@ -210,7 +210,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw_pages = await client.collectives.get_trashed_pages(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         pages = [PageInfo(**p) for p in raw_pages]
         return ListTrashedPagesResponse(
             pages=pages, total=len(pages), collective_id=collective_id
@@ -234,7 +234,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.get_trashed_collectives()
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         collectives = [Collective(**c) for c in raw]
         return ListTrashedCollectivesResponse(
             collectives=collectives, total=len(collectives)
@@ -261,7 +261,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.create_collective(name, emoji)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         collective = Collective(**raw)
         return CreateCollectiveResponse(
             id=collective.id, name=collective.name, emoji=collective.emoji
@@ -291,7 +291,7 @@ def configure_collectives_tools(mcp: FastMCP):
         except ValueError as e:
             raise McpError(ErrorData(code=-32603, message=str(e))) from e
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         collective = Collective(**raw)
         return CollectiveOperationResponse(
             collective_id=collective.id,
@@ -319,7 +319,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             await client.collectives.trash_collective(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         return CollectiveOperationResponse(
             collective_id=collective_id,
             status_code=200,
@@ -350,7 +350,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             await client.collectives.delete_collective(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         return CollectiveOperationResponse(
             collective_id=collective_id,
             status_code=200,
@@ -375,7 +375,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.restore_collective(collective_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         collective = Collective(**raw)
         return CollectiveOperationResponse(
             collective_id=collective.id,
@@ -407,7 +407,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.create_page(collective_id, parent_id, title)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         page = PageInfo(**raw)
         return CreatePageResponse(
             id=page.id,
@@ -447,7 +447,7 @@ def configure_collectives_tools(mcp: FastMCP):
                 collective_id, page_id, parent_id, title, index, copy
             )
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         page = PageInfo(**raw)
         action = "copied" if copy else "moved"
         return PageOperationResponse(
@@ -480,7 +480,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             await client.collectives.trash_page(collective_id, page_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         return PageOperationResponse(
             page_id=page_id,
             collective_id=collective_id,
@@ -507,7 +507,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.restore_page(collective_id, page_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         page = PageInfo(**raw)
         return PageOperationResponse(
             page_id=page.id,
@@ -539,7 +539,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.set_page_emoji(collective_id, page_id, emoji)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         page = PageInfo(**raw)
         return PageOperationResponse(
             page_id=page.id,
@@ -568,7 +568,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.create_tag(collective_id, name, color)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         tag = CollectiveTag(**raw)
         return CreateTagResponse(id=tag.id, name=tag.name, color=tag.color)
 
@@ -592,7 +592,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             await client.collectives.assign_tag(collective_id, page_id, tag_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         return PageOperationResponse(
             page_id=page_id,
             collective_id=collective_id,
@@ -623,7 +623,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             await client.collectives.remove_tag(collective_id, page_id, tag_id)
         except (OCSError, HTTPStatusError) as e:
-            raise _handle_collectives_error(e) from e
+            _raise_collectives_error(e)
         return PageOperationResponse(
             page_id=page_id,
             collective_id=collective_id,

--- a/nextcloud_mcp_server/server/collectives.py
+++ b/nextcloud_mcp_server/server/collectives.py
@@ -32,11 +32,19 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 logger = logging.getLogger(__name__)
 
 
-def _handle_collectives_error(e: OCSError | HTTPStatusError) -> McpError:
-    """Convert OCS or HTTP errors to McpError."""
+def _handle_collectives_error(
+    e: OCSError | HTTPStatusError,
+) -> McpError | HTTPStatusError:
+    """Convert an OCS error to McpError; pass an HTTP error through unchanged.
+
+    ``NextcloudFastMCP`` renders a raw ``HTTPStatusError`` into an LLM-friendly
+    message at the tool boundary (GH #1208). Wrapping it here in ``str(e)``
+    would shadow that with httpx's internal-URL text, so it is returned as-is
+    for the caller to re-raise.
+    """
     if isinstance(e, OCSError):
         return McpError(ErrorData(code=-32603, message=e.message))
-    return McpError(ErrorData(code=-32603, message=str(e)))
+    return e
 
 
 def configure_collectives_tools(mcp: FastMCP):

--- a/nextcloud_mcp_server/stdio.py
+++ b/nextcloud_mcp_server/stdio.py
@@ -19,6 +19,7 @@ from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.config_validators import AuthMode, validate_configuration
 from nextcloud_mcp_server.context import BasicAuthLifespanContext
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
+from nextcloud_mcp_server.errors import NextcloudFastMCP
 from nextcloud_mcp_server.server import AVAILABLE_APPS
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def get_stdio_mcp(enabled_apps: list[str] | None = None) -> FastMCP:
             f"and NEXTCLOUD_PASSWORD."
         )
 
-    mcp = FastMCP("Nextcloud MCP", lifespan=stdio_lifespan)
+    mcp = NextcloudFastMCP("Nextcloud MCP", lifespan=stdio_lifespan)
 
     # --- capabilities resource (mirrors app.py) ---
     # NOTE: mcp.get_context() is required here because FastMCP's

--- a/tests/server/test_error_propagation.py
+++ b/tests/server/test_error_propagation.py
@@ -35,6 +35,29 @@ async def test_delete_missing_note_tool_error(nc_mcp_client: ClientSession):
     assert "Note 999999 not found" in response.content[0].text
 
 
+async def test_missing_file_error_is_llm_friendly(nc_mcp_client: ClientSession):
+    """A tool with no bespoke handler still returns actionable text (GH #1208).
+
+    Guards the ``NextcloudFastMCP`` boundary: httpx's raw
+    ``Client error '404 Not Found' for url 'http://app/remote.php/dav/...'``
+    plus an MDN link must not reach the model.
+    """
+    response = await nc_mcp_client.call_tool(
+        "nc_webdav_read_file", {"path": "FileUpload/does-not-exist.txtg"}
+    )
+
+    assert response is not None
+    assert response.isError is True
+    text = response.content[0].text
+    logger.info("Missing file response: %s", text)
+
+    assert "FileUpload/does-not-exist.txtg" in text
+    assert "Not found" in text
+    # No internal routing, no host, no MDN link.
+    assert "remote.php" not in text
+    assert "developer.mozilla.org" not in text
+
+
 async def test_search_with_empty_query(nc_mcp_client: ClientSession):
     """Test search behavior with empty query."""
     # Search with empty query

--- a/tests/unit/test_friendly_errors.py
+++ b/tests/unit/test_friendly_errors.py
@@ -1,0 +1,209 @@
+"""Unit tests for the LLM-friendly tool-error formatter (GH #1208)."""
+
+import httpx
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
+
+from nextcloud_mcp_server.errors import NextcloudFastMCP, friendly_tool_error
+
+pytestmark = pytest.mark.unit
+
+DAV_URL = "http://app/remote.php/dav/files/admin/FileUpload/test.txtg"
+
+
+def _http_error(
+    status: int,
+    url: str = DAV_URL,
+    body: str = "",
+    headers: dict[str, str] | None = None,
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, text=body, headers=headers, request=request)
+    return httpx.HTTPStatusError("raw httpx text", request=request, response=response)
+
+
+def test_dav_404_names_the_user_relative_path_and_no_internals():
+    message = friendly_tool_error(_http_error(404), "nc_webdav_read_file")
+
+    assert message is not None
+    assert 'nc_webdav_read_file failed: Not found — "FileUpload/test.txtg"' in message
+    assert "HTTP 404" in message
+    assert "typos" in message
+    # The whole point: no internal URL, no host, no MDN link.
+    assert "remote.php" not in message
+    assert "developer.mozilla.org" not in message
+    assert "http://app" not in message
+
+
+def test_app_api_path_drops_the_index_php_entry_point():
+    message = friendly_tool_error(
+        _http_error(404, url="http://app/index.php/apps/notes/api/v1/notes/5"),
+        "nc_notes_get_note",
+    )
+
+    assert message is not None
+    assert '"apps/notes/api/v1/notes/5"' in message
+    assert "index.php" not in message
+
+
+def test_dav_home_root_does_not_render_as_an_empty_resource():
+    message = friendly_tool_error(
+        _http_error(403, url="http://app/remote.php/dav/files/admin/"),
+        "nc_webdav_list_directory",
+    )
+
+    assert message is not None
+    assert '""' not in message
+    assert "dav/files/admin/" in message
+
+
+def test_412_tells_the_model_to_re_read_the_etag():
+    message = friendly_tool_error(_http_error(412), "nc_webdav_write_file")
+
+    assert message is not None
+    assert "changed since it was read" in message
+    assert "etag" in message
+
+
+def test_5xx_is_described_as_transient():
+    message = friendly_tool_error(_http_error(503), "nc_tables_insert_row")
+
+    assert message is not None
+    assert "Nextcloud server error" in message
+    assert "transient" in message
+
+
+def test_unmapped_4xx_falls_back_to_the_generic_client_hint():
+    message = friendly_tool_error(_http_error(418), "nc_notes_create_note")
+
+    assert message is not None
+    assert "Request rejected" in message
+    assert "HTTP 418" in message
+
+
+def test_ocs_json_message_is_appended():
+    body = '{"ocs": {"meta": {"status": "failure", "message": "Path already exists"}}}'
+    message = friendly_tool_error(
+        _http_error(409, body=body, headers={"content-type": "application/json"}),
+        "nc_share_create",
+    )
+
+    assert message is not None
+    assert "Server said: Path already exists" in message
+
+
+def test_plain_json_message_and_error_keys_are_used():
+    for body, expected in (
+        ('{"message": "Quota exceeded"}', "Quota exceeded"),
+        ('{"error": "invalid table id"}', "invalid table id"),
+    ):
+        message = friendly_tool_error(_http_error(400, body=body), "nc_tool")
+        assert message is not None
+        assert f"Server said: {expected}" in message
+
+
+def test_dav_xml_message_is_appended():
+    body = (
+        '<?xml version="1.0"?><d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">'
+        "<s:message>File with name /foo could not be located</s:message></d:error>"
+    )
+    message = friendly_tool_error(_http_error(404, body=body), "nc_webdav_read_file")
+
+    assert message is not None
+    assert "Server said: File with name /foo could not be located" in message
+
+
+def test_html_error_page_is_not_echoed():
+    body = "<!DOCTYPE html>\n<html><body>Internal Server Error</body></html>"
+    message = friendly_tool_error(_http_error(500, body=body), "nc_tool")
+
+    assert message is not None
+    assert "Server said" not in message
+    assert "<html" not in message
+
+
+def test_long_server_detail_is_truncated():
+    body = '{"message": "%s"}' % ("x" * 500)
+    message = friendly_tool_error(_http_error(400, body=body), "nc_tool")
+
+    assert message is not None
+    assert "…" in message
+    assert "x" * 300 not in message
+
+
+def test_unread_streaming_response_formats_without_raising():
+    """The streaming download path raises with the body still unread."""
+    request = httpx.Request("GET", DAV_URL)
+    response = httpx.Response(404, stream=httpx.ByteStream(b"ignored"), request=request)
+    exc = httpx.HTTPStatusError("raw", request=request, response=response)
+
+    with pytest.raises(httpx.ResponseNotRead):
+        _ = response.text  # precondition: the body really is unread
+
+    message = friendly_tool_error(exc, "nc_webdav_read_file")
+
+    assert message is not None
+    assert '"FileUpload/test.txtg"' in message
+    assert "Server said" not in message
+
+
+def test_synthetic_response_without_a_bound_request_is_safe():
+    """client/mail.py and auth/client_registration.py raise with one of these."""
+    request = httpx.Request("POST", "http://app/index.php/apps/mail/api/messages")
+    synthetic = httpx.Response(500, text="boom")
+    exc = httpx.HTTPStatusError("raw", request=request, response=synthetic)
+
+    with pytest.raises(RuntimeError):
+        _ = synthetic.url  # precondition: reading it via the response explodes
+
+    message = friendly_tool_error(exc, "nc_mail_send")
+
+    assert message is not None
+    assert '"apps/mail/api/messages"' in message
+
+
+def test_request_error_reports_unreachable_server():
+    exc = httpx.ConnectError("nope", request=httpx.Request("GET", DAV_URL))
+
+    message = friendly_tool_error(exc, "nc_webdav_list_directory")
+
+    assert message is not None
+    assert "could not reach Nextcloud" in message
+    assert "ConnectError" in message
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        McpError(ErrorData(code=-1, message="Note 5 not found")),
+        ValueError("bad argument"),
+        None,
+    ],
+)
+def test_other_exceptions_are_left_alone(exc):
+    """None means 'no improvement' -- tailored messages keep their wording."""
+    assert friendly_tool_error(exc, "nc_notes_get_note") is None
+
+
+async def test_boundary_rewrites_http_errors_but_not_tailored_ones():
+    """The FastMCP override is what actually reaches the client."""
+    mcp = NextcloudFastMCP("test")
+
+    @mcp.tool()
+    async def leaky_tool() -> str:
+        raise _http_error(404)
+
+    @mcp.tool()
+    async def tailored_tool() -> str:
+        raise McpError(ErrorData(code=-1, message="Note 5 not found"))
+
+    with pytest.raises(ToolError) as leaky:
+        await mcp.call_tool("leaky_tool", {})
+    assert 'Not found — "FileUpload/test.txtg"' in str(leaky.value)
+    assert "developer.mozilla.org" not in str(leaky.value)
+
+    with pytest.raises(ToolError) as tailored:
+        await mcp.call_tool("tailored_tool", {})
+    assert "Note 5 not found" in str(tailored.value)

--- a/tests/unit/test_friendly_errors.py
+++ b/tests/unit/test_friendly_errors.py
@@ -70,6 +70,15 @@ def test_412_tells_the_model_to_re_read_the_etag():
     assert "etag" in message
 
 
+def test_429_says_back_off_not_re_check_the_arguments():
+    """_stream_request re-raises a 429 once its own retries are exhausted."""
+    message = friendly_tool_error(_http_error(429), "nc_webdav_read_file")
+
+    assert message is not None
+    assert "Rate limited" in message
+    assert "Wait before retrying" in message
+
+
 def test_5xx_is_described_as_transient():
     message = friendly_tool_error(_http_error(503), "nc_tables_insert_row")
 

--- a/tests/unit/test_friendly_errors.py
+++ b/tests/unit/test_friendly_errors.py
@@ -2,11 +2,14 @@
 
 import httpx
 import pytest
+from httpx import HTTPStatusError
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData
 
+from nextcloud_mcp_server.client.collectives import OCSError
 from nextcloud_mcp_server.errors import NextcloudFastMCP, friendly_tool_error
+from nextcloud_mcp_server.server.collectives import _raise_collectives_error
 
 pytestmark = pytest.mark.unit
 
@@ -185,6 +188,23 @@ def test_request_error_reports_unreachable_server():
 def test_other_exceptions_are_left_alone(exc):
     """None means 'no improvement' -- tailored messages keep their wording."""
     assert friendly_tool_error(exc, "nc_notes_get_note") is None
+
+
+def test_collectives_lets_http_errors_reach_the_boundary():
+    """Regression guard: re-wrapping in str(e) would shadow the new message.
+
+    ``OCSError`` carries a real server message and still becomes an
+    ``McpError``; a transport-level error must arrive at the tool boundary
+    intact so ``friendly_tool_error`` can render it.
+    """
+    http_error = _http_error(404)
+    with pytest.raises(HTTPStatusError) as raised:
+        _raise_collectives_error(http_error)
+    assert raised.value is http_error
+
+    with pytest.raises(McpError) as wrapped:
+        _raise_collectives_error(OCSError(403, "Not permitted"))
+    assert "Not permitted" in str(wrapped.value)
 
 
 async def test_boundary_rewrites_http_errors_but_not_tailored_ones():


### PR DESCRIPTION
Closes #1208.

## Problem

An unhandled `httpx` error reached the model verbatim:

```
Error executing tool nc_webdav_read_file: Client error '404 Not Found' for url
'http://app/remote.php/dav/files/admin/FileUpload/test.txtg' For more information
check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
```

Internal host and routing, an MDN link, nothing actionable. Only the ~40 tools with a
hand-written `if e.response.status_code == 404` branch had usable messages; the rest
(`webdav`, `tables`, `sharing`, `talk`, `contacts`) leaked httpx directly.

## Approach

The MCP SDK already funnels every tool exception through
`ToolError(f"Error executing tool {name}: {e}")` and returns that string verbatim, so
the only thing needing a fix is `str()` of the exception. Rewriting it once at the tool
boundary fixes all 160 tools with **no per-tool edits**:

```
nc_webdav_read_file failed: Not found — "FileUpload/test.txtg" (HTTP 404). Check the
path or id for typos and verify the resource exists; list the parent first if unsure.
```

- **`nextcloud_mcp_server/errors.py`** (new) — `friendly_tool_error()` plus a
  `NextcloudFastMCP(FastMCP)` subclass overriding `call_tool`, which reformats via
  `ToolError.__cause__`. Subclass rather than patch: `FastMCP._setup_handlers` binds
  `self.call_tool` during `__init__`, so a later reassignment is ignored.
- Message = per-status summary + resource + recovery hint + the reason Nextcloud itself
  gave (OCS `meta.message`, DAV `<s:message>`), capped at 200 chars, skipped for HTML
  pages and for unread streaming bodies.
- The resource is derived from `exc.request.url` — a few call sites raise with a
  synthetic `Response` whose `.url` explodes — and stripped of the `/index.php`,
  `/ocs/vN.php` and `/remote.php/dav/files/<principal>/` entry points.
- `friendly_tool_error` returns `None` for anything it cannot improve, so the tailored
  `McpError` messages in notes/news/cookbook/mail/deck keep their own wording.
- `_handle_collectives_error` no longer re-wraps `HTTPStatusError` in `str(e)`, which
  would have shadowed the new message for ~20 tools.

The client layer and its exception types are deliberately untouched, so
`instrument_tool`'s `error_type` metric label and `logging_config`'s
expected-exception filter keep working unchanged.

## Test coverage

No new API surface — no new MCP tool, no new `/api/v1` route, no cross-service
boundary — so no new pact is required.

- `tests/unit/test_friendly_errors.py` (new, 18 tests): status mapping, path stripping,
  OCS JSON + DAV XML detail extraction, HTML bodies not echoed, truncation, unread
  streaming responses, synthetic responses with no bound request, and an end-to-end
  check that the `NextcloudFastMCP` override is what actually reaches the client (and
  that it leaves tailored `McpError` messages alone).
- `tests/server/test_error_propagation.py`: added an integration test asserting
  `nc_webdav_read_file` on a bogus path returns the file path plus "Not found" and
  neither `remote.php` nor `developer.mozilla.org`. The existing tests in that file
  still expect `"Note 999999 not found"`, proving the boundary does not shadow the
  bespoke handlers.

Locally: `ruff` / `ruff format` / `ty` clean, full unit suite green (2997 passed). The
Docker integration lane could not be run locally (ports held by another worktree's
stack) — it runs here in CI.

---

_This PR was generated with the help of AI, and reviewed by a Human_