### PR TITLE
feat(calendar): write the parameters the tools only pretended to accept

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -75,29 +75,34 @@ def _rrule_to_string(rrule: Any) -> str:
 
 def _shorthand_would_lose(
     stored: list[dict[str, Any]],
-    minutes: int,
-    actions: list[str],
     default_description: str,
     default_summary: str,
 ) -> bool:
-    """True when the shorthand rebuild cannot reproduce the stored alarms.
+    """True when the stored alarms carry shape the shorthand cannot express.
 
-    ``reminder_minutes``/``reminder_email`` collapse to at most one DISPLAY plus
-    one EMAIL, both at a single whole-minute offset with the default wording.
-    Anything the stored set carries beyond that — a second alarm at another
-    offset, an absolute trigger, a ``RELATED=END`` qualifier, a custom summary or
-    per-alarm description — is discarded by the rebuild.
+    ``reminder_minutes``/``reminder_email`` rebuild to at most one DISPLAY plus
+    one EMAIL, sharing a single whole-minute offset and the default wording. A
+    stored set outside that shape — an absolute or sub-minute trigger, several
+    distinct offsets, two alarms of the same action, a ``RELATED`` qualifier, a
+    custom summary or per-alarm description — cannot survive the rebuild.
 
-    Checking only for a missing ``minutes_before`` caught the absolute triggers
-    and none of the rest, so two DISPLAY alarms at different offsets collapsed
-    into one silently. This compares against what the rebuild will actually
-    produce instead of against one shape it cannot express.
+    What the caller is *changing* is deliberately not part of this. A new offset,
+    or dropping the EMAIL alarm via ``reminder_email=False``, is the request
+    being honoured, not data being lost. Comparing each stored offset against the
+    new target made this fire on the most ordinary update there is — nudging a
+    reminder's offset — which would have trained the reader to ignore it.
     """
-    if len(stored) > len(actions):
+    offsets = {reminder.get("minutes_before") for reminder in stored}
+    if len(offsets) > 1:
         return True
+
+    seen_actions = [reminder.get("action") for reminder in stored]
+    if len(seen_actions) != len(set(seen_actions)):
+        return True
+
     return any(
-        reminder.get("minutes_before") != minutes
-        or reminder.get("action") not in actions
+        "minutes_before" not in reminder
+        or reminder.get("action") not in ("DISPLAY", "EMAIL")
         or reminder.get("related")
         # An EMAIL alarm the shorthand itself wrote carries the component title
         # as its subject, so that value is reproducible and not a loss.
@@ -1511,9 +1516,7 @@ class CalendarClient:
         )
 
         actions = ["DISPLAY"] + (["EMAIL"] if want_email else [])
-        if _shorthand_would_lose(
-            stored, minutes, actions, default_description, default_summary
-        ):
+        if _shorthand_would_lose(stored, default_description, default_summary):
             logger.warning(
                 "reminder_minutes/reminder_email rebuilds the alarms as one "
                 "%s at %d minutes, which does not reproduce the %d stored "

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -195,6 +195,16 @@ def _format_until(end_date: str, *, all_day: bool, tz: dt.tzinfo | None = None) 
         ) from None
 
     if all_day:
+        if end_date != end_date.split("T")[0]:
+            # RFC 5545 ties UNTIL's value type to DTSTART's, so an all-day series
+            # can only be bounded by a DATE. Dropping the time is the sole
+            # correct reading rather than a caller error, hence debug not warn —
+            # but it should still be visible to anyone wondering where it went.
+            logger.debug(
+                "recurrence_end_date %r carries a time of day, which an all-day "
+                "series cannot express in UNTIL; using the date alone",
+                end_date,
+            )
         return parsed.date().strftime("%Y%m%d")
 
     if end_date == end_date.split("T")[0]:

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -109,7 +109,11 @@ def _rrule_with_until(
     """
     parts = _rrule_parts_without_bounds(rrule_str, replace=replace)
     all_day = isinstance(dtstart, dt.date) and not isinstance(dtstart, dt.datetime)
-    return ";".join([*parts, f"UNTIL={_format_until(end_date, all_day=all_day)}"])
+    # DTSTART's zone is what "that day" means to the caller, so an end-of-day
+    # boundary has to be built in it before being converted to UTC.
+    tz = None if all_day else getattr(dtstart, "tzinfo", None)
+    until = _format_until(end_date, all_day=all_day, tz=tz)
+    return ";".join([*parts, f"UNTIL={until}"])
 
 
 def _rrule_parts_without_bounds(rrule_str: str, *, replace: bool) -> list[str]:
@@ -129,8 +133,17 @@ def _rrule_parts_without_bounds(rrule_str: str, *, replace: bool) -> list[str]:
     return parts
 
 
-def _format_until(end_date: str, *, all_day: bool) -> str:
-    """Render ``end_date`` as an UNTIL value of the type DTSTART requires."""
+def _format_until(end_date: str, *, all_day: bool, tz: dt.tzinfo | None = None) -> str:
+    """Render ``end_date`` as an UNTIL value of the type DTSTART requires.
+
+    ``tz`` is DTSTART's own zone. RFC 5545 requires UNTIL to be *formatted* in
+    UTC for a date-time DTSTART, but that is a serialisation rule, not an
+    instruction to anchor the boundary to UTC midnight: "until June 30th" means
+    the end of June 30th where the event happens. Anchoring in UTC drops the
+    last occurrence of any evening event in a zone behind UTC, because its real
+    instant falls on the following UTC date — 21:00 in New York on the 30th is
+    01:00 UTC on the 1st, past a ``T235959Z`` cutoff.
+    """
     try:
         parsed = dt.datetime.fromisoformat(end_date)
     except ValueError:
@@ -145,12 +158,9 @@ def _format_until(end_date: str, *, all_day: bool) -> str:
         # Date-only input: bound the whole day rather than midnight, which would
         # exclude an occurrence happening later on that date.
         parsed = parsed.replace(hour=23, minute=59, second=59)
-    parsed = (
-        parsed.replace(tzinfo=dt.UTC)
-        if parsed.tzinfo is None
-        else parsed.astimezone(dt.UTC)
-    )
-    return parsed.strftime("%Y%m%dT%H%M%SZ")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz or dt.UTC)
+    return parsed.astimezone(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _occurrence_is_done(component: Any) -> bool:
@@ -1907,6 +1917,15 @@ class CalendarClient:
                         component["RRULE"] = vRecur.from_ical(rrule_str)
                     elif "RRULE" in component:
                         del component["RRULE"]
+                    elif event_data.get("recurrence_end_date"):
+                        # No stored rule and none supplied: there is nothing for
+                        # the end date to bound, and inventing a series from an
+                        # end date alone would be a guess.
+                        logger.warning(
+                            "recurrence_end_date was given for an event with no "
+                            "recurrence rule, so it has no effect; pass "
+                            "recurrence_rule as well to make the event recur"
+                        )
 
                 # Update timestamps
                 now = dt.datetime.now(dt.UTC)

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1314,16 +1314,24 @@ class CalendarClient:
 
     @staticmethod
     def _extract_valarms(component: Any) -> list[dict[str, Any]]:
-        """Read a component's VALARMs back into ``Reminder``-shaped dicts."""
+        """Read a component's VALARMs back into ``Reminder``-shaped dicts.
+
+        An alarm that cannot be represented is skipped rather than surfaced
+        half-built, because the caller's next step is model validation and a
+        malformed alarm must cost at most itself, never the listing it is in.
+        """
         reminders = []
         for sub in component.subcomponents:
-            if sub.name == "VALARM":
-                reminders.append(CalendarClient._extract_valarm(sub))
+            if sub.name != "VALARM":
+                continue
+            reminder = CalendarClient._extract_valarm(sub)
+            if reminder is not None:
+                reminders.append(reminder)
         return reminders
 
     @staticmethod
-    def _extract_valarm(alarm: Any) -> dict[str, Any]:
-        """Read one VALARM into a ``Reminder``-shaped dict.
+    def _extract_valarm(alarm: Any) -> dict[str, Any] | None:
+        """Read one VALARM into a ``Reminder``-shaped dict, or ``None``.
 
         Stored data is normalised to what ``Reminder`` accepts, because this
         parses whatever any CalDAV client wrote, not only what we write. RFC 5545
@@ -1333,6 +1341,12 @@ class CalendarClient:
         todo appears in, rather than the one alarm. Nextcloud's own
         ``ReminderService`` discards an alarm it does not recognise instead of
         rejecting its component, so unknown actions degrade to DISPLAY here.
+
+        ``None`` means the alarm has no usable TRIGGER. RFC 5545 makes TRIGGER
+        mandatory and Nextcloud cannot schedule an alarm without one, so there is
+        nothing to report — and ``Reminder`` requires exactly one trigger field,
+        so returning a trigger-less dict would fail validation for the whole
+        component just as an unknown ACTION would.
         """
         action = str(alarm.get("action", "DISPLAY")).upper()
         if action not in _VALARM_ACTIONS:
@@ -1353,8 +1367,12 @@ class CalendarClient:
             reminder["summary"] = str(summary)
 
         trigger = alarm.get("trigger")
-        if trigger is None:
-            return reminder
+        if trigger is None or getattr(trigger, "dt", None) is None:
+            logger.warning(
+                "Skipping a VALARM with no usable TRIGGER; RFC 5545 requires one "
+                "and Nextcloud cannot schedule the alarm without it"
+            )
+            return None
 
         value = trigger.dt
         if not isinstance(value, dt.timedelta):
@@ -1929,6 +1947,12 @@ class CalendarClient:
                 # here would emit exactly the mismatched RRULE that makes clients
                 # discard the recurrence set.
                 if event_data.get("recurring") is False:
+                    if event_data.get("recurrence_end_date"):
+                        logger.warning(
+                            "recurring=False was passed in the same update that "
+                            "set recurrence_end_date, so the series is removed "
+                            "and the end date has nothing to bound"
+                        )
                     if "RRULE" in component:
                         del component["RRULE"]
                 elif (

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1306,9 +1306,17 @@ class CalendarClient:
                 vDDDTypes.from_ical(str(reminder["trigger"])),
                 parameters=params,
             )
-        else:
+        elif "minutes_before" in reminder:
             minutes = int(reminder["minutes_before"])
             alarm.add("trigger", dt.timedelta(minutes=-minutes), parameters=params)
+        else:
+            # The Reminder model already enforces this for anything arriving via
+            # an MCP tool, but the client is usable directly and a bare KeyError
+            # would name a dict key rather than the thing the caller got wrong.
+            raise ValueError(
+                "a reminder needs one of trigger_at, trigger or minutes_before; "
+                f"got {sorted(reminder)}"
+            )
 
         return alarm
 
@@ -1952,6 +1960,12 @@ class CalendarClient:
                             "recurring=False was passed in the same update that "
                             "set recurrence_end_date, so the series is removed "
                             "and the end date has nothing to bound"
+                        )
+                    if event_data.get("recurrence_rule"):
+                        logger.warning(
+                            "recurring=False was passed in the same update that "
+                            "set recurrence_rule, so the series is removed and "
+                            "the new rule is discarded"
                         )
                     if "RRULE" in component:
                         del component["RRULE"]

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -44,6 +44,11 @@ _PENDING_MAX_LOOKBACK = dt.timedelta(days=366 * 3)
 # An occurrence in one of these states is finished and not part of the backlog.
 _TODO_DONE_STATUSES = frozenset({"COMPLETED", "CANCELLED"})
 
+# Fallback VALARM DESCRIPTION per component type. RFC 5545 requires the property
+# on DISPLAY and EMAIL alarms, so a reminder that omits it still needs wording.
+_EVENT_REMINDER_DESCRIPTION = "Event reminder"
+_TODO_REMINDER_DESCRIPTION = "Todo reminder"
+
 
 def _rrule_to_string(rrule: Any) -> str:
     """Render an icalendar ``vRecur`` as an RFC 5545 RRULE value.
@@ -1244,7 +1249,7 @@ class CalendarClient:
     def _build_valarm(
         reminder: dict[str, Any],
         default_summary: str,
-        default_description: str = "Event reminder",
+        default_description: str = _EVENT_REMINDER_DESCRIPTION,
     ) -> Alarm:
         """Build one VALARM from a ``Reminder``-shaped dict.
 
@@ -1342,7 +1347,7 @@ class CalendarClient:
         component: Any,
         reminders: list[dict[str, Any]],
         default_summary: str,
-        default_description: str = "Event reminder",
+        default_description: str = _EVENT_REMINDER_DESCRIPTION,
     ) -> None:
         """Replace every VALARM on ``component`` with ``reminders``, in order."""
         component.subcomponents = [
@@ -1360,7 +1365,7 @@ class CalendarClient:
         component: Any,
         data: dict[str, Any],
         default_summary: str,
-        default_description: str = "Event reminder",
+        default_description: str = _EVENT_REMINDER_DESCRIPTION,
     ) -> None:
         """Write alarms onto ``component`` from whichever form the caller used.
 
@@ -1970,7 +1975,7 @@ class CalendarClient:
 
         # Alarms/reminders
         self._apply_reminders(
-            todo, todo_data, todo_data.get("summary", ""), "Todo reminder"
+            todo, todo_data, todo_data.get("summary", ""), _TODO_REMINDER_DESCRIPTION
         )
 
         # Add timestamps
@@ -2198,7 +2203,7 @@ class CalendarClient:
                         component,
                         todo_data,
                         todo_data.get("summary") or str(component.get("summary", "")),
-                        "Todo reminder",
+                        _TODO_REMINDER_DESCRIPTION,
                     )
 
                     # Update timestamps

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -73,6 +73,40 @@ def _rrule_to_string(rrule: Any) -> str:
         return str(rrule)
 
 
