### PR TITLE
fix(observability): make the fleet metric say why it isn't recording

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -310,6 +310,26 @@ count by (client_name) (
 ) > 1
 ```
 
+### When a fleet metric is empty
+
+`mcp_client_sessions_total` and `mcp_client_capability` populate from the
+`tools/call` handler. If they have **no series at all** while
+`mcp_tool_outcomes_total` does, the recording is bailing out early and the
+server says which branch, once per process, at WARNING:
+
+| Log line contains | Meaning |
+|---|---|
+| `no request context on a tool call` | the instrumentation is not wired into the handler it expects |
+| `has no client_params on a tool call` | the session handling the call is not the one that ran `initialize` |
+
+```logql
+{namespace=~"tenant-.*", container="nextcloud-mcp-server"}
+  |= "MCP client fleet metrics"
+```
+
+Logged once per cause per process deliberately — this runs on the tool-call hot
+path, so a per-request line would be its own incident. A restart re-arms it.
+
 **Client-identity cardinality cap hit** — `client_name` collapses to `_other`
 past 50 distinct identities. The real fleet is single digits, so this firing
 means either a genuinely new class of client or a peer rotating its declared

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -273,7 +273,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                     "(per-user authorization applies)",
                     access_token.resource,
                 )
-            self._record_mgmt_grant(outcome, from_cache)
+            self._record_mgmt_grant(outcome, from_cache, access_token.client_id)
             return access_token
 
         # Enforce ALLOWED_MGMT_CLIENT allowlist (fail-closed when unset)
@@ -304,7 +304,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                 client_id=token_client_id,
             )
 
-        self._record_mgmt_grant(outcome, from_cache)
+        self._record_mgmt_grant(outcome, from_cache, access_token.client_id)
         return access_token
 
     async def _verify_mcp_audience(self, token: str) -> AccessToken | None:
@@ -374,7 +374,13 @@ class UnifiedTokenVerifier(TokenVerifier):
                     token,
                     "no 'sub' or 'preferred_username' claim in token payload",
                 )
-            record_oauth_token_validation(validation_method, "valid")
+            # client_id from the AccessToken, not omitted: without it every
+            # `valid` record labels `client_id="unknown"`, so the metric can say
+            # why a client was rejected but not which client succeeded — and a
+            # rejection rate needs both halves to mean anything.
+            record_oauth_token_validation(
+                validation_method, "valid", client_id=access_token.client_id
+            )
             return access_token
 
         except Exception as e:
@@ -654,7 +660,9 @@ class UnifiedTokenVerifier(TokenVerifier):
         )
         return None
 
-    def _record_mgmt_grant(self, outcome: dict[str, str], from_cache: bool) -> None:
+    def _record_mgmt_grant(
+        self, outcome: dict[str, str], from_cache: bool, client_id: str | None = None
+    ) -> None:
         """Record a management-API request as accepted, once it actually is.
 
         Authentication succeeding is not the same as the request being granted:
@@ -669,7 +677,9 @@ class UnifiedTokenVerifier(TokenVerifier):
         """
         if from_cache:
             return
-        record_oauth_token_validation(outcome.get("method", "unknown"), "valid")
+        record_oauth_token_validation(
+            outcome.get("method", "unknown"), "valid", client_id=client_id
+        )
 
     def _note(
         self,

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1000,6 +1000,9 @@ _seen_client_ids: set[str] = set()
 
 def _warn_once(cause: str, message: str, *args: object) -> None:
     """Log a cause the first time it occurs in this process, then stay quiet."""
+    # ponytail: unsynchronised check-then-set, matching _bounded_label and the
+    # session claim. Worst case is one duplicate line per cause per process, on
+    # a first-request race; a lock on a logging gate would cost more.
     if cause in _warned_causes:
         return
     _warned_causes.add(cause)

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1015,8 +1015,13 @@ def _client_label(value: object, limit: int = 64) -> str:
 
     Note this bounds the size of one value, not the number of distinct values —
     see :func:`_bounded_client_name` for that half.
+
+    Empty maps to "unknown" alongside None. `AccessToken.client_id` defaults to
+    `""` when the payload carries no client_id claim, so without this an absent
+    identity would record as an empty label — a second spelling of "we don't
+    know" that splits the series and reads as a rendering bug on a dashboard.
     """
-    return str(value)[:limit] if value is not None else "unknown"
+    return str(value)[:limit] if value else "unknown"
 
 
 def _first_present(*candidates: tuple[object, str]) -> object | None:

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -984,6 +984,11 @@ _SESSION_RECORDED_ATTR = "_astrolabe_fleet_recorded"
 # 50 is far above the real fleet (single digits) and far below anything that
 # strains the registry, so crossing it is itself a signal — see the
 # client_name="_other" alert in docs/observability.md.
+# Causes already reported by _warn_once. Instrumentation that fails silently is
+# the failure this whole metric family exists to remove, so its own failures say
+# so — but once per process, not once per request, since these fire on a hot path.
+_warned_causes: set[str] = set()
+
 _MAX_TRACKED_CLIENTS = 50
 _OVERFLOW_LABEL = "_other"
 _seen_client_names: set[str] = set()
@@ -991,6 +996,14 @@ _seen_client_names: set[str] = set()
 # the rejection path, so they are at least as untrusted as clientInfo.name and
 # must not share its budget.
 _seen_client_ids: set[str] = set()
+
+
+def _warn_once(cause: str, message: str, *args: object) -> None:
+    """Log a cause the first time it occurs in this process, then stay quiet."""
+    if cause in _warned_causes:
+        return
+    _warned_causes.add(cause)
+    logger.warning(message, *args)
 
 
 def _client_label(value: object, limit: int = 64) -> str:
@@ -1073,7 +1086,14 @@ def record_client_session() -> None:
     try:
         ctx = request_ctx.get()
     except LookupError:
-        # Called outside a request scope (startup, tests). Expected, not an error.
+        # Legitimate outside a request (startup, direct calls in tests), but this
+        # function is only wired into the CallToolRequest handler, where a missing
+        # request context means the wiring is wrong.
+        _warn_once(
+            "no_request_ctx",
+            "MCP client fleet metrics: no request context on a tool call — "
+            "mcp_client_sessions_total will stay empty",
+        )
         return
     session = ctx.session
     # ponytail: unsynchronised check-then-set, so two requests racing on a
@@ -1083,7 +1103,16 @@ def record_client_session() -> None:
         return
     params = getattr(session, "client_params", None)
     if params is None:
-        # Session has not completed initialize yet; try again on the next call.
+        # Expected once, between transport creation and the initialize handshake
+        # completing. Persisting past that means the session this handler sees is
+        # not the one that processed initialize, and the fleet metric will never
+        # populate — which is exactly what happened in 0.162.0.
+        _warn_once(
+            "no_client_params",
+            "MCP client fleet metrics: session %s has no client_params on a tool "
+            "call — mcp_client_sessions_total will stay empty",
+            type(session).__name__,
+        )
         return
     # Claim the session before doing the work, so a failure below costs one
     # warning for this session rather than one per tool call.

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -17,6 +17,7 @@ so every assertion here is on a *delta*.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -231,6 +232,55 @@ class TestRecordClientSession:
             request_ctx.reset(token)
 
         assert metric_sample(SESSIONS, labels) - before == 1
+
+
+class TestSilentFailureDiagnostics:
+    """The instrumentation must be able to report on its own failure.
+
+    0.162.0 shipped with `mcp_client_sessions_total` recording nothing in
+    production while `mcp_tool_outcomes_total` — incremented two lines later in
+    the same handler — worked. Both early-returns in `record_client_session`
+    were silent at every log level, so the metric could not say why it was
+    empty. That is the exact failure this whole metric family exists to remove,
+    rebuilt inside the thing removing it.
+    """
+
+    def setup_method(self):
+        metrics_module._warned_causes.clear()
+
+    def test_missing_request_context_says_so(self, caplog):
+        with caplog.at_level(
+            logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
+        ):
+            record_client_session()
+
+        assert any("no request context" in r.message for r in caplog.records)
+
+    def test_missing_client_params_says_so(self, caplog):
+        token = _activate(_FakeSession(None))
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
+            ):
+                record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert any("no client_params" in r.message for r in caplog.records)
+
+    def test_warns_once_per_process_not_per_request(self, caplog):
+        """These fire on the tool-call hot path — one line, not one per call."""
+        token = _activate(_FakeSession(None))
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
+            ):
+                for _ in range(25):
+                    record_client_session()
+        finally:
+            request_ctx.reset(token)
+
+        assert len([r for r in caplog.records if "no client_params" in r.message]) == 1
 
 
 class TestCallToolOutcomes:

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -234,6 +234,36 @@ class TestRecordClientSession:
         assert metric_sample(SESSIONS, labels) - before == 1
 
 
+class TestAbsentIdentityLabelling:
+    """ "Absent" must have exactly one spelling."""
+
+    def test_empty_client_id_records_as_unknown(self, metric_sample):
+        """`AccessToken.client_id` defaults to "" when the payload has no claim.
+
+        Recording that verbatim gives an empty label — a second spelling of
+        "we don't know" that splits the series in two and reads as a rendering
+        bug on a dashboard. CI caught this the moment client_id started being
+        passed on the acceptance path: two tests expecting "unknown" began
+        seeing "" instead.
+        """
+        unknown = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        empty = {**unknown, "client_id": ""}
+        before_unknown = metric_sample("mcp_oauth_token_validations_total", unknown)
+
+        record_oauth_token_validation("jwt", "valid", "none", "")
+
+        assert (
+            metric_sample("mcp_oauth_token_validations_total", unknown) - before_unknown
+            == 1
+        )
+        assert metric_sample("mcp_oauth_token_validations_total", empty) == 0
+
+
 class TestSilentFailureDiagnostics:
     """The instrumentation must be able to report on its own failure.
 

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -43,25 +43,32 @@ OUTCOMES = "mcp_tool_outcomes_total"
 
 
 @pytest.fixture(autouse=True)
-def _isolate_seen_client_names():
-    """Snapshot/restore the module-global client-name set around every test.
+def _isolate_module_globals():
+    """Snapshot/restore *every* process-global this module mutates.
 
-    ``_seen_client_names`` is process-global and never expires, so the
-    capacity test below (which mints ~70 identities) would otherwise leave the
-    cap exhausted for whatever runs next — silently turning an assertion on a
-    real ``client_name`` into one on ``"_other"``. Nothing enforces test order
-    here, so relying on file-definition order would be a latent flake rather
-    than a guarantee.
+    Three of them now: the two cardinality budgets and the warned-cause set.
+    All are process-global and never expire, so a test that fills one leaves it
+    filled for whatever runs next — the capacity test mints ~70 identities, and
+    the diagnostics tests mark both causes as already-warned. Either would
+    silently turn a later assertion into its opposite (a real ``client_name``
+    reading as ``"_other"``; an expected warning not firing).
+
+    Deliberately covers all three rather than naming them, because the previous
+    version covered two and a third was added without noticing the asymmetry.
+    Anything added to the tuple below gets the same treatment for free.
     """
-    saved_names = set(metrics_module._seen_client_names)
-    saved_ids = set(metrics_module._seen_client_ids)
+    names = ("_seen_client_names", "_seen_client_ids", "_warned_causes")
+    saved = {n: set(getattr(metrics_module, n)) for n in names}
+    # Cleared, not just restored: the diagnostics tests need an unwarned slate
+    # to observe the once-per-process behaviour at all.
+    getattr(metrics_module, "_warned_causes").clear()
     try:
         yield
     finally:
-        metrics_module._seen_client_names.clear()
-        metrics_module._seen_client_names.update(saved_names)
-        metrics_module._seen_client_ids.clear()
-        metrics_module._seen_client_ids.update(saved_ids)
+        for n in names:
+            current = getattr(metrics_module, n)
+            current.clear()
+            current.update(saved[n])
 
 
 def _client_params(
@@ -274,9 +281,6 @@ class TestSilentFailureDiagnostics:
     empty. That is the exact failure this whole metric family exists to remove,
     rebuilt inside the thing removing it.
     """
-
-    def setup_method(self):
-        metrics_module._warned_causes.clear()
 
     def test_missing_request_context_says_so(self, caplog):
         with caplog.at_level(

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1557,6 +1557,50 @@ class TestRejectionObservability:
         assert granted is not None
         assert metric_sample(self.VALIDATIONS, accepted) - before == 1
 
+    async def test_cache_hit_does_not_rerecord_valid(
+        self, base_settings, metric_sample
+    ):
+        """A polled token is validated once, not once per request.
+
+        Astrolabe polls the management API continuously with the same token.
+        Recording `valid` on every cache hit would make the metric count
+        *requests* rather than *validations*, so the denominator would drift
+        with polling frequency rather than with anything meaningful.
+
+        The previous commit asserted this invariant in its message and left it
+        resting on a manual trace. Given this PR has five separate instances of
+        a test watching the wrong signal, an untested claim is the one shape it
+        should not ship.
+        """
+        accepted = {
+            "method": "jwt",
+            "result": "valid",
+            "reason": "none",
+            "client_id": "unknown",
+        }
+        before = metric_sample(self.VALIDATIONS, accepted)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier._allowed_mgmt_clients = frozenset({"astrolabe"})
+        verifier.jwks_client = MagicMock()
+        token = self._jwt_for("astrolabe")
+        verify = AsyncMock(
+            return_value={
+                "sub": "alice",
+                "client_id": "astrolabe",
+                "exp": int(time.time()) + 600,
+            }
+        )
+        with patch.object(verifier, "_verify_jwt_signature", verify):
+            first = await verifier.verify_token_for_management_api(token)
+            second = await verifier.verify_token_for_management_api(token)
+
+        assert first is not None and second is not None
+        # Second call was served from cache — the validator never ran again...
+        assert verify.await_count == 1
+        # ...and the grant was not counted twice.
+        assert metric_sample(self.VALIDATIONS, accepted) - before == 1
+
     def test_opaque_token_client_id_degrades_to_unknown(self, base_settings):
         """An opaque token carries no readable client_id — don't invent one."""
         verifier = UnifiedTokenVerifier(base_settings)

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1532,7 +1532,7 @@ class TestRejectionObservability:
             "method": "jwt",
             "result": "valid",
             "reason": "none",
-            "client_id": "unknown",
+            "client_id": "astrolabe",
         }
         before = metric_sample(self.VALIDATIONS, accepted)
 
@@ -1576,7 +1576,7 @@ class TestRejectionObservability:
             "method": "jwt",
             "result": "valid",
             "reason": "none",
-            "client_id": "unknown",
+            "client_id": "astrolabe",
         }
         before = metric_sample(self.VALIDATIONS, accepted)
 


### PR DESCRIPTION
Follow-up to #1230, from checking it in production. Deck #972.

## The bug

`mcp_client_sessions_total` and `mcp_client_capability` record **nothing** on `tenant-blackbox-demo`, while `mcp_tool_outcomes_total` — incremented two lines later in the *same* wrapped handler — works:

```
mcp_tool_outcomes_total{tool_name="nc_webdav_find_by_name", outcome="success"}    2
mcp_tool_outcomes_total{tool_name="nc_tables_list_tables",  outcome="tool_error"} 1
mcp_client_sessions_total                                                         (no series)
```

So `record_client_session()` returns early every time. And **there is no way to tell which of its two early-returns fired**, because both are silent at every log level:

```python
except LookupError:
    return                    # silent
