### PR TITLE
feat(observability): record why each OAuth token is rejected, and for whom

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -101,12 +101,21 @@ most consequential changes are silent — see the alerts below.
   rejection ends the MCP session and forces the user to re-authenticate, so
   `reason` and `client_id` are what turn a bare failure count into an
   actionable one.
-  - `method`: `jwt` | `introspect` | `userinfo` | `unknown`
-  - `result`: `valid` | `invalid` (the caller's token) | `error` (ours)
+  - `method`: `jwt` | `introspect` | `userinfo` | `allowlist` | `unknown`
+  - `result`: `valid` | `invalid` (the caller's token) | `error` (ours).
+    Derived from `reason`, not set independently, so the two cannot drift.
   - `reason`: `expired`, `inactive`, `bad_signature`, `bad_issuer`,
-    `bad_audience`, `not_configured`, `network_error`, `unknown` — `none` when valid
+    `bad_audience`, `not_allowlisted`, `not_configured`, `network_error`,
+    `unknown` — `none` when valid
   - `client_id`: read from the *unverified* token, so length-clamped and capped
-    at 50 distinct values (`_other` beyond)
+    at 50 distinct values (`_other` beyond), on a budget of its own
+
+  > On a deployment with **no** validator configured, expect
+  > `method="introspect"`, not `"jwt"`. Both entry points gate on
+  > `self.jwks_client` before attempting JWT verification, so an unconfigured
+  > JWKS means tokens fall through to introspection rather than being rejected
+  > as `method="jwt"`. Alert on `reason="not_configured"` rather than on a
+  > particular `method`.
 - `mcp_oauth_token_cache_hits_total` - Cache hit/miss rate
 - `mcp_oauth_refresh_token_operations_total` - Refresh token storage ops
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -96,7 +96,17 @@ most consequential changes are silent — see the alerts below.
 
 ### OAuth Flow Metrics
 
-- `mcp_oauth_token_validations_total` - Token validation count
+- `mcp_oauth_token_validations_total{method, result, reason, client_id}` -
+  Token validations. **This is the "why was a client disconnected" metric.** A
+  rejection ends the MCP session and forces the user to re-authenticate, so
+  `reason` and `client_id` are what turn a bare failure count into an
+  actionable one.
+  - `method`: `jwt` | `introspect` | `userinfo` | `unknown`
+  - `result`: `valid` | `invalid` (the caller's token) | `error` (ours)
+  - `reason`: `expired`, `inactive`, `bad_signature`, `bad_issuer`,
+    `bad_audience`, `not_configured`, `network_error`, `unknown` — `none` when valid
+  - `client_id`: read from the *unverified* token, so length-clamped and capped
+    at 50 distinct values (`_other` beyond)
 - `mcp_oauth_token_cache_hits_total` - Cache hit/miss rate
 - `mcp_oauth_refresh_token_operations_total` - Refresh token storage ops
 
@@ -248,6 +258,28 @@ topk(10, sum(rate(mcp_tool_calls_total[5m])) by (tool_name))
 **Nextcloud API Health**:
 ```promql
 sum(rate(mcp_nextcloud_api_requests_total{status_code!~"2.."}[5m])) by (app)
+```
+
+**Why is a client being disconnected?** — the first query to run when a
+connector reports dropping out. A rejection forces the user to log in again, so
+even a handful a day is user-visible:
+```promql
+sum by (client_id, method, reason) (
+  increase(mcp_oauth_token_validations_total{result!="valid"}[1h])
+) > 0
+```
+
+Split by who is at fault: `result="invalid"` is the caller's token (expired,
+revoked, wrong audience); `result="error"` is ours (`not_configured`,
+`network_error`) and should page:
+```promql
+sum by (reason) (increase(mcp_oauth_token_validations_total{result="error"}[15m])) > 0
+```
+
+`reason="not_configured"` deserves its own alert — a missing JWKS or
+introspection endpoint rejects *every* token, so it breaks all clients at once:
+```promql
+sum(increase(mcp_oauth_token_validations_total{reason="not_configured"}[5m])) > 0
 ```
 
 **MCP client fleet — who is connected, at which protocol version**:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -286,7 +286,10 @@ sum by (reason) (increase(mcp_oauth_token_validations_total{result="error"}[15m]
 ```
 
 `reason="not_configured"` deserves its own alert — a missing JWKS or
-introspection endpoint rejects *every* token, so it breaks all clients at once:
+introspection endpoint, or an unset `ALLOWED_MGMT_CLIENT`, rejects *every*
+token, so it breaks all clients at once. Note the deliberate split on the
+allowlist path: an empty allowlist is `not_configured` (ours, pageable) while a
+client merely absent from a populated one is `not_allowlisted` (theirs):
 ```promql
 sum(increase(mcp_oauth_token_validations_total{reason="not_configured"}[5m])) > 0
 ```

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -304,23 +304,22 @@ class UnifiedTokenVerifier(TokenVerifier):
                 if payload:
                     record_oauth_token_validation("jwt", "valid")
                 else:
-                    record_oauth_token_validation("jwt", "invalid")
+                    # _verify_jwt_signature() already recorded the rejection
+                    # with its reason; recording again here would double-count.
                     # Fall back to introspection if JWT verification failed
                     if self.introspection_uri:
                         validation_method = "introspect"
                         payload = await self._introspect_token(token)
                         if payload:
                             record_oauth_token_validation("introspect", "valid")
-                        else:
-                            record_oauth_token_validation("introspect", "invalid")
+                        # else: _introspect_token() already recorded it.
             else:
                 # Fall back to introspection for opaque tokens
                 validation_method = "introspect"
                 payload = await self._introspect_token(token)
                 if payload:
                     record_oauth_token_validation("introspect", "valid")
-                else:
-                    record_oauth_token_validation("introspect", "invalid")
+                # else: _introspect_token() already recorded it.
                 if not payload:
                     return None
 
@@ -337,9 +336,13 @@ class UnifiedTokenVerifier(TokenVerifier):
                     self.settings.oidc_client_id,
                     self.settings.nextcloud_mcp_server_url,
                 )
-                # Record as invalid due to audience mismatch
-                record_oauth_token_validation(validation_method, "invalid")
-                return None
+                return self._reject(
+                    validation_method,
+                    "bad_audience",
+                    token,
+                    f"got {audiences}, need {self.settings.oidc_client_id} "
+                    f"or {self.settings.nextcloud_mcp_server_url}",
+                )
 
             logger.info(
                 "MCP audience validated - token can be used directly "
@@ -349,9 +352,9 @@ class UnifiedTokenVerifier(TokenVerifier):
             return self._create_access_token(token, payload)
 
         except Exception as e:
-            logger.error("Token verification failed: %s", e)
-            record_oauth_token_validation(validation_method, "error")
-            return None
+            return self._reject(
+                validation_method, "unknown", token, str(e), result="error"
+            )
 
     async def _verify_without_audience_check(
         self, token: str, cache_key: str
@@ -396,7 +399,8 @@ class UnifiedTokenVerifier(TokenVerifier):
                 if payload:
                     record_oauth_token_validation("jwt", "valid")
                 else:
-                    record_oauth_token_validation("jwt", "invalid")
+                    # _verify_jwt_signature() already recorded the rejection
+                    # with its reason; recording again would double-count.
                     return None
             else:
                 # Opaque token: try introspection first (only when configured),
@@ -409,8 +413,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                     payload = await self._introspect_token(token)
                     if payload:
                         record_oauth_token_validation("introspect", "valid")
-                    else:
-                        record_oauth_token_validation("introspect", "invalid")
+                    # else: _introspect_token() already recorded it.
 
                 # Fall through to userinfo when introspection is unconfigured or
                 # returned None. NOTE: _introspect_token returns None for BOTH an
@@ -427,7 +430,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                     if payload:
                         record_oauth_token_validation("userinfo", "valid")
                     else:
-                        record_oauth_token_validation("userinfo", "invalid")
+                        # _validate_via_userinfo() already recorded it.
                         return None
 
                 if payload is None:
@@ -455,9 +458,9 @@ class UnifiedTokenVerifier(TokenVerifier):
             )
 
         except Exception as e:
-            logger.error("Management API token verification failed: %s", e)
-            record_oauth_token_validation(validation_method, "error")
-            return None
+            return self._reject(
+                validation_method, "unknown", token, str(e), result="error"
+            )
 
     def _has_mcp_audience(self, payload: dict[str, Any]) -> bool:
         """
@@ -513,6 +516,60 @@ class UnifiedTokenVerifier(TokenVerifier):
         """
         return "." in token and token.count(".") == 2
 
+    @staticmethod
+    def _claimed_client_id(token: str) -> str | None:
+        """Read the client_id a token *claims*, without verifying it.
+
+        A rejected token has by definition not been validated, so its contents
+        are untrusted — but they are also the only thing that says which client
+        was turned away, which is exactly what an operator needs to know. The
+        value is treated as untrusted downstream (clamped and count-bounded
+        before it becomes a metric label) rather than being thrown away.
+
+        Returns None for opaque tokens and anything unparseable.
+        """
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except Exception:
+            return None
+        for key in ("client_id", "azp", "aud"):
+            value = claims.get(key)
+            if isinstance(value, str) and value:
+                return value
+            if isinstance(value, list) and value and isinstance(value[0], str):
+                return value[0]
+        return None
+
+    def _reject(
+        self,
+        method: str,
+        reason: str,
+        token: str,
+        detail: str | None = None,
+        result: str = "invalid",
+    ) -> None:
+        """Record and log a token rejection, then return None for the caller.
+
+        Every rejection path funnels through here so the *reason* survives.
+        Previously each path logged its own line at its own level (several at
+        DEBUG, invisible in production) and reported a bare "invalid" to the
+        metric — so a client whose users were being forced to re-authenticate
+        produced a counter that said only "something was rejected".
+
+        WARNING, not INFO: a rejection ends an MCP client's session and makes a
+        human log in again. That is not routine.
+        """
+        client_id = self._claimed_client_id(token)
+        record_oauth_token_validation(method, result, reason, client_id)
+        logger.warning(
+            "Token rejected (%s/%s) for client %s%s",
+            method,
+            reason,
+            client_id or "unknown",
+            f": {detail}" if detail else "",
+        )
+        return None
+
     async def _verify_jwt_signature(
         self, token: str, skip_issuer_check: bool = False
     ) -> dict[str, Any] | None:
@@ -531,8 +588,10 @@ class UnifiedTokenVerifier(TokenVerifier):
             # contract without an assert inside the try/except below, which
             # would have swallowed the AssertionError and reported a
             # configuration bug as an invalid token (python:S5779).
-            logger.debug("No JWKS client configured; cannot verify JWT signature")
-            return None
+            # Was DEBUG, i.e. invisible at the production log level: a missing
+            # JWKS client rejects every JWT, so the one condition that breaks
+            # all clients at once was the quietest thing in here.
+            return self._reject("jwt", "not_configured", token)
 
         try:
             # Get signing key from JWKS
@@ -568,17 +627,14 @@ class UnifiedTokenVerifier(TokenVerifier):
             return payload
 
         except jwt.ExpiredSignatureError:
-            logger.info("JWT token has expired")
-            return None
+            return self._reject("jwt", "expired", token)
         except jwt.InvalidIssuerError as e:
-            logger.warning("JWT issuer validation failed: %s", e)
-            return None
+            return self._reject("jwt", "bad_issuer", token, str(e))
         except jwt.InvalidTokenError as e:
-            logger.warning("JWT validation failed: %s", e)
-            return None
+            # Covers signature failures, malformed tokens and bad `iat`.
+            return self._reject("jwt", "bad_signature", token, str(e))
         except Exception as e:
-            logger.error("Unexpected error during JWT verification: %s", e)
-            return None
+            return self._reject("jwt", "unknown", token, str(e), result="error")
 
     async def _introspect_token(self, token: str) -> dict[str, Any] | None:
         """
@@ -591,8 +647,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             Token payload if active, None if inactive or invalid
         """
         if not self.introspection_uri:
-            logger.debug("No introspection endpoint configured")
-            return None
+            return self._reject("introspect", "not_configured", token)
 
         # Introspection requires client authentication. Checked before the try
         # rather than asserted inside it: the except below would have caught
@@ -601,11 +656,12 @@ class UnifiedTokenVerifier(TokenVerifier):
         client_id = self.settings.oidc_client_id
         client_secret = self.settings.oidc_client_secret
         if client_id is None or client_secret is None:
-            logger.debug(
-                "Introspection endpoint configured but OIDC client credentials are not; "
-                "cannot introspect"
+            return self._reject(
+                "introspect",
+                "not_configured",
+                token,
+                "introspection endpoint set but OIDC client credentials are not",
             )
-            return None
 
         try:
             response = await self.http_client.post(
@@ -619,8 +675,7 @@ class UnifiedTokenVerifier(TokenVerifier):
 
                 # Check if token is active
                 if not introspection_data.get("active", False):
-                    logger.info("Token introspection returned inactive=false")
-                    return None
+                    return self._reject("introspect", "inactive", token)
 
                 logger.debug(
                     "Token introspected successfully for user: %s",
@@ -628,30 +683,31 @@ class UnifiedTokenVerifier(TokenVerifier):
                 )
                 return introspection_data
 
-            elif response.status_code in (400, 401, 403):
-                logger.warning(
-                    "Token introspection failed: HTTP %s. Response: %s",
-                    response.status_code,
-                    response.text[:200] if response.text else "empty",
-                )
-                return None
             else:
-                logger.warning(
-                    "Unexpected response from introspection: %s. Response: %s",
-                    response.status_code,
-                    response.text[:200] if response.text else "empty",
+                # 400/401/403 mean the *server's* introspection credentials are
+                # wrong, not the caller's token; anything else is unexpected.
+                # Both are our problem, not the client's.
+                return self._reject(
+                    "introspect",
+                    "not_configured"
+                    if response.status_code in (400, 401, 403)
+                    else "unknown",
+                    token,
+                    f"HTTP {response.status_code}: "
+                    f"{response.text[:200] if response.text else 'empty'}",
+                    result="error",
                 )
-                return None
 
         except httpx.TimeoutException:
-            logger.error("Timeout while introspecting token")
-            return None
+            return self._reject(
+                "introspect", "network_error", token, "timeout", result="error"
+            )
         except httpx.RequestError as e:
-            logger.error("Network error while introspecting token: %s", e)
-            return None
+            return self._reject(
+                "introspect", "network_error", token, str(e), result="error"
+            )
         except Exception as e:
-            logger.error("Unexpected error during token introspection: %s", e)
-            return None
+            return self._reject("introspect", "unknown", token, str(e), result="error")
 
     async def _validate_via_userinfo(self, token: str) -> dict[str, Any] | None:
         """Validate an opaque token by calling the OIDC userinfo endpoint.
@@ -689,15 +745,19 @@ class UnifiedTokenVerifier(TokenVerifier):
         # self.userinfo_uri before invoking this, but the guard keeps the method
         # safe to call directly (e.g. in unit tests).
         if not self.userinfo_uri:
-            logger.debug("No userinfo endpoint configured")
-            return None
+            return self._reject("userinfo", "not_configured", token)
 
         # userinfo_uri comes from the OIDC discovery document (admin-configured),
         # not from user input — but guard the scheme anyway to satisfy SSRF
         # scanners and to fail fast on a misconfigured endpoint.
         if not self.userinfo_uri.startswith(("https://", "http://")):
-            logger.error("Refusing non-HTTP userinfo_uri: %s", self.userinfo_uri)
-            return None
+            return self._reject(
+                "userinfo",
+                "not_configured",
+                token,
+                f"refusing non-HTTP userinfo_uri: {self.userinfo_uri}",
+                result="error",
+            )
 
         try:
             response = await self.http_client.get(
@@ -705,27 +765,39 @@ class UnifiedTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except httpx.TimeoutException:
-            logger.error("Timeout while validating token via userinfo")
-            return None
+            return self._reject(
+                "userinfo", "network_error", token, "timeout", result="error"
+            )
         except httpx.RequestError as e:
-            logger.error("Network error while validating token via userinfo: %s", e)
-            return None
+            return self._reject(
+                "userinfo", "network_error", token, str(e), result="error"
+            )
 
         if response.status_code != 200:
-            logger.warning(
-                "Userinfo token validation failed: HTTP %s", response.status_code
+            # userinfo answers 401 for an expired or revoked opaque token; that
+            # is the caller's token being bad, not our configuration.
+            return self._reject(
+                "userinfo",
+                "inactive" if response.status_code == 401 else "unknown",
+                token,
+                f"HTTP {response.status_code}",
             )
-            return None
 
         try:
             data = response.json()
         except Exception as e:
-            logger.error("Failed to parse userinfo response: %s", e)
-            return None
+            return self._reject(
+                "userinfo",
+                "unknown",
+                token,
+                f"unparseable response: {e}",
+                result="error",
+            )
 
         if not data.get("sub"):
-            logger.warning("Userinfo response missing 'sub' claim")
-            return None
+            return self._reject(
+                "userinfo", "unknown", token, "response missing 'sub' claim"
+            )
 
         logger.debug("Token validated via userinfo for user: %s", data.get("sub"))
         return data

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -280,11 +280,20 @@ class UnifiedTokenVerifier(TokenVerifier):
             # same funnel anyway: from the operator's side this is
             # indistinguishable from any other reason a client stopped working,
             # and answering "why was it disconnected?" is the point.
+            #
+            # An *empty* allowlist is a different failure from a client missing
+            # off a populated one: it rejects every client, and it is our
+            # misconfiguration rather than the caller's token. Same shape as the
+            # JWKS/introspection `not_configured` cases, so it belongs on the
+            # same pageable side of the result split.
+            unconfigured = not self._allowed_mgmt_clients
             return self._reject(
                 "allowlist",
-                "not_allowlisted",
+                "not_configured" if unconfigured else "not_allowlisted",
                 token,
-                f"client_id {token_client_id!r} not in ALLOWED_MGMT_CLIENT",
+                "ALLOWED_MGMT_CLIENT is unset — every management client is rejected"
+                if unconfigured
+                else f"client_id {token_client_id!r} not in ALLOWED_MGMT_CLIENT",
                 # Already verified — the token validated, it is only the
                 # authorization that failed. Re-deriving from the raw bytes
                 # would lose it entirely for opaque tokens.
@@ -913,9 +922,10 @@ class UnifiedTokenVerifier(TokenVerifier):
         # Extract username (sub claim, with fallback to preferred_username)
         username = payload.get("sub") or payload.get("preferred_username")
         if not username:
-            logger.error(
-                "No 'sub' or 'preferred_username' claim found in token payload"
-            )
+            # Deliberately silent: every caller routes a None result through
+            # _reject(), whose WARNING carries the client_id and reason this
+            # line lacked. Logging here too would give one rejection two lines
+            # — the shape already removed from the bad_audience path.
             return None
 
         # Extract scopes from scope claim (space-separated string)

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -685,7 +685,6 @@ class UnifiedTokenVerifier(TokenVerifier):
             preceding = " → ".join(f"{m}/{r}" for m, r, _ in chain[:-1])
             detail = f"after {preceding}" + (f": {detail}" if detail else "")
         return self._reject(method, reason, token, detail)
-        return None
 
     async def _verify_jwt_signature(
         self,

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -346,20 +346,27 @@ class UnifiedTokenVerifier(TokenVerifier):
                     f"or {self.settings.nextcloud_mcp_server_url}",
                 )
 
-            # Recorded here, not at each validation stage. A signature can
-            # verify and the token still be refused for the wrong audience —
-            # counting the stage as "valid" and then the refusal as
-            # "bad_audience" made one token produce two events, and inflated
-            # `result="valid"` relative to tokens actually accepted. One token,
-            # one event, recorded at the point of acceptance.
-            record_oauth_token_validation(validation_method, "valid")
-
             logger.info(
                 "MCP audience validated - token can be used directly "
                 "(Nextcloud will validate its own audience)"
             )
 
-            return self._create_access_token(token, payload)
+            # Recorded only once the AccessToken actually exists — not at each
+            # validation stage, and not merely once the audience check passes.
+            # `_create_access_token` still returns None (without raising) for a
+            # payload carrying no `sub`/`preferred_username`, so recording any
+            # earlier means a token that is about to be refused is counted as
+            # accepted. "valid" has to mean the caller got a token.
+            access_token = self._create_access_token(token, payload)
+            if access_token is None:
+                return self._reject(
+                    validation_method,
+                    "unknown",
+                    token,
+                    "no 'sub' or 'preferred_username' claim in token payload",
+                )
+            record_oauth_token_validation(validation_method, "valid")
+            return access_token
 
         except Exception as e:
             return self._reject(validation_method, "unknown", token, str(e))
@@ -404,11 +411,11 @@ class UnifiedTokenVerifier(TokenVerifier):
                 payload = await self._verify_jwt_signature(
                     token, skip_issuer_check=True
                 )
-                if payload:
-                    record_oauth_token_validation("jwt", "valid")
-                else:
+                if not payload:
                     # _verify_jwt_signature() already recorded the rejection
                     # with its reason; recording again would double-count.
+                    # Success is recorded once, below, when the AccessToken
+                    # actually exists.
                     return None
             else:
                 # Opaque token: try introspection first (only when configured),
@@ -419,9 +426,8 @@ class UnifiedTokenVerifier(TokenVerifier):
                 if self.introspection_uri:
                     validation_method = "introspect"
                     payload = await self._introspect_token(token)
-                    if payload:
-                        record_oauth_token_validation("introspect", "valid")
-                    # else: _introspect_token() already recorded it.
+                    # A rejection here is already recorded by
+                    # _introspect_token(); success is recorded once, below.
 
                 # Fall through to userinfo when introspection is unconfigured or
                 # returned None. NOTE: _introspect_token returns None for BOTH an
@@ -435,9 +441,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                     # by the outer handler is attributed correctly.
                     validation_method = "userinfo"
                     payload = await self._validate_via_userinfo(token)
-                    if payload:
-                        record_oauth_token_validation("userinfo", "valid")
-                    else:
+                    if not payload:
                         # _validate_via_userinfo() already recorded it.
                         return None
 
@@ -466,12 +470,25 @@ class UnifiedTokenVerifier(TokenVerifier):
             # Cache and return the token. via_userinfo is derived from how we
             # actually validated — never from a payload claim (see
             # _create_access_token_with_cache_key).
-            return self._create_access_token_with_cache_key(
+            access_token = self._create_access_token_with_cache_key(
                 token,
                 payload,
                 cache_key,
                 via_userinfo=(validation_method == "userinfo"),
             )
+            # Recorded here rather than per validation stage: creation still
+            # returns None (without raising) for a payload with no
+            # `sub`/`preferred_username`, and a stage passing is not the same
+            # thing as the caller getting a token.
+            if access_token is None:
+                return self._reject(
+                    validation_method,
+                    "unknown",
+                    token,
+                    "no 'sub' or 'preferred_username' claim in token payload",
+                )
+            record_oauth_token_validation(validation_method, "valid")
+            return access_token
 
         except Exception as e:
             return self._reject(validation_method, "unknown", token, str(e))

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -12,7 +12,9 @@ Key Design Principles:
 - Token reuse IS allowed for multi-audience tokens (RFC 8707)
 """
 
+import base64
 import hashlib
+import json
 import logging
 import time
 from typing import Any
@@ -273,11 +275,17 @@ class UnifiedTokenVerifier(TokenVerifier):
         # Enforce ALLOWED_MGMT_CLIENT allowlist (fail-closed when unset)
         token_client_id = access_token.client_id
         if not token_client_id or token_client_id not in self._allowed_mgmt_clients:
-            logger.warning(
-                "Management API token rejected: client_id %r not in ALLOWED_MGMT_CLIENT",
-                token_client_id,
+            # Authorization, not validation — the token is genuine, its client
+            # is simply not on the management allowlist. Recorded through the
+            # same funnel anyway: from the operator's side this is
+            # indistinguishable from any other reason a client stopped working,
+            # and answering "why was it disconnected?" is the point.
+            return self._reject(
+                "allowlist",
+                "not_allowlisted",
+                token,
+                f"client_id {token_client_id!r} not in ALLOWED_MGMT_CLIENT",
             )
-            return None
 
         return access_token
 
@@ -330,12 +338,6 @@ class UnifiedTokenVerifier(TokenVerifier):
             # Validate MCP audience is present
             if not self._has_mcp_audience(payload):
                 audiences = payload.get("aud", [])
-                logger.error(
-                    "Token rejected: Missing MCP audience. Got %s, need MCP (%s or %s)",
-                    audiences,
-                    self.settings.oidc_client_id,
-                    self.settings.nextcloud_mcp_server_url,
-                )
                 return self._reject(
                     validation_method,
                     "bad_audience",
@@ -352,9 +354,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             return self._create_access_token(token, payload)
 
         except Exception as e:
-            return self._reject(
-                validation_method, "unknown", token, str(e), result="error"
-            )
+            return self._reject(validation_method, "unknown", token, str(e))
 
     async def _verify_without_audience_check(
         self, token: str, cache_key: str
@@ -458,9 +458,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             )
 
         except Exception as e:
-            return self._reject(
-                validation_method, "unknown", token, str(e), result="error"
-            )
+            return self._reject(validation_method, "unknown", token, str(e))
 
     def _has_mcp_audience(self, payload: dict[str, Any]) -> bool:
         """
@@ -518,7 +516,7 @@ class UnifiedTokenVerifier(TokenVerifier):
 
     @staticmethod
     def _claimed_client_id(token: str) -> str | None:
-        """Read the client_id a token *claims*, without verifying it.
+        """Read the client_id a token *claims*, without verifying anything.
 
         A rejected token has by definition not been validated, so its contents
         are untrusted — but they are also the only thing that says which client
@@ -526,11 +524,27 @@ class UnifiedTokenVerifier(TokenVerifier):
         value is treated as untrusted downstream (clamped and count-bounded
         before it becomes a metric label) rather than being thrown away.
 
+        The payload segment is base64-decoded directly rather than going through
+        ``jwt.decode(..., verify_signature=False)``. Same result, but it does not
+        route untrusted input through the JWT library at all, so there is no
+        chance of the value being mistaken for an authenticated claim by a later
+        reader (or by a security scanner — python:S5659 flags the library call
+        regardless of intent, and suppressing it would hide the real thing).
+
         Returns None for opaque tokens and anything unparseable.
         """
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None  # opaque token, not a JWS
         try:
-            claims = jwt.decode(token, options={"verify_signature": False})
+            # Restore the padding base64url encoding strips.
+            payload = parts[1]
+            claims = json.loads(
+                base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+            )
         except Exception:
+            return None
+        if not isinstance(claims, dict):
             return None
         for key in ("client_id", "azp", "aud"):
             value = claims.get(key)
@@ -540,13 +554,22 @@ class UnifiedTokenVerifier(TokenVerifier):
                 return value[0]
         return None
 
+    # Whose problem is it? A rejection is either the caller presenting a token
+    # we cannot accept, or this server being unable to validate one. Those want
+    # different responses — the second should page — so `result` is derived from
+    # `reason` here rather than passed in at each call site. It was a parameter
+    # defaulting to "invalid", and 4 of the 6 `not_configured` sites silently
+    # took the default, which put the single most total failure mode in the
+    # system (no validator configured at all) on the *client's* side of the
+    # split, contradicting the documented contract.
+    _OUR_FAULT_REASONS = frozenset({"not_configured", "network_error", "unknown"})
+
     def _reject(
         self,
         method: str,
         reason: str,
         token: str,
         detail: str | None = None,
-        result: str = "invalid",
     ) -> None:
         """Record and log a token rejection, then return None for the caller.
 
@@ -560,11 +583,13 @@ class UnifiedTokenVerifier(TokenVerifier):
         human log in again. That is not routine.
         """
         client_id = self._claimed_client_id(token)
+        result = "error" if reason in self._OUR_FAULT_REASONS else "invalid"
         record_oauth_token_validation(method, result, reason, client_id)
         logger.warning(
-            "Token rejected (%s/%s) for client %s%s",
+            "Token rejected (%s/%s, %s) for client %s%s",
             method,
             reason,
+            "our fault" if result == "error" else "caller's token",
             client_id or "unknown",
             f": {detail}" if detail else "",
         )
@@ -634,7 +659,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             # Covers signature failures, malformed tokens and bad `iat`.
             return self._reject("jwt", "bad_signature", token, str(e))
         except Exception as e:
-            return self._reject("jwt", "unknown", token, str(e), result="error")
+            return self._reject("jwt", "unknown", token, str(e))
 
     async def _introspect_token(self, token: str) -> dict[str, Any] | None:
         """
@@ -695,19 +720,14 @@ class UnifiedTokenVerifier(TokenVerifier):
                     token,
                     f"HTTP {response.status_code}: "
                     f"{response.text[:200] if response.text else 'empty'}",
-                    result="error",
                 )
 
         except httpx.TimeoutException:
-            return self._reject(
-                "introspect", "network_error", token, "timeout", result="error"
-            )
+            return self._reject("introspect", "network_error", token, "timeout")
         except httpx.RequestError as e:
-            return self._reject(
-                "introspect", "network_error", token, str(e), result="error"
-            )
+            return self._reject("introspect", "network_error", token, str(e))
         except Exception as e:
-            return self._reject("introspect", "unknown", token, str(e), result="error")
+            return self._reject("introspect", "unknown", token, str(e))
 
     async def _validate_via_userinfo(self, token: str) -> dict[str, Any] | None:
         """Validate an opaque token by calling the OIDC userinfo endpoint.
@@ -756,7 +776,6 @@ class UnifiedTokenVerifier(TokenVerifier):
                 "not_configured",
                 token,
                 f"refusing non-HTTP userinfo_uri: {self.userinfo_uri}",
-                result="error",
             )
 
         try:
@@ -765,13 +784,9 @@ class UnifiedTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except httpx.TimeoutException:
-            return self._reject(
-                "userinfo", "network_error", token, "timeout", result="error"
-            )
+            return self._reject("userinfo", "network_error", token, "timeout")
         except httpx.RequestError as e:
-            return self._reject(
-                "userinfo", "network_error", token, str(e), result="error"
-            )
+            return self._reject("userinfo", "network_error", token, str(e))
 
         if response.status_code != 200:
             # userinfo answers 401 for an expired or revoked opaque token; that
@@ -787,11 +802,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             data = response.json()
         except Exception as e:
             return self._reject(
-                "userinfo",
-                "unknown",
-                token,
-                f"unparseable response: {e}",
-                result="error",
+                "userinfo", "unknown", token, f"unparseable response: {e}"
             )
 
         if not data.get("sub"):

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -236,9 +236,12 @@ class UnifiedTokenVerifier(TokenVerifier):
                 del self._token_cache[cache_key]
 
         from_cache = access_token is not None
+        outcome: dict[str, str] = {}
         if access_token is None:
             oauth_token_cache_hits_total.labels(hit="false").inc()
-            access_token = await self._verify_without_audience_check(token, cache_key)
+            access_token = await self._verify_without_audience_check(
+                token, cache_key, outcome
+            )
 
         if access_token is None:
             return None
@@ -270,6 +273,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                     "(per-user authorization applies)",
                     access_token.resource,
                 )
+            self._record_mgmt_grant(outcome, from_cache)
             return access_token
 
         # Enforce ALLOWED_MGMT_CLIENT allowlist (fail-closed when unset)
@@ -300,6 +304,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                 client_id=token_client_id,
             )
 
+        self._record_mgmt_grant(outcome, from_cache)
         return access_token
 
     async def _verify_mcp_audience(self, token: str) -> AccessToken | None:
@@ -376,7 +381,10 @@ class UnifiedTokenVerifier(TokenVerifier):
             return self._reject(validation_method, "unknown", token, str(e))
 
     async def _verify_without_audience_check(
-        self, token: str, cache_key: str
+        self,
+        token: str,
+        cache_key: str,
+        outcome: dict[str, str] | None = None,
     ) -> AccessToken | None:
         """
         Verify token validity without checking MCP audience or issuer.
@@ -472,9 +480,8 @@ class UnifiedTokenVerifier(TokenVerifier):
                 cache_key,
                 via_userinfo=(validation_method == "userinfo"),
             )
-            # Recorded here rather than per validation stage: creation still
-            # returns None (without raising) for a payload with no
-            # `sub`/`preferred_username`, and a stage passing is not the same
+            # Creation still returns None (without raising) for a payload with
+            # no `sub`/`preferred_username`, and a stage passing is not the same
             # thing as the caller getting a token.
             if access_token is None:
                 return self._reject(
@@ -483,7 +490,14 @@ class UnifiedTokenVerifier(TokenVerifier):
                     token,
                     "no 'sub' or 'preferred_username' claim in token payload",
                 )
-            record_oauth_token_validation(validation_method, "valid")
+            # NOT recorded as `valid` here. This method's caller still has the
+            # ALLOWED_MGMT_CLIENT decision to make, and a token refused there is
+            # not a token that was served. Recording at this point counted a
+            # rejected request as both accepted and rejected. The caller reports
+            # which validator succeeded via `outcome` and records once, at the
+            # point the request is actually granted.
+            if outcome is not None:
+                outcome["method"] = validation_method
             return access_token
 
         except Exception as e:
@@ -639,6 +653,23 @@ class UnifiedTokenVerifier(TokenVerifier):
             f": {detail}" if detail else "",
         )
         return None
+
+    def _record_mgmt_grant(self, outcome: dict[str, str], from_cache: bool) -> None:
+        """Record a management-API request as accepted, once it actually is.
+
+        Authentication succeeding is not the same as the request being granted:
+        ALLOWED_MGMT_CLIENT can still refuse a perfectly valid token. Recording
+        `valid` when the token verified counted a refused request as both
+        served and rejected, which is the same "record at the point the
+        decision was actually made" invariant applied one method further out.
+
+        Cache hits are skipped so this keeps counting *validations*, matching
+        the existing behaviour where a cached token records no validation at
+        all (``mcp_oauth_token_cache_hits_total`` covers that side).
+        """
+        if from_cache:
+            return
+        record_oauth_token_validation(outcome.get("method", "unknown"), "valid")
 
     def _note(
         self,

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -285,6 +285,10 @@ class UnifiedTokenVerifier(TokenVerifier):
                 "not_allowlisted",
                 token,
                 f"client_id {token_client_id!r} not in ALLOWED_MGMT_CLIENT",
+                # Already verified — the token validated, it is only the
+                # authorization that failed. Re-deriving from the raw bytes
+                # would lose it entirely for opaque tokens.
+                client_id=token_client_id,
             )
 
         return access_token
@@ -578,6 +582,7 @@ class UnifiedTokenVerifier(TokenVerifier):
         reason: str,
         token: str,
         detail: str | None = None,
+        client_id: str | None = None,
     ) -> None:
         """Record and log a token rejection, then return None for the caller.
 
@@ -589,8 +594,17 @@ class UnifiedTokenVerifier(TokenVerifier):
 
         WARNING, not INFO: a rejection ends an MCP client's session and makes a
         human log in again. That is not routine.
+
+        Args:
+            client_id: Pass this when the caller already holds a *verified*
+                client id, i.e. the token validated and was then rejected on
+                authorization grounds. Only the validation paths need the
+                fallback below, and that fallback can only read a JWT — an
+                opaque token would otherwise be recorded as "unknown" despite
+                its identity being known, which is precisely the population
+                (Astrolabe's opaque management tokens) this metric exists for.
         """
-        client_id = self._claimed_client_id(token)
+        client_id = client_id or self._claimed_client_id(token)
         result = "error" if reason in self._OUR_FAULT_REASONS else "invalid"
         record_oauth_token_validation(method, result, reason, client_id)
         logger.warning(

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -434,8 +434,16 @@ class UnifiedTokenVerifier(TokenVerifier):
                         return None
 
                 if payload is None:
-                    # No validator was configured, or none succeeded. Don't record
-                    # a userinfo failure metric when userinfo was never attempted.
+                    if not self.introspection_uri and not self.userinfo_uri:
+                        # Nothing was even attempted: an opaque token arrived and
+                        # this server has no way to validate one. That is the
+                        # management-API twin of the quiet `jwks_client is None`
+                        # branch this PR started from, and it was quieter still —
+                        # not DEBUG, nothing at all.
+                        return self._reject("unknown", "not_configured", token)
+                    # A validator ran and failed; it already recorded the
+                    # rejection with its own reason. Recording again here would
+                    # double-count and attribute it to the wrong method.
                     return None
 
             # Both branches above either set a populated payload or have already

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -313,24 +313,20 @@ class UnifiedTokenVerifier(TokenVerifier):
             if self._is_jwt_format(token) and self.jwks_client:
                 validation_method = "jwt"
                 payload = await self._verify_jwt_signature(token)
-                if payload:
-                    record_oauth_token_validation("jwt", "valid")
-                else:
+                if not payload:
                     # _verify_jwt_signature() already recorded the rejection
                     # with its reason; recording again here would double-count.
                     # Fall back to introspection if JWT verification failed
                     if self.introspection_uri:
                         validation_method = "introspect"
                         payload = await self._introspect_token(token)
-                        if payload:
-                            record_oauth_token_validation("introspect", "valid")
-                        # else: _introspect_token() already recorded it.
+                        # A rejection here is already recorded by
+                        # _introspect_token(); success is recorded once, below,
+                        # after the audience check actually accepts the token.
             else:
                 # Fall back to introspection for opaque tokens
                 validation_method = "introspect"
                 payload = await self._introspect_token(token)
-                if payload:
-                    record_oauth_token_validation("introspect", "valid")
                 # else: _introspect_token() already recorded it.
                 if not payload:
                     return None
@@ -349,6 +345,14 @@ class UnifiedTokenVerifier(TokenVerifier):
                     f"got {audiences}, need {self.settings.oidc_client_id} "
                     f"or {self.settings.nextcloud_mcp_server_url}",
                 )
+
+            # Recorded here, not at each validation stage. A signature can
+            # verify and the token still be refused for the wrong audience —
+            # counting the stage as "valid" and then the refusal as
+            # "bad_audience" made one token produce two events, and inflated
+            # `result="valid"` relative to tokens actually accepted. One token,
+            # one event, recorded at the point of acceptance.
+            record_oauth_token_validation(validation_method, "valid")
 
             logger.info(
                 "MCP audience validated - token can be used directly "

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -598,11 +598,17 @@ class UnifiedTokenVerifier(TokenVerifier):
         Args:
             client_id: Pass this when the caller already holds a *verified*
                 client id, i.e. the token validated and was then rejected on
-                authorization grounds. Only the validation paths need the
-                fallback below, and that fallback can only read a JWT — an
-                opaque token would otherwise be recorded as "unknown" despite
-                its identity being known, which is precisely the population
-                (Astrolabe's opaque management tokens) this metric exists for.
+                authorization grounds. The fallback below can only read a JWT,
+                so an opaque token would otherwise be recorded as "unknown"
+                despite its identity being known — and clients may present
+                either token type, so that is not a rare shape.
+
+                An *empty* value falls back too, deliberately. A verified
+                payload can carry `azp`/`aud` without a top-level `client_id`
+                (`_create_access_token_with_cache_key` reads only the latter,
+                defaulting to ""), and for a JWT the fallback re-reads those
+                same already-verified bytes. Preferring "" over a recoverable
+                identity would lose information for no gain.
         """
         client_id = client_id or self._claimed_client_id(token)
         result = "error" if reason in self._OUR_FAULT_REASONS else "invalid"
@@ -680,6 +686,14 @@ class UnifiedTokenVerifier(TokenVerifier):
         except jwt.InvalidTokenError as e:
             # Covers signature failures, malformed tokens and bad `iat`.
             return self._reject("jwt", "bad_signature", token, str(e))
+        except jwt.PyJWKClientError as e:
+            # Fetching the signing key failed — the JWKS endpoint is down, slow
+            # or unreachable. Nothing is wrong with the caller's token. This is
+            # NOT an InvalidTokenError subclass, so without an explicit clause
+            # it lands in the generic handler as "unknown", and a JWKS outage
+            # reads differently from the introspection and userinfo outages it
+            # is the exact peer of.
+            return self._reject("jwt", "network_error", token, str(e))
         except Exception as e:
             return self._reject("jwt", "unknown", token, str(e))
 

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -317,32 +317,27 @@ class UnifiedTokenVerifier(TokenVerifier):
             AccessToken if valid with MCP audience, None otherwise
         """
         validation_method = "unknown"
+        # Stage failures accumulate here; the chain is recorded once, at the
+        # end, so asking two validators about one token still produces one
+        # rejection. See _note() / _reject_chain().
+        chain: list[tuple[str, str, str | None]] = []
         try:
             # Attempt JWT verification first
             if self._is_jwt_format(token) and self.jwks_client:
                 validation_method = "jwt"
-                payload = await self._verify_jwt_signature(token)
-                if not payload:
-                    # _verify_jwt_signature() already recorded the rejection
-                    # with its reason; recording again here would double-count.
+                payload = await self._verify_jwt_signature(token, chain=chain)
+                if not payload and self.introspection_uri:
                     # Fall back to introspection if JWT verification failed
-                    if self.introspection_uri:
-                        validation_method = "introspect"
-                        payload = await self._introspect_token(token)
-                        # A rejection here is already recorded by
-                        # _introspect_token(); success is recorded once, below,
-                        # after the audience check actually accepts the token.
+                    validation_method = "introspect"
+                    payload = await self._introspect_token(token, chain=chain)
             else:
                 # Fall back to introspection for opaque tokens
                 validation_method = "introspect"
-                payload = await self._introspect_token(token)
-                # else: _introspect_token() already recorded it.
-                if not payload:
-                    return None
+                payload = await self._introspect_token(token, chain=chain)
 
             # Check payload is valid
             if not payload:
-                return None
+                return self._reject_chain(chain, token)
 
             # Validate MCP audience is present
             if not self._has_mcp_audience(payload):
@@ -412,20 +407,18 @@ class UnifiedTokenVerifier(TokenVerifier):
             AccessToken if valid, None otherwise
         """
         validation_method = "unknown"
+        # See _verify_mcp_audience: one rejection per token, recorded terminally.
+        chain: list[tuple[str, str, str | None]] = []
         try:
             # Attempt JWT verification first
             # Skip issuer check for management API tokens (may have internal URL)
             if self._is_jwt_format(token) and self.jwks_client:
                 validation_method = "jwt"
                 payload = await self._verify_jwt_signature(
-                    token, skip_issuer_check=True
+                    token, skip_issuer_check=True, chain=chain
                 )
                 if not payload:
-                    # _verify_jwt_signature() already recorded the rejection
-                    # with its reason; recording again would double-count.
-                    # Success is recorded once, below, when the AccessToken
-                    # actually exists.
-                    return None
+                    return self._reject_chain(chain, token)
             else:
                 # Opaque token: try introspection first (only when configured),
                 # then fall back to userinfo. userinfo validates opaque tokens
@@ -434,9 +427,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                 payload = None
                 if self.introspection_uri:
                     validation_method = "introspect"
-                    payload = await self._introspect_token(token)
-                    # A rejection here is already recorded by
-                    # _introspect_token(); success is recorded once, below.
+                    payload = await self._introspect_token(token, chain=chain)
 
                 # Fall through to userinfo when introspection is unconfigured or
                 # returned None. NOTE: _introspect_token returns None for BOTH an
@@ -449,10 +440,9 @@ class UnifiedTokenVerifier(TokenVerifier):
                     # Set validation_method first so a userinfo exception caught
                     # by the outer handler is attributed correctly.
                     validation_method = "userinfo"
-                    payload = await self._validate_via_userinfo(token)
+                    payload = await self._validate_via_userinfo(token, chain=chain)
                     if not payload:
-                        # _validate_via_userinfo() already recorded it.
-                        return None
+                        return self._reject_chain(chain, token)
 
                 if payload is None:
                     if not self.introspection_uri and not self.userinfo_uri:
@@ -462,10 +452,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                         # branch this PR started from, and it was quieter still —
                         # not DEBUG, nothing at all.
                         return self._reject("unknown", "not_configured", token)
-                    # A validator ran and failed; it already recorded the
-                    # rejection with its own reason. Recording again here would
-                    # double-count and attribute it to the wrong method.
-                    return None
+                    return self._reject_chain(chain, token)
 
             # Both branches above either set a populated payload or have already
             # returned None, so payload is guaranteed truthy here.
@@ -653,8 +640,58 @@ class UnifiedTokenVerifier(TokenVerifier):
         )
         return None
 
+    def _note(
+        self,
+        chain: list[tuple[str, str, str | None]] | None,
+        method: str,
+        reason: str,
+        token: str,
+        detail: str | None = None,
+    ) -> None:
+        """Record a rejection, or defer it when a fallback may still succeed.
+
+        A verifier that falls back — JWT then introspection, introspection then
+        userinfo — asks two validators about one token. Each failing stage used
+        to record and log independently, so a single expired token produced two
+        metric increments and two WARNINGs. That is the *same* "two breadcrumbs
+        to correlate" problem this work set out to remove, rebuilt one layer up
+        and made louder by promoting the lines to WARNING.
+
+        When ``chain`` is provided the stage failure is appended to it and the
+        caller records once, terminally, via :meth:`_reject_chain`. When it is
+        None — a direct call, including from tests — the rejection is recorded
+        immediately, since there is no chain to be the tail of.
+        """
+        if chain is None:
+            return self._reject(method, reason, token, detail)
+        chain.append((method, reason, detail))
+        return None
+
+    def _reject_chain(
+        self, chain: list[tuple[str, str, str | None]], token: str
+    ) -> None:
+        """Record a fallback chain's outcome as the single rejection it is.
+
+        Attributed to the **last** validator tried, because that is the one
+        whose refusal actually produced the 401. Earlier stages are folded into
+        the detail so the whole story stays on one line — losing "the JWT was
+        expired *and then* introspection said inactive" would trade one problem
+        for another.
+        """
+        if not chain:
+            return None
+        method, reason, detail = chain[-1]
+        if len(chain) > 1:
+            preceding = " → ".join(f"{m}/{r}" for m, r, _ in chain[:-1])
+            detail = f"after {preceding}" + (f": {detail}" if detail else "")
+        return self._reject(method, reason, token, detail)
+        return None
+
     async def _verify_jwt_signature(
-        self, token: str, skip_issuer_check: bool = False
+        self,
+        token: str,
+        skip_issuer_check: bool = False,
+        chain: list[tuple[str, str, str | None]] | None = None,
     ) -> dict[str, Any] | None:
         """
         Verify JWT token with signature validation using JWKS.
@@ -674,7 +711,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             # Was DEBUG, i.e. invisible at the production log level: a missing
             # JWKS client rejects every JWT, so the one condition that breaks
             # all clients at once was the quietest thing in here.
-            return self._reject("jwt", "not_configured", token)
+            return self._note(chain, "jwt", "not_configured", token)
 
         try:
             # Get signing key from JWKS
@@ -710,12 +747,12 @@ class UnifiedTokenVerifier(TokenVerifier):
             return payload
 
         except jwt.ExpiredSignatureError:
-            return self._reject("jwt", "expired", token)
+            return self._note(chain, "jwt", "expired", token)
         except jwt.InvalidIssuerError as e:
-            return self._reject("jwt", "bad_issuer", token, str(e))
+            return self._note(chain, "jwt", "bad_issuer", token, str(e))
         except jwt.InvalidTokenError as e:
             # Covers signature failures, malformed tokens and bad `iat`.
-            return self._reject("jwt", "bad_signature", token, str(e))
+            return self._note(chain, "jwt", "bad_signature", token, str(e))
         except jwt.PyJWKClientError as e:
             # Fetching the signing key failed — the JWKS endpoint is down, slow
             # or unreachable. Nothing is wrong with the caller's token. This is
@@ -723,11 +760,13 @@ class UnifiedTokenVerifier(TokenVerifier):
             # it lands in the generic handler as "unknown", and a JWKS outage
             # reads differently from the introspection and userinfo outages it
             # is the exact peer of.
-            return self._reject("jwt", "network_error", token, str(e))
+            return self._note(chain, "jwt", "network_error", token, str(e))
         except Exception as e:
-            return self._reject("jwt", "unknown", token, str(e))
+            return self._note(chain, "jwt", "unknown", token, str(e))
 
-    async def _introspect_token(self, token: str) -> dict[str, Any] | None:
+    async def _introspect_token(
+        self, token: str, chain: list[tuple[str, str, str | None]] | None = None
+    ) -> dict[str, Any] | None:
         """
         Validate token by calling the introspection endpoint (RFC 7662).
 
@@ -738,7 +777,7 @@ class UnifiedTokenVerifier(TokenVerifier):
             Token payload if active, None if inactive or invalid
         """
         if not self.introspection_uri:
-            return self._reject("introspect", "not_configured", token)
+            return self._note(chain, "introspect", "not_configured", token)
 
         # Introspection requires client authentication. Checked before the try
         # rather than asserted inside it: the except below would have caught
@@ -747,7 +786,8 @@ class UnifiedTokenVerifier(TokenVerifier):
         client_id = self.settings.oidc_client_id
         client_secret = self.settings.oidc_client_secret
         if client_id is None or client_secret is None:
-            return self._reject(
+            return self._note(
+                chain,
                 "introspect",
                 "not_configured",
                 token,
@@ -766,7 +806,7 @@ class UnifiedTokenVerifier(TokenVerifier):
 
                 # Check if token is active
                 if not introspection_data.get("active", False):
-                    return self._reject("introspect", "inactive", token)
+                    return self._note(chain, "introspect", "inactive", token)
 
                 logger.debug(
                     "Token introspected successfully for user: %s",
@@ -778,7 +818,8 @@ class UnifiedTokenVerifier(TokenVerifier):
                 # 400/401/403 mean the *server's* introspection credentials are
                 # wrong, not the caller's token; anything else is unexpected.
                 # Both are our problem, not the client's.
-                return self._reject(
+                return self._note(
+                    chain,
                     "introspect",
                     "not_configured"
                     if response.status_code in (400, 401, 403)
@@ -789,13 +830,15 @@ class UnifiedTokenVerifier(TokenVerifier):
                 )
 
         except httpx.TimeoutException:
-            return self._reject("introspect", "network_error", token, "timeout")
+            return self._note(chain, "introspect", "network_error", token, "timeout")
         except httpx.RequestError as e:
-            return self._reject("introspect", "network_error", token, str(e))
+            return self._note(chain, "introspect", "network_error", token, str(e))
         except Exception as e:
-            return self._reject("introspect", "unknown", token, str(e))
+            return self._note(chain, "introspect", "unknown", token, str(e))
 
-    async def _validate_via_userinfo(self, token: str) -> dict[str, Any] | None:
+    async def _validate_via_userinfo(
+        self, token: str, chain: list[tuple[str, str, str | None]] | None = None
+    ) -> dict[str, Any] | None:
         """Validate an opaque token by calling the OIDC userinfo endpoint.
 
         Fallback for opaque access tokens that the Nextcloud ``oidc`` app's
@@ -831,13 +874,14 @@ class UnifiedTokenVerifier(TokenVerifier):
         # self.userinfo_uri before invoking this, but the guard keeps the method
         # safe to call directly (e.g. in unit tests).
         if not self.userinfo_uri:
-            return self._reject("userinfo", "not_configured", token)
+            return self._note(chain, "userinfo", "not_configured", token)
 
         # userinfo_uri comes from the OIDC discovery document (admin-configured),
         # not from user input — but guard the scheme anyway to satisfy SSRF
         # scanners and to fail fast on a misconfigured endpoint.
         if not self.userinfo_uri.startswith(("https://", "http://")):
-            return self._reject(
+            return self._note(
+                chain,
                 "userinfo",
                 "not_configured",
                 token,
@@ -850,14 +894,15 @@ class UnifiedTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except httpx.TimeoutException:
-            return self._reject("userinfo", "network_error", token, "timeout")
+            return self._note(chain, "userinfo", "network_error", token, "timeout")
         except httpx.RequestError as e:
-            return self._reject("userinfo", "network_error", token, str(e))
+            return self._note(chain, "userinfo", "network_error", token, str(e))
 
         if response.status_code != 200:
             # userinfo answers 401 for an expired or revoked opaque token; that
             # is the caller's token being bad, not our configuration.
-            return self._reject(
+            return self._note(
+                chain,
                 "userinfo",
                 "inactive" if response.status_code == 401 else "unknown",
                 token,
@@ -867,13 +912,13 @@ class UnifiedTokenVerifier(TokenVerifier):
         try:
             data = response.json()
         except Exception as e:
-            return self._reject(
-                "userinfo", "unknown", token, f"unparseable response: {e}"
+            return self._note(
+                chain, "userinfo", "unknown", token, f"unparseable response: {e}"
             )
 
         if not data.get("sub"):
-            return self._reject(
-                "userinfo", "unknown", token, "response missing 'sub' claim"
+            return self._note(
+                chain, "userinfo", "unknown", token, "response missing 'sub' claim"
             )
 
         logger.debug("Token validated via userinfo for user: %s", data.get("sub"))

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -168,8 +168,15 @@ nextcloud_api_retries_total = Counter(
 
 oauth_token_validations_total = Counter(
     "mcp_oauth_token_validations_total",
-    "Total OAuth token validation attempts",
-    ["method", "result"],  # method: introspect | jwt; result: valid | invalid | error
+    "OAuth token validation attempts. `reason` is why a non-valid result "
+    "happened — without it a rejection is uninterpretable, and a rejection is "
+    "what forces an MCP client's user to log in again. `client_id` attributes "
+    "it, so 'which client is being disconnected, and why' is one query.",
+    # method: jwt | introspect | userinfo | unknown
+    # result: valid | invalid | error
+    # reason: none (valid) | expired | inactive | bad_signature | bad_issuer
+    #         | bad_audience | not_configured | network_error | unknown
+    ["method", "result", "reason", "client_id"],
 )
 
 oauth_token_cache_hits_total = Counter(
@@ -973,6 +980,10 @@ _SESSION_RECORDED_ATTR = "_astrolabe_fleet_recorded"
 _MAX_TRACKED_CLIENTS = 50
 _OVERFLOW_LABEL = "_other"
 _seen_client_names: set[str] = set()
+# Separate registry for OAuth client_ids: they come off *unverified* tokens on
+# the rejection path, so they are at least as untrusted as clientInfo.name and
+# must not share its budget.
+_seen_client_ids: set[str] = set()
 
 
 def _client_label(value: object, limit: int = 64) -> str:
@@ -1005,22 +1016,31 @@ def _first_present(*candidates: tuple[object, str]) -> object | None:
     return None
 
 
-def _bounded_client_name(name: str) -> str:
-    """Bound the *number* of distinct client identities, not just their length.
+def _bounded_label(value: str, seen: set[str]) -> str:
+    """Bound the *number* of distinct values a peer can put in one label.
 
-    Returns ``name`` while under the cap, ``_OVERFLOW_LABEL`` after. Together
-    with :func:`_client_label` this closes the cardinality vector: a peer can
-    neither send one enormous name nor mint unboundedly many small ones.
+    Returns ``value`` while under the cap, ``_OVERFLOW_LABEL`` after. Paired
+    with :func:`_client_label` this closes the cardinality vector from both
+    ends: a peer can neither send one enormous value nor mint unboundedly many
+    small ones.
+
+    ``seen`` is per-dimension so one untrusted label cannot exhaust another's
+    budget.
     """
-    if name in _seen_client_names:
-        return name
-    if len(_seen_client_names) >= _MAX_TRACKED_CLIENTS:
+    if value in seen:
+        return value
+    if len(seen) >= _MAX_TRACKED_CLIENTS:
         return _OVERFLOW_LABEL
     # ponytail: unsynchronised. Concurrent first-sightings can race past the
     # cap by the number of in-flight requests — irrelevant against a limit of
-    # 50, and a lock on every session would cost more than the slack.
-    _seen_client_names.add(name)
-    return name
+    # 50, and a lock on every request would cost more than the slack.
+    seen.add(value)
+    return value
+
+
+def _bounded_client_name(name: str) -> str:
+    """Bound the number of distinct MCP client identities (``clientInfo.name``)."""
+    return _bounded_label(name, _seen_client_names)
 
 
 def _minor_version(version: object) -> str:
@@ -1216,15 +1236,31 @@ def record_nextcloud_api_retry(app: str, reason: str) -> None:
     nextcloud_api_retries_total.labels(app=app, reason=reason).inc()
 
 
-def record_oauth_token_validation(method: str, result: str) -> None:
+def record_oauth_token_validation(
+    method: str,
+    result: str,
+    reason: str = "none",
+    client_id: str | None = None,
+) -> None:
     """
     Record an OAuth token validation.
 
     Args:
-        method: Validation method ("introspect" or "jwt")
-        result: Validation result ("valid", "invalid", or "error")
+        method: Validation method — "jwt", "introspect", "userinfo" or "unknown".
+        result: "valid", "invalid", or "error".
+        reason: Why a non-valid result happened — "expired", "inactive",
+            "bad_signature", "bad_issuer", "bad_audience", "not_configured",
+            "network_error", "unknown". "none" for a valid result.
+        client_id: OAuth client the token claims to belong to, if recoverable.
+            Read from an *unverified* token on the rejection path, so it is
+            untrusted input and is both length-clamped and count-bounded.
     """
-    oauth_token_validations_total.labels(method=method, result=result).inc()
+    oauth_token_validations_total.labels(
+        method=method,
+        result=result,
+        reason=reason,
+        client_id=_bounded_label(_client_label(client_id), _seen_client_ids),
+    ).inc()
 
 
 def record_db_operation(

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -172,8 +172,11 @@ oauth_token_validations_total = Counter(
     "happened — without it a rejection is uninterpretable, and a rejection is "
     "what forces an MCP client's user to log in again. `client_id` attributes "
     "it, so 'which client is being disconnected, and why' is one query.",
-    # Keep these in sync with docs/observability.md and with
-    # UnifiedTokenVerifier._OUR_FAULT_REASONS when adding a rejection path.
+    # CANONICAL vocabulary — this is the one place the values are enumerated in
+    # code. When adding a rejection path, update this list, then
+    # UnifiedTokenVerifier._OUR_FAULT_REASONS (which decides `result`) and
+    # docs/observability.md (which carries the alert queries). Do not re-list
+    # them in docstrings: a third copy drifted out of sync inside a single PR.
     # method: jwt | introspect | userinfo | allowlist | unknown
     # result: valid | invalid (caller's token) | error (ours) — derived from
     #         reason in _reject(), never set independently
@@ -1249,15 +1252,23 @@ def record_oauth_token_validation(
     """
     Record an OAuth token validation.
 
+    The permitted values for ``method``, ``result`` and ``reason`` are
+    enumerated once, on the ``oauth_token_validations_total`` definition above.
+    This docstring deliberately does not repeat them: it used to, drifted out of
+    sync within a single PR, and made a third copy of a list that already exists
+    in two places. Describing what each argument *means* is this docstring's
+    job; the vocabulary has one home.
+
     Args:
-        method: Validation method — "jwt", "introspect", "userinfo" or "unknown".
-        result: "valid", "invalid", or "error".
-        reason: Why a non-valid result happened — "expired", "inactive",
-            "bad_signature", "bad_issuer", "bad_audience", "not_configured",
-            "network_error", "unknown". "none" for a valid result.
-        client_id: OAuth client the token claims to belong to, if recoverable.
-            Read from an *unverified* token on the rejection path, so it is
-            untrusted input and is both length-clamped and count-bounded.
+        method: Which validator produced this outcome.
+        result: Whose problem it is — valid, the caller's token, or ours.
+            Derived from ``reason`` by ``UnifiedTokenVerifier._reject``; never
+            pass it independently of the reason.
+        reason: Why a non-valid result happened. "none" for a valid result.
+        client_id: OAuth client the token belongs to. Verified on the
+            authorization paths, but read from an *unverified* token on the
+            validation ones — so treated as untrusted regardless, and both
+            length-clamped and count-bounded.
     """
     oauth_token_validations_total.labels(
         method=method,

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -172,10 +172,14 @@ oauth_token_validations_total = Counter(
     "happened — without it a rejection is uninterpretable, and a rejection is "
     "what forces an MCP client's user to log in again. `client_id` attributes "
     "it, so 'which client is being disconnected, and why' is one query.",
-    # method: jwt | introspect | userinfo | unknown
-    # result: valid | invalid | error
+    # Keep these in sync with docs/observability.md and with
+    # UnifiedTokenVerifier._OUR_FAULT_REASONS when adding a rejection path.
+    # method: jwt | introspect | userinfo | allowlist | unknown
+    # result: valid | invalid (caller's token) | error (ours) — derived from
+    #         reason in _reject(), never set independently
     # reason: none (valid) | expired | inactive | bad_signature | bad_issuer
-    #         | bad_audience | not_configured | network_error | unknown
+    #         | bad_audience | not_allowlisted | not_configured
+    #         | network_error | unknown
     ["method", "result", "reason", "client_id"],
 )
 

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -29,6 +29,7 @@ from nextcloud_mcp_server.observability.metrics import (
     _MAX_TRACKED_CLIENTS,
     instrument_call_tool_outcomes,
     record_client_session,
+    record_oauth_token_validation,
 )
 
 pytestmark = pytest.mark.unit
@@ -51,12 +52,15 @@ def _isolate_seen_client_names():
     here, so relying on file-definition order would be a latent flake rather
     than a guarantee.
     """
-    saved = set(metrics_module._seen_client_names)
+    saved_names = set(metrics_module._seen_client_names)
+    saved_ids = set(metrics_module._seen_client_ids)
     try:
         yield
     finally:
         metrics_module._seen_client_names.clear()
-        metrics_module._seen_client_names.update(saved)
+        metrics_module._seen_client_names.update(saved_names)
+        metrics_module._seen_client_ids.clear()
+        metrics_module._seen_client_ids.update(saved_ids)
 
 
 def _client_params(
@@ -382,3 +386,31 @@ class TestLabelCardinality:
                 request_ctx.reset(token)
 
         assert metric_sample(SESSIONS, overflow_labels) - before >= 20
+
+    def test_client_id_budget_is_separate_from_client_name(self, metric_sample):
+        """The two untrusted labels must not share a cap.
+
+        `clientInfo.name` (MCP handshake) and `client_id` (unverified rejected
+        token) are both peer-supplied. A shared budget would let a peer exhaust
+        one dimension by flooding the other — and the flood would come from the
+        *rejection* path, which is exactly where identifying the client matters
+        most.
+        """
+        overflow = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "expired",
+            "client_id": "_other",
+        }
+        before = metric_sample("mcp_oauth_token_validations_total", overflow)
+
+        for i in range(_MAX_TRACKED_CLIENTS + 10):
+            record_oauth_token_validation(
+                "jwt", "invalid", "expired", f"rotating-client-{i}"
+            )
+
+        assert (
+            metric_sample("mcp_oauth_token_validations_total", overflow) - before >= 10
+        )
+        # The client_name budget is untouched by that flood.
+        assert len(metrics_module._seen_client_names) < _MAX_TRACKED_CLIENTS

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1184,14 +1184,31 @@ class TestRejectionObservability:
             before_other
         )
 
+    @pytest.mark.parametrize(
+        ("token_kind", "make_token"),
+        [
+            ("jwt", lambda self: self._jwt_for("not-on-the-list")),
+            # The realistic case for this path: Astrolabe's management tokens
+            # are opaque, so nothing can be recovered from the raw bytes. The
+            # JWT-shaped case masked the bug — _claimed_client_id happened to
+            # succeed and the metric looked correct.
+            ("opaque", lambda self: "opaque-token-no-dots"),
+        ],
+    )
     async def test_management_allowlist_rejection_is_recorded(
-        self, base_settings, metric_sample
+        self, base_settings, metric_sample, token_kind, make_token
     ):
         """An allowlist rejection disconnects a client like any other.
 
         It is authorization rather than validation, but from the operator's
         side it is indistinguishable — a client that suddenly stops working —
         and the client_id is right there, so it goes through the same funnel.
+
+        Parametrized over token *shape* because the two differ in where the
+        identity can be read from. By this point the caller holds a verified
+        `access_token.client_id`; re-deriving it from the raw bytes only works
+        for a JWT, so an opaque token would record `client_id="unknown"` —
+        and opaque is exactly what Astrolabe's management tokens are.
         """
         labels = {
             "method": "allowlist",
@@ -1203,7 +1220,7 @@ class TestRejectionObservability:
 
         verifier = UnifiedTokenVerifier(base_settings)
         verifier._allowed_mgmt_clients = frozenset({"astrolabe"})
-        token = self._jwt_for("not-on-the-list")
+        token = make_token(self)
         with patch.object(
             verifier,
             "_verify_without_audience_check",

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -5,6 +5,7 @@ Tests multi-audience token validation without requiring real network calls or
 IdP connections.
 """
 
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -962,3 +963,175 @@ class TestUserinfoFallback:
         ):
             result = await verifier._validate_via_userinfo("opaque-token")
         assert result is None
+
+
+class TestRejectionObservability:
+    """Every token rejection must say *why*, and for *which client*.
+
+    A rejection is not a routine event: it ends the MCP session and forces the
+    user to authenticate again. Before this, the reason was known deep inside
+    the verifier and then discarded — the metric recorded a bare "invalid" and
+    several reasons were logged at DEBUG, i.e. invisible in production. The
+    question "why was this client disconnected?" was unanswerable from
+    telemetry alone.
+    """
+
+    VALIDATIONS = "mcp_oauth_token_validations_total"
+
+    @staticmethod
+    def _jwt_for(client_id: str | None = "mistral-client", **claims) -> str:
+        payload = {"sub": "alice", **claims}
+        if client_id is not None:
+            payload["client_id"] = client_id
+        return jwt.encode(payload, "secret", algorithm="HS256")
+
+    @staticmethod
+    def _failing_verify(exc):
+        """Fail only the *verifying* decode, leaving the unverified one working.
+
+        `_verify_jwt_signature` and `_claimed_client_id` both call `jwt.decode`;
+        a blanket patch would break the client_id read too and hide the label
+        under "unknown". In production they genuinely differ — PyJWT skips every
+        check when `verify_signature=False`, so an expired token still yields
+        its claims. The mock has to preserve that difference or the test proves
+        nothing about the real path.
+        """
+        real_decode = jwt.decode
+
+        def _decode(token, *args, **kwargs):
+            if (kwargs.get("options") or {}).get("verify_signature") is False:
+                return real_decode(token, *args, **kwargs)
+            raise exc
+
+        return _decode
+
+    async def test_expired_jwt_records_reason_and_client(
+        self, base_settings, metric_sample
+    ):
+        """The signature the Mistral disconnects actually produce."""
+        labels = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "expired",
+            "client_id": "mistral-client",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        with patch(
+            "nextcloud_mcp_server.auth.unified_verifier.jwt.decode",
+            side_effect=self._failing_verify(jwt.ExpiredSignatureError("expired")),
+        ):
+            assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    @pytest.mark.parametrize(
+        ("exc", "reason"),
+        [
+            (jwt.InvalidIssuerError("bad iss"), "bad_issuer"),
+            (jwt.InvalidSignatureError("bad sig"), "bad_signature"),
+        ],
+    )
+    async def test_jwt_failure_modes_are_distinguishable(
+        self, base_settings, metric_sample, exc, reason
+    ):
+        """Expiry, a wrong issuer and a bad signature need different responses."""
+        labels = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": reason,
+            "client_id": "mistral-client",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        with patch(
+            "nextcloud_mcp_server.auth.unified_verifier.jwt.decode",
+            side_effect=self._failing_verify(exc),
+        ):
+            assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    async def test_inactive_introspection_records_reason(
+        self, base_settings, metric_sample
+    ):
+        """`active=false` is the opaque-token equivalent of an expired JWT."""
+        labels = {
+            "method": "introspect",
+            "result": "invalid",
+            "reason": "inactive",
+            "client_id": "unknown",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"active": False}
+        verifier.http_client.post = AsyncMock(return_value=response)
+
+        assert await verifier._introspect_token("opaque-token") is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    async def test_missing_jwks_is_visible_not_debug(
+        self, base_settings, metric_sample, caplog
+    ):
+        """A missing JWKS client rejects *every* JWT — it must not be quiet.
+
+        This was logged at DEBUG, so the single misconfiguration that breaks
+        all clients at once produced nothing at the production log level.
+        """
+        labels = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "not_configured",
+            "client_id": "mistral-client",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = None
+        with caplog.at_level(
+            logging.WARNING, logger="nextcloud_mcp_server.auth.unified_verifier"
+        ):
+            assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+        assert any("not_configured" in r.message for r in caplog.records)
+
+    async def test_rejection_logs_client_at_warning(self, base_settings, caplog):
+        """One WARNING carrying client + reason, not breadcrumbs to trace-join."""
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        with (
+            patch(
+                "nextcloud_mcp_server.auth.unified_verifier.jwt.decode",
+                side_effect=self._failing_verify(jwt.ExpiredSignatureError("expired")),
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="nextcloud_mcp_server.auth.unified_verifier"
+            ),
+        ):
+            await verifier._verify_jwt_signature(self._jwt_for("acme-connector"))
+
+        assert any(
+            "acme-connector" in r.message and "expired" in r.message
+            for r in caplog.records
+        )
+
+    def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
+        """An opaque token carries no readable client_id — don't invent one."""
+        verifier = UnifiedTokenVerifier(base_settings)
+        assert verifier._claimed_client_id("not-a-jwt") is None
+
+    def test_client_id_falls_back_through_claims(self, base_settings):
+        """Not every issuer uses `client_id`; azp and aud are the usual others."""
+        verifier = UnifiedTokenVerifier(base_settings)
+        azp = jwt.encode({"sub": "a", "azp": "via-azp"}, "s", algorithm="HS256")
+        aud = jwt.encode({"sub": "a", "aud": ["via-aud"]}, "s", algorithm="HS256")
+        assert verifier._claimed_client_id(azp) == "via-azp"
+        assert verifier._claimed_client_id(aud) == "via-aud"

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import jwt
 import pytest
+from mcp.server.auth.provider import AccessToken
 
 from nextcloud_mcp_server.auth.unified_verifier import UnifiedTokenVerifier
 from nextcloud_mcp_server.config import Settings
@@ -1087,7 +1088,10 @@ class TestRejectionObservability:
         """
         labels = {
             "method": "jwt",
-            "result": "invalid",
+            # "error", not "invalid": nothing is wrong with the caller's token,
+            # we simply cannot validate it. That distinction is what makes the
+            # result="error" alert pageable.
+            "result": "error",
             "reason": "not_configured",
             "client_id": "mistral-client",
         }
@@ -1135,3 +1139,93 @@ class TestRejectionObservability:
         aud = jwt.encode({"sub": "a", "aud": ["via-aud"]}, "s", algorithm="HS256")
         assert verifier._claimed_client_id(azp) == "via-azp"
         assert verifier._claimed_client_id(aud) == "via-aud"
+
+    @pytest.mark.parametrize(
+        ("reason", "expected_result"),
+        [
+            ("expired", "invalid"),
+            ("inactive", "invalid"),
+            ("bad_signature", "invalid"),
+            ("bad_issuer", "invalid"),
+            ("bad_audience", "invalid"),
+            ("not_allowlisted", "invalid"),
+            ("not_configured", "error"),
+            ("network_error", "error"),
+            ("unknown", "error"),
+        ],
+    )
+    def test_result_is_derived_from_reason(
+        self, base_settings, metric_sample, reason, expected_result
+    ):
+        """`result` splits blame, and must not be settable independently.
+
+        It used to be a `_reject()` parameter defaulting to "invalid", and 4 of
+        the 6 `not_configured` call sites silently took the default — putting
+        "no validator configured at all", the one failure that rejects every
+        client's every token, on the *caller's* side of the split. Deriving it
+        from `reason` makes that class of drift impossible rather than merely
+        fixed once.
+        """
+        labels = {
+            "method": "jwt",
+            "result": expected_result,
+            "reason": reason,
+            "client_id": "mistral-client",
+        }
+        other = "invalid" if expected_result == "error" else "error"
+        before = metric_sample(self.VALIDATIONS, labels)
+        before_other = metric_sample(self.VALIDATIONS, {**labels, "result": other})
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._reject("jwt", reason, self._jwt_for())
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+        assert metric_sample(self.VALIDATIONS, {**labels, "result": other}) == (
+            before_other
+        )
+
+    async def test_management_allowlist_rejection_is_recorded(
+        self, base_settings, metric_sample
+    ):
+        """An allowlist rejection disconnects a client like any other.
+
+        It is authorization rather than validation, but from the operator's
+        side it is indistinguishable — a client that suddenly stops working —
+        and the client_id is right there, so it goes through the same funnel.
+        """
+        labels = {
+            "method": "allowlist",
+            "result": "invalid",
+            "reason": "not_allowlisted",
+            "client_id": "not-on-the-list",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._allowed_mgmt_clients = frozenset({"astrolabe"})
+        token = self._jwt_for("not-on-the-list")
+        with patch.object(
+            verifier,
+            "_verify_without_audience_check",
+            AsyncMock(
+                return_value=AccessToken(
+                    token=token,
+                    client_id="not-on-the-list",
+                    scopes=[],
+                    expires_at=int(time.time()) + 600,
+                )
+            ),
+        ):
+            assert await verifier.verify_token_for_management_api(token) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    def test_bad_audience_logs_once(self, base_settings, caplog):
+        """One line per rejection — this path used to log ERROR *and* WARNING."""
+        verifier = UnifiedTokenVerifier(base_settings)
+        with caplog.at_level(
+            logging.DEBUG, logger="nextcloud_mcp_server.auth.unified_verifier"
+        ):
+            verifier._reject("jwt", "bad_audience", self._jwt_for(), "got []")
+
+        assert len([r for r in caplog.records if "bad_audience" in r.message]) == 1

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1245,6 +1245,62 @@ class TestRejectionObservability:
 
         assert metric_sample(self.VALIDATIONS, accepted) - before == 1
 
+    @pytest.mark.parametrize(
+        ("surface", "method_name", "kwargs"),
+        [
+            ("mcp", "_verify_mcp_audience", {}),
+            (
+                "management",
+                "_verify_without_audience_check",
+                {"cache_key": "mgmt:nosub"},
+            ),
+        ],
+    )
+    async def test_no_phantom_valid_when_token_creation_fails(
+        self, base_settings, metric_sample, surface, method_name, kwargs
+    ):
+        """A token that yields no AccessToken is a rejection, not an acceptance.
+
+        `_create_access_token*` returns None — without raising — for a payload
+        carrying no `sub`/`preferred_username`. Recording "valid" before that
+        point meant a signature- and audience-valid token could be counted as
+        accepted while the caller got None, the session ended and the user was
+        sent back through login: the exact silent-rejection shape this work
+        exists to remove, surviving in the one place round 6's fix didn't reach.
+
+        Checked on both surfaces because they had drifted apart — the
+        management path was still recording per-stage.
+        """
+        accepted = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        rejected = {
+            "method": "jwt",
+            "result": "error",
+            "reason": "unknown",
+            "client_id": "mistral-client",
+        }
+        before_accepted = metric_sample(self.VALIDATIONS, accepted)
+        before_rejected = metric_sample(self.VALIDATIONS, rejected)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        # Signature and audience are fine; the payload simply names no user.
+        with patch.object(
+            verifier,
+            "_verify_jwt_signature",
+            AsyncMock(return_value={"aud": ["test-client-id"]}),
+        ):
+            assert (
+                await getattr(verifier, method_name)(self._jwt_for(), **kwargs) is None
+            )
+
+        assert metric_sample(self.VALIDATIONS, accepted) == before_accepted
+        assert metric_sample(self.VALIDATIONS, rejected) - before_rejected == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1473,6 +1473,90 @@ class TestRejectionObservability:
         assert metric_sample(self.VALIDATIONS, rejected) == before_rejected
         assert metric_sample(self.VALIDATIONS, accepted) - before_accepted == 1
 
+    async def test_allowlist_rejection_records_no_valid_end_to_end(
+        self, base_settings, metric_sample
+    ):
+        """A request refused by the allowlist is not also counted as served.
+
+        Deliberately drives the REAL `_verify_without_audience_check` rather
+        than mocking it. Every other allowlist test patches that method out,
+        so its `valid` record never ran and the double-count was invisible —
+        the tests asserted on the rejection they set up and never saw the
+        acceptance they also caused.
+
+        Authentication succeeding is not the request being granted: the
+        allowlist still has a say, and until it has spoken nothing has been
+        served.
+        """
+        accepted_jwt = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        rejected = {
+            "method": "allowlist",
+            "result": "invalid",
+            "reason": "not_allowlisted",
+            "client_id": "not-on-the-list",
+        }
+        before_accepted = metric_sample(self.VALIDATIONS, accepted_jwt)
+        before_rejected = metric_sample(self.VALIDATIONS, rejected)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._allowed_mgmt_clients = frozenset({"astrolabe"})
+        verifier.jwks_client = MagicMock()
+        token = self._jwt_for("not-on-the-list")
+        # Signature verifies and a token is created — only the allowlist refuses.
+        with patch.object(
+            verifier,
+            "_verify_jwt_signature",
+            AsyncMock(
+                return_value={
+                    "sub": "alice",
+                    "client_id": "not-on-the-list",
+                    "exp": int(time.time()) + 600,
+                }
+            ),
+        ):
+            assert await verifier.verify_token_for_management_api(token) is None
+
+        assert metric_sample(self.VALIDATIONS, rejected) - before_rejected == 1
+        assert metric_sample(self.VALIDATIONS, accepted_jwt) == before_accepted
+
+    async def test_allowlisted_request_records_valid_once(
+        self, base_settings, metric_sample
+    ):
+        """The granted path still records exactly one `valid`, once cleared."""
+        accepted = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        before = metric_sample(self.VALIDATIONS, accepted)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._allowed_mgmt_clients = frozenset({"astrolabe"})
+        verifier.jwks_client = MagicMock()
+        with patch.object(
+            verifier,
+            "_verify_jwt_signature",
+            AsyncMock(
+                return_value={
+                    "sub": "alice",
+                    "client_id": "astrolabe",
+                    "exp": int(time.time()) + 600,
+                }
+            ),
+        ):
+            granted = await verifier.verify_token_for_management_api(
+                self._jwt_for("astrolabe")
+            )
+
+        assert granted is not None
+        assert metric_sample(self.VALIDATIONS, accepted) - before == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1373,6 +1373,106 @@ class TestRejectionObservability:
 
         assert metric_sample(self.VALIDATIONS, labels) - before == 1
 
+    async def test_fallback_chain_records_one_rejection(
+        self, base_settings, metric_sample, caplog
+    ):
+        """Two validators, one token, one rejection.
+
+        With both JWKS and introspection configured — the ordinary
+        defence-in-depth deployment — an expired JWT is refused twice: the
+        signature check sees `expired`, then introspection sees `inactive` for
+        the same token. Recording each stage independently rebuilt the exact
+        "two breadcrumbs to correlate" problem this work exists to remove, and
+        made it louder by promoting both lines to WARNING.
+        """
+        jwt_labels = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "expired",
+            "client_id": "mistral-client",
+        }
+        introspect_labels = {
+            "method": "introspect",
+            "result": "invalid",
+            "reason": "inactive",
+            "client_id": "mistral-client",
+        }
+        before_jwt = metric_sample(self.VALIDATIONS, jwt_labels)
+        before_introspect = metric_sample(self.VALIDATIONS, introspect_labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"active": False}
+        verifier.http_client.post = AsyncMock(return_value=response)
+
+        with (
+            patch(
+                "nextcloud_mcp_server.auth.unified_verifier.jwt.decode",
+                side_effect=self._failing_verify(jwt.ExpiredSignatureError("expired")),
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="nextcloud_mcp_server.auth.unified_verifier"
+            ),
+        ):
+            assert await verifier._verify_mcp_audience(self._jwt_for()) is None
+
+        # Attributed to the validator that actually produced the 401...
+        assert (
+            metric_sample(self.VALIDATIONS, introspect_labels) - before_introspect == 1
+        )
+        # ...and the earlier stage is not a second event.
+        assert metric_sample(self.VALIDATIONS, jwt_labels) == before_jwt
+
+        rejections = [r for r in caplog.records if "Token rejected" in r.message]
+        assert len(rejections) == 1, [r.message for r in rejections]
+        # The whole story survives on that one line.
+        assert "jwt/expired" in rejections[0].message
+
+    async def test_accepted_after_fallback_records_no_rejection(
+        self, base_settings, metric_sample
+    ):
+        """A token the fallback rescues was never rejected.
+
+        JWT verification failing and introspection then succeeding is one
+        accepted token. Recording the failed stage made an accepted token
+        produce a rejection *and* a valid — inflating both sides of every
+        ratio in docs/observability.md at once.
+        """
+        rejected = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "expired",
+            "client_id": "mistral-client",
+        }
+        accepted = {
+            "method": "introspect",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        before_rejected = metric_sample(self.VALIDATIONS, rejected)
+        before_accepted = metric_sample(self.VALIDATIONS, accepted)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "active": True,
+            "sub": "alice",
+            "aud": ["test-client-id"],
+        }
+        verifier.http_client.post = AsyncMock(return_value=response)
+
+        with patch(
+            "nextcloud_mcp_server.auth.unified_verifier.jwt.decode",
+            side_effect=self._failing_verify(jwt.ExpiredSignatureError("expired")),
+        ):
+            assert await verifier._verify_mcp_audience(self._jwt_for()) is not None
+
+        assert metric_sample(self.VALIDATIONS, rejected) == before_rejected
+        assert metric_sample(self.VALIDATIONS, accepted) - before_accepted == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1127,6 +1127,56 @@ class TestRejectionObservability:
             for r in caplog.records
         )
 
+    async def test_jwks_outage_is_a_network_error_not_unknown(
+        self, base_settings, metric_sample
+    ):
+        """A JWKS fetch failure is our IdP being unreachable, not a bad token.
+
+        `PyJWKClientError` is not an `InvalidTokenError` subclass, so without an
+        explicit clause it lands in the generic handler as "unknown" — leaving a
+        JWKS outage looking different from the introspection and userinfo
+        outages it is the exact peer of, on a dashboard built to tell causes
+        apart.
+        """
+        labels = {
+            "method": "jwt",
+            "result": "error",
+            "reason": "network_error",
+            "client_id": "mistral-client",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        verifier.jwks_client.get_signing_key_from_jwt.side_effect = (
+            jwt.PyJWKClientError("could not fetch JWKS")
+        )
+
+        assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    def test_empty_verified_client_id_falls_back(self, base_settings, metric_sample):
+        """An empty verified id recovers azp/aud rather than recording nothing.
+
+        A verified payload can carry `azp`/`aud` with no top-level `client_id`,
+        and for a JWT the fallback re-reads the same already-verified bytes.
+        Honouring "" strictly would lose a recoverable identity for no gain.
+        """
+        labels = {
+            "method": "allowlist",
+            "result": "invalid",
+            "reason": "not_allowlisted",
+            "client_id": "via-azp",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        token = jwt.encode({"sub": "a", "azp": "via-azp"}, "s", algorithm="HS256")
+        verifier._reject("allowlist", "not_allowlisted", token, client_id="")
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1177,6 +1177,74 @@ class TestRejectionObservability:
 
         assert metric_sample(self.VALIDATIONS, labels) - before == 1
 
+    async def test_bad_audience_records_one_event_not_two(
+        self, base_settings, metric_sample
+    ):
+        """A token refused on audience is not also counted as valid.
+
+        The signature verifying and the token being *accepted* are different
+        events. Recording "valid" per validation stage and then "bad_audience"
+        at the refusal made one token produce two increments, inflating
+        `result="valid"` relative to tokens actually accepted — and every ratio
+        query in docs/observability.md is built on that denominator.
+        """
+        rejected = {
+            "method": "jwt",
+            "result": "invalid",
+            "reason": "bad_audience",
+            "client_id": "mistral-client",
+        }
+        accepted = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        before_rejected = metric_sample(self.VALIDATIONS, rejected)
+        before_accepted = metric_sample(self.VALIDATIONS, accepted)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        # Signature verifies, but the audience is somebody else's.
+        with patch.object(
+            verifier,
+            "_verify_jwt_signature",
+            AsyncMock(return_value={"sub": "alice", "aud": ["someone-else"]}),
+        ):
+            assert await verifier._verify_mcp_audience(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, rejected) - before_rejected == 1
+        assert metric_sample(self.VALIDATIONS, accepted) == before_accepted
+
+    async def test_accepted_token_records_valid_once(
+        self, base_settings, metric_sample
+    ):
+        """The accepted path still records exactly one `valid` event."""
+        accepted = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        before = metric_sample(self.VALIDATIONS, accepted)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        with patch.object(
+            verifier,
+            "_verify_jwt_signature",
+            AsyncMock(
+                return_value={
+                    "sub": "alice",
+                    "aud": ["test-client-id"],
+                    "exp": int(time.time()) + 600,
+                }
+            ),
+        ):
+            assert await verifier._verify_mcp_audience(self._jwt_for()) is not None
+
+        assert metric_sample(self.VALIDATIONS, accepted) - before == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1301,6 +1301,78 @@ class TestRejectionObservability:
         assert metric_sample(self.VALIDATIONS, accepted) == before_accepted
         assert metric_sample(self.VALIDATIONS, rejected) - before_rejected == 1
 
+    async def test_missing_sub_rejection_logs_once(self, base_settings, caplog):
+        """One line per rejection — this path briefly logged ERROR *and* WARNING.
+
+        Introduced by the round-7 fix: routing the None result through _reject()
+        added a WARNING on top of the pre-existing ERROR inside
+        _create_access_token_with_cache_key. The round-7 test asserted only on
+        the metric, so it passed while the duplicate went in — the same blind
+        spot test_bad_audience_logs_once exists to prevent on the other path.
+        """
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        with (
+            patch.object(
+                verifier,
+                "_verify_jwt_signature",
+                AsyncMock(return_value={"aud": ["test-client-id"]}),
+            ),
+            caplog.at_level(
+                logging.DEBUG, logger="nextcloud_mcp_server.auth.unified_verifier"
+            ),
+        ):
+            assert await verifier._verify_mcp_audience(self._jwt_for()) is None
+
+        lines = [r for r in caplog.records if "sub" in r.message]
+        assert len(lines) == 1, [r.message for r in lines]
+
+    @pytest.mark.parametrize(
+        ("allowlist", "reason", "result"),
+        [
+            # Empty allowlist rejects every client — our misconfiguration.
+            (frozenset(), "not_configured", "error"),
+            # Populated allowlist, this client absent — the caller's problem.
+            (frozenset({"astrolabe"}), "not_allowlisted", "invalid"),
+        ],
+    )
+    async def test_empty_allowlist_is_our_fault_not_the_callers(
+        self, base_settings, metric_sample, allowlist, reason, result
+    ):
+        """ "Nobody is allowed" and "you are not allowed" need different responses.
+
+        An unset ALLOWED_MGMT_CLIENT breaks every management client at once —
+        the same shape as the JWKS/introspection `not_configured` cases carved
+        out as pageable. Reporting it as the caller's invalid token would keep
+        it out of the result="error" alert that exists to catch exactly this.
+        """
+        labels = {
+            "method": "allowlist",
+            "result": result,
+            "reason": reason,
+            "client_id": "not-on-the-list",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._allowed_mgmt_clients = allowlist
+        token = self._jwt_for("not-on-the-list")
+        with patch.object(
+            verifier,
+            "_verify_without_audience_check",
+            AsyncMock(
+                return_value=AccessToken(
+                    token=token,
+                    client_id="not-on-the-list",
+                    scopes=[],
+                    expires_at=int(time.time()) + 600,
+                )
+            ),
+        ):
+            assert await verifier.verify_token_for_management_api(token) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1229,3 +1229,71 @@ class TestRejectionObservability:
             verifier._reject("jwt", "bad_audience", self._jwt_for(), "got []")
 
         assert len([r for r in caplog.records if "bad_audience" in r.message]) == 1
+
+    async def test_opaque_no_validator_configured_is_recorded(
+        self, base_settings, metric_sample
+    ):
+        """The last silent rejection path: an opaque token with no validator.
+
+        The management-API twin of the `jwks_client is None` branch this work
+        started from — and quieter still, since that one at least logged at
+        DEBUG while this returned None with no metric and no log at all.
+        """
+        labels = {
+            "method": "unknown",
+            "result": "error",
+            "reason": "not_configured",
+            "client_id": "unknown",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        base_settings.introspection_uri = None
+        base_settings.userinfo_uri = None
+        verifier = UnifiedTokenVerifier(base_settings)
+
+        assert (
+            await verifier._verify_without_audience_check("opaque-token", "mgmt:none")
+            is None
+        )
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    async def test_failed_validator_is_not_double_counted(
+        self, base_settings, metric_sample
+    ):
+        """A validator that ran and failed already recorded it — don't record twice.
+
+        The catch-all `payload is None` is reached both when nothing was tried
+        and when something was tried and failed. Only the first is silent; the
+        naive fix records both and inflates every introspection failure into two
+        events attributed to different methods.
+        """
+        no_validator = {
+            "method": "unknown",
+            "result": "error",
+            "reason": "not_configured",
+            "client_id": "unknown",
+        }
+        inactive = {
+            "method": "introspect",
+            "result": "invalid",
+            "reason": "inactive",
+            "client_id": "unknown",
+        }
+        before_nv = metric_sample(self.VALIDATIONS, no_validator)
+        before_inactive = metric_sample(self.VALIDATIONS, inactive)
+
+        base_settings.userinfo_uri = None
+        verifier = UnifiedTokenVerifier(base_settings)
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"active": False}
+        verifier.http_client.post = AsyncMock(return_value=response)
+
+        assert (
+            await verifier._verify_without_audience_check("opaque-token", "mgmt:x")
+            is None
+        )
+
+        # Exactly one event, from _introspect_token, attributed to introspect.
+        assert metric_sample(self.VALIDATIONS, inactive) - before_inactive == 1
+        assert metric_sample(self.VALIDATIONS, no_validator) == before_nv


### PR DESCRIPTION
Stacked on #1229.

## Why

A rejected token isn't routine — it ends the MCP session and forces a human to log in again. That's the failure users report as *"the connector keeps disconnecting"*, and it's the one thing our telemetry couldn't explain.

This came out of investigating a live Mistral connector dropout. The evidence was there in the logs, but only as two INFO breadcrumbs that had to be joined by `trace_id`:

```
14:37:47.452 INFO  JWT token has expired                       ┐ same
14:37:47.625 INFO  Token introspection returned inactive=false ┘ trace_id
```

Neither line names the client. The metric said `{method="jwt", result="invalid"}` — a rejection happened, somewhere, to someone.

## The gap this closes

| Before | After |
|---|---|
| `{method, result}` — rejection count only | `{method, result, reason, client_id}` |
| Reason known internally, discarded at `return None` | `reason` carried to the metric and one log line |
| `not_configured` cases logged at **DEBUG** | WARNING — see below |
| Two INFO breadcrumbs, trace-join to interpret | one WARNING with method + reason + client |
| "was it their token or our config?" unanswerable | `result=invalid` (caller) vs `error` (ours) |

`reason` ∈ `expired | inactive | bad_signature | bad_issuer | bad_audience | not_configured | network_error | unknown`.

The DEBUG one is worth calling out: **"No JWKS client configured"** and **"No introspection endpoint configured"** reject *every* token from *every* client. The single most total failure mode in the system was the quietest line in the file, invisible at the production log level. It now records `reason="not_configured"` and has its own alert.

## Explicitly not covered by #1229

Worth being direct, since it's the same workstream: the fleet metrics in the parent PR hang off `instrument_call_tool_outcomes`, which wraps the `CallToolRequest` handler. **A 401 is rejected by the auth middleware before any request reaches that handler.** So a disconnected client isn't an error there — its `mcp_client_sessions_total` series just *stops*, with no reason attached. #1229 measures the fleet that gets in; this measures the ones turned away.

## Design notes

- **`client_id` comes from the *unverified* token.** A rejected token is by definition unvalidated, so that's the only place its identity exists. Rather than discard it, it's kept and treated as untrusted — length-clamped and count-bounded via the same mechanism as `clientInfo.name`, with its **own** budget so one untrusted label can't exhaust the other's.
- **Single `_reject()` funnel** for all ~16 rejection paths. Previously each logged its own line at its own level with its own content.
- **Outer duplicate records removed.** The inner path now owns the record with its reason; keeping both would double-count every rejection.
- `_bounded_client_name` generalised to `_bounded_label(value, seen)` rather than copied.

## Queries this enables

```promql
# why is a client being disconnected
sum by (client_id, method, reason) (
  increase(mcp_oauth_token_validations_total{result!="valid"}[1h])
) > 0

# our fault, not theirs — should page
sum by (reason) (increase(mcp_oauth_token_validations_total{result="error"}[15m])) > 0

# rejects every token from every client
sum(increase(mcp_oauth_token_validations_total{reason="not_configured"}[5m])) > 0
```

## Testing

New `TestRejectionObservability` (8 tests): each JWT failure mode maps to a distinct `reason`; `active=false` records `inactive`; a missing JWKS client is WARNING-visible and labelled; the log line carries client + reason; opaque tokens degrade to `client_id="unknown"` rather than inventing one; `azp`/`aud` fallbacks.

One test detail worth a look — `_verify_jwt_signature` and `_claimed_client_id` both call `jwt.decode`, so a blanket patch would break the client_id read and hide the label under `"unknown"`. In production they genuinely differ (PyJWT skips every check when `verify_signature=False`, so an expired token still yields its claims). The mock preserves that difference, or the test would prove nothing about the real path.

**3143 unit tests pass**; ruff, ruff-format, ty clean. `ty` earned its keep mid-change: an orphaned `return None` left a *valid* JWT being rejected on the management-API path.

**Test tiers**: no new HTTP/MCP API surface — instrumentation on an existing verification path — so the e2e + contract gate doesn't apply. `-m unit` is the relevant tier.

---

_This PR was generated with the help of AI, and reviewed by a Human_
