### PR TITLE
chore(search): deferred review nits from the rerank stack

### DIFF
--- a/nextcloud_mcp_server/providers/gateway_rerank.py
+++ b/nextcloud_mcp_server/providers/gateway_rerank.py
@@ -152,10 +152,16 @@ class GatewayRerankClient:
             "top_n": len(documents),
         }
         try:
+            # Clamp the connect timeout to the overall budget. SEARCH_RERANK_
+            # TIMEOUT_SECONDS is validated only as > 0, so an operator setting
+            # it to 1s would otherwise still spend up to 5s connecting — five
+            # times the budget they configured — before the read budget even
+            # starts. Immaterial at the 30s default; this only bites at
+            # deliberately aggressive settings, which is exactly when a caller
+            # is relying on the number they set.
+            connect_timeout = min(_RERANK_CONNECT_TIMEOUT_SECONDS, self._timeout)
             async with httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    self._timeout, connect=_RERANK_CONNECT_TIMEOUT_SECONDS
-                )
+                timeout=httpx.Timeout(self._timeout, connect=connect_timeout)
             ) as client:
                 resp = await client.post(
                     f"{self._base}/rerank",

--- a/nextcloud_mcp_server/usage/search.py
+++ b/nextcloud_mcp_server/usage/search.py
@@ -92,4 +92,8 @@ async def record_search_usage(
         # (record_usage_event swallows its own write failures). Metering is on,
         # so warn — a silent DEBUG line would hide "operator enabled metering
         # but gets no data".
-        logger.warning("usage metering hook (tokens_embedded) skipped")
+        # exc_info: the message alone is a fixed string with no traceback, which
+        # is thin for triage — and this helper now serves three call sites
+        # (the MCP tool and both HTTP search endpoints), so "which one" and
+        # "why" both matter when it fires.
+        logger.warning("usage metering hook (tokens_embedded) skipped", exc_info=True)

--- a/tests/unit/providers/test_gateway_rerank.py
+++ b/tests/unit/providers/test_gateway_rerank.py
@@ -139,6 +139,51 @@ async def test_transport_failure_raises_rerank_error(monkeypatch):
         await GatewayRerankClient("https://gw.example", "m").rerank("q", ["a", "b"])
 
 
+class TestTimeoutBudget:
+    """The configured timeout is the caller's whole budget, connect included."""
+
+    @staticmethod
+    def _captured_timeout(monkeypatch) -> list[httpx.Timeout]:
+        seen: list[httpx.Timeout] = []
+        original = httpx.AsyncClient
+
+        def _factory(*args, **kwargs):
+            seen.append(kwargs.get("timeout"))
+            kwargs["transport"] = httpx.MockTransport(
+                lambda r: httpx.Response(
+                    200, json={"results": [{"index": 0, "relevance_score": 1.0}]}
+                )
+            )
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", _factory)
+        return seen
+
+    async def test_connect_is_clamped_to_a_shorter_overall_budget(self, monkeypatch):
+        """`SEARCH_RERANK_TIMEOUT_SECONDS` is validated only as > 0, so a 1s
+        setting would otherwise still allow a 5s connect — 5x the configured
+        budget, before the read budget even starts."""
+        seen = self._captured_timeout(monkeypatch)
+
+        await GatewayRerankClient(
+            "https://gw.example", "m", timeout_seconds=1.0
+        ).rerank("q", ["a", "b"])
+
+        assert seen[0].connect == 1.0
+
+    async def test_connect_keeps_its_own_floor_at_the_default(self, monkeypatch):
+        """Clamping must not shrink connect on a normal configuration — the
+        default budget is far larger than the connect allowance."""
+        seen = self._captured_timeout(monkeypatch)
+
+        await GatewayRerankClient(
+            "https://gw.example", "m", timeout_seconds=30.0
+        ).rerank("q", ["a", "b"])
+
+        assert seen[0].connect == 5.0
+        assert seen[0].read == 30.0
+
+
 class TestResponseParsing:
     """`_parse` is the contract boundary — everything downstream trusts it."""
 


### PR DESCRIPTION
Top of the stack: #1218 → #1220 → #1221 → #1224 → this.

Two non-blocking findings raised during review of #1220 and #1221 and
deliberately deferred there — each would have restarted a ~15-minute integration
matrix on a PR that already had a clean verdict, for a change with no
behavioural effect on the happy path. Collected here so they aren't lost.

## 1. Usage-metering failure log had no traceback

`usage/search.py`'s `except Exception` logged a fixed string with no exception
detail, so a `UsageEventStore.shared()` / store-construction failure gave an
operator nothing to triage from. Raised on #1220, which correctly noted it was
carried over verbatim from the code that PR *moved* rather than introduced by
it — but also that the helper now serves **three** call sites (the MCP tool and
both HTTP search endpoints), so "which one" and "why" both matter when it fires.

Now logs with `exc_info=True`.

## 2. Rerank connect timeout ignored the configured budget

`GatewayRerankClient` passed `httpx.Timeout(self._timeout, connect=5.0)` with the
connect value hardcoded, while `SEARCH_RERANK_TIMEOUT_SECONDS` is validated only
as `> 0`. An operator setting it to `1` would still spend up to 5s connecting —
**five times the budget they configured** — before the read budget even started.

Immaterial at the 30s default, which is why it was a nit. It bites precisely
when someone has deliberately set an aggressive number and is relying on it.
Clamped to `min(connect_default, configured)`.

Two tests: the clamped case (1s budget ⇒ 1s connect) and the default case
(30s budget ⇒ connect stays at its 5s floor, read at 30s), so the clamp can't
silently shrink connect on a normal configuration.

## Test

`ruff check`, `ruff format --check`, `ty check` clean; unit suite 3108 under the
same `-m unit -n auto` invocation CI uses; `pytest -m contract` 18 passed,
1 skipped.

No API surface change — one log call and one timeout argument — so the repo's
e2e/Pact gate doesn't apply.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)