### PR TITLE
feat(observability): record MCP client fleet and tool-delivery semantics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -62,6 +62,29 @@ The Helm chart has moved to a [separate repository](https://github.com/cbcoutinh
 - `mcp_tool_calls_total` - Tool invocation count by status
 - `mcp_tool_duration_seconds` - Tool execution latency
 - `mcp_tool_errors_total` - Tool errors by type
+- `mcp_tool_outcomes_total` - How the SDK *delivered* each call: `success` |
+  `tool_error` | `protocol_error`
+
+> `mcp_tool_outcomes_total` labels `tool_name` with the tool's **registered MCP
+> name**, whereas `mcp_tool_calls_total` uses the Python `func.__name__`. These
+> differ for the OAuth tools (e.g. `tool_provision_access` vs
+> `provision_nextcloud_access`). Don't join the two on `tool_name`.
+
+### MCP Client Fleet Metrics
+
+Records who is connecting and how tool results reach them. These exist as a
+baseline for the mcp python-sdk 1.x → 2.x (protocol 2026-07-28) upgrade, whose
+most consequential changes are silent — see the alerts below.
+
+- `mcp_client_sessions_total{client_name, client_version, protocol_version}` -
+  sessions observed, counted once per session. `client_version` is truncated to
+  `major.minor`.
+- `mcp_client_capability{client_name, capability}` - 1/0 per `elicitation` /
+  `sampling` / `roots`, from the client's most recent session.
+- `mcp_elicitation_total{prompt, outcome, reason}` - elicitation results.
+  `outcome` is `accepted` | `declined` | `cancelled` | `message_only`; `reason`
+  splits the silent `message_only` fallback into `no_elicit_attr` |
+  `not_implemented` | `error` (`none` otherwise).
 
 ### Nextcloud API Metrics
 
@@ -192,8 +215,15 @@ When tracing is enabled, all logs include `trace_id` and `span_id`:
 
 **Request Rate (req/s)**:
 ```promql
-sum(rate(mcp_http_requests_total[5m])) by (method, endpoint)
+sum(rate(mcp_http_requests_total[5m])) by (method, exported_endpoint)
 ```
+
+> Group by `exported_endpoint`, **not** `endpoint`. The application sets
+> `endpoint`, but the Prometheus Operator's ServiceMonitor injects a target
+> label of the same name whose value is the Service port name (`metrics`).
+> With the default `honorLabels: false`, Prometheus keeps the target label and
+> renames the scraped one to `exported_endpoint`. Grouping by `endpoint`
+> silently collapses every route into a single series.
 
 **Error Rate (%)**:
 ```promql
@@ -204,7 +234,7 @@ sum(rate(mcp_http_requests_total{status_code=~"5.."}[5m]))
 **P95 Latency**:
 ```promql
 histogram_quantile(0.95,
-  sum(rate(mcp_http_request_duration_seconds_bucket[5m])) by (le, endpoint)
+  sum(rate(mcp_http_request_duration_seconds_bucket[5m])) by (le, exported_endpoint)
 )
 ```
 
@@ -216,6 +246,47 @@ topk(10, sum(rate(mcp_tool_calls_total[5m])) by (tool_name))
 **Nextcloud API Health**:
 ```promql
 sum(rate(mcp_nextcloud_api_requests_total{status_code!~"2.."}[5m])) by (app)
+```
+
+**MCP client fleet — who is connected, at which protocol version**:
+```promql
+sum by (client_name, client_version, protocol_version) (
+  increase(mcp_client_sessions_total[1d])
+)
+```
+
+**Protocol-version change (the SDK-upgrade tripwire)** — fires when any client
+reports more than one protocol version in a day, i.e. a client started
+negotiating something new:
+```promql
+count by (client_name) (
+  count by (client_name, protocol_version) (increase(mcp_client_sessions_total[1d]) > 0)
+) > 1
+```
+
+**Client identity stopped resolving** — the accessors that read `clientInfo` /
+`capabilities` / `protocolVersion` off the SDK session degrade to `"unknown"`
+rather than raising, so an SDK field rename shows up here rather than in the
+logs. Non-zero means the instrumentation needs updating for the new SDK shape:
+```promql
+sum(increase(mcp_client_sessions_total{client_name="unknown"}[1h])) > 0
+```
+
+**Tool errors arriving as protocol errors** — exactly 0 on mcp 1.x by
+construction, since the SDK converts every exception except
+`UrlElicitationRequiredError` into `CallToolResult(isError=True)`. Any non-zero
+reading means tool failures stopped being visible to the model:
+```promql
+sum(increase(mcp_tool_outcomes_total{outcome="protocol_error"}[1h])) > 0
+```
+
+**Elicitation lost its back-channel** — `not_implemented` is the normal case for
+clients that never supported elicitation, so it is excluded; the other reasons
+appearing is the regression:
+```promql
+sum by (prompt, reason) (
+  increase(mcp_elicitation_total{outcome="message_only", reason!="not_implemented"}[1h])
+) > 0
 ```
 
 **Ingest throughput — documents/s and pages/s**:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -78,7 +78,9 @@ most consequential changes are silent — see the alerts below.
 
 - `mcp_client_sessions_total{client_name, client_version, protocol_version}` -
   sessions observed, counted once per session. `client_version` is truncated to
-  `major.minor`.
+  `major.minor`; `client_name` is length-clamped and collapses to `_other` past
+  50 distinct identities (both halves of the cardinality bound, since
+  `clientInfo` is caller-chosen).
 - `mcp_client_capability{client_name, capability}` - 1/0 per `elicitation` /
   `sampling` / `roots`, from the client's most recent session.
 - `mcp_elicitation_total{prompt, outcome, reason}` - elicitation results.
@@ -262,6 +264,14 @@ negotiating something new:
 count by (client_name) (
   count by (client_name, protocol_version) (increase(mcp_client_sessions_total[1d]) > 0)
 ) > 1
+```
+
+**Client-identity cardinality cap hit** — `client_name` collapses to `_other`
+past 50 distinct identities. The real fleet is single digits, so this firing
+means either a genuinely new class of client or a peer rotating its declared
+`clientInfo.name` per session:
+```promql
+sum(increase(mcp_client_sessions_total{client_name="_other"}[1h])) > 0
 ```
 
 **Client identity stopped resolving** — the accessors that read `clientInfo` /

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -114,6 +114,7 @@ from nextcloud_mcp_server.observability import (
     setup_tracing,
 )
 from nextcloud_mcp_server.observability.metrics import (
+    instrument_call_tool_outcomes,
     record_dependency_check,
     set_dependency_health,
 )
@@ -1882,6 +1883,13 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
         logger.info(
             "Dynamic tool filtering enabled for OAuth mode (JWT and Bearer tokens)"
         )
+
+    # Client-fleet observability: records the calling client's identity,
+    # capabilities and negotiated protocol version, plus whether the SDK
+    # delivered each tool call as CallToolResult(isError=True) or as a JSON-RPC
+    # error. Deliberately outside the `if oauth_enabled` block above — unlike
+    # the tool filter, this must work in every deployment mode.
+    instrument_call_tool_outcomes(mcp)
 
     mcp_app = mcp.streamable_http_app()
 

--- a/nextcloud_mcp_server/auth/elicitation.py
+++ b/nextcloud_mcp_server/auth/elicitation.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import Context
 from pydantic import BaseModel, Field
 
 from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.observability.metrics import record_elicitation
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ async def _run_elicit(
     message: str,
     schema: type[BaseModel],
     *,
-    log_label: str,
+    prompt: str,
 ) -> tuple[str, Any]:
     """Shared elicit-or-fallback flow used by all elicitation prompts.
 
@@ -84,12 +85,24 @@ async def _run_elicit(
     elicitation actually ran (any of the first three outcomes), else None.
     Callers needing post-accept inspection (e.g. the data-acknowledged
     warning in :func:`present_login_url`) read it from ``result``.
+
+    ``prompt`` identifies which prompt is running ("login_flow" /
+    "provisioning_required"); it labels both the log lines and the
+    ``mcp_elicitation_total`` metric.
+
+    Every fallback here is deliberately silent to the caller — the point is to
+    degrade rather than fail — which is exactly why each one is counted. When
+    the MCP SDK moves to protocol 2026-07-28 the back-channel disappears and
+    elicitation starts landing in the generic ``reason="error"`` branch (or a
+    dedicated ``"no_back_channel"`` one, once that exception exists to catch);
+    without these counters that transition is invisible.
     """
     if not hasattr(ctx, "elicit"):
         logger.debug(
             "Elicitation not available on context — message_only fallback (%s)",
-            log_label,
+            prompt,
         )
+        record_elicitation(prompt, "message_only", "no_elicit_attr")
         return "message_only", None
 
     try:
@@ -97,26 +110,31 @@ async def _run_elicit(
     except NotImplementedError:
         logger.debug(
             "Elicitation not supported by client — message_only fallback (%s)",
-            log_label,
+            prompt,
         )
+        record_elicitation(prompt, "message_only", "not_implemented")
         return "message_only", None
     except Exception as e:
         logger.warning(
             "Elicitation failed unexpectedly for %s (%s: %s), "
             "falling back to message_only",
-            log_label,
+            prompt,
             type(e).__name__,
             e,
         )
+        record_elicitation(prompt, "message_only", "error")
         return "message_only", None
 
     if result.action == "accept":
-        logger.info("User acknowledged %s", log_label)
+        logger.info("User acknowledged %s", prompt)
+        record_elicitation(prompt, "accepted")
         return "accepted", result
     if result.action == "decline":
-        logger.info("User declined %s", log_label)
+        logger.info("User declined %s", prompt)
+        record_elicitation(prompt, "declined")
         return "declined", result
-    logger.info("User cancelled %s", log_label)
+    logger.info("User cancelled %s", prompt)
+    record_elicitation(prompt, "cancelled")
     return "cancelled", result
 
 
@@ -152,7 +170,7 @@ async def present_login_url(
         ctx,
         message,
         LoginFlowConfirmation,
-        log_label="login flow completion",
+        prompt="login_flow",
     )
 
     if (
@@ -213,6 +231,6 @@ async def present_provisioning_required(ctx: Context) -> str:
         ctx,
         message,
         ProvisioningRequiredConfirmation,
-        log_label="provisioning-required prompt",
+        prompt="provisioning_required",
     )
     return outcome

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -960,15 +960,50 @@ def record_tool_error(tool_name: str, error_type: str) -> None:
 _FLEET_CAPABILITIES = ("elicitation", "sampling", "roots")
 _SESSION_RECORDED_ATTR = "_astrolabe_fleet_recorded"
 
+# Ceiling on distinct client identities tracked. Truncating a label bounds how
+# big one value can get; it does nothing about how *many* distinct values a peer
+# can mint. `clientInfo.name` is chosen by the caller, so a client embedding a
+# session id or random suffix would grow the series count without limit, and
+# prometheus_client entries never expire. Beyond this many, everything new
+# collapses into `_OVERFLOW_LABEL`.
+#
+# 50 is far above the real fleet (single digits) and far below anything that
+# strains the registry, so crossing it is itself a signal — see the
+# client_name="_other" alert in docs/observability.md.
+_MAX_TRACKED_CLIENTS = 50
+_OVERFLOW_LABEL = "_other"
+_seen_client_names: set[str] = set()
+
 
 def _client_label(value: object, limit: int = 64) -> str:
-    """Clamp a client-supplied value before it becomes a metric label.
+    """Clamp a client-supplied value's *length* before it becomes a label.
 
     ``clientInfo`` arrives from the peer, so its length is not ours to trust:
-    unbounded label values are a memory exhaustion vector against the
+    an unbounded label value is a memory exhaustion vector against the
     process-global registry.
+
+    Note this bounds the size of one value, not the number of distinct values —
+    see :func:`_bounded_client_name` for that half.
     """
     return str(value)[:limit] if value is not None else "unknown"
+
+
+def _bounded_client_name(name: str) -> str:
+    """Bound the *number* of distinct client identities, not just their length.
+
+    Returns ``name`` while under the cap, ``_OVERFLOW_LABEL`` after. Together
+    with :func:`_client_label` this closes the cardinality vector: a peer can
+    neither send one enormous name nor mint unboundedly many small ones.
+    """
+    if name in _seen_client_names:
+        return name
+    if len(_seen_client_names) >= _MAX_TRACKED_CLIENTS:
+        return _OVERFLOW_LABEL
+    # ponytail: unsynchronised. Concurrent first-sightings can race past the
+    # cap by the number of in-flight requests — irrelevant against a limit of
+    # 50, and a lock on every session would cost more than the slack.
+    _seen_client_names.add(name)
+    return name
 
 
 def _minor_version(version: object) -> str:
@@ -1034,7 +1069,7 @@ def record_client_session() -> None:
             params, "protocolVersion", None
         )
         # ---------------------------------------------------------------------
-        name = _client_label(getattr(info, "name", None))
+        name = _bounded_client_name(_client_label(getattr(info, "name", None)))
         mcp_client_sessions_total.labels(
             client_name=name,
             client_version=_minor_version(getattr(info, "version", None)),
@@ -1091,9 +1126,29 @@ def instrument_call_tool_outcomes(mcp: Any) -> None:
     server = mcp._mcp_server
     original = server.request_handlers[types.CallToolRequest]
 
+    def _tool_label(name: str) -> str:
+        """Reduce a requested tool name to a registered one, or "unknown".
+
+        ``req.params.name`` is whatever the caller put in the JSON-RPC body; it
+        is not validated against the registry before this handler runs. Used
+        raw it would be an unbounded-cardinality vector — a client sending
+        garbage names mints a permanent series each — and it would pollute the
+        ``protocol_error`` tripwire with caller-chosen values that have nothing
+        to do with the SDK upgrade this metric exists to watch.
+
+        Resolved per request rather than snapshotted, so tools registered after
+        this wrapper is installed still label correctly.
+        """
+        try:
+            if mcp._tool_manager.get_tool(name) is not None:
+                return name
+        except Exception:  # pragma: no cover - registry shape is SDK-internal
+            logger.debug("Could not consult the tool registry", exc_info=True)
+        return "unknown"
+
     async def handler(req: types.CallToolRequest) -> types.ServerResult:
         record_client_session()
-        tool_name = req.params.name
+        tool_name = _tool_label(req.params.name)
         try:
             result = await original(req)
         except Exception:

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -18,7 +18,10 @@ import functools
 import logging
 import threading
 import time
+from typing import Any
 
+from mcp import types
+from mcp.server.lowlevel.server import request_ctx
 from prometheus_client import (
     REGISTRY,
     Counter,
@@ -77,6 +80,46 @@ mcp_tool_errors_total = Counter(
     "mcp_tool_errors_total",
     "Total MCP tool errors by type",
     ["tool_name", "error_type"],
+)
+
+# =============================================================================
+# MCP Client Fleet Metrics
+# =============================================================================
+#
+# Baseline for the mcp python-sdk 1.x -> 2.x (protocol 2026-07-28) upgrade,
+# whose two most consequential changes are silent: elicitation loses its
+# back-channel, and an MCPError raised in a tool stops becoming
+# CallToolResult(isError=True) and becomes a JSON-RPC error instead. Neither
+# raises, neither shows up in existing metrics. These four record the fleet
+# composition and delivery semantics so the change is visible as a step in a
+# graph rather than a bug report.
+
+mcp_client_sessions_total = Counter(
+    "mcp_client_sessions_total",
+    "MCP sessions observed, by client identity and negotiated protocol version",
+    ["client_name", "client_version", "protocol_version"],
+)
+
+mcp_client_capability = Gauge(
+    "mcp_client_capability",
+    "1 if this client's most recent session declared the capability, else 0",
+    ["client_name", "capability"],
+)
+
+mcp_elicitation_total = Counter(
+    "mcp_elicitation_total",
+    "Elicitation prompt outcomes; reason splits the message_only fallback causes",
+    ["prompt", "outcome", "reason"],
+)
+
+mcp_tool_outcomes_total = Counter(
+    "mcp_tool_outcomes_total",
+    "How the MCP SDK delivered each tool call: success | tool_error "
+    "(CallToolResult.isError, the model sees the message) | protocol_error "
+    "(JSON-RPC error, the model does not). Note tool_name here is the tool's "
+    "*registered* MCP name, which differs from mcp_tool_calls_total's "
+    "func.__name__ for the OAuth tools.",
+    ["tool_name", "outcome"],
 )
 
 # =============================================================================
@@ -908,6 +951,167 @@ def record_tool_error(tool_name: str, error_type: str) -> None:
         error_type: Type of error (e.g., "HTTPStatusError", "ValueError")
     """
     mcp_tool_errors_total.labels(tool_name=tool_name, error_type=error_type).inc()
+
+
+# =============================================================================
+# MCP Client Fleet Instrumentation
+# =============================================================================
+
+_FLEET_CAPABILITIES = ("elicitation", "sampling", "roots")
+_SESSION_RECORDED_ATTR = "_astrolabe_fleet_recorded"
+
+
+def _client_label(value: object, limit: int = 64) -> str:
+    """Clamp a client-supplied value before it becomes a metric label.
+
+    ``clientInfo`` arrives from the peer, so its length is not ours to trust:
+    unbounded label values are a memory exhaustion vector against the
+    process-global registry.
+    """
+    return str(value)[:limit] if value is not None else "unknown"
+
+
+def _minor_version(version: object) -> str:
+    """Reduce a version to ``major.minor``.
+
+    Full patch versions would add a new series on every client release, which
+    buys nothing — we want to spot "Claude Code 2.1 changed protocol version",
+    not track point releases.
+    """
+    return ".".join(_client_label(version, 32).split(".")[:2])
+
+
+def record_client_session() -> None:
+    """Record the calling MCP client's identity and capabilities, once per session.
+
+    Reads the SDK's per-request contextvar rather than taking a ``Context``, so
+    it works in every deployment mode (single-user, multi-user BasicAuth, Login
+    Flow v2, OAuth) and for every tool, including the auth/oauth tools that
+    carry no ``@instrument_tool``.
+
+    Never raises: instrumentation must not be able to fail a tool call.
+    """
+    try:
+        ctx = request_ctx.get()
+    except LookupError:
+        # Called outside a request scope (startup, tests). Expected, not an error.
+        return
+    session = ctx.session
+    # ponytail: unsynchronised check-then-set, so two requests racing on a
+    # brand-new session can each record it once. Bounded at one extra count per
+    # session; a lock here would cost more than the error is worth.
+    if getattr(session, _SESSION_RECORDED_ATTR, False):
+        return
+    params = getattr(session, "client_params", None)
+    if params is None:
+        # Session has not completed initialize yet; try again on the next call.
+        return
+    # Claim the session before doing the work, so a failure below costs one
+    # warning for this session rather than one per tool call.
+    setattr(session, _SESSION_RECORDED_ATTR, True)
+
+    try:
+        # --- the only SDK-version-sensitive lines in the codebase ------------
+        # mcp 1.x: client_params.clientInfo / .capabilities / .protocolVersion
+        # mcp 2.x: client_params.client_info, session.client_capabilities,
+        #          request_context.protocol_version (negotiated, not requested).
+        # Both spellings are tried so this keeps recording *through* the
+        # upgrade. A metric that silently zeroed itself at the moment of
+        # comparison would destroy the baseline it exists to provide.
+        #
+        # Note these getattr defaults swallow AttributeError, so a rename that
+        # neither spelling covers does NOT raise — it records
+        # client_name="unknown". That is deliberate (instrumentation must not
+        # fail a tool call) and is the post-upgrade signal to alert on; see
+        # docs/observability.md.
+        info = getattr(params, "client_info", None) or getattr(
+            params, "clientInfo", None
+        )
+        caps = getattr(session, "client_capabilities", None) or getattr(
+            params, "capabilities", None
+        )
+        protocol = getattr(ctx, "protocol_version", None) or getattr(
+            params, "protocolVersion", None
+        )
+        # ---------------------------------------------------------------------
+        name = _client_label(getattr(info, "name", None))
+        mcp_client_sessions_total.labels(
+            client_name=name,
+            client_version=_minor_version(getattr(info, "version", None)),
+            protocol_version=_client_label(protocol, 32),
+        ).inc()
+        for capability in _FLEET_CAPABILITIES:
+            # Set explicitly to 0 when absent, so a client that *stops*
+            # declaring a capability shows a drop rather than a stale 1.
+            mcp_client_capability.labels(client_name=name, capability=capability).set(
+                1 if getattr(caps, capability, None) is not None else 0
+            )
+    except Exception:
+        # Backstop for anything the accessors above don't absorb (a label-value
+        # rejection, say). WARNING rather than DEBUG because this metric is the
+        # baseline for an SDK upgrade — losing it silently defeats the purpose.
+        # Bounded to one line per session by the claim above.
+        logger.warning(
+            "Could not record MCP client session metrics — the SDK's client_params "
+            "shape may have changed",
+            exc_info=True,
+        )
+
+
+def record_elicitation(prompt: str, outcome: str, reason: str = "none") -> None:
+    """Record the outcome of an elicitation prompt.
+
+    Args:
+        prompt: Which prompt ran — "login_flow" or "provisioning_required".
+        outcome: "accepted", "declined", "cancelled", or "message_only". These
+            are exactly the strings ``_run_elicit`` returns, so the metric and
+            that function's contract cannot drift apart.
+        reason: Why a message_only fallback happened — "no_elicit_attr" (the
+            context exposes no elicit()), "not_implemented" (the client declined
+            the capability), or "error" (elicit raised). "none" for the three
+            real outcomes. mcp 2.x adds "no_back_channel".
+    """
+    mcp_elicitation_total.labels(prompt=prompt, outcome=outcome, reason=reason).inc()
+
+
+def instrument_call_tool_outcomes(mcp: Any) -> None:
+    """Wrap the low-level CallToolRequest handler to record how the SDK replied.
+
+    The tool_error/protocol_error distinction is made *inside* the SDK, one
+    frame above ``FastMCP.call_tool``: the handler either returns
+    ``CallToolResult(isError=True)`` or lets an exception escape into
+    ``_handle_request``, which turns it into a JSON-RPC error. This is the only
+    place that can observe which happened.
+
+    Doing the same classification inside ``instrument_tool`` by inspecting the
+    exception type would merely re-encode our current belief about the SDK, so
+    the metric would read identically before and after the 2.x upgrade and
+    detect nothing — which is the one thing this metric exists to do.
+    """
+    server = mcp._mcp_server
+    original = server.request_handlers[types.CallToolRequest]
+
+    async def handler(req: types.CallToolRequest) -> types.ServerResult:
+        record_client_session()
+        tool_name = req.params.name
+        try:
+            result = await original(req)
+        except Exception:
+            # Deliberately Exception, not BaseException: anyio cancellation is
+            # not a protocol error and must not poison this signal.
+            mcp_tool_outcomes_total.labels(
+                tool_name=tool_name, outcome="protocol_error"
+            ).inc()
+            raise
+        # v1 wraps the result in the ServerResult RootModel; v2 returns the
+        # CallToolResult directly.
+        is_error = bool(getattr(getattr(result, "root", result), "isError", False))
+        mcp_tool_outcomes_total.labels(
+            tool_name=tool_name, outcome="tool_error" if is_error else "success"
+        ).inc()
+        return result
+
+    server.request_handlers[types.CallToolRequest] = handler
 
 
 def record_nextcloud_api_call(

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -18,9 +18,9 @@ import functools
 import logging
 import threading
 import time
-from typing import Any
 
 from mcp import types
+from mcp.server.fastmcp import FastMCP
 from mcp.server.lowlevel.server import request_ctx
 from prometheus_client import (
     REGISTRY,
@@ -988,6 +988,23 @@ def _client_label(value: object, limit: int = 64) -> str:
     return str(value)[:limit] if value is not None else "unknown"
 
 
+def _first_present(*candidates: tuple[object, str]) -> object | None:
+    """Return the first attribute that is actually *present*, else None.
+
+    Deliberately tests ``is not None`` rather than truthiness. The obvious
+    ``getattr(a, "x", None) or getattr(b, "y", None)`` would treat a present
+    but falsy value — an empty string, a 0 — as missing and silently fall
+    through to the other spelling. That is not hypothetical for the SDK
+    upgrade this instrumentation exists to watch: mcp 2.x has unversioned
+    servers report an empty string rather than omitting the field.
+    """
+    for obj, attr in candidates:
+        value = getattr(obj, attr, None)
+        if value is not None:
+            return value
+    return None
+
+
 def _bounded_client_name(name: str) -> str:
     """Bound the *number* of distinct client identities, not just their length.
 
@@ -1059,14 +1076,12 @@ def record_client_session() -> None:
         # client_name="unknown". That is deliberate (instrumentation must not
         # fail a tool call) and is the post-upgrade signal to alert on; see
         # docs/observability.md.
-        info = getattr(params, "client_info", None) or getattr(
-            params, "clientInfo", None
+        info = _first_present((params, "client_info"), (params, "clientInfo"))
+        caps = _first_present(
+            (session, "client_capabilities"), (params, "capabilities")
         )
-        caps = getattr(session, "client_capabilities", None) or getattr(
-            params, "capabilities", None
-        )
-        protocol = getattr(ctx, "protocol_version", None) or getattr(
-            params, "protocolVersion", None
+        protocol = _first_present(
+            (ctx, "protocol_version"), (params, "protocolVersion")
         )
         # ---------------------------------------------------------------------
         name = _bounded_client_name(_client_label(getattr(info, "name", None)))
@@ -1109,7 +1124,7 @@ def record_elicitation(prompt: str, outcome: str, reason: str = "none") -> None:
     mcp_elicitation_total.labels(prompt=prompt, outcome=outcome, reason=reason).inc()
 
 
-def instrument_call_tool_outcomes(mcp: Any) -> None:
+def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
     """Wrap the low-level CallToolRequest handler to record how the SDK replied.
 
     The tool_error/protocol_error distinction is made *inside* the SDK, one

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -1,0 +1,297 @@
+"""Unit tests for MCP client-fleet observability.
+
+These metrics exist to make the mcp python-sdk 1.x -> 2.x (protocol 2026-07-28)
+upgrade's *silent* behaviour changes visible. Two things are pinned here:
+
+1. ``record_client_session`` records who is connecting, with what capabilities,
+   at which protocol version — deduplicated per session and with every
+   client-supplied label clamped.
+2. ``instrument_call_tool_outcomes`` distinguishes a tool error the model can
+   see (``CallToolResult.isError``) from a protocol error it cannot (a JSON-RPC
+   error). On mcp 1.x the latter is 0 by construction, which is precisely what
+   makes it a usable regression alarm after the upgrade.
+
+Counters live in the process-global ``REGISTRY`` and never reset between tests,
+so every assertion here is on a *delta*.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from mcp import types
+from mcp.server.lowlevel.server import request_ctx
+from mcp.shared.exceptions import McpError
+
+from nextcloud_mcp_server.observability.metrics import (
+    instrument_call_tool_outcomes,
+    record_client_session,
+)
+
+pytestmark = pytest.mark.unit
+
+# ``metric_sample`` is provided as a shared fixture in tests/unit/conftest.py.
+
+SESSIONS = "mcp_client_sessions_total"
+CAPABILITY = "mcp_client_capability"
+OUTCOMES = "mcp_tool_outcomes_total"
+
+
+def _client_params(
+    *,
+    name: str = "claude-code",
+    version: str = "2.0.13",
+    protocol: str = "2025-06-18",
+    elicitation: bool = True,
+) -> types.InitializeRequestParams:
+    return types.InitializeRequestParams(
+        protocolVersion=protocol,
+        capabilities=types.ClientCapabilities(
+            elicitation=types.ElicitationCapability() if elicitation else None,
+        ),
+        clientInfo=types.Implementation(name=name, version=version),
+    )
+
+
+class _FakeSession:
+    """Minimal stand-in for ServerSession — only ``client_params`` is read."""
+
+    def __init__(self, params: types.InitializeRequestParams | None) -> None:
+        self.client_params = params
+
+
+def _activate(session: _FakeSession):
+    """Install a request context carrying ``session``, as the SDK does."""
+    return request_ctx.set(
+        SimpleNamespace(request_id=1, meta=None, session=session, lifespan_context=None)
+    )
+
+
+class TestRecordClientSession:
+    def test_records_identity_and_capabilities(self, metric_session, metric_sample):
+        labels = {
+            "client_name": "claude-code",
+            # "2.0.13" truncated to major.minor: a new series per patch release
+            # would make the fleet view unreadable within weeks.
+            "client_version": "2.0",
+            "protocol_version": "2025-06-18",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        record_client_session()
+
+        assert metric_sample(SESSIONS, labels) - before == 1
+        assert (
+            metric_sample(
+                CAPABILITY, {"client_name": "claude-code", "capability": "elicitation"}
+            )
+            == 1
+        )
+        # Explicitly zeroed rather than left absent, so a client that *stops*
+        # declaring a capability reads as a drop instead of a stale 1.
+        assert (
+            metric_sample(
+                CAPABILITY, {"client_name": "claude-code", "capability": "sampling"}
+            )
+            == 0
+        )
+
+    def test_dedups_per_session(self, metric_session, metric_sample):
+        labels = {
+            "client_name": "claude-code",
+            "client_version": "2.0",
+            "protocol_version": "2025-06-18",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        record_client_session()
+        record_client_session()
+        record_client_session()
+
+        assert metric_sample(SESSIONS, labels) - before == 1
+
+    def test_new_session_records_again(self, metric_session, metric_sample):
+        labels = {
+            "client_name": "claude-code",
+            "client_version": "2.0",
+            "protocol_version": "2025-06-18",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        record_client_session()
+        token = _activate(_FakeSession(_client_params()))
+        try:
+            record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert metric_sample(SESSIONS, labels) - before == 2
+
+    def test_no_request_context_is_a_noop(self, metric_sample):
+        """Outside a request the contextvar is unset — must not raise."""
+        labels = {
+            "client_name": "claude-code",
+            "client_version": "2.0",
+            "protocol_version": "2025-06-18",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        record_client_session()
+
+        assert metric_sample(SESSIONS, labels) == before
+
+    def test_uninitialized_session_is_a_noop(self, metric_sample):
+        """A session that has not completed initialize has no client_params."""
+        labels = {
+            "client_name": "unknown",
+            "client_version": "unknown",
+            "protocol_version": "unknown",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        token = _activate(_FakeSession(None))
+        try:
+            record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert metric_sample(SESSIONS, labels) == before
+
+    def test_client_labels_are_clamped(self, metric_sample):
+        """clientInfo is peer-supplied; unbounded labels would be a memory DoS."""
+        token = _activate(_FakeSession(_client_params(name="x" * 200, version="1.2.3")))
+        try:
+            record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert (
+            metric_sample(
+                SESSIONS,
+                {
+                    "client_name": "x" * 64,
+                    "client_version": "1.2",
+                    "protocol_version": "2025-06-18",
+                },
+            )
+            == 1
+        )
+
+    def test_unrecognised_params_shape_degrades_to_unknown(self, metric_sample):
+        """An SDK field rename surfaces as client_name="unknown", not an error.
+
+        The accessors use ``getattr(..., None)``, which swallows AttributeError
+        by design — instrumentation must never fail a tool call. The consequence
+        is that if mcp 2.x renames these fields in a way the dual-spelling block
+        does not cover, the metric keeps recording but every label reads
+        "unknown". That is the signal to watch for after the upgrade; it is
+        alerted on in docs/observability.md rather than logged.
+        """
+
+        class _UnrecognisedParams:
+            """Params object exposing none of the names we know about."""
+
+        labels = {
+            "client_name": "unknown",
+            "client_version": "unknown",
+            "protocol_version": "unknown",
+        }
+        before = metric_sample(SESSIONS, labels)
+
+        token = _activate(_FakeSession(_UnrecognisedParams()))
+        try:
+            record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert metric_sample(SESSIONS, labels) - before == 1
+
+
+class TestCallToolOutcomes:
+    """The tool_error vs protocol_error split — the core upgrade tripwire."""
+
+    @staticmethod
+    def _wrap(inner):
+        mcp = SimpleNamespace(
+            _mcp_server=SimpleNamespace(request_handlers={types.CallToolRequest: inner})
+        )
+        instrument_call_tool_outcomes(mcp)
+        return mcp._mcp_server.request_handlers[types.CallToolRequest]
+
+    @staticmethod
+    def _request(name: str = "nc_notes_create_note") -> types.CallToolRequest:
+        return types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(name=name, arguments={}),
+        )
+
+    async def test_success(self, metric_sample):
+        labels = {"tool_name": "nc_notes_create_note", "outcome": "success"}
+        before = metric_sample(OUTCOMES, labels)
+
+        async def inner(_req):
+            return types.ServerResult(types.CallToolResult(content=[], isError=False))
+
+        await self._wrap(inner)(self._request())
+
+        assert metric_sample(OUTCOMES, labels) - before == 1
+
+    async def test_tool_error(self, metric_sample):
+        """isError=True — the model sees the message and can react."""
+        labels = {"tool_name": "nc_notes_create_note", "outcome": "tool_error"}
+        before = metric_sample(OUTCOMES, labels)
+
+        async def inner(_req):
+            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+
+        await self._wrap(inner)(self._request())
+
+        assert metric_sample(OUTCOMES, labels) - before == 1
+
+    async def test_protocol_error_and_exception_propagates(self, metric_sample):
+        """An escaping exception becomes a JSON-RPC error; the model sees nothing.
+
+        This is 0 on mcp 1.x by construction — the SDK converts every exception
+        except UrlElicitationRequiredError into isError=True — so any non-zero
+        reading after the 2.x upgrade is the MCPError semantics flip.
+        """
+        labels = {"tool_name": "nc_notes_create_note", "outcome": "protocol_error"}
+        before = metric_sample(OUTCOMES, labels)
+
+        async def inner(_req):
+            raise McpError(types.ErrorData(code=types.INTERNAL_ERROR, message="boom"))
+
+        handler = self._wrap(inner)
+        request = self._request()
+
+        with pytest.raises(McpError):
+            await handler(request)
+
+        assert metric_sample(OUTCOMES, labels) - before == 1
+
+    async def test_cancellation_is_not_a_protocol_error(self, metric_sample):
+        """anyio cancellation is a BaseException and must not poison the signal."""
+        labels = {"tool_name": "nc_notes_create_note", "outcome": "protocol_error"}
+        before = metric_sample(OUTCOMES, labels)
+
+        async def inner(_req):
+            raise KeyboardInterrupt
+
+        handler = self._wrap(inner)
+        request = self._request()
+
+        with pytest.raises(KeyboardInterrupt):
+            await handler(request)
+
+        assert metric_sample(OUTCOMES, labels) == before
+
+
+@pytest.fixture
+def metric_session():
+    """Activate a request context with an initialized client session."""
+    token = _activate(_FakeSession(_client_params()))
+    try:
+        yield
+    finally:
+        request_ctx.reset(token)

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -24,6 +24,7 @@ from mcp import types
 from mcp.server.lowlevel.server import request_ctx
 from mcp.shared.exceptions import McpError
 
+from nextcloud_mcp_server.observability import metrics as metrics_module
 from nextcloud_mcp_server.observability.metrics import (
     _MAX_TRACKED_CLIENTS,
     instrument_call_tool_outcomes,
@@ -37,6 +38,25 @@ pytestmark = pytest.mark.unit
 SESSIONS = "mcp_client_sessions_total"
 CAPABILITY = "mcp_client_capability"
 OUTCOMES = "mcp_tool_outcomes_total"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_seen_client_names():
+    """Snapshot/restore the module-global client-name set around every test.
+
+    ``_seen_client_names`` is process-global and never expires, so the
+    capacity test below (which mints ~70 identities) would otherwise leave the
+    cap exhausted for whatever runs next — silently turning an assertion on a
+    real ``client_name`` into one on ``"_other"``. Nothing enforces test order
+    here, so relying on file-definition order would be a latent flake rather
+    than a guarantee.
+    """
+    saved = set(metrics_module._seen_client_names)
+    try:
+        yield
+    finally:
+        metrics_module._seen_client_names.clear()
+        metrics_module._seen_client_names.update(saved)
 
 
 def _client_params(

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -25,6 +25,7 @@ from mcp.server.lowlevel.server import request_ctx
 from mcp.shared.exceptions import McpError
 
 from nextcloud_mcp_server.observability.metrics import (
+    _MAX_TRACKED_CLIENTS,
     instrument_call_tool_outcomes,
     record_client_session,
 )
@@ -212,9 +213,15 @@ class TestCallToolOutcomes:
     """The tool_error vs protocol_error split — the core upgrade tripwire."""
 
     @staticmethod
-    def _wrap(inner):
+    def _wrap(inner, registered=("nc_notes_create_note",)):
+        """Wrap ``inner``, with ``registered`` standing in for the tool registry."""
         mcp = SimpleNamespace(
-            _mcp_server=SimpleNamespace(request_handlers={types.CallToolRequest: inner})
+            _mcp_server=SimpleNamespace(
+                request_handlers={types.CallToolRequest: inner}
+            ),
+            _tool_manager=SimpleNamespace(
+                get_tool=lambda name: object() if name in registered else None
+            ),
         )
         instrument_call_tool_outcomes(mcp)
         return mcp._mcp_server.request_handlers[types.CallToolRequest]
@@ -295,3 +302,63 @@ def metric_session():
         yield
     finally:
         request_ctx.reset(token)
+
+
+class TestLabelCardinality:
+    """Both halves of the cardinality bound: value size AND value count.
+
+    Prometheus entries never expire, so a peer that can influence a label value
+    can grow the process-global registry without limit. `clientInfo.name` and
+    the `tools/call` `name` are both caller-chosen, so both are bounded — the
+    former by a cap on distinct values, the latter by the tool registry.
+    """
+
+    async def test_unregistered_tool_name_collapses_to_unknown(self, metric_sample):
+        """A bogus tools/call name must not mint a series of its own.
+
+        Left raw this would also pollute the protocol_error tripwire with
+        caller-chosen labels that say nothing about the SDK upgrade.
+        """
+        bogus = "../../etc/passwd" + "A" * 500
+        bogus_labels = {"tool_name": bogus, "outcome": "tool_error"}
+        unknown_labels = {"tool_name": "unknown", "outcome": "tool_error"}
+        before_unknown = metric_sample(OUTCOMES, unknown_labels)
+
+        async def inner(_req):
+            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+
+        handler = TestCallToolOutcomes._wrap(inner)
+        await handler(
+            types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(name=bogus, arguments={}),
+            )
+        )
+
+        assert metric_sample(OUTCOMES, bogus_labels) == 0
+        assert metric_sample(OUTCOMES, unknown_labels) - before_unknown == 1
+
+    def test_distinct_client_names_are_capped(self, metric_sample):
+        """A client varying clientInfo.name per session cannot grow series forever.
+
+        Length-clamping alone does not close this: it bounds how big one value
+        gets, not how many distinct ones a peer can mint.
+        """
+        overflow_labels = {
+            "client_name": "_other",
+            "client_version": "1.0",
+            "protocol_version": "2025-06-18",
+        }
+        before = metric_sample(SESSIONS, overflow_labels)
+
+        # Well past the cap, each session declaring a fresh identity.
+        for i in range(_MAX_TRACKED_CLIENTS + 20):
+            token = _activate(
+                _FakeSession(_client_params(name=f"rotating-{i}", version="1.0.0"))
+            )
+            try:
+                record_client_session()
+            finally:
+                request_ctx.reset(token)
+
+        assert metric_sample(SESSIONS, overflow_labels) - before >= 20

--- a/tests/unit/test_elicitation.py
+++ b/tests/unit/test_elicitation.py
@@ -191,3 +191,86 @@ async def test_present_provisioning_required_cancel_returns_cancelled():
         result = await present_provisioning_required(ctx)
 
     assert result == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Elicitation outcome metrics
+#
+# The three message_only fallbacks are silent by design — the caller gets a
+# degraded-but-working flow and nothing raises. That is exactly why they are
+# counted separately: when the MCP SDK moves to protocol 2026-07-28 the
+# server-initiated back-channel disappears and elicitation starts failing into
+# the generic `error` branch. Without a per-reason baseline, that transition
+# looks like nothing at all.
+# ---------------------------------------------------------------------------
+
+_ELICITATION = "mcp_elicitation_total"
+_PROVISIONING = "provisioning_required"
+
+
+async def _run_provisioning(ctx) -> str:
+    fake = _fake_settings()
+    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+        return await present_provisioning_required(ctx)
+
+
+@pytest.mark.parametrize(
+    ("elicit", "expected_reason"),
+    [
+        (None, "no_elicit_attr"),
+        (AsyncMock(side_effect=NotImplementedError()), "not_implemented"),
+        (AsyncMock(side_effect=RuntimeError("no back-channel")), "error"),
+    ],
+    ids=["no_elicit_attr", "not_implemented", "error"],
+)
+async def test_message_only_reasons_are_distinguishable(
+    metric_sample, elicit, expected_reason
+):
+    """Each message_only cause lands on its own `reason`, and only its own."""
+    all_reasons = ("no_elicit_attr", "not_implemented", "error")
+    labels = {
+        "prompt": _PROVISIONING,
+        "outcome": "message_only",
+        "reason": expected_reason,
+    }
+    before = {
+        r: metric_sample(_ELICITATION, {**labels, "reason": r}) for r in all_reasons
+    }
+
+    if elicit is None:
+        # A context that exposes no elicit() at all.
+        ctx = SimpleNamespace()
+    else:
+        ctx = MagicMock()
+        ctx.elicit = elicit
+
+    assert await _run_provisioning(ctx) == "message_only"
+
+    for reason in all_reasons:
+        delta = (
+            metric_sample(_ELICITATION, {**labels, "reason": reason}) - before[reason]
+        )
+        assert delta == (1 if reason == expected_reason else 0), (
+            f"reason={reason} moved by {delta}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("action", "outcome"),
+    [("accept", "accepted"), ("decline", "declined"), ("cancel", "cancelled")],
+)
+async def test_real_outcomes_record_reason_none(metric_sample, action, outcome):
+    """Outcomes where elicitation actually ran carry reason="none"."""
+    labels = {"prompt": _PROVISIONING, "outcome": outcome, "reason": "none"}
+    before = metric_sample(_ELICITATION, labels)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(
+        return_value=SimpleNamespace(
+            action=action, data=SimpleNamespace(acknowledged=True)
+        )
+    )
+
+    assert await _run_provisioning(ctx) == outcome
+
+    assert metric_sample(_ELICITATION, labels) - before == 1


### PR DESCRIPTION
## Why

We're planning the `mcp` python-sdk 1.29 → 2.x (protocol 2026-07-28) upgrade. **This PR is not that upgrade** — it's the instrumentation that has to exist *first*, because the upgrade's two most consequential changes are silent:

- elicitation loses its server-initiated back-channel, so progressive consent degrades to `message_only` without erroring;
- an `MCPError` raised inside a tool stops becoming `CallToolResult(isError=True)` and becomes a JSON-RPC error the model never sees.

Neither raises. Neither appears in any metric we emit today. A regression would surface as a user report rather than a graph.

Nothing currently records which clients connect, at what protocol version, with which capabilities. The dev deployment alone serves three independent MCP client implementations, and they differ in exactly the dimension the upgrade moves — measured over 7d at the gateway, one opens 170 SSE `GET` back-channel streams and 240 `DELETE` session terminations, while another opens **zero of either**. Validating the upgrade against a single client would miss it.

## What

Four metrics:

| Metric | Purpose |
|---|---|
| `mcp_client_sessions_total{client_name,client_version,protocol_version}` | fleet composition; alert when a client's negotiated version changes |
| `mcp_client_capability{client_name,capability}` | who declares `elicitation`/`sampling`/`roots` — i.e. who a deprecation will hurt |
| `mcp_elicitation_total{prompt,outcome,reason}` | makes the silent `message_only` fallback countable, split by cause |
| `mcp_tool_outcomes_total{tool_name,outcome}` | `success` / `tool_error` / `protocol_error` |

## The design decision worth reviewing

**The hook is the low-level `CallToolRequest` handler, not the existing `@instrument_tool` decorator.**

The SDK decides `tool_error` vs `protocol_error` one frame *above* `FastMCP.call_tool` (`mcp/server/lowlevel/server.py`): the handler either returns `CallToolResult(isError=True)` or lets an exception escape into `_handle_request`. Classifying by exception type inside our decorator would only re-encode *our current belief about the SDK* — the metric would read identically before and after the upgrade and detect nothing, which is the one thing it exists to do.

The wrapper also works in every deployment mode (`list_tools_filtered` is inside `if oauth_enabled`) and covers the 7 auth/oauth tools that carry no `@instrument_tool`.

`mcp_tool_outcomes_total` is a **new** metric rather than a third `status` on `mcp_tool_calls_total` because:
1. `protocol_error` is provably 0 on mcp 1.x — the SDK converts every exception except `UrlElicitationRequiredError` (which this repo never raises) — so the alert is a one-liner against a known-zero baseline;
2. the two use different `tool_name` spaces (registered MCP name vs `func.__name__`, which differ for the OAuth tools);
3. adding a `status` value would silently change what existing `status="error"` queries match.

## Notable behaviours, all pinned by tests

- **Cardinality**: `clientInfo` is peer-controlled. Labels are clamped (`name[:64]`) and versions truncated to `major.minor` — unbounded label values are a memory-exhaustion vector against the process-global registry.
- **Dedup**: once per session via an attribute on the session object, GC'd with it. The session is *claimed before* the work, so an unexpected failure costs one warning per session rather than one per tool call.
- **Forward compatibility**: the accessors try both the 1.x and 2.x spellings so the baseline keeps recording *through* the upgrade. Where neither matches they degrade to `client_name="unknown"` rather than raising — instrumentation must not fail a tool call — and `docs/observability.md` alerts on exactly that.

## Also fixed

`docs/observability.md` recommended grouping dashboard queries `by (method, endpoint)`, which collapses every route into one series. The app's `endpoint` label collides with the ServiceMonitor's target label of the same name, so Prometheus keeps the target label and renames the scraped one to `exported_endpoint`. Docs now say so. (I originally diagnosed this as a metric bug — it isn't; the data was always there.)

## Test coverage

New `tests/unit/test_client_fleet_metrics.py` (11 tests) + 6 added to `tests/unit/test_elicitation.py`. All assert on deltas, since `prometheus_client`'s registry is process-global.

The `unknown`-degradation test is worth a look: I wrote it expecting an exception path, it failed, and it was right to — `getattr(x, "name", None)` swallows `AttributeError`. The test now pins the real contract and the alert covers it.

**Test tiers**: this PR adds no HTTP/MCP API surface — it's instrumentation around existing tools — so the e2e + contract gate doesn't apply. `-m unit` is the relevant tier: **3133 pass**. ruff / ruff-format / ty clean; `sonar analyze secrets` clean.

## Verification after deploy

```
curl -s localhost:9090/metrics | grep -E 'mcp_client_|mcp_elicitation_|mcp_tool_outcomes_'
```

`mcp_tool_outcomes_total{outcome="protocol_error"}` **must read 0** on mcp 1.29. If it doesn't, the core assumption above is wrong and the upgrade plan needs revisiting before it starts.

---

_This PR was generated with the help of AI, and reviewed by a Human_