...
if params is None:
    return                    # silent
```

Twelve review rounds on #1230 went into eliminating silent failures on the rejection path. The same flaw went straight into the acceptance path of the metric built to replace them. The instrumentation can't report on itself.

## What this PR does — and deliberately doesn't

**Does:** makes both paths name themselves, once per process per cause. These run on the tool-call hot path, so per-request logging would be its own bug; `_warn_once` bounds it.

**Doesn't:** fix the root cause blind. Inspection has already failed to settle it — `ctx.session` is the third `RequestContext` field and correct, and `_client_params` is set on `InitializeRequest`, so neither is obviously wrong from reading. Production naming the branch is the cheapest next step, and guessing risks a second wrong fix on top of the first.

## Sibling defect, same check

`valid` records carried `client_id="unknown"` — only the rejection path passed one:

```
mcp_oauth_token_validations_total{method="jwt", result="valid", reason="none", client_id="unknown"}  5
```

So the metric could say *why a client was rejected* but not *which client succeeded* — and a rejection **rate** needs both halves. Both acceptance points now pass the verified `access_token.client_id`.

Worth naming why this survived review: **every test asserted on rejections.** Same root as the five test-blind-spots #1230 worked through — asserting on what I'd just written rather than on what could break.

## Also

Restores `f1b5c2fd` (cache-hit invariant test), which missed the #1230 merge by about a minute and was stranded on the merged branch.

## Tests

Three new, covering that each early-return names itself and that the warning is bounded to one line per process rather than one per tool call.

**Test tiers**: no API surface change — instrumentation and logging only — so the e2e + contract gate doesn't apply.

---

_This PR was generated with the help of AI, and reviewed by a Human_
