### PR TITLE
fix(mail): two semicolons regressed, and the guard from #1194 never ran

### DIFF
--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -182,7 +182,7 @@ def configure_mail_tools(mcp: FastMCP):
                   address or display name
                 * ``subject:``, ``body:`` — substring match (``body:`` searches
                   IMAP server-side and is slower)
-                * ``tags:`` — comma-separated tag *database ids* (not names;
+                * ``tags:`` — comma-separated tag *database ids* (not names,
                   get one from nc_mail_create_tag)
                 * ``start:``, ``end:`` — date bounds
                 * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
@@ -450,7 +450,7 @@ def configure_mail_tools(mcp: FastMCP):
     ) -> MailActionResponse:
         """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
 
-        Only the flags you pass are changed; omitted ones are left alone. Use
+        Only the flags you pass are changed. Omitted ones are left alone. Use
         ``seen=True`` after processing a message so it does not look unhandled,
         and ``seen=False`` to mark it unread again.
 

--- a/tests/test_tool_description_metacharacters.py
+++ b/tests/test_tool_description_metacharacters.py
@@ -19,6 +19,10 @@ import pathlib
 
 import pytest
 
+# The CI job runs ``pytest -m unit``, so an unmarked test is collected and then
+# deselected: it never fails, it just silently stops running.
+pytestmark = pytest.mark.unit
+
 METACHARACTERS = ("&&", ";", "||", "$(", "> ", "< ")
 
 # Tools whose description legitimately contains a metacharacter inside a quoted


### PR DESCRIPTION
The metacharacter guard added in #1194 has never actually run, and two semicolons have already come back because of it.

### The regressions

| Tool | Prose | Introduced by |
|---|---|---|
| `nc_mail_list_messages` | ``tag *database ids* (not names; get one from nc_mail_create_tag)`` | `3c320687` (#1148) |
| `nc_mail_set_flags` | `Only the flags you pass are changed; omitted ones are left alone.` | `0b6655cd` |

Both are ordinary English punctuation, so anti-injection gateways drop the two tools from `tools/list` without reporting anything — the failure mode described in #1183. Rewritten as a comma and a period respectively, following the guidance in the guard's own assertion message.

### Why the guard was silent

The unit-test job runs `uv run --frozen pytest -q -m unit` (`.github/workflows/test.yml:42`), and `tests/test_tool_description_metacharacters.py` carries no marker. pytest collects it and then deselects it: it cannot fail, it simply stops running. 185 test files carry `mark.unit`, so the selection does discriminate — this one was just missing it.

Measured on `master` at 69bb0c8, on the file itself:

```
without pytestmark: no tests collected (8 deselected)
with    pytestmark: 8 tests collected
```

### Verification

- `pytest -m unit tests/test_tool_description_metacharacters.py` → **8 passed**
- Same run with `mail.py` reverted → **1 failed**, naming both offenders — the guard demonstrably catches this class of regression once it is selected
- Allowlist unchanged and still justified: `nc_calendar_create_event` (RFC 5545) and `nc_webdav_write_file` (MIME `type;base64`) remain the only tools carrying a semicolon, and `test_allowlist_has_no_stale_entries` still passes
- `ruff format --diff`, `ruff check` and `ty check` all clean

Refs #1183
