### PR TITLE
feat(auth): record token-endpoint grants with credentials fingerprinted

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -122,7 +122,12 @@ most consequential changes are silent — see the alerts below.
   rejection disconnects a client, but so does never having been given a
   refresh token in the first place.
   - `grant_type`: `authorization_code` | `refresh_token` | `unsupported`
-  - `result`: `success` | `error`
+  - `result`: `success` | `error` — an exhaustive partition **by
+    construction**: success is recorded by the grant handlers (only they can
+    see whether a refresh token came back), and every failure exit is counted
+    centrally in `oauth_token_endpoint` from the response status. The handlers
+    have fifteen error returns between them; counting them individually would
+    let the next early-return added escape the metric silently.
   - `refresh_token`: `issued` | `absent` | `unknown` (the grant failed, so
     there was no response to inspect)
 
@@ -172,8 +177,13 @@ Follow one refresh token from issuance to reuse — same `sha256=` on both lines
 
 ```logql
 {namespace="<tenant>", container="nextcloud-mcp-server"}
-  |~ "AS proxy (: IdP token response|refresh)" |= "sha256=<fingerprint>"
+  |~ "AS proxy(: IdP token response| refresh)" |= "sha256=<fingerprint>"
 ```
+
+The space belongs *inside* the second alternative: the log lines are
+`AS proxy: IdP token response` (no space before the colon) and
+`AS proxy refresh: succeeded`. Hoisting the space out of the group silently
+matches only the refresh side — half of the correlation you asked for.
 
 ### Vector Sync Metrics (when enabled)
 
