### PR TITLE
docs(search): correct false calibration claim on rerank_score

### DIFF
--- a/nextcloud_mcp_server/api/management.py
+++ b/nextcloud_mcp_server/api/management.py
@@ -43,8 +43,22 @@ _server_start_time = time.time()
 
 # The search algorithms astrolabe's McpServerClient understands (the ``algorithm``
 # request param to /api/v1/search and /api/v1/vector-viz/search): ``semantic``
-# (dense only), ``bm25`` (sparse/keyword only), ``hybrid`` (dense+sparse fusion).
+# (dense only), ``bm25``, ``hybrid``.
 # Single source of truth, also consumed by api/visualization.py for validation.
+#
+# CAVEAT — ``bm25`` and ``hybrid`` are currently BEHAVIOURALLY IDENTICAL. Both are
+# routed to ``BM25HybridSearchAlgorithm`` by ``_build_search_algorithm``
+# (api/visualization.py), which always issues dense AND sparse prefetches and
+# returns the fused score. There is no sparse-only path, so ``bm25`` does not mean
+# "keyword only" — it differs from ``hybrid`` only in the string echoed back as
+# ``search_method``. A previous version of this comment claimed "sparse/keyword
+# only", which a caller could reasonably act on.
+#
+# Consequence for callers: raw BM25 scores (unbounded, values above 8 observed)
+# never reach a caller's ``score`` field on either name. What they see is the RRF
+# fused score, bounded by ``2/VECTOR_SEARCH_RRF_K``, or an unbounded DBSF score.
+# Either giving ``bm25`` a genuinely sparse-only path or dropping it from the
+# advertised set is a behaviour change and is tracked on Deck #958, not here.
 SUPPORTED_SEARCH_ALGORITHMS: tuple[str, ...] = ("semantic", "bm25", "hybrid")
 
 

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -41,10 +41,14 @@ class SemanticSearchResult(BaseModel):
         default=None,
         description=(
             "Cross-encoder relevance, present only when the optional rerank "
-            "stage ran (see the response's `reranked` flag). Unlike `score` "
-            "this IS calibrated — it is a direct query/document relevance "
-            "estimate rather than a rank artifact — so it is comparable across "
-            "queries and is what the results are ordered by when present. "
+            "stage ran (see the response's `reranked` flag). It is what the "
+            "results are ordered by when present, and it separates relevant "
+            "from irrelevant far better than `score` does. "
+            "It is NOT a calibrated probability and NOT comparable across "
+            "queries. Measured on a 60-query labelled set, documents scoring "
+            "in [0.6, 0.8) were actually relevant only about 50-72% of the "
+            "time, so rendering this value to a user as a percentage overstates "
+            "it. Use it to rank and to compare candidates WITHIN one response. "
             "`score` is left untouched so `score_threshold`, which filters on "
             "the retrieval score, keeps referring to the same quantity."
         ),

--- a/nextcloud_mcp_server/search/algorithms.py
+++ b/nextcloud_mcp_server/search/algorithms.py
@@ -199,10 +199,14 @@ class SearchResult:
     #   * ``score_threshold`` is applied inside Qdrant against the retrieval
     #     score, so overwriting would leave the filter and the returned value
     #     referring to different quantities;
-    #   * ``score`` is documented above as an ordering artifact that is not
-    #     calibrated, while a cross-encoder score is — conditionally changing
-    #     which of those a field holds, based on a server flag, would leave no
-    #     consumer able to interpret it;
+    #   * the two are on incomparable scales — ``score`` is a rank artifact
+    #     bounded by ``2/VECTOR_SEARCH_RRF_K`` (~0.033 at k=60) while a
+    #     cross-encoder score spans [0, 1] — so conditionally changing which of
+    #     them a field holds, based on a server flag, would leave no consumer
+    #     able to interpret it. NB a cross-encoder score is better SEPARATED
+    #     (23x on medians, AUC 0.839 vs 0.765 on a 60-query labelled set) but is
+    #     NOT calibrated: [0.6, 0.8) was relevant only ~50-72% of the time.
+    #     Neither field is a probability, and neither may be shown as one;
     #   * ``__post_init__`` rejects negatives, and clamping a negative
     #     cross-encoder score to 0.0 would collapse the tail into a tie and
     #     silently leave it in retrieval order behind a reranked head.

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -220,6 +220,14 @@ def configure_semantic_tools(mcp: FastMCP):
                 0.1 returns nothing at all. Leave at 0.0 (the default) and cut
                 by rank via `limit` instead. DBSF scores are distribution-
                 normalized and can exceed 1.0.