+def _shorthand_would_lose(
+    stored: list[dict[str, Any]],
+    minutes: int,
+    actions: list[str],
+    default_description: str,
+    default_summary: str,
+) -> bool:
+    """True when the shorthand rebuild cannot reproduce the stored alarms.
+
+    ``reminder_minutes``/``reminder_email`` collapse to at most one DISPLAY plus
+    one EMAIL, both at a single whole-minute offset with the default wording.
+    Anything the stored set carries beyond that — a second alarm at another
+    offset, an absolute trigger, a ``RELATED=END`` qualifier, a custom summary or
+    per-alarm description — is discarded by the rebuild.
+
+    Checking only for a missing ``minutes_before`` caught the absolute triggers
+    and none of the rest, so two DISPLAY alarms at different offsets collapsed
+    into one silently. This compares against what the rebuild will actually
+    produce instead of against one shape it cannot express.
+    """
+    if len(stored) > len(actions):
+        return True
+    return any(
+        reminder.get("minutes_before") != minutes
+        or reminder.get("action") not in actions
+        or reminder.get("related")
+        # An EMAIL alarm the shorthand itself wrote carries the component title
+        # as its subject, so that value is reproducible and not a loss.
+        or (reminder.get("summary") or default_summary) != default_summary
+        or (reminder.get("description") or default_description) != default_description
+        for reminder in stored
+    )
+
+
 def _warn_if_hex_color(color: str) -> None:
     """Warn when a COLOR value will not survive Nextcloud's Calendar UI.
 
@@ -1476,15 +1510,17 @@ class CalendarClient:
             else any(r["action"] == "EMAIL" for r in stored)
         )
 
-        # The shorthand can only express one whole-minute offset, so any stored
-        # alarm outside that shape is about to be replaced by the rebuild below.
-        unrepresentable = [r for r in stored if "minutes_before" not in r]
-        if unrepresentable:
+        actions = ["DISPLAY"] + (["EMAIL"] if want_email else [])
+        if _shorthand_would_lose(
+            stored, minutes, actions, default_description, default_summary
+        ):
             logger.warning(
-                "reminder_minutes/reminder_email will replace %d stored alarm(s) "
-                "the shorthand cannot express (absolute or sub-minute triggers); "
-                "use the reminders list to edit those without losing them",
-                len(unrepresentable),
+                "reminder_minutes/reminder_email rebuilds the alarms as one "
+                "%s at %d minutes, which does not reproduce the %d stored "
+                "alarm(s); use the reminders list to edit them without loss",
+                "/".join(actions),
+                minutes,
+                len(stored),
             )
 
         if minutes <= 0 and want_email:
@@ -1498,9 +1534,6 @@ class CalendarClient:
         if minutes <= 0:
             return
 
-        actions = ["DISPLAY"]
-        if want_email:
-            actions.append("EMAIL")
         for action in actions:
             component.add_component(
                 self._build_valarm(
@@ -1674,7 +1707,9 @@ class CalendarClient:
             if until:
                 # vRecur stores UNTIL as a single-element list of date/datetime.
                 value = until[0] if isinstance(until, list) else until
-                event_data["recurrence_end"] = value.isoformat()
+                # Same key the update tool accepts, so a read value can be fed
+                # straight back in — the write side is recurrence_end_date.
+                event_data["recurrence_end_date"] = value.isoformat()
 
         # Handle attendees
         attendees = []

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -102,22 +102,30 @@ def _rrule_with_until(
     update path: applying an end date to the *stored* rule of an already-bounded
     series means "move the end", not "contradict yourself".
     """
+    parts = _rrule_parts_without_bounds(rrule_str, replace=replace)
+    all_day = isinstance(dtstart, dt.date) and not isinstance(dtstart, dt.datetime)
+    return ";".join([*parts, f"UNTIL={_format_until(end_date, all_day=all_day)}"])
+
+
+def _rrule_parts_without_bounds(rrule_str: str, *, replace: bool) -> list[str]:
+    """Split an RRULE into parts, dropping or rejecting UNTIL/COUNT."""
     parts = []
     for part in rrule_str.split(";"):
         if not part:
             continue
         name = part.split("=", 1)[0].strip().upper()
-        if name in ("UNTIL", "COUNT"):
-            if not replace:
-                raise ValueError(
-                    f"recurrence_end_date conflicts with {name} already present in "
-                    f"recurrence_rule ({rrule_str!r}); pass one or the other"
-                )
-            continue
-        parts.append(part)
+        if name not in ("UNTIL", "COUNT"):
+            parts.append(part)
+        elif not replace:
+            raise ValueError(
+                f"recurrence_end_date conflicts with {name} already present in "
+                f"recurrence_rule ({rrule_str!r}); pass one or the other"
+            )
+    return parts
 
-    all_day = isinstance(dtstart, dt.date) and not isinstance(dtstart, dt.datetime)
-    date_part = end_date.split("T")[0]
+
+def _format_until(end_date: str, *, all_day: bool) -> str:
+    """Render ``end_date`` as an UNTIL value of the type DTSTART requires."""
     try:
         parsed = dt.datetime.fromisoformat(end_date)
     except ValueError:
@@ -126,20 +134,18 @@ def _rrule_with_until(
         ) from None
 
     if all_day:
-        until = parsed.date().strftime("%Y%m%d")
-    else:
-        if end_date == date_part:
-            # Date-only input: bound the whole day rather than midnight, which
-            # would exclude an occurrence happening later on that date.
-            parsed = parsed.replace(hour=23, minute=59, second=59)
-        parsed = (
-            parsed.replace(tzinfo=dt.UTC)
-            if parsed.tzinfo is None
-            else parsed.astimezone(dt.UTC)
-        )
-        until = parsed.strftime("%Y%m%dT%H%M%SZ")
+        return parsed.date().strftime("%Y%m%d")
 
-    return ";".join([*parts, f"UNTIL={until}"])
+    if end_date == end_date.split("T")[0]:
+        # Date-only input: bound the whole day rather than midnight, which would
+        # exclude an occurrence happening later on that date.
+        parsed = parsed.replace(hour=23, minute=59, second=59)
+    parsed = (
+        parsed.replace(tzinfo=dt.UTC)
+        if parsed.tzinfo is None
+        else parsed.astimezone(dt.UTC)
+    )
+    return parsed.strftime("%Y%m%dT%H%M%SZ")
 
 
 def _occurrence_is_done(component: Any) -> bool:
@@ -1286,40 +1292,46 @@ class CalendarClient:
     @staticmethod
     def _extract_valarms(component: Any) -> list[dict[str, Any]]:
         """Read a component's VALARMs back into ``Reminder``-shaped dicts."""
-        reminders: list[dict[str, Any]] = []
+        reminders = []
         for sub in component.subcomponents:
-            if sub.name != "VALARM":
-                continue
-            reminder: dict[str, Any] = {
-                "action": str(sub.get("action", "DISPLAY")).upper(),
-                "description": str(sub.get("description", "")),
-            }
-            summary = sub.get("summary")
-            if summary:
-                reminder["summary"] = str(summary)
-
-            trigger = sub.get("trigger")
-            if trigger is not None:
-                value = trigger.dt
-                if isinstance(value, dt.timedelta):
-                    # Emit exactly one trigger field, because that is what
-                    # ``Reminder`` accepts — a dict carrying both would not
-                    # validate when a caller feeds a read reminder back into an
-                    # update. Whole-minute offsets take the friendlier
-                    # ``minutes_before``; anything else keeps its raw duration.
-                    total = value.total_seconds()
-                    if total <= 0 and total % 60 == 0:
-                        reminder["minutes_before"] = int(-total // 60)
-                    else:
-                        reminder["trigger"] = vDDDTypes(value).to_ical().decode("utf-8")
-                    related = trigger.params.get("RELATED") if trigger.params else None
-                    if related:
-                        reminder["related"] = str(related).upper()
-                else:
-                    reminder["trigger_at"] = value.isoformat()
-
-            reminders.append(reminder)
+            if sub.name == "VALARM":
+                reminders.append(CalendarClient._extract_valarm(sub))
         return reminders
+
+    @staticmethod
+    def _extract_valarm(alarm: Any) -> dict[str, Any]:
+        """Read one VALARM into a ``Reminder``-shaped dict."""
+        reminder: dict[str, Any] = {
+            "action": str(alarm.get("action", "DISPLAY")).upper(),
+            "description": str(alarm.get("description", "")),
+        }
+        summary = alarm.get("summary")
+        if summary:
+            reminder["summary"] = str(summary)
+
+        trigger = alarm.get("trigger")
+        if trigger is None:
+            return reminder
+
+        value = trigger.dt
+        if not isinstance(value, dt.timedelta):
+            reminder["trigger_at"] = value.isoformat()
+            return reminder
+
+        # Emit exactly one trigger field, because that is what ``Reminder``
+        # accepts — a dict carrying both would not validate when a caller feeds
+        # a read reminder back into an update. Whole-minute offsets take the
+        # friendlier ``minutes_before``, anything else keeps its raw duration.
+        total = value.total_seconds()
+        if total <= 0 and total % 60 == 0:
+            reminder["minutes_before"] = int(-total // 60)
+        else:
+            reminder["trigger"] = vDDDTypes(value).to_ical().decode("utf-8")
+
+        related = trigger.params.get("RELATED") if trigger.params else None
+        if related:
+            reminder["related"] = str(related).upper()
+        return reminder
 
     @staticmethod
     def _sync_valarms(

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1376,6 +1376,13 @@ class CalendarClient:
 
         Passing none of the three leaves existing alarms alone, which is what
         makes an unrelated update non-destructive.
+
+        The two shorthand fields are independently updatable: whichever one the
+        caller omits is read back off the stored alarms rather than assumed. The
+        rebuild would otherwise erase what the caller never mentioned —
+        ``reminder_email=True`` on its own would find no minutes, clear every
+        VALARM and add nothing back, and ``reminder_minutes=45`` on its own would
+        silently drop a stored EMAIL alarm.
         """
         if "reminders" in data:
             self._sync_valarms(
@@ -1389,13 +1396,32 @@ class CalendarClient:
         if "reminder_minutes" not in data and "reminder_email" not in data:
             return
 
-        minutes = data.get("reminder_minutes", 0) or 0
-        self._sync_valarms(component, [], default_summary)
+        stored = self._extract_valarms(component)
+        if "reminder_minutes" in data:
+            minutes = data["reminder_minutes"] or 0
+        else:
+            minutes = next(
+                (r["minutes_before"] for r in stored if "minutes_before" in r), 0
+            )
+        want_email = (
+            data["reminder_email"]
+            if "reminder_email" in data
+            else any(r["action"] == "EMAIL" for r in stored)
+        )
+
+        if minutes <= 0 and want_email:
+            logger.warning(
+                "reminder_email was requested but no reminder_minutes was given "
+                "and none could be read from the stored alarms, so there is no "
+                "offset to schedule it at"
+            )
+
+        self._sync_valarms(component, [], default_summary, default_description)
         if minutes <= 0:
             return
 
         actions = ["DISPLAY"]
-        if data.get("reminder_email"):
+        if want_email:
             actions.append("EMAIL")
         for action in actions:
             component.add_component(

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -49,6 +49,10 @@ _TODO_DONE_STATUSES = frozenset({"COMPLETED", "CANCELLED"})
 _EVENT_REMINDER_DESCRIPTION = "Event reminder"
 _TODO_REMINDER_DESCRIPTION = "Todo reminder"
 
+# The VALARM actions Nextcloud actually schedules (ReminderService::REMINDER_TYPES).
+# RFC 5545 permits other IANA/X- tokens, which it stores but silently ignores.
+_VALARM_ACTIONS = frozenset({"DISPLAY", "EMAIL", "AUDIO"})
+
 
 def _rrule_to_string(rrule: Any) -> str:
     """Render an icalendar ``vRecur`` as an RFC 5545 RRULE value.
@@ -1319,9 +1323,29 @@ class CalendarClient:
 
     @staticmethod
     def _extract_valarm(alarm: Any) -> dict[str, Any]:
-        """Read one VALARM into a ``Reminder``-shaped dict."""
+        """Read one VALARM into a ``Reminder``-shaped dict.
+
+        Stored data is normalised to what ``Reminder`` accepts, because this
+        parses whatever any CalDAV client wrote, not only what we write. RFC 5545
+        §3.8.6.1 allows ACTION to carry any IANA or ``X-`` token, so a legacy
+        ``PROCEDURE`` or a custom action is realistic — and left unnormalised it
+        would fail the model's ``Literal`` and take down the whole listing the
+        todo appears in, rather than the one alarm. Nextcloud's own
+        ``ReminderService`` discards an alarm it does not recognise instead of
+        rejecting its component, so unknown actions degrade to DISPLAY here.
+        """
+        action = str(alarm.get("action", "DISPLAY")).upper()
+        if action not in _VALARM_ACTIONS:
+            logger.warning(
+                "VALARM action %r is not one of %s; reporting it as DISPLAY. "
+                "Nextcloud does not schedule non-standard alarms either",
+                action,
+                ", ".join(sorted(_VALARM_ACTIONS)),
+            )
+            action = "DISPLAY"
+
         reminder: dict[str, Any] = {
-            "action": str(alarm.get("action", "DISPLAY")).upper(),
+            "action": action,
             "description": str(alarm.get("description", "")),
         }
         summary = alarm.get("summary")
@@ -1348,7 +1372,9 @@ class CalendarClient:
             reminder["trigger"] = vDDDTypes(value).to_ical().decode("utf-8")
 
         related = trigger.params.get("RELATED") if trigger.params else None
-        if related:
+        if related and str(related).upper() in ("START", "END"):
+            # Same reasoning as ACTION: anything else is malformed input that
+            # must not propagate into the model and break the caller's listing.
             reminder["related"] = str(related).upper()
         return reminder
 
@@ -1418,6 +1444,17 @@ class CalendarClient:
             if "reminder_email" in data
             else any(r["action"] == "EMAIL" for r in stored)
         )
+
+        # The shorthand can only express one whole-minute offset, so any stored
+        # alarm outside that shape is about to be replaced by the rebuild below.
+        unrepresentable = [r for r in stored if "minutes_before" not in r]
+        if unrepresentable:
+            logger.warning(
+                "reminder_minutes/reminder_email will replace %d stored alarm(s) "
+                "the shorthand cannot express (absolute or sub-minute triggers); "
+                "use the reminders list to edit those without losing them",
+                len(unrepresentable),
+            )
 
         if minutes <= 0 and want_email:
             logger.warning(
@@ -1916,6 +1953,12 @@ class CalendarClient:
                             )
                         component["RRULE"] = vRecur.from_ical(rrule_str)
                     elif "RRULE" in component:
+                        if event_data.get("recurrence_end_date"):
+                            logger.warning(
+                                "recurrence_rule was cleared in the same update "
+                                "that set recurrence_end_date, so the series is "
+                                "removed and the end date has nothing to bound"
+                            )
                         del component["RRULE"]
                     elif event_data.get("recurrence_end_date"):
                         # No stored rule and none supplied: there is nothing for

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -64,6 +64,84 @@ def _rrule_to_string(rrule: Any) -> str:
         return str(rrule)
 
 
+def _warn_if_hex_color(color: str) -> None:
+    """Warn when a COLOR value will not survive Nextcloud's Calendar UI.
+
+    RFC 7986 §5.9 defines COLOR as a CSS3 colour *name*, and Nextcloud takes that
+    literally: ``getHexForColorName()`` in the Calendar app is a plain
+    ``css3Colors[name]`` lookup, so ``#FF0000`` resolves to null and the event
+    colour is dropped on display. The property is still written — other CalDAV
+    clients may honour it — but the caller deserves to know it will not show up.
+    """
+    if color.startswith("#"):
+        logger.warning(
+            "Event color %r is a hex value; Nextcloud's Calendar UI only renders "
+            "CSS3 colour names (e.g. 'tomato') and will ignore it",
+            color,
+        )
+
+
+def _rrule_with_until(
+    rrule_str: str, end_date: str, dtstart: Any, *, replace: bool = False
+) -> str:
+    """Return ``rrule_str`` with an ``UNTIL`` derived from ``end_date``.
+
+    RFC 5545 §3.3.10 ties UNTIL's value type to DTSTART's: a DATE-valued DTSTART
+    (an all-day event) takes a DATE, and anything else takes a UTC date-time —
+    including a TZID-bound DTSTART, whose UNTIL must still be expressed in UTC.
+    Getting this wrong is not cosmetic; clients drop a recurrence set whose UNTIL
+    does not match, so the series silently never ends.
+
+    ``end_date`` is inclusive-by-day: a date-only value becomes the last moment of
+    that day (23:59:59 UTC) for a timed event, so "recur until June 30th" keeps the
+    occurrence *on* June 30th rather than dropping it.
+
+    An existing UNTIL or COUNT raises ``ValueError`` — they are mutually exclusive
+    with UNTIL in one rule, and quietly choosing a winner is the silent-ignore
+    behaviour this exists to remove. ``replace=True`` drops them instead, for the
+    update path: applying an end date to the *stored* rule of an already-bounded
+    series means "move the end", not "contradict yourself".
+    """
+    parts = []
+    for part in rrule_str.split(";"):
+        if not part:
+            continue
+        name = part.split("=", 1)[0].strip().upper()
+        if name in ("UNTIL", "COUNT"):
+            if not replace:
+                raise ValueError(
+                    f"recurrence_end_date conflicts with {name} already present in "
+                    f"recurrence_rule ({rrule_str!r}); pass one or the other"
+                )
+            continue
+        parts.append(part)
+
+    all_day = isinstance(dtstart, dt.date) and not isinstance(dtstart, dt.datetime)
+    date_part = end_date.split("T")[0]
+    try:
+        parsed = dt.datetime.fromisoformat(end_date)
+    except ValueError:
+        raise ValueError(
+            f"recurrence_end_date {end_date!r} is not an ISO 8601 date or datetime"
+        ) from None
+
+    if all_day:
+        until = parsed.date().strftime("%Y%m%d")
+    else:
+        if end_date == date_part:
+            # Date-only input: bound the whole day rather than midnight, which
+            # would exclude an occurrence happening later on that date.
+            parsed = parsed.replace(hour=23, minute=59, second=59)
+        parsed = (
+            parsed.replace(tzinfo=dt.UTC)
+            if parsed.tzinfo is None
+            else parsed.astimezone(dt.UTC)
+        )
+        until = parsed.strftime("%Y%m%dT%H%M%SZ")
+
+    return ";".join([*parts, f"UNTIL={until}"])
+
+
 def _occurrence_is_done(component: Any) -> bool:
     """True when a VTODO occurrence is finished.
 
@@ -1156,6 +1234,150 @@ class CalendarClient:
         )
         return parsed, None
 
+    @staticmethod
+    def _build_valarm(reminder: dict[str, Any], default_summary: str) -> Alarm:
+        """Build one VALARM from a ``Reminder``-shaped dict.
+
+        Trigger precedence is ``trigger_at`` > ``trigger`` > ``minutes_before``;
+        the model guarantees exactly one is set, so the order only decides which
+        wins if a caller reaches this helper directly.
+
+        Two RFC 5545 rules are enforced here rather than left to the server:
+
+        * ``RELATED`` qualifies a *duration* trigger. Attaching it to an absolute
+          one produces ``TRIGGER;RELATED=START;VALUE=DATE-TIME:...``, which is
+          invalid, so it is only emitted on the relative branches.
+        * An ``EMAIL`` alarm must carry ``SUMMARY`` (the subject) alongside
+          ``DESCRIPTION`` (the body). Nextcloud addresses the message itself,
+          from the component's ATTENDEEs and the calendar's sharees, so no
+          alarm-level ATTENDEE is needed.
+        """
+        alarm = Alarm()
+        action = reminder.get("action", "DISPLAY")
+        alarm.add("action", action)
+        alarm.add("description", reminder.get("description", "Event reminder"))
+        if action == "EMAIL":
+            alarm.add("summary", reminder.get("summary") or default_summary)
+
+        params: dict[str, str] = {}
+        related = reminder.get("related")
+        if related:
+            params["RELATED"] = str(related)
+
+        if reminder.get("trigger_at"):
+            trigger_dt = dt.datetime.fromisoformat(str(reminder["trigger_at"]))
+            if trigger_dt.tzinfo is None:
+                trigger_dt = trigger_dt.replace(tzinfo=dt.UTC)
+            # RELATED is deliberately dropped here: it has no meaning on an
+            # absolute trigger and makes the property invalid.
+            alarm.add("trigger", trigger_dt, parameters={"VALUE": "DATE-TIME"})
+        elif reminder.get("trigger"):
+            alarm.add(
+                "trigger",
+                vDDDTypes.from_ical(str(reminder["trigger"])),
+                parameters=params,
+            )
+        else:
+            minutes = int(reminder["minutes_before"])
+            alarm.add("trigger", dt.timedelta(minutes=-minutes), parameters=params)
+
+        return alarm
+
+    @staticmethod
+    def _extract_valarms(component: Any) -> list[dict[str, Any]]:
+        """Read a component's VALARMs back into ``Reminder``-shaped dicts."""
+        reminders: list[dict[str, Any]] = []
+        for sub in component.subcomponents:
+            if sub.name != "VALARM":
+                continue
+            reminder: dict[str, Any] = {
+                "action": str(sub.get("action", "DISPLAY")).upper(),
+                "description": str(sub.get("description", "")),
+            }
+            summary = sub.get("summary")
+            if summary:
+                reminder["summary"] = str(summary)
+
+            trigger = sub.get("trigger")
+            if trigger is not None:
+                value = trigger.dt
+                if isinstance(value, dt.timedelta):
+                    # Emit exactly one trigger field, because that is what
+                    # ``Reminder`` accepts — a dict carrying both would not
+                    # validate when a caller feeds a read reminder back into an
+                    # update. Whole-minute offsets take the friendlier
+                    # ``minutes_before``; anything else keeps its raw duration.
+                    total = value.total_seconds()
+                    if total <= 0 and total % 60 == 0:
+                        reminder["minutes_before"] = int(-total // 60)
+                    else:
+                        reminder["trigger"] = vDDDTypes(value).to_ical().decode("utf-8")
+                    related = trigger.params.get("RELATED") if trigger.params else None
+                    if related:
+                        reminder["related"] = str(related).upper()
+                else:
+                    reminder["trigger_at"] = value.isoformat()
+
+            reminders.append(reminder)
+        return reminders
+
+    @staticmethod
+    def _sync_valarms(
+        component: Any, reminders: list[dict[str, Any]], default_summary: str
+    ) -> None:
+        """Replace every VALARM on ``component`` with ``reminders``, in order."""
+        component.subcomponents = [
+            sub for sub in component.subcomponents if sub.name != "VALARM"
+        ]
+        for reminder in reminders:
+            component.add_component(
+                CalendarClient._build_valarm(reminder, default_summary)
+            )
+
+    def _apply_reminders(
+        self,
+        component: Any,
+        data: dict[str, Any],
+        default_summary: str,
+        default_description: str = "Event reminder",
+    ) -> None:
+        """Write alarms onto ``component`` from whichever form the caller used.
+
+        An explicit ``reminders`` list is authoritative and replaces everything.
+        Otherwise the older ``reminder_minutes`` / ``reminder_email`` pair is
+        honoured as shorthand: a DISPLAY alarm, plus an EMAIL alarm at the same
+        offset when ``reminder_email`` is set.
+
+        Passing none of the three leaves existing alarms alone, which is what
+        makes an unrelated update non-destructive.
+        """
+        if "reminders" in data:
+            self._sync_valarms(component, data.get("reminders") or [], default_summary)
+            return
+
+        if "reminder_minutes" not in data and "reminder_email" not in data:
+            return
+
+        minutes = data.get("reminder_minutes", 0) or 0
+        self._sync_valarms(component, [], default_summary)
+        if minutes <= 0:
+            return
+
+        actions = ["DISPLAY"]
+        if data.get("reminder_email"):
+            actions.append("EMAIL")
+        for action in actions:
+            component.add_component(
+                self._build_valarm(
+                    {
+                        "action": action,
+                        "description": default_description,
+                        "minutes_before": minutes,
+                    },
+                    default_summary,
+                )
+            )
+
     def _create_ical_event(self, event_data: dict[str, Any], event_uid: str) -> str:
         """Create iCalendar content from event data."""
         cal = Calendar()
@@ -1175,9 +1397,13 @@ class CalendarClient:
         tz_name = event_data.get("timezone", "")
         used_timezones: set[ZoneInfo] = set()
 
+        # Kept for the RRULE below, whose UNTIL must match DTSTART's value type.
+        dtstart_value: dt.date | dt.datetime | None = None
+
         if start_str:
             if all_day:
                 start_date = dt.datetime.fromisoformat(start_str.split("T")[0]).date()
+                dtstart_value = start_date
                 event.add("dtstart", start_date)
                 if end_str:
                     end_date = dt.datetime.fromisoformat(end_str.split("T")[0]).date()
@@ -1186,6 +1412,7 @@ class CalendarClient:
                 start_dt, zi = self._parse_event_datetime(start_str, tz_name)
                 if zi is not None:
                     used_timezones.add(zi)
+                dtstart_value = start_dt
                 event.add("dtstart", start_dt)
                 if end_str:
                     end_dt, zi = self._parse_event_datetime(end_str, tz_name)
@@ -1214,21 +1441,28 @@ class CalendarClient:
         if url:
             event.add("url", url)
 
-        # Handle recurrence
-        recurring = event_data.get("recurring", False)
-        if recurring:
-            recurrence_rule = event_data.get("recurrence_rule", "")
-            if recurrence_rule:
-                event.add("rrule", vRecur.from_ical(recurrence_rule))
+        # Add colour (RFC 7986 COLOR)
+        color = event_data.get("color", "")
+        if color:
+            _warn_if_hex_color(color)
+            event.add("color", color)
+
+        # Handle recurrence. A non-empty rule is itself the intent to recur —
+        # requiring recurring=True as well made recurrence_rule a no-op on this
+        # path while the update path applied it unconditionally, so the same
+        # argument meant different things depending on which tool you called.
+        # ``recurring=False`` remains an explicit opt-out.
+        recurrence_rule = event_data.get("recurrence_rule", "")
+        if recurrence_rule and event_data.get("recurring", True):
+            recurrence_end_date = event_data.get("recurrence_end_date", "")
+            if recurrence_end_date:
+                recurrence_rule = _rrule_with_until(
+                    recurrence_rule, recurrence_end_date, dtstart_value
+                )
+            event.add("rrule", vRecur.from_ical(recurrence_rule))
 
         # Add alarms/reminders
-        reminder_minutes = event_data.get("reminder_minutes", 0)
-        if reminder_minutes > 0:
-            alarm = Alarm()
-            alarm.add("action", "DISPLAY")
-            alarm.add("description", "Event reminder")
-            alarm.add("trigger", dt.timedelta(minutes=-reminder_minutes))
-            event.add_component(alarm)
+        self._apply_reminders(event, event_data, event_data.get("title", ""))
 
         # Add attendees
         attendees = event_data.get("attendees", "")
@@ -1261,6 +1495,10 @@ class CalendarClient:
             "privacy": str(component.get("class", "PUBLIC")),
             "url": str(component.get("url", "")),
         }
+
+        color = component.get("color")
+        if color:
+            event_data["color"] = str(color)
 
         # Handle dates. The ``.isoformat()`` representation already encodes the
         # storage semantics: no suffix for floating local, ``+00:00`` for UTC,
@@ -1295,6 +1533,13 @@ class CalendarClient:
         if rrule:
             event_data["recurring"] = True
             event_data["recurrence_rule"] = _rrule_to_string(rrule)
+            until = (
+                rrule[0].get("UNTIL") if isinstance(rrule, list) else rrule.get("UNTIL")
+            )
+            if until:
+                # vRecur stores UNTIL as a single-element list of date/datetime.
+                value = until[0] if isinstance(until, list) else until
+                event_data["recurrence_end"] = value.isoformat()
 
         # Handle attendees
         attendees = []
@@ -1305,6 +1550,10 @@ class CalendarClient:
                 attendees.append(str(attendee).replace("mailto:", ""))
         if attendees:
             event_data["attendees"] = ",".join(attendees)
+
+        reminders = self._extract_valarms(component)
+        if reminders:
+            event_data["reminders"] = reminders
 
         return event_data
 
@@ -1533,10 +1782,42 @@ class CalendarClient:
                     elif "CATEGORIES" in component:
                         del component["CATEGORIES"]
 
-                # Handle recurrence rule
-                if "recurrence_rule" in event_data:
-                    rrule_str = event_data["recurrence_rule"]
+                # Handle colour (RFC 7986 COLOR)
+                if "color" in event_data:
+                    color = event_data["color"]
+                    if color:
+                        _warn_if_hex_color(color)
+                        component["COLOR"] = color
+                    elif "COLOR" in component:
+                        del component["COLOR"]
+
+                # Handle recurrence. ``recurring=False`` clears the series, which
+                # previously required passing recurrence_rule="" instead — the
+                # flag itself did nothing. An end date may be applied to a rule
+                # supplied now or to the one already stored.
+                if event_data.get("recurring") is False:
+                    if "RRULE" in component:
+                        del component["RRULE"]
+                elif (
+                    "recurrence_rule" in event_data
+                    or "recurrence_end_date" in event_data
+                ):
+                    caller_supplied_rule = "recurrence_rule" in event_data
+                    rrule_str = (
+                        event_data["recurrence_rule"]
+                        if caller_supplied_rule
+                        else _rrule_to_string(component.get("rrule"))
+                    )
                     if rrule_str:
+                        end_date = event_data.get("recurrence_end_date", "")
+                        if end_date:
+                            dtstart = component.get("dtstart")
+                            rrule_str = _rrule_with_until(
+                                rrule_str,
+                                end_date,
+                                dtstart.dt if dtstart else None,
+                                replace=not caller_supplied_rule,
+                            )
                         component["RRULE"] = vRecur.from_ical(rrule_str)
                     elif "RRULE" in component:
                         del component["RRULE"]
@@ -1552,18 +1833,13 @@ class CalendarClient:
                             if email.strip():
                                 component.add("attendee", f"mailto:{email.strip()}")
 
-                # Handle reminder (VALARM)
-                if "reminder_minutes" in event_data:
-                    component.subcomponents = [
-                        sub for sub in component.subcomponents if sub.name != "VALARM"
-                    ]
-                    minutes = event_data["reminder_minutes"]
-                    if minutes > 0:
-                        alarm = Alarm()
-                        alarm.add("action", "DISPLAY")
-                        alarm.add("description", "Event reminder")
-                        alarm.add("trigger", dt.timedelta(minutes=-minutes))
-                        component.add_component(alarm)
+                # Handle reminders (VALARM). Omitting all reminder arguments
+                # preserves the stored alarms; ``reminders: []`` clears them.
+                self._apply_reminders(
+                    component,
+                    event_data,
+                    event_data.get("title") or str(component.get("summary", "")),
+                )
 
                 # Handle dates
                 used_timezones = self._apply_date_updates(component, event_data)
@@ -1658,6 +1934,11 @@ class CalendarClient:
         categories = todo_data.get("categories", "")
         if categories:
             todo.add("categories", categories.split(","))
+
+        # Alarms/reminders
+        self._apply_reminders(
+            todo, todo_data, todo_data.get("summary", ""), "Todo reminder"
+        )
 
         # Add timestamps
         now = dt.datetime.now(dt.UTC)
@@ -1808,6 +2089,10 @@ class CalendarClient:
                 todo_data["recurrence_rule"] = _rrule_to_string(rrule)
                 todo_data.update(self._pending_todo_occurrences(cal, component, now))
 
+            reminders = self._extract_valarms(component)
+            if reminders:
+                todo_data["reminders"] = reminders
+
             return todo_data
 
         except Exception as e:
@@ -1874,6 +2159,14 @@ class CalendarClient:
                                 c.strip() for c in categories_str.split(",")
                             ]
                             logger.debug("Set CATEGORIES to %s", categories_str)
+
+                    # Handle reminders (VALARM)
+                    self._apply_reminders(
+                        component,
+                        todo_data,
+                        todo_data.get("summary") or str(component.get("summary", "")),
+                        "Todo reminder",
+                    )
 
                     # Update timestamps
                     now = dt.datetime.now(dt.UTC)

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1280,11 +1280,16 @@ class CalendarClient:
           ``DESCRIPTION`` (the body). Nextcloud addresses the message itself,
           from the component's ATTENDEEs and the calendar's sharees, so no
           alarm-level ATTENDEE is needed.
+        * ``DESCRIPTION`` belongs to ``DISPLAY`` and ``EMAIL`` alarms only. The
+          ``audioprop`` grammar admits ACTION, TRIGGER, DURATION+REPEAT and
+          ATTACH — writing a description onto an AUDIO alarm produces a
+          spec-invalid component even though lenient parsers accept it.
         """
         alarm = Alarm()
         action = reminder.get("action", "DISPLAY")
         alarm.add("action", action)
-        alarm.add("description", reminder.get("description") or default_description)
+        if action in ("DISPLAY", "EMAIL"):
+            alarm.add("description", reminder.get("description") or default_description)
         if action == "EMAIL":
             alarm.add("summary", reminder.get("summary") or default_summary)
 

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1241,7 +1241,11 @@ class CalendarClient:
         return parsed, None
 
     @staticmethod
-    def _build_valarm(reminder: dict[str, Any], default_summary: str) -> Alarm:
+    def _build_valarm(
+        reminder: dict[str, Any],
+        default_summary: str,
+        default_description: str = "Event reminder",
+    ) -> Alarm:
         """Build one VALARM from a ``Reminder``-shaped dict.
 
         Trigger precedence is ``trigger_at`` > ``trigger`` > ``minutes_before``;
@@ -1261,7 +1265,7 @@ class CalendarClient:
         alarm = Alarm()
         action = reminder.get("action", "DISPLAY")
         alarm.add("action", action)
-        alarm.add("description", reminder.get("description", "Event reminder"))
+        alarm.add("description", reminder.get("description") or default_description)
         if action == "EMAIL":
             alarm.add("summary", reminder.get("summary") or default_summary)
 
@@ -1335,7 +1339,10 @@ class CalendarClient:
 
     @staticmethod
     def _sync_valarms(
-        component: Any, reminders: list[dict[str, Any]], default_summary: str
+        component: Any,
+        reminders: list[dict[str, Any]],
+        default_summary: str,
+        default_description: str = "Event reminder",
     ) -> None:
         """Replace every VALARM on ``component`` with ``reminders``, in order."""
         component.subcomponents = [
@@ -1343,7 +1350,9 @@ class CalendarClient:
         ]
         for reminder in reminders:
             component.add_component(
-                CalendarClient._build_valarm(reminder, default_summary)
+                CalendarClient._build_valarm(
+                    reminder, default_summary, default_description
+                )
             )
 
     def _apply_reminders(
@@ -1364,7 +1373,12 @@ class CalendarClient:
         makes an unrelated update non-destructive.
         """
         if "reminders" in data:
-            self._sync_valarms(component, data.get("reminders") or [], default_summary)
+            self._sync_valarms(
+                component,
+                data.get("reminders") or [],
+                default_summary,
+                default_description,
+            )
             return
 
         if "reminder_minutes" not in data and "reminder_email" not in data:
@@ -1803,10 +1817,39 @@ class CalendarClient:
                     elif "COLOR" in component:
                         del component["COLOR"]
 
+                # Handle attendees
+                if "attendees" in event_data:
+                    attendees_str = event_data["attendees"]
+                    # Remove all existing attendees first
+                    while "ATTENDEE" in component:
+                        del component["ATTENDEE"]
+                    if attendees_str:
+                        for email in attendees_str.split(","):
+                            if email.strip():
+                                component.add("attendee", f"mailto:{email.strip()}")
+
+                # Handle reminders (VALARM). Omitting all reminder arguments
+                # preserves the stored alarms; ``reminders: []`` clears them.
+                self._apply_reminders(
+                    component,
+                    event_data,
+                    event_data.get("title") or str(component.get("summary", "")),
+                )
+
+                # Handle dates
+                used_timezones = self._apply_date_updates(component, event_data)
+
                 # Handle recurrence. ``recurring=False`` clears the series, which
                 # previously required passing recurrence_rule="" instead — the
                 # flag itself did nothing. An end date may be applied to a rule
                 # supplied now or to the one already stored.
+                #
+                # This must run *after* _apply_date_updates: UNTIL's value type
+                # follows DTSTART, so an update that flips all_day and sets
+                # recurrence_end_date in one call has to see the DTSTART being
+                # written, not the one being replaced. Reading the stored value
+                # here would emit exactly the mismatched RRULE that makes clients
+                # discard the recurrence set.
                 if event_data.get("recurring") is False:
                     if "RRULE" in component:
                         del component["RRULE"]
@@ -1833,28 +1876,6 @@ class CalendarClient:
                         component["RRULE"] = vRecur.from_ical(rrule_str)
                     elif "RRULE" in component:
                         del component["RRULE"]
-
-                # Handle attendees
-                if "attendees" in event_data:
-                    attendees_str = event_data["attendees"]
-                    # Remove all existing attendees first
-                    while "ATTENDEE" in component:
-                        del component["ATTENDEE"]
-                    if attendees_str:
-                        for email in attendees_str.split(","):
-                            if email.strip():
-                                component.add("attendee", f"mailto:{email.strip()}")
-
-                # Handle reminders (VALARM). Omitting all reminder arguments
-                # preserves the stored alarms; ``reminders: []`` clears them.
-                self._apply_reminders(
-                    component,
-                    event_data,
-                    event_data.get("title") or str(component.get("summary", "")),
-                )
-
-                # Handle dates
-                used_timezones = self._apply_date_updates(component, event_data)
 
                 # Update timestamps
                 now = dt.datetime.now(dt.UTC)

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -35,9 +35,13 @@ class Reminder(BaseModel):
             "that minutes_before expresses awkwardly."
         ),
     )
-    description: str = Field(
-        default="Event reminder",
-        description="Alarm body; the message text for an EMAIL alarm",
+    description: Optional[str] = Field(
+        None,
+        description=(
+            "Alarm body, and the message text for an EMAIL alarm. Defaults to "
+            "'Event reminder' or 'Todo reminder' depending on what it is "
+            "attached to."
+        ),
     )
     summary: Optional[str] = Field(
         None,

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -1,10 +1,75 @@
 """Pydantic models for Calendar app responses."""
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .base import BaseResponse, StatusResponse
+
+
+class Reminder(BaseModel):
+    """A single VALARM on an event or todo.
+
+    Exactly one trigger must be given. ``trigger_at`` fires at an absolute
+    instant; ``minutes_before`` and ``trigger`` are relative to the component's
+    start (or its end, via ``related``).
+    """
+
+    action: Literal["DISPLAY", "EMAIL", "AUDIO"] = Field(
+        default="DISPLAY",
+        description=(
+            "Alarm type. Nextcloud silently discards any other value, so the "
+            "set is closed rather than free-form."
+        ),
+    )
+    minutes_before: Optional[int] = Field(
+        None, description="Fire this many minutes before the trigger point"
+    )
+    trigger_at: Optional[str] = Field(
+        None, description="Absolute ISO datetime to fire at"
+    )
+    trigger: Optional[str] = Field(
+        None,
+        description=(
+            "Raw RFC 5545 duration, e.g. ``-PT30M`` or ``-P1D``. Use for offsets "
+            "that minutes_before expresses awkwardly."
+        ),
+    )
+    description: str = Field(
+        default="Event reminder",
+        description="Alarm body; the message text for an EMAIL alarm",
+    )
+    summary: Optional[str] = Field(
+        None,
+        description=(
+            "Subject line of an EMAIL alarm. Defaults to the event/todo title. "
+            "Ignored for other actions, which have no SUMMARY in RFC 5545."
+        ),
+    )
+    related: Optional[Literal["START", "END"]] = Field(
+        None,
+        description=(
+            "Whether a relative trigger counts from the start or the end. "
+            "Only meaningful with minutes_before/trigger — RFC 5545 does not "
+            "allow RELATED on an absolute trigger."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_trigger(self) -> "Reminder":
+        given = [
+            name
+            for name in ("trigger_at", "trigger", "minutes_before")
+            if getattr(self, name) is not None
+        ]
+        if len(given) != 1:
+            raise ValueError(
+                "a reminder needs exactly one of trigger_at, trigger or "
+                f"minutes_before; got {given or 'none'}"
+            )
+        if self.related and self.trigger_at:
+            raise ValueError("related cannot be combined with an absolute trigger_at")
+        return self
 
 
 class Calendar(BaseModel):
@@ -96,7 +161,17 @@ class CalendarEvent(CalendarEventSummary):
     reminder_email: bool = Field(
         default=False, description="Whether to send email reminder"
     )
-    color: Optional[str] = Field(None, description="Event color")
+    reminders: List[Reminder] = Field(
+        default_factory=list,
+        description="The event's VALARMs, in document order",
+    )
+    color: Optional[str] = Field(
+        None,
+        description=(
+            "Event colour as a CSS3 colour name (RFC 7986 COLOR). Nextcloud's "
+            "Calendar UI ignores hex values."
+        ),
+    )
     etag: Optional[str] = Field(None, description="ETag for versioning")
 
 
@@ -246,6 +321,10 @@ class Todo(BaseModel):
     )
     recurrence_rule: str = Field(
         default="", description="RFC 5545 RRULE value, e.g. 'FREQ=YEARLY;INTERVAL=1'"
+    )
+    reminders: List[Reminder] = Field(
+        default_factory=list,
+        description="The todo's VALARMs, in document order",
     )
     pending_count: Optional[int] = Field(
         None,

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -154,7 +154,14 @@ class CalendarEvent(CalendarEventSummary):
     last_modified: Optional[str] = Field(None, description="Last modification datetime")
     recurring: bool = Field(default=False, description="Whether event is recurring")
     recurrence_rule: Optional[str] = Field(None, description="RFC5545 recurrence rule")
-    recurrence_end: Optional[str] = Field(None, description="Recurrence end date")
+    recurrence_end_date: Optional[str] = Field(
+        None,
+        description=(
+            "When the series stops recurring, read back from the rule's UNTIL. "
+            "Named to match the write-side parameter so a value read from an "
+            "event can be passed straight back into an update."
+        ),
+    )
     attendees: List[str] = Field(
         default_factory=list, description="List of attendee email addresses"
     )

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -23,7 +23,13 @@ class Reminder(BaseModel):
         ),
     )
     minutes_before: Optional[int] = Field(
-        None, description="Fire this many minutes before the trigger point"
+        None,
+        ge=0,
+        description=(
+            "Fire this many minutes before the trigger point. Negative values "
+            "are rejected rather than quietly flipped into an alarm *after* the "
+            "event — use trigger with a positive duration for that."
+        ),
     )
     trigger_at: Optional[str] = Field(
         None, description="Absolute ISO datetime to fire at"

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -116,7 +116,7 @@ def configure_calendar_tools(mcp: FastMCP):
         description: str = "",
         location: str = "",
         categories: str = "",
-        recurring: bool = False,
+        recurring: bool | None = None,
         recurrence_rule: str = "",
         recurrence_end_date: str = "",
         reminder_minutes: int = 15,
@@ -152,8 +152,8 @@ def configure_calendar_tools(mcp: FastMCP):
             location: Event location
             categories: Comma-separated categories (e.g., "work,meeting")
             recurring: Whether this is a recurring event. A non-empty
-                ``recurrence_rule`` already implies recurrence; pass ``False``
-                only to explicitly suppress it.
+                ``recurrence_rule`` already implies recurrence, so leave this
+                unset unless you want to suppress it with ``False``.
             recurrence_rule: RFC5545 RRULE (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR")
             recurrence_end_date: Date (or ISO datetime) the series stops
                 recurring, written as the rule's ``UNTIL``. Inclusive: a
@@ -195,7 +195,6 @@ def configure_calendar_tools(mcp: FastMCP):
             "description": description,
             "location": location,
             "categories": categories,
-            "recurring": recurring,
             "recurrence_rule": recurrence_rule,
             "recurrence_end_date": recurrence_end_date,
             "reminder_minutes": reminder_minutes,
@@ -208,6 +207,12 @@ def configure_calendar_tools(mcp: FastMCP):
             "color": color,
             "timezone": timezone,
         }
+        # Only forward ``recurring`` when the caller actually set it. Sending the
+        # default would pin it to False on every call, which is what made
+        # recurrence_rule a no-op here — the client reads a present-but-False
+        # flag as an explicit opt-out.
+        if recurring is not None:
+            event_data["recurring"] = recurring
         if reminders is not None:
             event_data["reminders"] = _reminders_to_dicts(reminders)
 

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -16,12 +16,23 @@ from nextcloud_mcp_server.models.calendar import (
     ListCalendarsResponse,
     ListEventsResponse,
     ListTodosResponse,
+    Reminder,
     Todo,
     UpcomingEventsResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
+
+
+def _reminders_to_dicts(reminders: list[Reminder]) -> list[dict[str, Any]]:
+    """Flatten validated reminders for the dict-based client layer.
+
+    ``exclude_none`` matters: the client distinguishes an absent trigger field
+    from one explicitly set, so leaving ``None``s in would make every reminder
+    look like it carried all three.
+    """
+    return [reminder.model_dump(exclude_none=True) for reminder in reminders]
 
 
 def _completion_payload(completed: str | None = None) -> dict[str, Any]:
@@ -117,6 +128,7 @@ def configure_calendar_tools(mcp: FastMCP):
         url: str = "",
         color: str = "",
         timezone: str = "",
+        reminders: list[Reminder] | None = None,
     ):
         """Create a comprehensive calendar event with full feature support.
 
@@ -139,21 +151,36 @@ def configure_calendar_tools(mcp: FastMCP):
             description: Event description/details
             location: Event location
             categories: Comma-separated categories (e.g., "work,meeting")
-            recurring: Whether this is a recurring event
+            recurring: Whether this is a recurring event. A non-empty
+                ``recurrence_rule`` already implies recurrence; pass ``False``
+                only to explicitly suppress it.
             recurrence_rule: RFC5545 RRULE (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR")
-            recurrence_end_date: When to stop recurring
+            recurrence_end_date: Date (or ISO datetime) the series stops
+                recurring, written as the rule's ``UNTIL``. Inclusive: a
+                date-only value keeps that day's occurrence. Rejected if
+                ``recurrence_rule`` already carries ``UNTIL`` or ``COUNT``.
             reminder_minutes: Minutes before event to send reminder
-            reminder_email: Whether to send email notification
+            reminder_email: Also send an email reminder, as a second VALARM with
+                ``ACTION:EMAIL``. Nextcloud addresses it to the event's
+                attendees and the calendar's sharees.
             status: Event status: CONFIRMED, TENTATIVE, or CANCELLED
             priority: Priority level 1-9 (1=highest, 9=lowest, 5=normal)
             privacy: Privacy level: PUBLIC, PRIVATE, or CONFIDENTIAL
             attendees: Comma-separated email addresses
             url: Related URL for the event
-            color: Event color (hex or name)
+            color: Event colour as a CSS3 colour name (e.g. ``"tomato"``).
+                Nextcloud's Calendar UI resolves COLOR through a CSS3 name
+                lookup, so a hex value is stored but never rendered.
             timezone: Optional IANA timezone name (e.g. ``"America/New_York"``).
                 Applied only when ``start_datetime``/``end_datetime`` are naive
                 (no offset, no ``Z``). Ignored — with a warning — when the
                 inputs already carry an explicit offset.
+            reminders: Ordered list of alarms, replacing ``reminder_minutes`` /
+                ``reminder_email`` when given. Each needs exactly one of
+                ``minutes_before``, ``trigger`` (RFC 5545 duration) or
+                ``trigger_at`` (absolute), plus an optional ``action``
+                (DISPLAY/EMAIL/AUDIO), ``description``, ``summary`` (EMAIL
+                subject) and ``related`` (START/END).
 
         Returns:
             Dict with event creation result
@@ -181,6 +208,8 @@ def configure_calendar_tools(mcp: FastMCP):
             "color": color,
             "timezone": timezone,
         }
+        if reminders is not None:
+            event_data["reminders"] = _reminders_to_dicts(reminders)
 
         return await client.calendar.create_event(calendar_name, event_data)
 
@@ -351,6 +380,7 @@ def configure_calendar_tools(mcp: FastMCP):
         # Recurrence updates
         recurring: bool | None = None,
         recurrence_rule: str | None = None,
+        recurrence_end_date: str | None = None,
         # Notification updates
         reminder_minutes: int | None = None,
         reminder_email: bool | None = None,
@@ -362,14 +392,26 @@ def configure_calendar_tools(mcp: FastMCP):
         url: str | None = None,
         color: str | None = None,
         timezone: str | None = None,
+        reminders: list[Reminder] | None = None,
         etag: str = "",
     ):
         """Update any aspect of an existing event.
 
-        Pass ``timezone`` (IANA name, e.g. ``"America/New_York"``) together
-        with a naive ``start_datetime`` / ``end_datetime`` to rewrite DTSTART
-        / DTEND as TZID-bound. See ``nc_calendar_create_event`` for the full
-        encoding rules.
+        Only the arguments you pass are touched. Everything else on the stored
+        event is preserved. See ``nc_calendar_create_event`` for the shared
+        parameter semantics, including the datetime encoding rules that
+        ``timezone`` selects between.
+
+        Recurrence, specifically:
+
+        * ``recurrence_rule=""`` or ``recurring=False`` removes the series.
+        * ``recurrence_end_date`` alone re-bounds the *stored* rule, replacing
+          any ``UNTIL``/``COUNT`` it carries. Combined with an explicit
+          ``recurrence_rule`` that already bounds itself, it raises instead —
+          that combination contradicts itself within one request.
+
+        Reminders, likewise. Omit them all and the stored alarms survive. Pass
+        ``reminders=[]`` to clear them, or a list to replace them wholesale.
         """
         client = await get_client(ctx)
 
@@ -393,6 +435,8 @@ def configure_calendar_tools(mcp: FastMCP):
             event_data["recurring"] = recurring
         if recurrence_rule is not None:
             event_data["recurrence_rule"] = recurrence_rule
+        if recurrence_end_date is not None:
+            event_data["recurrence_end_date"] = recurrence_end_date
         if reminder_minutes is not None:
             event_data["reminder_minutes"] = reminder_minutes
         if reminder_email is not None:
@@ -411,6 +455,8 @@ def configure_calendar_tools(mcp: FastMCP):
             event_data["color"] = color
         if timezone is not None:
             event_data["timezone"] = timezone
+        if reminders is not None:
+            event_data["reminders"] = _reminders_to_dicts(reminders)
 
         return await client.calendar.update_event(
             calendar_name, event_uid, event_data, etag
@@ -1089,6 +1135,7 @@ def configure_calendar_tools(mcp: FastMCP):
         due: str = "",
         dtstart: str = "",
         categories: str = "",
+        reminders: list[Reminder] | None = None,
     ):
         """Create a new todo/task in a calendar.
 
@@ -1102,6 +1149,8 @@ def configure_calendar_tools(mcp: FastMCP):
             due: Due date/time (ISO format, e.g., "2025-01-15T14:00:00")
             dtstart: Start date/time (ISO format)
             categories: Comma-separated categories (e.g., "work,urgent")
+            reminders: Ordered list of alarms. See ``nc_calendar_create_event``
+                for the shape.
 
         Returns:
             Dict with todo creation result
@@ -1117,6 +1166,8 @@ def configure_calendar_tools(mcp: FastMCP):
             "dtstart": dtstart,
             "categories": categories,
         }
+        if reminders is not None:
+            todo_data["reminders"] = _reminders_to_dicts(reminders)
 
         return await client.calendar.create_todo(calendar_name, todo_data)
 
@@ -1139,6 +1190,7 @@ def configure_calendar_tools(mcp: FastMCP):
         dtstart: Optional[str] = None,
         completed: Optional[str] = None,
         categories: Optional[str] = None,
+        reminders: list[Reminder] | None = None,
     ):
         """Update an existing todo/task.
 
@@ -1155,6 +1207,8 @@ def configure_calendar_tools(mcp: FastMCP):
             dtstart: New start date/time (ISO format)
             completed: Completion timestamp (ISO format)
             categories: New categories (comma-separated)
+            reminders: Replacement alarm list. Omit to keep the stored alarms,
+                or pass ``[]`` to clear them.
 
         Returns:
             Dict with todo update result
@@ -1181,6 +1235,8 @@ def configure_calendar_tools(mcp: FastMCP):
             todo_data["completed"] = completed
         if categories is not None:
             todo_data["categories"] = categories
+        if reminders is not None:
+            todo_data["reminders"] = _reminders_to_dicts(reminders)
 
         return await client.calendar.update_todo(calendar_name, todo_uid, todo_data)
 

--- a/tests/server/test_calendar_events_mcp.py
+++ b/tests/server/test_calendar_events_mcp.py
@@ -122,3 +122,143 @@ async def test_mcp_update_event_extended_fields(
                 await nc_client.calendar.delete_event(calendar_name, event_uid)
             except Exception:
                 pass
+
+
+async def test_mcp_create_event_writes_previously_ignored_fields(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
+):
+    """recurrence_end_date, color and reminder_email reach the stored iCal (GH #1251).
+
+    All three were accepted and documented by the tool but consumed by nothing,
+    so the round trip through a real Nextcloud is the assertion that matters —
+    a unit test on the serializer would have passed before the fix as well.
+    """
+    calendar_name = temporary_calendar
+    event_uid = None
+
+    try:
+        tomorrow = datetime.now() + timedelta(days=1)
+        create_result = await nc_mcp_client.call_tool(
+            "nc_calendar_create_event",
+            {
+                "calendar_name": calendar_name,
+                "title": "Weekly sync",
+                "start_datetime": tomorrow.strftime("%Y-%m-%dT14:00:00"),
+                "end_datetime": tomorrow.strftime("%Y-%m-%dT15:00:00"),
+                "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+                "recurrence_end_date": "2026-12-31",
+                "color": "tomato",
+                "reminder_minutes": 15,
+                "reminder_email": True,
+            },
+        )
+        assert create_result.isError is False, (
+            f"MCP event creation failed: {create_result.content}"
+        )
+        event_uid = json.loads(create_result.content[0].text)["uid"]
+
+        event, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
+
+        assert "UNTIL=20261231" in event.get("recurrence_rule", ""), (
+            f"Expected UNTIL in rrule, got: {event.get('recurrence_rule')}"
+        )
+        assert event.get("color") == "tomato", (
+            f"Expected COLOR persisted, got: {event.get('color')}"
+        )
+        actions = [r["action"] for r in event.get("reminders", [])]
+        assert actions == ["DISPLAY", "EMAIL"], (
+            f"Expected a DISPLAY and an EMAIL alarm, got: {actions}"
+        )
+
+        logger.info("MCP create with previously-ignored fields verified")
+
+    finally:
+        if event_uid:
+            try:
+                await nc_client.calendar.delete_event(calendar_name, event_uid)
+            except Exception:
+                pass
+
+
+async def test_mcp_update_event_ordered_reminders(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
+):
+    """Ordered reminders survive a real CalDAV round trip (supersedes PR #969).
+
+    Order, an absolute trigger and the preserve-vs-clear distinction are the
+    parts a server can quietly mangle, so all three are checked after storage
+    rather than at serialization time.
+    """
+    calendar_name = temporary_calendar
+    event_uid = None
+
+    try:
+        tomorrow = datetime.now() + timedelta(days=1)
+        create_result = await nc_mcp_client.call_tool(
+            "nc_calendar_create_event",
+            {
+                "calendar_name": calendar_name,
+                "title": "Launch review",
+                "start_datetime": tomorrow.strftime("%Y-%m-%dT14:00:00"),
+                "end_datetime": tomorrow.strftime("%Y-%m-%dT15:00:00"),
+                "reminders": [
+                    {"action": "EMAIL", "minutes_before": 1440, "description": "Prep"},
+                    {"action": "DISPLAY", "minutes_before": 10, "description": "Now"},
+                ],
+            },
+        )
+        assert create_result.isError is False, (
+            f"MCP event creation failed: {create_result.content}"
+        )
+        event_uid = json.loads(create_result.content[0].text)["uid"]
+
+        event, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
+        stored = event.get("reminders", [])
+        assert [r["description"] for r in stored] == ["Prep", "Now"], (
+            f"Expected reminder order preserved, got: {stored}"
+        )
+        assert [r["action"] for r in stored] == ["EMAIL", "DISPLAY"]
+        assert [r["minutes_before"] for r in stored] == [1440, 10]
+
+        # An unrelated update must leave the alarms alone.
+        touch_result = await nc_mcp_client.call_tool(
+            "nc_calendar_update_event",
+            {
+                "calendar_name": calendar_name,
+                "event_uid": event_uid,
+                "location": "Room 2",
+            },
+        )
+        assert touch_result.isError is False, (
+            f"MCP event update failed: {touch_result.content}"
+        )
+        touched, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
+        assert len(touched.get("reminders", [])) == 2, (
+            f"Expected reminders preserved, got: {touched.get('reminders')}"
+        )
+
+        # An explicit empty list clears them.
+        clear_result = await nc_mcp_client.call_tool(
+            "nc_calendar_update_event",
+            {
+                "calendar_name": calendar_name,
+                "event_uid": event_uid,
+                "reminders": [],
+            },
+        )
+        assert clear_result.isError is False, (
+            f"MCP reminder clear failed: {clear_result.content}"
+        )
+        cleared, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
+        assert not cleared.get("reminders"), (
+            f"Expected reminders cleared, got: {cleared.get('reminders')}"
+        )
+
+        logger.info("MCP ordered reminders verified")
+
+    finally:
+        if event_uid:
+            try:
+                await nc_client.calendar.delete_event(calendar_name, event_uid)
+            except Exception:
+                pass

--- a/tests/server/test_calendar_events_mcp.py
+++ b/tests/server/test_calendar_events_mcp.py
@@ -180,6 +180,68 @@ async def test_mcp_create_event_writes_previously_ignored_fields(
                 pass
 
 
+async def test_mcp_update_event_shorthand_reminder_fields_are_independent(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
+):
+    """Updating one shorthand reminder field must not erase the other's effect.
+
+    Against a real store rather than a synthesised iCal, because the bug this
+    guards was precisely that the update path rebuilt alarms from the request
+    alone and never consulted what was already saved.
+    """
+    calendar_name = temporary_calendar
+    event_uid = None
+
+    try:
+        tomorrow = datetime.now() + timedelta(days=1)
+        create_result = await nc_mcp_client.call_tool(
+            "nc_calendar_create_event",
+            {
+                "calendar_name": calendar_name,
+                "title": "Retro",
+                "start_datetime": tomorrow.strftime("%Y-%m-%dT14:00:00"),
+                "end_datetime": tomorrow.strftime("%Y-%m-%dT15:00:00"),
+                "reminder_minutes": 15,
+                "reminder_email": True,
+            },
+        )
+        assert create_result.isError is False, (
+            f"MCP event creation failed: {create_result.content}"
+        )
+        event_uid = json.loads(create_result.content[0].text)["uid"]
+
+        # Change only the offset: the EMAIL alarm must survive at the new offset.
+        update_result = await nc_mcp_client.call_tool(
+            "nc_calendar_update_event",
+            {
+                "calendar_name": calendar_name,
+                "event_uid": event_uid,
+                "reminder_minutes": 45,
+            },
+        )
+        assert update_result.isError is False, (
+            f"MCP event update failed: {update_result.content}"
+        )
+
+        event, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
+        reminders = event.get("reminders", [])
+        assert sorted(r["action"] for r in reminders) == ["DISPLAY", "EMAIL"], (
+            f"Expected both alarms preserved, got: {reminders}"
+        )
+        assert {r.get("minutes_before") for r in reminders} == {45}, (
+            f"Expected both alarms moved to 45 minutes, got: {reminders}"
+        )
+
+        logger.info("MCP shorthand reminder independence verified")
+
+    finally:
+        if event_uid:
+            try:
+                await nc_client.calendar.delete_event(calendar_name, event_uid)
+            except Exception:
+                pass
+
+
 async def test_mcp_update_event_ordered_reminders(
     nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
 ):

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -743,6 +743,33 @@ def test_reminder_email_alone_can_add_an_email_alarm_to_a_display_only_event():
     assert {r["minutes_before"] for r in reminders} == {20}
 
 
+def test_shorthand_update_warns_before_replacing_alarms_it_cannot_express(caplog):
+    """The shorthand carries one whole-minute offset, so richer alarms are lost.
+
+    That is inherent to the two-field form rather than a bug, but it is
+    destructive, so it must not happen quietly — the caller needs to know the
+    reminders list is the tool for editing those.
+    """
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "reminders": [
+                {"trigger_at": "2026-02-09T20:00:00Z", "description": "Absolute"},
+                {"trigger": "-PT90S", "description": "Sub-minute"},
+            ],
+        },
+        "uid-unrepresentable",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        updated = client._merge_ical_properties(stored, {"reminder_minutes": 30})
+
+    assert "cannot express" in caplog.text
+    reminders = client._parse_ical_event(updated)["reminders"]
+    assert [r["minutes_before"] for r in reminders] == [30]
+
+
 def test_reminder_minutes_zero_still_clears_everything():
     """An explicit zero is a request to remove the alarms, not a missing value."""
     client, stored = _shorthand_event()

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -897,6 +897,52 @@ def test_foreign_valarm_action_does_not_break_the_model(caplog):
     assert todo.reminders[0].related is None
 
 
+def _todo_with_alarm(alarm_body: str) -> str:
+    return (
+        "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Other Client//EN\n"
+        "BEGIN:VTODO\nUID:uid-malformed\nSUMMARY:Backup\n"
+        f"BEGIN:VALARM\n{alarm_body}\nEND:VALARM\n"
+        "END:VTODO\nEND:VCALENDAR\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "alarm_body",
+    [
+        "ACTION:PROCEDURE\nTRIGGER:-PT30M\nDESCRIPTION:Legacy",
+        "ACTION:X-CUSTOM-THING\nTRIGGER:-PT30M",
+        "ACTION:DISPLAY\nTRIGGER;RELATED=PARENT:-PT30M",
+        "ACTION:DISPLAY\nDESCRIPTION:No trigger at all",
+        "ACTION:DISPLAY",
+    ],
+    ids=[
+        "legacy-procedure-action",
+        "x-prefixed-action",
+        "foreign-related-param",
+        "missing-trigger",
+        "bare-action-only",
+    ],
+)
+def test_no_stored_alarm_shape_can_break_a_listing(alarm_body):
+    """Whatever another CalDAV client wrote, one alarm costs at most itself.
+
+    ``Todo(**todo_data)`` is built in a plain list comprehension, so a
+    ValidationError from any nested Reminder fails the entire
+    ``nc_calendar_list_todos`` call rather than the single item. Every field the
+    model constrains — the action Literal, the related Literal, the exactly-one
+    trigger rule — is therefore normalised or dropped on the way out of the iCal,
+    and this covers each of those shapes rather than the one that was reported.
+    """
+    from nextcloud_mcp_server.models.calendar import Todo
+
+    todo_data = _pure_client()._parse_ical_todo(_todo_with_alarm(alarm_body))
+
+    todo = Todo(**todo_data)
+    for reminder in todo.reminders:
+        assert reminder.action in ("DISPLAY", "EMAIL", "AUDIO")
+        assert reminder.related in (None, "START", "END")
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -437,6 +437,29 @@ def test_recurrence_end_date_uses_date_until_for_all_day_events():
     assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630;BYDAY=TU"
 
 
+def test_all_day_end_date_drops_a_time_of_day_visibly(caplog):
+    """An all-day series can only be bounded by a DATE, so a time is dropped.
+
+    That is the sole correct reading rather than a caller error, but it should
+    not happen invisibly — every other lossy edge in this change set says so.
+    """
+    with caplog.at_level(logging.DEBUG, logger="nextcloud_mcp_server.client.calendar"):
+        ical = _pure_client()._create_ical_event(
+            {
+                "title": "Bin day",
+                "start_datetime": "2026-02-10",
+                "end_datetime": "2026-02-11",
+                "all_day": True,
+                "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+                "recurrence_end_date": "2026-06-30T18:00:00",
+            },
+            "uid-allday-truncate",
+        )
+
+    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630;BYDAY=TU"
+    assert "cannot express in UNTIL" in caplog.text
+
+
 @pytest.mark.parametrize("bound", ["COUNT=5", "UNTIL=20260101T000000Z"])
 def test_recurrence_end_date_rejects_a_rule_that_already_bounds_itself(bound):
     """Two end conditions in one request is a contradiction, not a preference.

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -771,7 +771,39 @@ def test_recurrence_end_date_is_utc_even_for_a_tzid_bound_dtstart():
     )
 
     assert str(_vevent(ical)["DTSTART"].params.get("TZID")) == "America/New_York"
-    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630T235959Z;BYDAY=TU"
+    # 23:59:59 in New York on the 30th, expressed as the UTC instant RFC 5545
+    # requires: 03:59:59 on July 1st.
+    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260701T035959Z;BYDAY=TU"
+
+
+def test_evening_occurrence_survives_its_own_recurrence_end_date():
+    """The last occurrence must not be dropped for being late in the day.
+
+    An evening event in a zone behind UTC has a real instant on the *following*
+    UTC date. Anchoring the inclusive end-of-day to UTC midnight put the cutoff
+    before that instant, silently excluding the very occurrence the caller named
+    the end date to keep. 21:00 on 2026-06-30 in New York is 01:00Z on 07-01,
+    which a UTC-anchored ``UNTIL=20260630T235959Z`` would have excluded.
+    """
+    ical = _pure_client()._create_ical_event(
+        {
+            "title": "Evening class",
+            "start_datetime": "2026-06-02T21:00:00",
+            "end_datetime": "2026-06-02T22:00:00",
+            "timezone": "America/New_York",
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-evening",
+    )
+
+    component = _vevent(ical)
+    until = component.get("rrule")["UNTIL"][0]
+    last_occurrence = component["DTSTART"].dt.replace(month=6, day=30)
+
+    assert until >= last_occurrence, (
+        f"UNTIL {until} excludes the 2026-06-30 occurrence at {last_occurrence}"
+    )
 
 
 def test_unrelated_update_preserves_reminders_but_empty_list_clears_them():

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -694,6 +694,86 @@ def test_reminder_email_shorthand_adds_a_second_email_alarm():
     assert {a.get("trigger").dt for a in alarms} == {timedelta(minutes=-15)}
 
 
+def _shorthand_event():
+    """An event carrying both shorthand alarms, as the create path builds them."""
+    client = _pure_client()
+    return client, client._create_ical_event(
+        {**TIMED_EVENT, "reminder_minutes": 15, "reminder_email": True},
+        "uid-shorthand-update",
+    )
+
+
+def test_reminder_email_alone_keeps_the_stored_offset():
+    """Updating one shorthand field must not erase what the other one set.
+
+    ``reminder_email`` on its own used to find no ``reminder_minutes``, clear
+    every VALARM and return before adding any back — silent total loss, and
+    worse than master, where the flag was merely inert.
+    """
+    client, stored = _shorthand_event()
+
+    updated = client._merge_ical_properties(stored, {"reminder_email": False})
+
+    reminders = client._parse_ical_event(updated)["reminders"]
+    assert [r["action"] for r in reminders] == ["DISPLAY"]
+    assert reminders[0]["minutes_before"] == 15
+
+
+def test_reminder_minutes_alone_keeps_the_stored_email_alarm():
+    """The mirror case: changing the offset must not drop the EMAIL alarm."""
+    client, stored = _shorthand_event()
+
+    updated = client._merge_ical_properties(stored, {"reminder_minutes": 45})
+
+    reminders = client._parse_ical_event(updated)["reminders"]
+    assert [r["action"] for r in reminders] == ["DISPLAY", "EMAIL"]
+    assert {r["minutes_before"] for r in reminders} == {45}
+
+
+def test_reminder_email_alone_can_add_an_email_alarm_to_a_display_only_event():
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {**TIMED_EVENT, "reminder_minutes": 20}, "uid-display-only"
+    )
+
+    updated = client._merge_ical_properties(stored, {"reminder_email": True})
+
+    reminders = client._parse_ical_event(updated)["reminders"]
+    assert [r["action"] for r in reminders] == ["DISPLAY", "EMAIL"]
+    assert {r["minutes_before"] for r in reminders} == {20}
+
+
+def test_reminder_minutes_zero_still_clears_everything():
+    """An explicit zero is a request to remove the alarms, not a missing value."""
+    client, stored = _shorthand_event()
+
+    updated = client._merge_ical_properties(stored, {"reminder_minutes": 0})
+
+    assert "reminders" not in client._parse_ical_event(updated)
+
+
+def test_recurrence_end_date_is_utc_even_for_a_tzid_bound_dtstart():
+    """RFC 5545 §3.3.10: UNTIL is UTC whenever DTSTART is a date-time.
+
+    A TZID-bound DTSTART is the case most likely to tempt a local-time UNTIL,
+    which clients would reject along with the whole recurrence set.
+    """
+    ical = _pure_client()._create_ical_event(
+        {
+            "title": "NY standup",
+            "start_datetime": "2026-02-10T10:00:00",
+            "end_datetime": "2026-02-10T11:00:00",
+            "timezone": "America/New_York",
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-tzid-until",
+    )
+
+    assert str(_vevent(ical)["DTSTART"].params.get("TZID")) == "America/New_York"
+    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630T235959Z;BYDAY=TU"
+
+
 def test_unrelated_update_preserves_reminders_but_empty_list_clears_them():
     """Omission preserves, ``[]`` clears — the distinction the API promises."""
     client = _pure_client()

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -661,6 +661,33 @@ def test_email_reminder_carries_a_summary():
     assert str(alarm.get("description"))
 
 
+def test_audio_alarm_carries_no_description():
+    """RFC 5545 §3.8.6.1: ``audioprop`` has no DESCRIPTION.
+
+    DISPLAY and EMAIL require one, AUDIO does not admit one. Writing it anyway
+    produces a spec-invalid component that only lenient parsers forgive.
+    """
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "reminders": [{"action": "AUDIO", "minutes_before": 10}]},
+        "uid-audio",
+    )
+
+    alarm = _valarms(ical)[0]
+    assert str(alarm.get("action")) == "AUDIO"
+    assert alarm.get("description") is None
+    assert alarm.get("summary") is None
+
+
+def test_negative_minutes_before_is_rejected():
+    """The name says 'before'; a negative value would silently mean 'after'."""
+    from pydantic import ValidationError
+
+    from nextcloud_mcp_server.models.calendar import Reminder
+
+    with pytest.raises(ValidationError):
+        Reminder(minutes_before=-5)
+
+
 def test_related_is_omitted_from_an_absolute_trigger():
     """RELATED qualifies a duration. On a DATE-TIME trigger it is invalid iCal."""
     ical = _pure_client()._create_ical_event(

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -493,6 +493,59 @@ def test_update_end_date_alone_rebounds_the_stored_rule():
     assert _rrule(moved) == "FREQ=WEEKLY;UNTIL=20260731T235959Z;BYDAY=TU"
 
 
+def test_end_date_follows_the_dtstart_written_in_the_same_update():
+    """UNTIL's value type must track the *new* DTSTART, not the replaced one.
+
+    Flipping a timed series to all-day while setting recurrence_end_date in one
+    call used to compute the value type from the stored DTSTART, because the
+    recurrence block ran before ``_apply_date_updates``. The result was a DATE
+    DTSTART against a date-time UNTIL — the mismatch clients silently discard.
+    """
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {**TIMED_EVENT, "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU"}, "uid-flip"
+    )
+
+    flipped = client._merge_ical_properties(
+        stored,
+        {
+            "all_day": True,
+            "start_datetime": "2026-03-10",
+            "end_datetime": "2026-03-11",
+            "recurrence_end_date": "2026-06-30",
+        },
+    )
+
+    assert _rrule(flipped) == "FREQ=WEEKLY;UNTIL=20260630;BYDAY=TU"
+
+
+def test_end_date_follows_a_timed_dtstart_written_in_the_same_update():
+    """The mirror case: all-day flipped to timed takes a UTC date-time UNTIL."""
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {
+            "title": "Bin day",
+            "start_datetime": "2026-02-10",
+            "end_datetime": "2026-02-11",
+            "all_day": True,
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+        },
+        "uid-flip-back",
+    )
+
+    flipped = client._merge_ical_properties(
+        stored,
+        {
+            "all_day": False,
+            "start_datetime": "2026-03-10T09:00:00Z",
+            "end_datetime": "2026-03-10T10:00:00Z",
+            "recurrence_end_date": "2026-06-30",
+        },
+    )
+
+    assert _rrule(flipped) == "FREQ=WEEKLY;UNTIL=20260630T235959Z;BYDAY=TU"
+
+
 def test_update_recurring_false_clears_the_series():
     """``recurring=False`` used to do nothing; only ``recurrence_rule=""`` worked."""
     client = _pure_client()
@@ -670,6 +723,25 @@ def test_todo_reminders_round_trip():
     assert client._parse_ical_todo(ical)["reminders"] == [
         {"action": "DISPLAY", "description": "Soon", "minutes_before": 360}
     ]
+
+
+def test_todo_reminder_without_a_description_says_todo():
+    """The per-component default has to reach the explicit reminders branch.
+
+    ``Reminder.description`` deliberately defaults to None so the caller's
+    component-specific wording wins. A model-level default would silently label
+    every todo alarm "Event reminder", since the todo tools expose no
+    reminder_minutes shorthand to carry the distinction.
+    """
+    client = _pure_client()
+    ical = client._create_ical_todo(
+        {"summary": "Water plants", "reminders": [{"minutes_before": 30}]},
+        "uid-todo-default",
+    )
+
+    assert client._parse_ical_todo(ical)["reminders"][0]["description"] == (
+        "Todo reminder"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -856,6 +856,47 @@ def test_todo_reminder_without_a_description_says_todo():
     )
 
 
+FOREIGN_ALARM_TODO = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Other Client//EN
+BEGIN:VTODO
+UID:uid-foreign
+SUMMARY:Backup
+BEGIN:VALARM
+ACTION:PROCEDURE
+TRIGGER;RELATED=PARENT:-PT30M
+DESCRIPTION:Legacy
+END:VALARM
+END:VTODO
+END:VCALENDAR
+"""
+
+
+def test_foreign_valarm_action_does_not_break_the_model(caplog):
+    """Stored data comes from any CalDAV client, not just this one.
+
+    RFC 5545 lets ACTION carry any IANA or ``X-`` token, and RELATED anything at
+    all in a malformed file. Left unnormalised, either fails ``Reminder``'s
+    Literal — and because ``Todo(**todo_data)`` is built in a plain list
+    comprehension, that would fail the entire listing rather than the one item.
+    Nextcloud discards an alarm it does not recognise; so do we.
+    """
+    from nextcloud_mcp_server.models.calendar import Todo
+
+    with caplog.at_level(logging.WARNING):
+        todo_data = _pure_client()._parse_ical_todo(FOREIGN_ALARM_TODO)
+
+    assert todo_data["reminders"] == [
+        {"action": "DISPLAY", "description": "Legacy", "minutes_before": 30}
+    ]
+    assert "PROCEDURE" in caplog.text
+
+    # The model is what actually crashed the listing, so build it.
+    todo = Todo(**todo_data)
+    assert todo.reminders[0].action == "DISPLAY"
+    assert todo.reminders[0].related is None
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -7,6 +7,9 @@ ourselves — we pass the raw credential plus an explicit ``auth_type`` and let
 caldav build whichever auth its backend needs.
 """
 
+import logging
+from datetime import timedelta
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -352,3 +355,336 @@ def test_expand_without_window_returns_master_event(mocker):
 
     assert result == [{"uid": "master"}]
     expand.assert_not_called()
+
+
+# ============= Event property round-trips (GH #1251) =============
+#
+# These cover parameters the tools accepted but never wrote to the iCal. Every
+# assertion goes through a reparse rather than a substring check, because the
+# failure mode being guarded against is a property that serialises but does not
+# survive being read back.
+
+
+def _pure_client():
+    """A CalendarClient for the pure iCal helpers.
+
+    Built without going through ``__init__`` so no DAV client — and no
+    credential — is involved; the helpers under test only touch dicts and
+    icalendar objects.
+    """
+    from nextcloud_mcp_server.client.calendar import CalendarClient
+
+    return CalendarClient.__new__(CalendarClient)
+
+
+def _vevent(ical):
+    from icalendar import Calendar as ICalendar
+
+    return ICalendar.from_ical(ical).walk("VEVENT")[0]
+
+
+def _rrule(ical):
+    return _vevent(ical).get("rrule").to_ical().decode()
+
+
+def _valarms(ical):
+    return [sub for sub in _vevent(ical).subcomponents if sub.name == "VALARM"]
+
+
+TIMED_EVENT = {
+    "title": "Standup",
+    "start_datetime": "2026-02-10T10:00:00Z",
+    "end_datetime": "2026-02-10T11:00:00Z",
+}
+
+
+def test_recurrence_end_date_uses_utc_datetime_until_for_timed_events():
+    """RFC 5545 §3.3.10: a DATE-TIME DTSTART requires a UTC DATE-TIME UNTIL.
+
+    A date-only end is inclusive — bounding at midnight would drop the
+    occurrence happening later that same day.
+    """
+    ical = _pure_client()._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-until-timed",
+    )
+
+    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630T235959Z;BYDAY=TU"
+
+
+def test_recurrence_end_date_uses_date_until_for_all_day_events():
+    """A DATE-valued DTSTART requires a DATE UNTIL, not a date-time.
+
+    Mismatched value types make clients discard the recurrence set, so the
+    series silently never ends.
+    """
+    ical = _pure_client()._create_ical_event(
+        {
+            "title": "Bin day",
+            "start_datetime": "2026-02-10",
+            "end_datetime": "2026-02-11",
+            "all_day": True,
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-until-allday",
+    )
+
+    assert _rrule(ical) == "FREQ=WEEKLY;UNTIL=20260630;BYDAY=TU"
+
+
+@pytest.mark.parametrize("bound", ["COUNT=5", "UNTIL=20260101T000000Z"])
+def test_recurrence_end_date_rejects_a_rule_that_already_bounds_itself(bound):
+    """Two end conditions in one request is a contradiction, not a preference.
+
+    RFC 5545 forbids COUNT and UNTIL together, and silently picking a winner is
+    exactly the ignore-the-argument behaviour this change removes.
+    """
+    event_data = {
+        **TIMED_EVENT,
+        "recurrence_rule": f"FREQ=DAILY;{bound}",
+        "recurrence_end_date": "2026-06-30",
+    }
+
+    with pytest.raises(ValueError, match="conflicts with"):
+        _pure_client()._create_ical_event(event_data, "uid-conflict")
+
+
+def test_recurrence_rule_applies_without_an_explicit_recurring_flag():
+    """A rule is itself the intent to recur.
+
+    Requiring ``recurring=True`` as well made the argument a no-op on create
+    while update honoured it unconditionally.
+    """
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "recurrence_rule": "FREQ=DAILY"}, "uid-implied"
+    )
+
+    assert _rrule(ical) == "FREQ=DAILY"
+
+
+def test_recurring_false_suppresses_the_rule_on_create():
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "recurrence_rule": "FREQ=DAILY", "recurring": False},
+        "uid-suppressed",
+    )
+
+    assert "rrule" not in _vevent(ical)
+
+
+def test_update_end_date_alone_rebounds_the_stored_rule():
+    """Moving the end of an already-bounded series is an edit, not a conflict."""
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-rebound",
+    )
+
+    moved = client._merge_ical_properties(stored, {"recurrence_end_date": "2026-07-31"})
+
+    assert _rrule(moved) == "FREQ=WEEKLY;UNTIL=20260731T235959Z;BYDAY=TU"
+
+
+def test_update_recurring_false_clears_the_series():
+    """``recurring=False`` used to do nothing; only ``recurrence_rule=""`` worked."""
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {**TIMED_EVENT, "recurrence_rule": "FREQ=DAILY"}, "uid-clear"
+    )
+
+    cleared = client._merge_ical_properties(stored, {"recurring": False})
+
+    assert "rrule" not in _vevent(cleared)
+
+
+def test_color_round_trips_and_can_be_removed():
+    client = _pure_client()
+    stored = client._create_ical_event({**TIMED_EVENT, "color": "tomato"}, "uid-color")
+
+    assert client._parse_ical_event(stored)["color"] == "tomato"
+
+    recoloured = client._merge_ical_properties(stored, {"color": "slateblue"})
+    assert client._parse_ical_event(recoloured)["color"] == "slateblue"
+
+    removed = client._merge_ical_properties(stored, {"color": ""})
+    assert "color" not in client._parse_ical_event(removed)
+
+
+def test_hex_color_is_written_but_warns(caplog):
+    """Nextcloud resolves COLOR through a CSS3 name table, so hex never renders.
+
+    The property is still written for other CalDAV clients; the warning is what
+    stops the caller believing it will show up in Nextcloud.
+    """
+    with caplog.at_level(logging.WARNING):
+        ical = _pure_client()._create_ical_event(
+            {**TIMED_EVENT, "color": "#FF0000"}, "uid-hex"
+        )
+
+    assert str(_vevent(ical).get("color")) == "#FF0000"
+    assert "CSS3 colour names" in caplog.text
+
+
+# ============= Ordered reminders (supersedes PR #969) =============
+
+
+def test_ordered_reminders_round_trip_in_order():
+    """Order is part of the contract: VALARMs come back as they were written."""
+    client = _pure_client()
+    ical = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "reminders": [
+                {"action": "EMAIL", "minutes_before": 60, "description": "Prep"},
+                {"action": "DISPLAY", "trigger": "-PT90S", "description": "Now"},
+                {
+                    "action": "DISPLAY",
+                    "trigger_at": "2026-02-09T20:00:00Z",
+                    "description": "Absolute",
+                },
+            ],
+        },
+        "uid-reminders",
+    )
+
+    reminders = client._parse_ical_event(ical)["reminders"]
+
+    assert [r["description"] for r in reminders] == ["Prep", "Now", "Absolute"]
+    # A whole-minute offset comes back as minutes_before; anything else keeps
+    # its raw duration, so exactly one trigger field is ever present.
+    assert reminders[0]["minutes_before"] == 60
+    assert reminders[1]["trigger"] == "-PT1M30S"
+    assert "minutes_before" not in reminders[1]
+    assert reminders[2]["trigger_at"].startswith("2026-02-09T20:00:00")
+
+
+def test_read_reminders_validate_as_the_reminder_model():
+    """What we hand back must be accepted as input again.
+
+    ``Reminder`` permits exactly one trigger field, so a read path emitting both
+    a duration and its minute equivalent would break the round-trip.
+    """
+    from nextcloud_mcp_server.models.calendar import Reminder
+
+    client = _pure_client()
+    ical = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "reminders": [
+                {"minutes_before": 30, "related": "END"},
+                {"trigger": "-PT90S"},
+                {"trigger_at": "2026-02-09T20:00:00Z"},
+            ],
+        },
+        "uid-revalidate",
+    )
+
+    for reminder in client._parse_ical_event(ical)["reminders"]:
+        Reminder(**reminder)
+
+
+def test_email_reminder_carries_a_summary():
+    """RFC 5545 §3.6.6 requires SUMMARY on an EMAIL alarm — it is the subject.
+
+    Nextcloud addresses the message from the event's ATTENDEEs and the
+    calendar's sharees, so no alarm-level ATTENDEE is needed.
+    """
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "reminders": [{"action": "EMAIL", "minutes_before": 15}]},
+        "uid-email",
+    )
+
+    alarm = _valarms(ical)[0]
+    assert str(alarm.get("action")) == "EMAIL"
+    assert str(alarm.get("summary")) == "Standup"
+    assert str(alarm.get("description"))
+
+
+def test_related_is_omitted_from_an_absolute_trigger():
+    """RELATED qualifies a duration. On a DATE-TIME trigger it is invalid iCal."""
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "reminders": [{"trigger_at": "2026-02-09T20:00:00Z"}]},
+        "uid-related",
+    )
+
+    trigger = _valarms(ical)[0].get("trigger")
+    assert "RELATED" not in trigger.params
+    assert trigger.params.get("VALUE") == "DATE-TIME"
+
+
+def test_related_survives_on_a_duration_trigger():
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "reminders": [{"minutes_before": 10, "related": "END"}]},
+        "uid-related-duration",
+    )
+
+    assert _valarms(ical)[0].get("trigger").params.get("RELATED") == "END"
+
+
+def test_reminder_email_shorthand_adds_a_second_email_alarm():
+    """The legacy pair stays supported: DISPLAY, plus EMAIL at the same offset."""
+    ical = _pure_client()._create_ical_event(
+        {**TIMED_EVENT, "reminder_minutes": 15, "reminder_email": True},
+        "uid-shorthand",
+    )
+
+    alarms = _valarms(ical)
+    assert [str(a.get("action")) for a in alarms] == ["DISPLAY", "EMAIL"]
+    assert {a.get("trigger").dt for a in alarms} == {timedelta(minutes=-15)}
+
+
+def test_unrelated_update_preserves_reminders_but_empty_list_clears_them():
+    """Omission preserves, ``[]`` clears — the distinction the API promises."""
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {**TIMED_EVENT, "reminders": [{"minutes_before": 10}, {"minutes_before": 60}]},
+        "uid-preserve",
+    )
+
+    preserved = client._merge_ical_properties(stored, {"location": "Office"})
+    assert len(client._parse_ical_event(preserved)["reminders"]) == 2
+
+    cleared = client._merge_ical_properties(stored, {"reminders": []})
+    assert "reminders" not in client._parse_ical_event(cleared)
+
+
+def test_todo_reminders_round_trip():
+    """VTODOs had no alarm handling at all before this change."""
+    client = _pure_client()
+    ical = client._create_ical_todo(
+        {
+            "summary": "Water plants",
+            "reminders": [{"trigger": "-PT6H", "description": "Soon"}],
+        },
+        "uid-todo-reminder",
+    )
+
+    assert client._parse_ical_todo(ical)["reminders"] == [
+        {"action": "DISPLAY", "description": "Soon", "minutes_before": 360}
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"minutes_before": 5, "trigger": "-PT5M"},
+        {"trigger_at": "2026-01-01T00:00:00Z", "related": "END"},
+    ],
+    ids=["no-trigger", "two-triggers", "related-with-absolute"],
+)
+def test_reminder_model_rejects_incoherent_triggers(payload):
+    from pydantic import ValidationError
+
+    from nextcloud_mcp_server.models.calendar import Reminder
+
+    with pytest.raises(ValidationError):
+        Reminder(**payload)

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -770,6 +770,90 @@ def test_reminder_email_alone_can_add_an_email_alarm_to_a_display_only_event():
     assert {r["minutes_before"] for r in reminders} == {20}
 
 
+def test_recurrence_end_reads_back_under_the_name_it_is_written_with():
+    """A value read off an event must be usable as an update argument.
+
+    The write side is ``recurrence_end_date``; surfacing the read side as
+    ``recurrence_end`` would hand callers a key that does nothing when passed
+    back — the same accept-then-ignore trap this change set exists to remove.
+    """
+    client = _pure_client()
+    ical = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "recurrence_rule": "FREQ=WEEKLY;BYDAY=TU",
+            "recurrence_end_date": "2026-06-30",
+        },
+        "uid-readback",
+    )
+
+    parsed = client._parse_ical_event(ical)
+    assert "recurrence_end" not in parsed
+    assert parsed["recurrence_end_date"].startswith("2026-06-30")
+
+    # Feeding it straight back must be a no-op, not a rejection or a shift.
+    reapplied = client._merge_ical_properties(
+        ical, {"recurrence_end_date": parsed["recurrence_end_date"]}
+    )
+    assert _rrule(reapplied) == _rrule(ical)
+
+
+def test_shorthand_warns_when_collapsing_several_representable_alarms(caplog):
+    """Two alarms the shorthand can each express still collapse into one.
+
+    The earlier check only looked for a missing ``minutes_before``, so a pair of
+    DISPLAY alarms at different offsets was judged representable and silently
+    became a single alarm. The warning has to compare against what the rebuild
+    actually produces, not against one shape it cannot express.
+    """
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "reminders": [
+                {"minutes_before": 10, "description": "Event reminder"},
+                {"minutes_before": 30, "description": "Event reminder"},
+            ],
+        },
+        "uid-collapse",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        updated = client._merge_ical_properties(stored, {"reminder_minutes": 5})
+
+    assert "does not reproduce" in caplog.text
+    assert [
+        r["minutes_before"] for r in client._parse_ical_event(updated)["reminders"]
+    ] == [5]
+
+
+def test_shorthand_warns_when_dropping_a_related_qualifier(caplog):
+    """``RELATED=END`` is representable-looking but not carried by the rebuild."""
+    client = _pure_client()
+    stored = client._create_ical_event(
+        {
+            **TIMED_EVENT,
+            "reminders": [{"minutes_before": 10, "related": "END"}],
+        },
+        "uid-related-loss",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        client._merge_ical_properties(stored, {"reminder_minutes": 10})
+
+    assert "does not reproduce" in caplog.text
+
+
+def test_shorthand_is_quiet_when_the_rebuild_reproduces_the_stored_alarms(caplog):
+    """The warning must not cry wolf on the case it is meant to allow."""
+    client, stored = _shorthand_event()
+
+    with caplog.at_level(logging.WARNING):
+        client._merge_ical_properties(stored, {"reminder_minutes": 15})
+
+    assert "does not reproduce" not in caplog.text
+
+
 def test_shorthand_update_warns_before_replacing_alarms_it_cannot_express(caplog):
     """The shorthand carries one whole-minute offset, so richer alarms are lost.
 
@@ -792,7 +876,7 @@ def test_shorthand_update_warns_before_replacing_alarms_it_cannot_express(caplog
     with caplog.at_level(logging.WARNING):
         updated = client._merge_ical_properties(stored, {"reminder_minutes": 30})
 
-    assert "cannot express" in caplog.text
+    assert "does not reproduce" in caplog.text
     reminders = client._parse_ical_event(updated)["reminders"]
     assert [r["minutes_before"] for r in reminders] == [30]
 

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -854,6 +854,33 @@ def test_shorthand_is_quiet_when_the_rebuild_reproduces_the_stored_alarms(caplog
     assert "does not reproduce" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"reminder_minutes": 45},
+        {"reminder_email": False},
+        {"reminder_minutes": 45, "reminder_email": False},
+    ],
+    ids=["new-offset", "drop-email", "both"],
+)
+def test_shorthand_is_quiet_when_the_caller_is_simply_changing_the_value(
+    caplog, update
+):
+    """Changing the offset, or dropping the email alarm, is the request itself.
+
+    An earlier version compared each stored offset against the new target, so it
+    fired on the most ordinary update there is — nudging a reminder's offset.
+    A warning that fires on the common path trains the reader to ignore it, which
+    costs exactly the shape-loss cases it exists to surface.
+    """
+    client, stored = _shorthand_event()
+
+    with caplog.at_level(logging.WARNING):
+        client._merge_ical_properties(stored, update)
+
+    assert "does not reproduce" not in caplog.text
+
+
 def test_shorthand_update_warns_before_replacing_alarms_it_cannot_express(caplog):
     """The shorthand carries one whole-minute offset, so richer alarms are lost.
 

--- a/tests/unit/server/test_calendar_create_recurrence.py
+++ b/tests/unit/server/test_calendar_create_recurrence.py
@@ -36,6 +36,13 @@ async def _captured_event_data(tool, mocker, **kwargs):
         "nextcloud_mcp_server.server.calendar.get_client",
         mocker.AsyncMock(return_value=client),
     )
+    # Pin the deployment mode. @require_scopes denies a request that carries a
+    # context but no verified token *only* under login-flow, so leaving this to
+    # the ambient environment makes the test pass locally and fail in CI.
+    mocker.patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=mocker.MagicMock(enable_login_flow=False),
+    )
 
     await tool.fn(
         calendar_name="personal",

--- a/tests/unit/server/test_calendar_create_recurrence.py
+++ b/tests/unit/server/test_calendar_create_recurrence.py
@@ -1,0 +1,83 @@
+"""Unit tests for what ``nc_calendar_create_event`` forwards to the client.
+
+The tool builds ``event_data`` as a flat dict of every parameter, which meant a
+``bool`` argument with a ``False`` default was indistinguishable from one the
+caller actually set. ``recurring`` was such a parameter: the client treats a
+present-but-False flag as an explicit opt-out, so every call pinned it off and
+``recurrence_rule`` was silently dropped no matter what the caller passed.
+
+Testing at the client layer misses this entirely — ``_create_ical_event``
+behaves correctly when the key is absent, and it is only absent if the *tool*
+leaves it out. CI's single-user integration lane is what surfaced it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from nextcloud_mcp_server.server.calendar import configure_calendar_tools
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def create_event_tool():
+    mcp = FastMCP("test")
+    configure_calendar_tools(mcp)
+    return mcp._tool_manager.get_tool("nc_calendar_create_event")
+
+
+async def _captured_event_data(tool, mocker, **kwargs):
+    """Call the tool with a stubbed client and return the dict it forwarded."""
+    client = mocker.MagicMock()
+    client.calendar.create_event = mocker.AsyncMock(return_value={"uid": "u"})
+    mocker.patch(
+        "nextcloud_mcp_server.server.calendar.get_client",
+        mocker.AsyncMock(return_value=client),
+    )
+
+    await tool.fn(
+        calendar_name="personal",
+        title="Standup",
+        start_datetime="2026-02-10T10:00:00Z",
+        ctx=mocker.MagicMock(),
+        **kwargs,
+    )
+
+    return client.calendar.create_event.call_args.args[1]
+
+
+async def test_recurring_is_omitted_when_the_caller_does_not_set_it(
+    create_event_tool, mocker
+):
+    """An unset flag must not reach the client as False.
+
+    The client reads ``recurring=False`` as "suppress the series", so forwarding
+    the default turned every ``recurrence_rule`` into a no-op.
+    """
+    event_data = await _captured_event_data(
+        create_event_tool, mocker, recurrence_rule="FREQ=WEEKLY;BYDAY=TU"
+    )
+
+    assert "recurring" not in event_data
+    assert event_data["recurrence_rule"] == "FREQ=WEEKLY;BYDAY=TU"
+
+
+@pytest.mark.parametrize("value", [True, False])
+async def test_recurring_is_forwarded_when_explicitly_set(
+    create_event_tool, mocker, value
+):
+    """Both explicit values still reach the client, including False."""
+    event_data = await _captured_event_data(
+        create_event_tool, mocker, recurrence_rule="FREQ=DAILY", recurring=value
+    )
+
+    assert event_data["recurring"] is value
+
+
+async def test_reminders_are_omitted_when_unset(create_event_tool, mocker):
+    """Same distinction for reminders: absent preserves, ``[]`` clears."""
+    event_data = await _captured_event_data(create_event_tool, mocker)
+
+    assert "reminders" not in event_data


### PR DESCRIPTION
## Summary

Closes #1251. **Supersedes #969** — that PR's ordered-reminders feature is included here, rebuilt on current master.

Three parameters were accepted, documented, and consumed by nothing. `nc_calendar_create_event` put `recurrence_end_date`, `reminder_email` and `color` into `event_data`; `nc_calendar_update_event` put two in. No `COLOR` property or `ACTION:EMAIL` VALARM was emitted anywhere in the package, and no `UNTIL` ever reached an RRULE. They landed unconsumed in the original calendar commit — nothing regressed, they never worked.

### What now happens

| parameter | behaviour |
|---|---|
| `recurrence_end_date` | becomes the rule's `UNTIL`. Also accepted by the update tool, which did not take it before. |
| `color` | becomes `COLOR` (RFC 7986), read back on parse. |
| `reminder_email` | adds a second VALARM with `ACTION:EMAIL` at the same offset. |
| `reminders` | new ordered, typed alarm list — see below. |

Two inconsistencies in the same family go with them: `recurrence_rule` was silently dropped on create unless `recurring=True` while update applied it unconditionally, and `recurring=False` on update did nothing (only `recurrence_rule=""` cleared the series).

### Details worth reviewing

Three behaviours were settled by reading Nextcloud's source rather than guessing, since each is easy to get plausibly wrong:

- **`UNTIL` value type.** RFC 5545 §3.3.10 ties it to DTSTART: a DATE for an all-day event, a UTC date-time otherwise — including for a TZID-bound DTSTART. A mismatch is not cosmetic, clients discard the whole recurrence set, so the series silently never ends. A date-only end is treated as inclusive (`23:59:59Z`) so "until June 30th" keeps that day's occurrence.
- **`COLOR` must be a CSS3 name.** `getHexForColorName()` in the Calendar app is a plain `css3Colors[name]` lookup, so `#FF0000` resolves to `null` and the UI ignores it entirely. The property is still written for other CalDAV clients, but the docstring no longer claims "hex or name" and a hex value logs a warning.
- **EMAIL alarms need no alarm-level ATTENDEE.** `ReminderService::REMINDER_TYPES` accepts `EMAIL`/`DISPLAY`/`AUDIO` and silently discards anything else, and `EmailProvider::send()` resolves recipients from the VEVENT's ATTENDEEs plus the calendar's sharees. RFC 5545 still requires `SUMMARY` and `DESCRIPTION` on an EMAIL alarm, so both are written.

Conflicts raise instead of resolving themselves: `recurrence_end_date` combined with a `recurrence_rule` that already carries `UNTIL` or `COUNT` is a contradiction within one request. Applying an end date *alone* to an already-bounded stored rule is treated as moving the end, which is the obvious intent.

### On superseding #969

#969 is 39 versions behind master and conflicting — master extracted `_apply_date_updates`, removed `_merge_ical_properties`'s `event_uid` argument (its test still passes three positional args and would `TypeError`), and made `_parse_ical_todo` recurrence-expanding. Rather than ask its author to rebase across all that, the feature is absorbed here with the design tightened:

- typed `Reminder` model instead of `list[dict[str, Any]]` with a docstring-only schema
- `SUMMARY` on EMAIL alarms, which #969 omitted, so an EMAIL alarm has no subject
- `RELATED` only on duration triggers — #969 set it before the trigger branch, emitting the invalid `TRIGGER;RELATED=START;VALUE=DATE-TIME:…`
- exactly one trigger field per reminder, enforced both ways, so a reminder read back from a stored event validates as input again
- todos included, and the SonarCloud S2068 `password="app-pw"` test kwarg not reintroduced

`reminder_minutes` and `reminder_email` remain supported shorthand, so no `BREAKING CHANGE:` footer. Silviu Chingaru is credited via `Co-Authored-By:`. **#969 should be closed when this merges.**

## Test Plan

Unit (`tests/unit/client/test_calendar.py`) — every assertion goes through a reparse rather than a substring check, since the failure mode being guarded against is a property that serialises but does not survive a read:

- `UNTIL` is a DATE for an all-day DTSTART and a UTC date-time for a timed one, built in DTSTART's own zone so an evening occurrence on the end date is not excluded
- conflicting `UNTIL`/`COUNT` raises, parameterized over both
- `recurrence_rule` applies without `recurring=True`, and `recurring=False` suppresses/clears
- an end date alone re-bounds the stored rule, and follows a DTSTART written in the same update
- `COLOR` round-trips and can be removed, hex warns
- ordered reminders keep their order, `[]` clears, an unrelated update preserves
- EMAIL alarms carry `SUMMARY`, AUDIO alarms carry no `DESCRIPTION`, `RELATED` is absent on absolute triggers and present on durations
- read reminders revalidate as `Reminder`, and no stored alarm shape — legacy `PROCEDURE`, `X-` action, foreign `RELATED`, missing `TRIGGER` — can fail a listing
- the shorthand preserves the field the caller omitted, warns only on genuine shape loss, and stays quiet on an ordinary offset change

Each fix in this branch was verified by reverting it and confirming the new guard fails, rather than by assuming.

e2e (`tests/server/test_calendar_events_mcp.py`, marker `integration`, alongside #544's existing coverage) — three tests driving the new parameters through the real MCP tools against a running stack and reading the event back from Nextcloud. These were **not** run locally (the local stack was stopped to avoid an OOM), so CI is the gate. **They have since gone green on every `single-user` lane across nc32/nc33/nc34 on repeated runs**, which is what verifies `COLOR` persistence, the `ACTION:EMAIL` alarm, `UNTIL`, ordered-reminder round-tripping, and shorthand independence against a real CalDAV store.

Contract (Pact): no changes needed. This is MCP tool surface, not the `/api/v1/*` provider surface that `astrolabe` consumes, and it makes no gateway call — so no consumer or provider pact is affected. Flagging explicitly rather than leaving the review gate to infer it.

---

_This PR was generated with the help of AI, and reviewed by a Human_