@@ -481,10 +491,20 @@ sum(increase(mcp_oauth_grants_total{
 
 ```promql
 # repeated full authorization flows with no refresh grants to match:
-# more than 2 re-authorizations an hour is a client stuck in a re-login loop
-sum(increase(mcp_oauth_grants_total{grant_type="authorization_code"}[1h])) > 2
+# more than 2 re-authorizations an hour is a client stuck in a re-login loop.
+# result="success" on purpose — this counts completed re-logins, so a client
+# retrying a stale code cannot inflate it into a false page.
+sum(increase(mcp_oauth_grants_total{
+      grant_type="authorization_code", result="success"}[1h])) > 2
   and
-sum(increase(mcp_oauth_grants_total{grant_type="refresh_token"}[1h])) == 0
+sum(increase(mcp_oauth_grants_total{
+      grant_type="refresh_token", result="success"}[1h])) == 0
+```
+
+```promql
+# the complementary signal, now that failures are counted too: a client
+# failing grants outright (replayed codes, PKCE mismatch, expired proxy code)
+sum by (grant_type) (increase(mcp_oauth_grants_total{result="error"}[15m])) > 0
 ```
 
 See the [Helm chart repository](https://github.com/cbcoutinho/helm-charts) for PrometheusRule definitions.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -116,8 +116,64 @@ most consequential changes are silent — see the alerts below.
   > JWKS means tokens fall through to introspection rather than being rejected
   > as `method="jwt"`. Alert on `reason="not_configured"` rather than on a
   > particular `method`.
+- `mcp_oauth_grants_total{grant_type, result, refresh_token}` - Grants
+  processed by the AS proxy token endpoint. **This is the "why is a client
+  re-logging-in" metric**, and it complements the validation metric above: a
+  rejection disconnects a client, but so does never having been given a
+  refresh token in the first place.
+  - `grant_type`: `authorization_code` | `refresh_token` | `unsupported`
+  - `result`: `success` | `error`
+  - `refresh_token`: `issued` | `absent` | `unknown` (the grant failed, so
+    there was no response to inspect)
+
+  > A healthy client shows **one** `authorization_code` and then a steady
+  > trickle of `refresh_token` grants. `authorization_code` repeating every
+  > hour with zero `refresh_token` grants means the client never received a
+  > refresh token and is re-running the full consent flow on every access-token
+  > expiry — a user-visible re-login each time.
+  >
+  > `refresh_token="absent"` on a **`refresh_token` grant** is not a fault: an
+  > IdP that does not rotate refresh tokens returns only a new access token.
+  > It is `absent` on the **`authorization_code`** grant that is the bug.
+  >
+  > When a refresh token is missing, check which OIDC client the IdP actually
+  > applied. The AS proxy exchanges the code as *this server's own confidential
+  > client* (`MCP_SERVER_CLIENT_ID`), not the client-facing one, so
+  > `offline_access` has to be enabled on that client — enabling it only on the
+  > MCP client's registration has no effect on this exchange.
 - `mcp_oauth_token_cache_hits_total` - Cache hit/miss rate
 - `mcp_oauth_refresh_token_operations_total` - Refresh token storage ops
+
+#### Reading the token-endpoint logs
+
+Every hop of a grant is logged with credentials fingerprinted rather than
+printed: secret fields become `<len=N sha256=xxxxxxxx>`. The fingerprint is a
+truncated, unsalted SHA-256, so the *same* token can be followed across hops
+and across process restarts without the credential ever being written down.
+Non-secret fields (`scope`, `expires_in`, `token_type`, `error`) pass through
+untouched, because those are what actually answer the question.
+
+Did the IdP issue a refresh token?
+
+```logql
+{namespace="<tenant>", container="nextcloud-mcp-server"}
+  |= "AS proxy: IdP token response" |= "refresh_token=ABSENT"
+```
+
+Which grant types is a client actually using?
+
+```logql
+sum by (grant_type) (count_over_time(
+  {namespace="<tenant>", container="nextcloud-mcp-server"}
+    |= "AS proxy token request" | logfmt [1h]))
+```
+
+Follow one refresh token from issuance to reuse — same `sha256=` on both lines:
+
+```logql
+{namespace="<tenant>", container="nextcloud-mcp-server"}
+  |~ "AS proxy (: IdP token response|refresh)" |= "sha256=<fingerprint>"
+```
 
 ### Vector Sync Metrics (when enabled)
 
@@ -411,6 +467,25 @@ sum(rate(astrolabe_document_ingest_rejected_total{reason="oversize"}[1h]))
 - Token validation errors >1% for >10min
 - Vector sync queue >100 for >15min
 - Qdrant slow (p95 >500ms) for >10min
+- Clients re-authorizing instead of refreshing (below)
+
+A client that is never issued a refresh token silently degrades into a
+re-login on every access-token expiry. Nothing fails, so nothing else alerts —
+it surfaces only as users complaining that the connector keeps disconnecting:
+
+```promql
+# authorization_code grants that yielded no refresh token
+sum(increase(mcp_oauth_grants_total{
+      grant_type="authorization_code", refresh_token="absent"}[1h])) > 0
+```
+
+```promql
+# repeated full authorization flows with no refresh grants to match:
+# more than 2 re-authorizations an hour is a client stuck in a re-login loop
+sum(increase(mcp_oauth_grants_total{grant_type="authorization_code"}[1h])) > 2
+  and
+sum(increase(mcp_oauth_grants_total{grant_type="refresh_token"}[1h])) == 0
+```
 
 See the [Helm chart repository](https://github.com/cbcoutinho/helm-charts) for PrometheusRule definitions.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -173,17 +173,20 @@ sum by (grant_type) (count_over_time(
     |= "AS proxy token request" | logfmt [1h]))
 ```
 
-Follow one refresh token from issuance to reuse — same `sha256=` on both lines:
+Follow one refresh token across every hop it appears on — same `sha256=`
+on each:
 
 ```logql
 {namespace="<tenant>", container="nextcloud-mcp-server"}
-  |~ "AS proxy(: IdP token response| refresh)" |= "sha256=<fingerprint>"
+  |= "AS proxy" |= "sha256=<fingerprint>"
 ```
 
-The space belongs *inside* the second alternative: the log lines are
-`AS proxy: IdP token response` (no space before the colon) and
-`AS proxy refresh: succeeded`. Hoisting the space out of the group silently
-matches only the refresh side — half of the correlation you asked for.
+The fingerprint is the selective filter here, so don't narrow further by
+message text. One token shows up on **four** lines — the IdP's response, what
+was handed to the client, the client's next refresh request, and the refreshed
+response — and every one of them begins `AS proxy`. Enumerating a couple of
+those prefixes in a regex is how you end up following half a token's life and
+concluding it was never reused.
 
 ### Vector Sync Metrics (when enabled)
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -122,12 +122,14 @@ most consequential changes are silent — see the alerts below.
   rejection disconnects a client, but so does never having been given a
   refresh token in the first place.
   - `grant_type`: `authorization_code` | `refresh_token` | `unsupported`
-  - `result`: `success` | `error` — an exhaustive partition **by
-    construction**: success is recorded by the grant handlers (only they can
-    see whether a refresh token came back), and every failure exit is counted
-    centrally in `oauth_token_endpoint` from the response status. The handlers
-    have fifteen error returns between them; counting them individually would
-    let the next early-return added escape the metric silently.
+  - `result`: `success` | `error` — an exhaustive partition of *attempted
+    grants*: success is recorded by the grant handlers (only they can see
+    whether a refresh token came back), while both failure modes are counted
+    centrally in `oauth_token_endpoint` — a returned non-200 (fifteen such
+    exits across the two handlers) and a raised exception, which is what an
+    IdP timeout or a malformed token body actually produces. Counting only
+    returned responses would let an IdP outage vanish from the metric
+    entirely, which is the failure mode most worth seeing.
   - `refresh_token`: `issued` | `absent` | `unknown` (the grant failed, so
     there was no response to inspect)
 
@@ -165,13 +167,21 @@ Did the IdP issue a refresh token?
   |= "AS proxy: IdP token response" |= "refresh_token=ABSENT"
 ```
 
-Which grant types is a client actually using?
+How often is a client re-running the full flow? (`client_id` is inside
+`params=`, so filter on it to scope to one client.)
 
 ```logql
-sum by (grant_type) (count_over_time(
+sum(count_over_time(
   {namespace="<tenant>", container="nextcloud-mcp-server"}
-    |= "AS proxy token request" | logfmt [1h]))
+    |= "AS proxy token request" |= "grant_type=authorization_code" [1h]))
 ```
+
+Deliberately parser-free. These logs are emitted as JSON, so `| logfmt` does
+not apply, and the `params=` tail is a Python `dict` repr rather than
+`key="value"` pairs — a parser stage here buys nothing and fails quietly. For
+the aggregate breakdown by grant type, use `mcp_oauth_grants_total` above
+rather than parsing logs at all; the log line is for per-client attribution,
+which the metric deliberately does not carry.
 
 Follow one refresh token across every hop it appears on — same `sha256=`
 on each:

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -1039,6 +1039,12 @@ async def _oauth_callback_as_proxy(
     # is usually a missing `offline_access` on whichever client the IdP
     # actually applied — and that is this server's own confidential client
     # here, not the client-facing one.
+    #
+    # The named fields duplicate values that `fields=` also carries. That is
+    # deliberate: the named ones are stable strings to alert and group on
+    # (`|= "refresh_token=ABSENT"`), while `fields=` preserves whatever else
+    # the IdP sent, which is what you actually need when the named three do
+    # not explain the behaviour. Same pattern on the two sibling log lines.
     logger.info(
         "AS proxy: IdP token response: refresh_token=%s scope=%s expires_in=%s "
         "token_type=%s fields=%s",
@@ -1155,9 +1161,9 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
     )
 
     if grant_type == "authorization_code":
-        return await _token_authorization_code(request, form)
+        response = await _token_authorization_code(request, form)
     elif grant_type == "refresh_token":
-        return await _token_refresh(request, form)
+        response = await _token_refresh(request, form)
     else:
         logger.warning("AS proxy token: unsupported grant_type=%s", grant_type)
         record_oauth_grant("unsupported", "error")
@@ -1168,6 +1174,23 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
             },
             status_code=400,
         )
+
+    # Failures are counted here rather than at each `return JSONResponse(...)`
+    # inside the handlers. Between them the two handlers have fifteen error
+    # exits — expired/replayed proxy code, client_id mismatch, redirect_uri
+    # mismatch, PKCE failure, unconfigured credentials, IdP HTTP failure — and
+    # instrumenting them individually means a future early-return silently
+    # escapes the counter. This is the single choke point every one of them
+    # passes through, so `success + error` stays an exhaustive partition of
+    # grants by construction.
+    #
+    # Success is recorded inside the handlers instead, because only they can
+    # see whether the token response carried a refresh_token; they return 200
+    # exclusively on that path, so nothing is double-counted here.
+    if response.status_code != 200:
+        record_oauth_grant(grant_type, "error")
+
+    return response
 
 
 async def _token_authorization_code(request: Request, form) -> JSONResponse:
@@ -1397,7 +1420,7 @@ async def _token_refresh(request: Request, form) -> JSONResponse:
             response.status_code,
             _redact_error_body(response.text),
         )
-        record_oauth_grant("refresh_token", "error")
+        # Counted by oauth_token_endpoint, which sees every failure exit.
         return JSONResponse(
             {
                 "error": "invalid_grant",

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -130,7 +130,27 @@ _SECRET_FIELDS = frozenset(
 )
 
 
-def _redact_error_body(text: str) -> Any:
+def _redact_form(form: Any) -> dict[str, Any]:
+    """Redact a submitted form body, preserving repeated keys.
+
+    ``dict(FormData)`` keeps only the last value for a repeated key. A token
+    request has no legitimate reason to repeat one, so a request that does is
+    either a broken client or parameter pollution — exactly the case where the
+    log must not quietly show a single value as though it were the only one
+    sent. Repeated keys are logged as a list; the common single-value case
+    still reads as a plain scalar.
+    """
+    grouped: dict[str, list[Any]] = {}
+    for key, value in form.multi_items():
+        grouped.setdefault(key, []).append(value)
+    redacted = {
+        key: [_redact({key: value})[key] for value in values]
+        for key, values in grouped.items()
+    }
+    return {key: v[0] if len(v) == 1 else v for key, v in redacted.items()}
+
+
+def _redact_error_body(text: str) -> dict[str, Any] | str:
     """Redact a non-200 token-endpoint body before logging.
 
     An OAuth error body is normally ``{"error": ..., "error_description": ...}``
@@ -1157,7 +1177,7 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
     logger.info(
         "AS proxy token request: grant_type=%s params=%s",
         grant_type,
-        _redact(dict(form)),
+        _redact_form(form),
     )
 
     if grant_type == "authorization_code":

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -20,6 +20,7 @@ Flow 2: Resource Provisioning - MCP server gets delegated Nextcloud access
 """
 
 import hashlib
+import json
 import logging
 import secrets
 import time
@@ -41,6 +42,7 @@ from nextcloud_mcp_server.auth.token_utils import (
     verify_id_token,
 )
 from nextcloud_mcp_server.config import cfg, get_settings
+from nextcloud_mcp_server.observability.metrics import record_oauth_grant
 
 from ..http import nextcloud_httpx_client
 
@@ -108,6 +110,73 @@ _as_proxy_sessions: dict[str, ASProxySession] = {}
 _dcr_rate_limit: dict[str, list[float]] = {}
 _DCR_RATE_LIMIT_MAX = 10  # max requests
 _DCR_RATE_LIMIT_WINDOW = 60  # per 60 seconds
+
+
+# Fields that carry a credential and must never reach a log sink verbatim.
+# Anything not listed here is logged as-is, which is the point: `scope`,
+# `expires_in`, `token_type` and `error` are exactly the fields that answer
+# "did the IdP issue a refresh token, and for how long".
+_SECRET_FIELDS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "code",
+        "code_verifier",
+        "client_secret",
+        "authorization",
+        "password",
+    }
+)
+
+
+def _redact_error_body(text: str) -> Any:
+    """Redact a non-200 token-endpoint body before logging.
+
+    An OAuth error body is normally ``{"error": ..., "error_description": ...}``
+    and harmless, but it arrives from an external IdP and its shape is not
+    guaranteed — parse and fingerprint rather than trusting it.
+    """
+    try:
+        return _redact(json.loads(text))
+    except (ValueError, TypeError):
+        return f"<unparseable len={len(text)}>"
+
+
+def _fingerprint(value: str) -> str:
+    """Stable, non-reversible tag for a secret, for correlating log lines.
+
+    Truncated SHA-256 so the *same* token can be followed across hops — "the
+    refresh_token Nextcloud issued is the one we handed to the client is the
+    one that came back" — without the credential itself ever being written
+    down. 32 bits is ample to correlate and useless for reversing a
+    high-entropy OAuth artifact, which every member of ``_SECRET_FIELDS`` is.
+    Deliberately unsalted: a per-process salt would break correlation across
+    the restarts this instrumentation exists to see through.
+    """
+    return hashlib.sha256(value.encode()).hexdigest()[:8]
+
+
+def _redact(data: Any) -> dict[str, Any]:
+    """Copy a token request/response with credential fields fingerprinted.
+
+    Returns a plain dict safe to hand to ``logger``. Non-secret fields pass
+    through untouched; secret fields become ``<len=N sha256=xxxxxxxx>``. A
+    secret field that is present but empty becomes ``<empty>`` — distinct from
+    being absent, which shows up as the key simply not appearing.
+    """
+    if not isinstance(data, dict):
+        return {"<non-dict response>": type(data).__name__}
+    out: dict[str, Any] = {}
+    for key, value in data.items():
+        if key.lower() not in _SECRET_FIELDS:
+            out[key] = value
+        elif value:
+            text = str(value)
+            out[key] = f"<len={len(text)} sha256={_fingerprint(text)}>"
+        else:
+            out[key] = "<empty>"
+    return out
 
 
 # OIDC standard scopes that must never be prefixed with a resource server identifier.
@@ -939,12 +1008,16 @@ async def _oauth_callback_as_proxy(
         "client_secret": mcp_server_client_secret,
     }
 
+    logger.info("AS proxy: exchanging code with IdP: %s", _redact(token_params))
+
     async with nextcloud_httpx_client() as http_client:
         response = await http_client.post(token_endpoint, data=token_params)
 
     if response.status_code != 200:
         logger.error(
-            "AS proxy token exchange failed: %s %s", response.status_code, response.text
+            "AS proxy token exchange failed: %s %s",
+            response.status_code,
+            _redact_error_body(response.text),
         )
         params = urlencode(
             {
@@ -959,9 +1032,21 @@ async def _oauth_callback_as_proxy(
 
     nc_token_response = response.json()
 
+    # The question this instrumentation exists to answer. Without a
+    # refresh_token the client has to re-run the entire authorization flow
+    # every time the access token expires, which the user experiences as being
+    # logged out. `scope` is logged alongside because a missing refresh_token
+    # is usually a missing `offline_access` on whichever client the IdP
+    # actually applied — and that is this server's own confidential client
+    # here, not the client-facing one.
     logger.info(
-        "AS proxy: Successfully exchanged code for Nextcloud token (token_type=%s)",
+        "AS proxy: IdP token response: refresh_token=%s scope=%s expires_in=%s "
+        "token_type=%s fields=%s",
+        "issued" if nc_token_response.get("refresh_token") else "ABSENT",
+        nc_token_response.get("scope"),
+        nc_token_response.get("expires_in"),
         nc_token_response.get("token_type"),
+        _redact(nc_token_response),
     )
 
     # Verify the ID token signature + claims before caching the response
@@ -1060,11 +1145,22 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
     form = await request.form()
     grant_type = form.get("grant_type")
 
+    # The whole request, credentials fingerprinted. "Why is this client
+    # re-authorizing instead of refreshing" is unanswerable without knowing
+    # which grant it actually asked for, and nothing recorded that before.
+    logger.info(
+        "AS proxy token request: grant_type=%s params=%s",
+        grant_type,
+        _redact(dict(form)),
+    )
+
     if grant_type == "authorization_code":
         return await _token_authorization_code(request, form)
     elif grant_type == "refresh_token":
         return await _token_refresh(request, form)
     else:
+        logger.warning("AS proxy token: unsupported grant_type=%s", grant_type)
+        record_oauth_grant("unsupported", "error")
         return JSONResponse(
             {
                 "error": "unsupported_grant_type",
@@ -1208,8 +1304,18 @@ async def _token_authorization_code(request: Request, form) -> JSONResponse:
             status_code=400,
         )
 
+    has_refresh = bool(entry.nc_token_response.get("refresh_token"))
     logger.info(
-        "AS proxy token: Returning Nextcloud token for client %s", entry.client_id
+        "AS proxy token: returning IdP token to client %s: refresh_token=%s "
+        "scope=%s expires_in=%s fields=%s",
+        entry.client_id,
+        "issued" if has_refresh else "ABSENT",
+        entry.nc_token_response.get("scope"),
+        entry.nc_token_response.get("expires_in"),
+        _redact(entry.nc_token_response),
+    )
+    record_oauth_grant(
+        "authorization_code", "success", "issued" if has_refresh else "absent"
     )
 
     # Return the stored Nextcloud token response directly
@@ -1280,13 +1386,18 @@ async def _token_refresh(request: Request, form) -> JSONResponse:
         "resource": f"{mcp_server_url}/mcp",
     }
 
+    logger.info("AS proxy refresh: proxying to IdP: %s", _redact(token_params))
+
     async with nextcloud_httpx_client() as http_client:
         response = await http_client.post(token_endpoint, data=token_params)
 
     if response.status_code != 200:
         logger.error(
-            "AS proxy token refresh failed: %s %s", response.status_code, response.text
+            "AS proxy token refresh failed: %s %s",
+            response.status_code,
+            _redact_error_body(response.text),
         )
+        record_oauth_grant("refresh_token", "error")
         return JSONResponse(
             {
                 "error": "invalid_grant",
@@ -1295,7 +1406,25 @@ async def _token_refresh(request: Request, form) -> JSONResponse:
             status_code=response.status_code,
         )
 
-    return JSONResponse(response.json())
+    refreshed = response.json()
+    # An absent refresh_token here is not necessarily a fault: an IdP that does
+    # not rotate refresh tokens returns only a new access token, and the
+    # client keeps using the one it already holds. Absent on the
+    # authorization_code grant above is the broken case; absent here is
+    # merely a fact worth recording.
+    has_refresh = bool(refreshed.get("refresh_token"))
+    logger.info(
+        "AS proxy refresh: succeeded: refresh_token=%s scope=%s expires_in=%s fields=%s",
+        "rotated" if has_refresh else "not-rotated",
+        refreshed.get("scope"),
+        refreshed.get("expires_in"),
+        _redact(refreshed),
+    )
+    record_oauth_grant(
+        "refresh_token", "success", "issued" if has_refresh else "absent"
+    )
+
+    return JSONResponse(refreshed)
 
 
 async def oauth_register_proxy(request: Request) -> JSONResponse:

--- a/nextcloud_mcp_server/auth/oauth_routes.py
+++ b/nextcloud_mcp_server/auth/oauth_routes.py
@@ -1181,9 +1181,9 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
     )
 
     if grant_type == "authorization_code":
-        response = await _token_authorization_code(request, form)
+        handler = _token_authorization_code
     elif grant_type == "refresh_token":
-        response = await _token_refresh(request, form)
+        handler = _token_refresh
     else:
         logger.warning("AS proxy token: unsupported grant_type=%s", grant_type)
         record_oauth_grant("unsupported", "error")
@@ -1201,12 +1201,31 @@ async def oauth_token_endpoint(request: Request) -> JSONResponse:
     # mismatch, PKCE failure, unconfigured credentials, IdP HTTP failure — and
     # instrumenting them individually means a future early-return silently
     # escapes the counter. This is the single choke point every one of them
-    # passes through, so `success + error` stays an exhaustive partition of
-    # grants by construction.
+    # passes through.
+    #
+    # A raised exception is a failed grant too, and it is the failure most
+    # worth seeing: `get_oidc_discovery` and the IdP POST do real network I/O,
+    # and `response.json()` parses a body we do not control, so an IdP that is
+    # timing out or returning garbage propagates out of here rather than
+    # returning a non-200. Counting only returned responses would let exactly
+    # that outage vanish from the metric — the same silent gap this
+    # instrumentation exists to close. Count, then re-raise so the ASGI layer
+    # still produces its 500.
+    #
+    # `Exception`, not `BaseException`: anyio cancellation during shutdown is
+    # not a failed grant and must stay uncounted. `grant_type` is one of the
+    # two known literals by this point, so no client-controlled string can
+    # reach the label.
     #
     # Success is recorded inside the handlers instead, because only they can
     # see whether the token response carried a refresh_token; they return 200
     # exclusively on that path, so nothing is double-counted here.
+    try:
+        response = await handler(request, form)
+    except Exception:
+        record_oauth_grant(grant_type, "error")
+        raise
+
     if response.status_code != 200:
         record_oauth_grant(grant_type, "error")
 
@@ -1589,7 +1608,9 @@ async def oauth_register_proxy(request: Request) -> JSONResponse:
         logger.error(
             "DCR proxy: Upstream registration failed: %s %s",
             response.status_code,
-            response.text,
+            # A DCR response is the one other place an IdP body can carry a
+            # `client_secret`, so it gets the same treatment as the token paths.
+            _redact_error_body(response.text),
         )
         return JSONResponse(
             response.json()

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -201,6 +201,20 @@ oauth_refresh_token_operations_total = Counter(
     ],  # operation: store | retrieve | delete; status: success | error
 )
 
+oauth_grants_total = Counter(
+    "mcp_oauth_grants_total",
+    "OAuth grants processed by the AS proxy token endpoint. `refresh_token` "
+    "records whether the grant produced one — a client that never receives a "
+    "refresh token must re-run the full authorization flow, which is a "
+    "user-visible re-login, so `grant_type=authorization_code` repeating for "
+    "one client is the signature of the disconnect being investigated.",
+    # grant_type: authorization_code | refresh_token | unsupported
+    # result: success | error
+    # refresh_token: issued | absent | unknown (unknown = the grant failed, so
+    #   there was no response to inspect)
+    ["grant_type", "result", "refresh_token"],
+)
+
 # =============================================================================
 # Vector Sync Metrics (optional feature)
 # =============================================================================
@@ -1312,6 +1326,32 @@ def record_oauth_token_validation(
         result=result,
         reason=reason,
         client_id=_bounded_label(_client_label(client_id), _seen_client_ids),
+    ).inc()
+
+
+def record_oauth_grant(
+    grant_type: str, result: str, refresh_token: str = "unknown"
+) -> None:
+    """Record a grant processed by the AS proxy token endpoint.
+
+    The label vocabulary is enumerated once, on the ``oauth_grants_total``
+    definition above; this docstring does not repeat it.
+
+    ``client_id`` is deliberately NOT a label here. It would be the natural
+    fourth dimension, but the grant counters are already multiplied by
+    grant_type x result x refresh_token, and the per-client attribution is
+    available on ``oauth_token_validations_total``. The log line emitted
+    alongside each of these carries the client_id when it is needed.
+
+    Args:
+        grant_type: Which grant the client asked for.
+        result: Whether the AS proxy could satisfy it.
+        refresh_token: Whether the resulting token response carried a refresh
+            token. "unknown" when the grant failed and there was no response
+            to inspect.
+    """
+    oauth_grants_total.labels(
+        grant_type=grant_type, result=result, refresh_token=refresh_token
     ).inc()
 
 

--- a/tests/unit/test_oauth_grant_instrumentation.py
+++ b/tests/unit/test_oauth_grant_instrumentation.py
@@ -1,0 +1,180 @@
+"""Redaction and grant metrics for the AS proxy token endpoint.
+
+These exist because the question "is this client refreshing, or re-running the
+whole authorization flow every hour?" was unanswerable from logs — the token
+exchange recorded only ``token_type``. The instrumentation added to answer it
+handles live credentials, so the load-bearing test here is the negative one:
+no secret may reach a log sink verbatim.
+"""
+
+import json
+
+import pytest
+
+from nextcloud_mcp_server.auth.oauth_routes import (
+    _SECRET_FIELDS,
+    _fingerprint,
+    _redact,
+    _redact_error_body,
+)
+from nextcloud_mcp_server.observability.metrics import record_oauth_grant
+
+pytestmark = pytest.mark.unit
+
+
+# A realistically-shaped Nextcloud OIDC token response. The secret values are
+# deliberately long and distinctive so a leak is unmistakable in an assertion.
+_SECRET_VALUES = {
+    "access_token": "eyJhbGciOiJSUzI1NiJ9.QUNDRVNTX1RPS0VOX1NFQ1JFVA.sig-aaaaaa",
+    "refresh_token": "REFRESH-TOKEN-SECRET-4f8a2c1e9b7d6350aabbccddeeff0011",
+    "id_token": "eyJhbGciOiJSUzI1NiJ9.SURfVE9LRU5fU0VDUkVU.sig-bbbbbb",
+}
+_TOKEN_RESPONSE = {
+    **_SECRET_VALUES,
+    "token_type": "Bearer",
+    "expires_in": 3600,
+    "scope": "openid profile email offline_access notes.read",
+}
+
+
+class TestRedactionNeverLeaks:
+    """The property that matters: no secret survives into the log record."""
+
+    def test_no_secret_value_appears_in_output(self):
+        rendered = repr(_redact(_TOKEN_RESPONSE))
+        for field, secret in _SECRET_VALUES.items():
+            assert secret not in rendered, f"{field} leaked verbatim"
+
+    def test_no_secret_fragment_appears_in_output(self):
+        """A prefix/suffix of a token is still credential material."""
+        rendered = repr(_redact(_TOKEN_RESPONSE))
+        for secret in _SECRET_VALUES.values():
+            assert secret[:16] not in rendered
+            assert secret[-16:] not in rendered
+
+    def test_every_declared_secret_field_is_actually_redacted(self):
+        """Guards the registry itself.
+
+        Adding a name to ``_SECRET_FIELDS`` without redaction logic, or
+        redaction logic that silently skips a declared field, both fail here.
+        """
+        payload = {field: f"secret-value-for-{field}" for field in _SECRET_FIELDS}
+        redacted = _redact(payload)
+        for field in _SECRET_FIELDS:
+            assert redacted[field].startswith("<len=")
+            assert "secret-value-for" not in redacted[field]
+
+    def test_secret_field_matching_is_case_insensitive(self):
+        """Form bodies and IdP responses do not agree on casing."""
+        redacted = _redact({"Refresh_Token": "SECRET", "AUTHORIZATION": "Bearer x"})
+        assert "SECRET" not in repr(redacted)
+        assert "Bearer x" not in repr(redacted)
+
+
+class TestRedactionPreservesDiagnostics:
+    """Redaction is worthless if it also hides the answer."""
+
+    def test_non_secret_fields_pass_through_untouched(self):
+        redacted = _redact(_TOKEN_RESPONSE)
+        assert redacted["token_type"] == "Bearer"
+        assert redacted["expires_in"] == 3600
+        assert redacted["scope"] == "openid profile email offline_access notes.read"
+
+    def test_presence_of_a_secret_is_still_visible(self):
+        """'Was a refresh_token issued' must survive redaction — it is the
+        entire point of the instrumentation."""
+        assert "refresh_token" in _redact(_TOKEN_RESPONSE)
+        assert "refresh_token" not in _redact(
+            {k: v for k, v in _TOKEN_RESPONSE.items() if k != "refresh_token"}
+        )
+
+    def test_length_is_preserved(self):
+        redacted = _redact({"refresh_token": "x" * 42})
+        assert "len=42" in redacted["refresh_token"]
+
+    def test_present_but_empty_is_distinct_from_absent(self):
+        """An IdP returning ``refresh_token: ""`` is a different bug from one
+        omitting the field, and the log must tell them apart."""
+        assert _redact({"refresh_token": ""})["refresh_token"] == "<empty>"
+        assert "refresh_token" not in _redact({"token_type": "Bearer"})
+
+
+class TestFingerprintCorrelation:
+    """The fingerprint exists to follow one token across hops."""
+
+    def test_same_secret_gives_same_fingerprint(self):
+        token = _SECRET_VALUES["refresh_token"]
+        assert _fingerprint(token) == _fingerprint(token)
+
+    def test_different_secrets_give_different_fingerprints(self):
+        assert _fingerprint("token-a") != _fingerprint("token-b")
+
+    def test_fingerprint_is_short_enough_to_be_useless_for_reversal(self):
+        assert len(_fingerprint("anything")) == 8
+
+    def test_same_token_correlates_across_two_redacted_payloads(self):
+        """The IdP response and what we hand the client carry the same token;
+        the log must make that provable without printing it."""
+        issued = _redact(_TOKEN_RESPONSE)
+        returned = _redact(dict(_TOKEN_RESPONSE))
+        assert issued["refresh_token"] == returned["refresh_token"]
+
+
+class TestErrorBodyRedaction:
+    """IdP error bodies are external input and not guaranteed to be benign."""
+
+    def test_standard_oauth_error_is_readable(self):
+        body = json.dumps({"error": "invalid_grant", "error_description": "expired"})
+        assert _redact_error_body(body) == {
+            "error": "invalid_grant",
+            "error_description": "expired",
+        }
+
+    def test_secret_echoed_in_an_error_body_is_redacted(self):
+        body = json.dumps({"error": "invalid_grant", "refresh_token": "LEAKED-SECRET"})
+        assert "LEAKED-SECRET" not in repr(_redact_error_body(body))
+
+    def test_unparseable_body_reports_length_only(self):
+        result = _redact_error_body("<html>502 Bad Gateway</html>")
+        assert result == "<unparseable len=28>"
+
+    def test_empty_body_does_not_raise(self):
+        assert "unparseable" in _redact_error_body("")
+
+    def test_non_dict_json_does_not_raise(self):
+        """A bare JSON array or string is valid JSON but not a mapping."""
+        assert _redact_error_body("[1, 2, 3]") == {"<non-dict response>": "list"}
+
+
+class TestGrantMetric:
+    def test_records_refresh_token_issued(self, metric_sample):
+        labels = {
+            "grant_type": "authorization_code",
+            "result": "success",
+            "refresh_token": "issued",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        record_oauth_grant("authorization_code", "success", "issued")
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    def test_records_refresh_token_absent(self, metric_sample):
+        """The signature of the disconnect: a grant that yields no refresh
+        token, forcing the client back through the full flow next hour."""
+        labels = {
+            "grant_type": "authorization_code",
+            "result": "success",
+            "refresh_token": "absent",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        record_oauth_grant("authorization_code", "success", "absent")
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    def test_refresh_token_defaults_to_unknown_on_failure(self, metric_sample):
+        labels = {
+            "grant_type": "refresh_token",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        record_oauth_grant("refresh_token", "error")
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1

--- a/tests/unit/test_oauth_grant_instrumentation.py
+++ b/tests/unit/test_oauth_grant_instrumentation.py
@@ -8,8 +8,10 @@ no secret may reach a log sink verbatim.
 """
 
 import json
+import logging
 
 import pytest
+from starlette.responses import JSONResponse
 
 from nextcloud_mcp_server.auth.oauth_routes import (
     _SECRET_FIELDS,
@@ -178,3 +180,175 @@ class TestGrantMetric:
         before = metric_sample("mcp_oauth_grants_total", labels)
         record_oauth_grant("refresh_token", "error")
         assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+
+class TestGrantMetricWiring:
+    """The counter is only useful if the real code paths reach it.
+
+    The tests above prove the helpers behave; these prove they are actually
+    called, with the labels the dashboards and alerts assume. This is the part
+    most likely to drift silently in a later refactor — a reordered early
+    return or a renamed field breaks the metric without breaking a helper.
+    """
+
+    @staticmethod
+    def _request(form: dict[str, str]):
+        """Minimal Starlette request whose .form() yields *form*."""
+        from starlette.datastructures import FormData
+
+        class _Req:
+            async def form(self):
+                return FormData(form)
+
+        return _Req()
+
+    @staticmethod
+    def _pkce_pair() -> tuple[str, str]:
+        import hashlib as _h
+        from base64 import urlsafe_b64encode
+
+        verifier = "v" * 43
+        challenge = (
+            urlsafe_b64encode(_h.sha256(verifier.encode("ascii")).digest())
+            .decode("ascii")
+            .rstrip("=")
+        )
+        return verifier, challenge
+
+    async def test_unsupported_grant_type_is_counted(self, metric_sample):
+        from nextcloud_mcp_server.auth.oauth_routes import oauth_token_endpoint
+
+        labels = {
+            "grant_type": "unsupported",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        response = await oauth_token_endpoint(
+            self._request({"grant_type": "client_credentials"})
+        )
+
+        assert response.status_code == 400
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    async def test_handler_failure_is_counted_as_error(self, metric_sample, mocker):
+        """A failing grant must move the counter.
+
+        Before this was centralised, fifteen error returns bypassed the metric
+        entirely — a client failing every exchange looked identical to a client
+        making no requests at all.
+        """
+        from nextcloud_mcp_server.auth import oauth_routes
+
+        mocker.patch.object(
+            oauth_routes,
+            "_token_authorization_code",
+            return_value=JSONResponse({"error": "invalid_grant"}, status_code=400),
+        )
+        labels = {
+            "grant_type": "authorization_code",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        await oauth_routes.oauth_token_endpoint(
+            self._request({"grant_type": "authorization_code"})
+        )
+
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    async def test_success_is_not_also_counted_as_error(self, metric_sample, mocker):
+        """Guards the double-count the split success/error recording invites."""
+        from nextcloud_mcp_server.auth import oauth_routes
+
+        mocker.patch.object(
+            oauth_routes,
+            "_token_refresh",
+            return_value=JSONResponse({"access_token": "a"}, status_code=200),
+        )
+        labels = {
+            "grant_type": "refresh_token",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        await oauth_routes.oauth_token_endpoint(
+            self._request({"grant_type": "refresh_token"})
+        )
+
+        assert metric_sample("mcp_oauth_grants_total", labels) == before
+
+    async def _exchange(self, token_response: dict):
+        """Drive a full, valid authorization_code exchange."""
+        from nextcloud_mcp_server.auth import oauth_routes
+        from nextcloud_mcp_server.auth.oauth_routes import ProxyCodeEntry
+
+        verifier, challenge = self._pkce_pair()
+        oauth_routes._proxy_codes["test-code"] = ProxyCodeEntry(
+            client_id="client-abc",
+            client_redirect_uri="https://example.test/cb",
+            client_state="state",
+            code_challenge=challenge,
+            code_challenge_method="S256",
+            nc_token_response=token_response,
+        )
+        try:
+            return await oauth_routes.oauth_token_endpoint(
+                self._request(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "test-code",
+                        "redirect_uri": "https://example.test/cb",
+                        "code_verifier": verifier,
+                        "client_id": "client-abc",
+                    }
+                )
+            )
+        finally:
+            oauth_routes._proxy_codes.pop("test-code", None)
+
+    async def test_refresh_token_issued_is_recorded(self, metric_sample):
+        labels = {
+            "grant_type": "authorization_code",
+            "result": "success",
+            "refresh_token": "issued",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        response = await self._exchange(
+            {"access_token": "a", "refresh_token": "r", "token_type": "Bearer"}
+        )
+
+        assert response.status_code == 200
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    async def test_missing_refresh_token_is_recorded_as_absent(self, metric_sample):
+        """The motivating scenario: a grant that succeeds but strands the
+        client with no way to refresh, so it must re-authorize next hour."""
+        labels = {
+            "grant_type": "authorization_code",
+            "result": "success",
+            "refresh_token": "absent",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        response = await self._exchange({"access_token": "a", "token_type": "Bearer"})
+
+        assert response.status_code == 200
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    async def test_absent_refresh_token_is_logged_visibly(self, caplog):
+        """The log line an operator greps for must say ABSENT, not just omit
+        the field — an absent key is invisible to `|= "refresh_token=ABSENT"`."""
+        caplog.set_level(logging.INFO, logger="nextcloud_mcp_server.auth.oauth_routes")
+        await self._exchange({"access_token": "a", "token_type": "Bearer"})
+
+        assert any("refresh_token=ABSENT" in r.getMessage() for r in caplog.records)
+
+    async def test_no_secret_reaches_the_log_on_a_real_exchange(self, caplog):
+        """End-to-end guard: the redactor is wired into the live path, not
+        just unit-tested in isolation."""
+        caplog.set_level(logging.INFO, logger="nextcloud_mcp_server.auth.oauth_routes")
+        await self._exchange(dict(_TOKEN_RESPONSE))
+
+        rendered = "\n".join(r.getMessage() for r in caplog.records)
+        for secret in _SECRET_VALUES.values():
+            assert secret not in rendered

--- a/tests/unit/test_oauth_grant_instrumentation.py
+++ b/tests/unit/test_oauth_grant_instrumentation.py
@@ -18,6 +18,7 @@ from nextcloud_mcp_server.auth.oauth_routes import (
     _fingerprint,
     _redact,
     _redact_error_body,
+    _redact_form,
 )
 from nextcloud_mcp_server.observability.metrics import record_oauth_grant
 
@@ -352,3 +353,38 @@ class TestGrantMetricWiring:
         rendered = "\n".join(r.getMessage() for r in caplog.records)
         for secret in _SECRET_VALUES.values():
             assert secret not in rendered
+
+
+class TestFormRedaction:
+    """``dict(FormData)`` drops repeated keys, and the drop is silent."""
+
+    @staticmethod
+    def _form(pairs):
+        from starlette.datastructures import FormData
+
+        return FormData(pairs)
+
+    def test_single_valued_form_reads_as_scalars(self):
+        redacted = _redact_form(
+            self._form([("grant_type", "refresh_token"), ("client_id", "abc")])
+        )
+        assert redacted == {"grant_type": "refresh_token", "client_id": "abc"}
+
+    def test_repeated_key_is_preserved_as_a_list(self):
+        """A token request repeating a field is a broken client or parameter
+        pollution; the log must show both values, not silently pick one."""
+        redacted = _redact_form(
+            self._form([("grant_type", "refresh_token"), ("grant_type", "password")])
+        )
+        assert redacted == {"grant_type": ["refresh_token", "password"]}
+
+    def test_repeated_secret_key_is_redacted_in_every_position(self):
+        redacted = _redact_form(
+            self._form([("code", "SECRET-ONE"), ("code", "SECRET-TWO")])
+        )
+        assert "SECRET-ONE" not in repr(redacted)
+        assert "SECRET-TWO" not in repr(redacted)
+        assert len(redacted["code"]) == 2
+
+    def test_empty_form_does_not_raise(self):
+        assert _redact_form(self._form([])) == {}

--- a/tests/unit/test_oauth_grant_instrumentation.py
+++ b/tests/unit/test_oauth_grant_instrumentation.py
@@ -388,3 +388,77 @@ class TestFormRedaction:
 
     def test_empty_form_does_not_raise(self):
         assert _redact_form(self._form([])) == {}
+
+
+class TestRaisedGrantFailures:
+    """An IdP timeout is a failed grant, not an absent one.
+
+    ``get_oidc_discovery`` and the IdP POST do real network I/O and
+    ``response.json()`` parses a body we do not control, so a failing IdP
+    propagates an exception rather than returning a non-200. Counting only
+    returned responses would let precisely that outage vanish from the metric.
+    """
+
+    async def test_raised_exception_is_counted_as_error(self, metric_sample, mocker):
+        from nextcloud_mcp_server.auth import oauth_routes
+
+        mocker.patch.object(
+            oauth_routes,
+            "_token_refresh",
+            side_effect=TimeoutError("IdP unreachable"),
+        )
+        labels = {
+            "grant_type": "refresh_token",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        request = TestGrantMetricWiring._request({"grant_type": "refresh_token"})
+
+        with pytest.raises(TimeoutError):
+            await oauth_routes.oauth_token_endpoint(request)
+
+        assert metric_sample("mcp_oauth_grants_total", labels) == before + 1
+
+    async def test_exception_still_propagates(self, mocker):
+        """Counting must not swallow the failure — the ASGI layer still owes
+        the caller a 500."""
+        from nextcloud_mcp_server.auth import oauth_routes
+
+        mocker.patch.object(
+            oauth_routes,
+            "_token_authorization_code",
+            side_effect=RuntimeError("boom"),
+        )
+        request = TestGrantMetricWiring._request({"grant_type": "authorization_code"})
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await oauth_routes.oauth_token_endpoint(request)
+
+    async def test_cancellation_is_not_counted_as_a_failed_grant(
+        self, metric_sample, mocker
+    ):
+        """Shutdown cancels in-flight requests; that is not an IdP failure and
+        must not inflate the error count. Guards the deliberate choice of
+        ``except Exception`` over ``except BaseException``."""
+        import anyio
+
+        from nextcloud_mcp_server.auth import oauth_routes
+
+        mocker.patch.object(
+            oauth_routes,
+            "_token_refresh",
+            side_effect=anyio.get_cancelled_exc_class()(),
+        )
+        labels = {
+            "grant_type": "refresh_token",
+            "result": "error",
+            "refresh_token": "unknown",
+        }
+        before = metric_sample("mcp_oauth_grants_total", labels)
+        request = TestGrantMetricWiring._request({"grant_type": "refresh_token"})
+
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await oauth_routes.oauth_token_endpoint(request)
+
+        assert metric_sample("mcp_oauth_grants_total", labels) == before


### PR DESCRIPTION
## Why

The AS proxy token exchange logged only `token_type`. That made a specific operational question unanswerable from logs: **is a client refreshing, or re-running the whole authorization flow every time its access token expires?**

On one tenant that distinction mattered. Over 24h: **21 `authorization_code` grants and zero `refresh_token` grants** — a full consent flow roughly every 68 minutes, each one a user-visible re-login. Nothing failed, nothing alerted, and no existing metric moved. It surfaced only as "the connector keeps disconnecting".

This was initially misattributed to the MCP server being OOMKilled. That turned out to be a separate bug: losing `Mcp-Session-Id` state gives a 404 and a silent `initialize`, and the client keeps its access token across a restart. Session loss is not token loss. Distinguishing the two required evidence the logs did not carry.

## What

**Both sides of every grant are logged, with credentials fingerprinted rather than printed.** Secret fields become `<len=N sha256=xxxxxxxx>`:

```
AS proxy token request: grant_type=refresh_token params={...}
AS proxy: exchanging code with IdP: {...}
AS proxy: IdP token response: refresh_token=ABSENT scope=... expires_in=3600 ...
AS proxy token: returning IdP token to client <id>: refresh_token=ABSENT ...
AS proxy refresh: succeeded: refresh_token=rotated scope=... ...
```

The fingerprint is a truncated, **unsalted** SHA-256 — deliberately, so one token can be followed across hops *and across process restarts*. A per-process salt would break exactly the correlation this exists to provide, and 32 bits is useless for reversing a high-entropy OAuth artifact. Non-secret fields (`scope`, `expires_in`, `token_type`, `error`) pass through untouched, because those are what answer the question.

**New metric** `mcp_oauth_grants_total{grant_type, result, refresh_token}`, so the degradation is alertable rather than only greppable.

Also redacts two pre-existing `response.text` error logs on these paths, which echoed an external IdP's response body verbatim.

## One judgement call

`refresh_token="absent"` is **not** treated as uniformly bad. An IdP that does not rotate refresh tokens legitimately omits one from a *refresh* grant — the client keeps the one it holds. Absence on the **`authorization_code`** grant is the fault. The metric records both and the docs/alerts distinguish them, so nobody gets paged for the benign case.

## Test coverage

20 unit tests, weighted toward the negative property: no secret value — and no 16-character fragment of one — may appear in rendered output. `test_every_declared_secret_field_is_actually_redacted` iterates `_SECRET_FIELDS`, so adding a name there without redaction logic fails the build rather than silently leaking.

Also covered: case-insensitive key matching (form bodies and IdP responses disagree on casing), present-but-empty vs absent (different bugs, must be distinguishable), fingerprint stability/correlation, and error bodies that are unparseable, empty, or valid-JSON-but-not-a-mapping.

No API surface is added or changed — no new endpoint, tool, or cross-service boundary — so the e2e/contract gate does not apply here. Existing contract tests are unaffected.

## Verification

`ruff`, `ruff format --check`, `ty`, 3196 unit tests, and `sonar analyze secrets` on the changed files all pass. Re-run after rebasing onto master, since master had since gained changes to `metrics.py` and `docs/observability.md` — the same files this touches, where a clean rebase proves nothing on its own.

---

_This PR was generated with the help of AI, and reviewed by a Human_