+                Two further reasons not to drive a UI control from this. It is
+                only meaningful for dense-only search, where the score is a
+                cosine similarity genuinely in [0, 1]. And it is applied by
+                Qdrant on the fused score BEFORE deduplication, reranking and
+                verify-on-read, so it is a recall cut taken before reranking can
+                reorder anything — a threshold that merely looks conservative
+                can silently remove the result the reranker would have promoted
+                to the top.
             fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion)
                    RRF: Good general-purpose fusion using reciprocal ranks
                    DBSF: Uses distribution-based normalization, may better balance different score ranges


### PR DESCRIPTION
## What

`SemanticSearchResult.rerank_score` told callers it **"IS calibrated"** and **"is comparable
across queries"**. Both are false. That field description is exactly what leads an LLM caller —
or a UI developer — to render `0.72` as "72% relevant".

Measured on a 60-question labelled set (1200 query/document pairs): documents scoring in
**[0.6, 0.8) were actually relevant only ~50-72% of the time**.

What the score *is* good at is **separation** — 23x on medians (relevant 0.1112 vs irrelevant
0.0048), AUC 0.839 vs 0.765 for the fused retrieval score. That is why it is the right ordering
key and the wrong percentage. The description now says so, and the same overstatement is
corrected in the `SearchResult` comment that justified keeping the two fields apart.

## Two other things a caller could act on incorrectly

**`bm25` and `hybrid` are behaviourally identical.** Both are routed to
`BM25HybridSearchAlgorithm` by `_build_search_algorithm`, which always issues dense **and**
sparse prefetches and returns the fused score. `select_search_algorithm` only validates the
name. There is no sparse-only path, so `bm25` differs from `hybrid` only in the string echoed
back as `search_method` — the previous `(sparse/keyword only)` comment described routing that
does not exist. A consequence worth stating: raw BM25 scores never reach a caller's `score`
field under either name.

Giving `bm25` a real sparse-only path, or dropping it from the advertised set, is a **behaviour
change** and is deliberately not in this PR.

**`score_threshold` is a pre-rerank recall cut.** Qdrant applies it to the fused score *before*
dedup, reranking and verify-on-read, so a threshold that merely looks conservative can remove
the result the reranker would have promoted to the top. It is only meaningful for
`algorithm=semantic`, where the score is a cosine similarity genuinely in [0, 1]. Under RRF the
top result scores about `2/VECTOR_SEARCH_RRF_K` (~0.033 at the default k=60), so a "10%"
reading of `0.1` returns nothing at all.

## Scope

**Docs only.** No behaviour change, no new field, no `management_api_version` bump, no new
capability, and nothing that requires a coordinated deploy with `astrolabe`. The companion
astrolabe change (stop rendering `score` as a percentage, make the relevance control relative
to the best result) is independent and works against **any** server version, in both
directions.

Kept to the repo's no-semicolons convention in tool-visible text (#1194).

## Test coverage

No API surface added or changed, so the e2e + contract gate does not apply. Verified that no
test pinned the old wording.

- `uv run ruff check` — passed
- `uv run ruff format --check` — 526 files already formatted
- `uv run ty check -- nextcloud_mcp_server` — passed
- `uv run pytest -m unit -n auto` — **3116 passed**

## Notes for the reviewer

- The measurement behind these numbers is recorded in an internal note, not in this repo.
- This branch also carries a submodule-pointer bump (`build: Update astrolabe checkout`) which
  is unrelated to the docs change. The `third_party/astrolabe` mount in `docker-compose.yml`
  remains commented out, so CI still builds against the published app store release.

---

_This PR was generated with the help of AI, and reviewed by a Human_
