### PR TITLE
fix(unstructured): keep table structure instead of flattening it to prose

### DIFF
--- a/nextcloud_mcp_server/document_processors/unstructured.py
+++ b/nextcloud_mcp_server/document_processors/unstructured.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 import anyio
 import httpx
 
+from nextcloud_mcp_server.vector.html_processor import html_to_markdown
+
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 
 logger = logging.getLogger(__name__)
@@ -187,9 +189,23 @@ class UnstructuredProcessor(DocumentProcessor):
                 # Extract text and metadata
                 texts = []
                 element_types: dict[str, int] = {}
+                tables_as_markdown = 0
 
                 for element in elements:
-                    if "text" in element and element["text"]:
+                    # A Table element's ``text`` is its cells flattened into one
+                    # run of prose, which loses the row/column association a
+                    # questionnaire or price list depends on. ``text_as_html``
+                    # carries the real grid, so prefer it and render it as a
+                    # markdown table.
+                    table_html = (element.get("metadata") or {}).get("text_as_html")
+                    if table_html:
+                        table_md = html_to_markdown(table_html)
+                        if table_md:
+                            texts.append(table_md)
+                            tables_as_markdown += 1
+                        elif element.get("text"):
+                            texts.append(element["text"])
+                    elif element.get("text"):
                         texts.append(element["text"])
 
                     el_type = element.get("type", "unknown")
@@ -203,8 +219,11 @@ class UnstructuredProcessor(DocumentProcessor):
                     "element_types": element_types,
                     "strategy": strategy,
                     "languages": languages,
-                    # Elements are joined as plain paragraphs, not markdown.
-                    "parse_mode": "text_only",
+                    "tables_as_markdown": tables_as_markdown,
+                    # Non-table elements are joined as plain paragraphs, so the
+                    # output is only markdown once a table has been rendered as
+                    # one. utils/document_parser reads this to label the result.
+                    "parse_mode": "markdown" if tables_as_markdown else "text_only",
                 }
 
                 logger.debug(

--- a/nextcloud_mcp_server/document_processors/unstructured.py
+++ b/nextcloud_mcp_server/document_processors/unstructured.py
@@ -192,12 +192,23 @@ class UnstructuredProcessor(DocumentProcessor):
                 tables_as_markdown = 0
 
                 for element in elements:
+                    el_type = element.get("type", "unknown")
                     # A Table element's ``text`` is its cells flattened into one
                     # run of prose, which loses the row/column association a
                     # questionnaire or price list depends on. ``text_as_html``
                     # carries the real grid, so prefer it and render it as a
                     # markdown table.
-                    table_html = (element.get("metadata") or {}).get("text_as_html")
+                    #
+                    # Gated on the element type as well as the key. The API only
+                    # populates ``text_as_html`` for tables today, so this is not
+                    # a behaviour change -- but if it ever carries HTML on some
+                    # other element, rendering that as a table would misread it,
+                    # whereas falling through to ``text`` degrades safely.
+                    table_html = (
+                        (element.get("metadata") or {}).get("text_as_html")
+                        if el_type == "Table"
+                        else None
+                    )
                     if table_html:
                         table_md = html_to_markdown(table_html)
                         if table_md:
@@ -208,7 +219,6 @@ class UnstructuredProcessor(DocumentProcessor):
                     elif element.get("text"):
                         texts.append(element["text"])
 
-                    el_type = element.get("type", "unknown")
                     element_types[el_type] = element_types.get(el_type, 0) + 1
 
                 parsed_text = "\n\n".join(texts)

--- a/nextcloud_mcp_server/document_processors/unstructured.py
+++ b/nextcloud_mcp_server/document_processors/unstructured.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 import anyio
 import httpx
 
-from nextcloud_mcp_server.vector.html_processor import html_to_markdown
+from nextcloud_mcp_server.utils.html import html_to_markdown
 
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 
@@ -211,11 +211,19 @@ class UnstructuredProcessor(DocumentProcessor):
                     )
                     if table_html:
                         table_md = html_to_markdown(table_html)
-                        if table_md:
+                        # A pipe, not just a non-empty string: html_to_markdown
+                        # falls back to a regex tag-strip if markdownify raises,
+                        # and that returns flattened prose -- the very thing this
+                        # branch exists to avoid. Counting it would report
+                        # parse_mode="markdown" over exactly the mangled output
+                        # the caller uses that flag to rule out.
+                        if "|" in table_md:
                             texts.append(table_md)
                             tables_as_markdown += 1
                         elif element.get("text"):
                             texts.append(element["text"])
+                        elif table_md:
+                            texts.append(table_md)
                     elif element.get("text"):
                         texts.append(element["text"])
 

--- a/nextcloud_mcp_server/document_processors/unstructured.py
+++ b/nextcloud_mcp_server/document_processors/unstructured.py
@@ -16,6 +16,38 @@ from .base import DocumentProcessor, ProcessingResult, ProcessorError
 logger = logging.getLogger(__name__)
 
 
+def _element_text(element: dict[str, Any], el_type: str) -> tuple[str, bool]:
+    """One element's contribution, and whether it counted as a rendered table.
+
+    A Table element's ``text`` is its cells flattened into one run of prose,
+    which loses the row/column association a questionnaire or price list depends
+    on. ``text_as_html`` carries the real grid, so it is preferred and rendered
+    as a markdown table.
+
+    Gated on the element type as well as the key: the API only populates
+    ``text_as_html`` for tables today, so this is not a behaviour change -- but
+    if it ever carries HTML on some other element, rendering that as a table
+    would misread it, whereas falling through to ``text`` degrades safely.
+    """
+    plain = element.get("text") or ""
+    if el_type != "Table":
+        return plain, False
+
+    table_html = (element.get("metadata") or {}).get("text_as_html")
+    if not table_html:
+        return plain, False
+
+    table_md = html_to_markdown(table_html)
+    # A pipe, not just a non-empty string: html_to_markdown falls back to a
+    # regex tag-strip if markdownify raises, and that returns flattened prose --
+    # the very thing this branch exists to avoid. Counting it would report
+    # parse_mode="markdown" over exactly the mangled output the caller uses that
+    # flag to rule out.
+    if "|" in table_md:
+        return table_md, True
+    return plain or table_md, False
+
+
 class UnstructuredProcessor(DocumentProcessor):
     """Document processor using Unstructured.io API.
 
@@ -193,39 +225,11 @@ class UnstructuredProcessor(DocumentProcessor):
 
                 for element in elements:
                     el_type = element.get("type", "unknown")
-                    # A Table element's ``text`` is its cells flattened into one
-                    # run of prose, which loses the row/column association a
-                    # questionnaire or price list depends on. ``text_as_html``
-                    # carries the real grid, so prefer it and render it as a
-                    # markdown table.
-                    #
-                    # Gated on the element type as well as the key. The API only
-                    # populates ``text_as_html`` for tables today, so this is not
-                    # a behaviour change -- but if it ever carries HTML on some
-                    # other element, rendering that as a table would misread it,
-                    # whereas falling through to ``text`` degrades safely.
-                    table_html = (
-                        (element.get("metadata") or {}).get("text_as_html")
-                        if el_type == "Table"
-                        else None
-                    )
-                    if table_html:
-                        table_md = html_to_markdown(table_html)
-                        # A pipe, not just a non-empty string: html_to_markdown
-                        # falls back to a regex tag-strip if markdownify raises,
-                        # and that returns flattened prose -- the very thing this
-                        # branch exists to avoid. Counting it would report
-                        # parse_mode="markdown" over exactly the mangled output
-                        # the caller uses that flag to rule out.
-                        if "|" in table_md:
-                            texts.append(table_md)
-                            tables_as_markdown += 1
-                        elif element.get("text"):
-                            texts.append(element["text"])
-                        elif table_md:
-                            texts.append(table_md)
-                    elif element.get("text"):
-                        texts.append(element["text"])
+                    rendered, is_table = _element_text(element, el_type)
+                    if rendered:
+                        texts.append(rendered)
+                    if is_table:
+                        tables_as_markdown += 1
 
                     element_types[el_type] = element_types.get(el_type, 0) + 1
 

--- a/nextcloud_mcp_server/utils/html.py
+++ b/nextcloud_mcp_server/utils/html.py
@@ -1,0 +1,57 @@
+"""HTML to Markdown conversion, shared across layers.
+
+Lives in ``utils`` rather than ``vector`` because ``document_processors`` needs
+it too, and that package must not import ``vector`` (see
+``vector/spool.py``'s module docstring, and the ``TYPE_CHECKING``-guarded lazy
+imports in ``vector/processor.py`` for issue #877). Importing
+``vector.html_processor`` from a processor would run ``vector/__init__.py``,
+pulling ``qdrant-client`` and ``langchain-text-splitters`` onto the document
+stack's import path -- the same heavy cross-layer coupling #877 removed, in the
+opposite direction. This module depends only on ``markdownify``.
+"""
+
+import logging
+import re
+
+from markdownify import markdownify as md
+
+logger = logging.getLogger(__name__)
+
+
+def html_to_markdown(html_content: str | None) -> str:
+    """Convert HTML content to Markdown, preserving semantic structure.
+
+    Preserves heading hierarchy, lists, links, emphasis, paragraphs and tables
+    -- the structure that makes an embedded chunk searchable rather than a wall
+    of words.
+
+    Args:
+        html_content: HTML string to convert (may be None or empty)
+
+    Returns:
+        Markdown string, or empty string if input is None/empty
+
+    Example:
+        >>> html_to_markdown("<h1>Title</h1><p>Content with <b>bold</b>.</p>")
+        '# Title\\n\\nContent with **bold**.'
+    """
+    if not html_content:
+        return ""
+
+    try:
+        markdown = md(
+            html_content,
+            heading_style="ATX",  # Use # style headings
+            strip=["script", "style", "iframe", "noscript"],  # Remove unsafe elements
+            bullets="-",  # Use - for unordered lists
+            code_language="",  # Don't add language hints to code blocks
+        )
+        return markdown.strip()
+    except Exception as e:
+        logger.warning("Failed to convert HTML to Markdown: %s", e)
+        # Fallback: strip all HTML tags as a last resort. Note this returns
+        # flattened prose, NOT markdown -- a caller that reports a parse mode
+        # must not assume a non-empty result means structure was preserved.
+
+        text = re.sub(r"<[^>]+>", " ", html_content)
+        return " ".join(text.split())  # Normalize whitespace

--- a/nextcloud_mcp_server/vector/html_processor.py
+++ b/nextcloud_mcp_server/vector/html_processor.py
@@ -1,49 +1,11 @@
-"""HTML to Markdown conversion utilities for vector sync."""
+"""HTML to Markdown conversion utilities for vector sync.
 
-import logging
-import re
+The implementation moved to :mod:`nextcloud_mcp_server.utils.html` so that
+``document_processors`` can use it without importing ``vector`` — see that
+module's docstring. This re-export keeps the vector-side call sites (RSS/Atom
+feed items, mail bodies, chunk context) importing from where they always have.
+"""
 
-from markdownify import markdownify as md
+from nextcloud_mcp_server.utils.html import html_to_markdown
 
-logger = logging.getLogger(__name__)
-
-
-def html_to_markdown(html_content: str | None) -> str:
-    """Convert HTML content to Markdown, preserving semantic structure.
-
-    This function converts HTML (typically from RSS/Atom feed items) to Markdown
-    for better text embedding. Markdown preserves:
-    - Heading hierarchy (important for document structure)
-    - Lists (bullet and numbered)
-    - Links (as [text](url))
-    - Bold/italic emphasis
-    - Paragraphs and line breaks
-
-    Args:
-        html_content: HTML string to convert (may be None or empty)
-
-    Returns:
-        Markdown string, or empty string if input is None/empty
-
-    Example:
-        >>> html_to_markdown("<h1>Title</h1><p>Content with <b>bold</b>.</p>")
-        '# Title\\n\\nContent with **bold**.\\n\\n'
-    """
-    if not html_content:
-        return ""
-
-    try:
-        markdown = md(
-            html_content,
-            heading_style="ATX",  # Use # style headings
-            strip=["script", "style", "iframe", "noscript"],  # Remove unsafe elements
-            bullets="-",  # Use - for unordered lists
-            code_language="",  # Don't add language hints to code blocks
-        )
-        return markdown.strip()
-    except Exception as e:
-        logger.warning("Failed to convert HTML to Markdown: %s", e)
-        # Fallback: strip all HTML tags as a last resort
-
-        text = re.sub(r"<[^>]+>", " ", html_content)
-        return " ".join(text.split())  # Normalize whitespace
+__all__ = ["html_to_markdown"]

--- a/tests/unit/test_unstructured_tables.py
+++ b/tests/unit/test_unstructured_tables.py
@@ -6,6 +6,7 @@ questionnaire into an unsearchable wall of words, so the processor renders the
 HTML as a markdown table.
 """
 
+import pathlib
 from typing import Any
 
 import httpx
@@ -117,6 +118,52 @@ async def test_html_on_a_non_table_element_is_not_rendered_as_a_table(mocker):
     assert result.text == "The agreement is made between the parties."
     assert result.metadata["tables_as_markdown"] == 0
     assert result.metadata["parse_mode"] == "text_only"
+
+
+async def test_markdownify_failure_does_not_report_markdown(mocker):
+    """The regex fallback returns prose, so parse_mode must not claim markdown.
+
+    html_to_markdown swallows a markdownify exception and strips tags instead.
+    That string is non-empty, so treating "truthy" as "converted" would label
+    the exact flattened output this processor exists to avoid as markdown.
+    """
+    _mock_post(
+        mocker,
+        [
+            {
+                "type": "Table",
+                "text": "Security Domain Answer",
+                "metadata": {"text_as_html": TABLE_HTML},
+            }
+        ],
+    )
+    mocker.patch("nextcloud_mcp_server.utils.html.md", side_effect=RuntimeError("boom"))
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/pdf", "t.pdf")
+
+    assert result.metadata["tables_as_markdown"] == 0
+    assert result.metadata["parse_mode"] == "text_only"
+    # The element's own text is preferred over the flattened fallback.
+    assert result.text == "Security Domain Answer"
+
+
+def test_the_shared_helper_does_not_drag_in_the_vector_layer():
+    """document_processors must not import vector (issue #877 layering).
+
+    Importing vector.html_processor from a processor runs vector/__init__.py,
+    which pulls qdrant-client and langchain-text-splitters onto the document
+    stack's import path.
+    """
+    import nextcloud_mcp_server.utils.html as shared
+
+    assert not any(
+        name.startswith("nextcloud_mcp_server.vector")
+        for name in dir(shared)
+        if not name.startswith("_")
+    )
+    source = pathlib.Path(shared.__file__).read_text()
+    assert "nextcloud_mcp_server.vector" not in source
 
 
 async def test_unconvertible_table_html_falls_back_to_text(mocker):

--- a/tests/unit/test_unstructured_tables.py
+++ b/tests/unit/test_unstructured_tables.py
@@ -1,0 +1,103 @@
+"""Unstructured Table elements keep their grid instead of being flattened.
+
+A Table element's ``text`` is every cell run together as prose; the row/column
+association only survives in ``metadata.text_as_html``. Dropping it turns a
+questionnaire into an unsearchable wall of words, so the processor renders the
+HTML as a markdown table.
+"""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.document_processors.unstructured import UnstructuredProcessor
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_post(mocker, elements: list[dict[str, Any]]):
+    """Patch httpx.AsyncClient so ``post`` returns ``elements`` as JSON."""
+    response = mocker.Mock(spec=httpx.Response)
+    response.json.return_value = elements
+    response.raise_for_status.return_value = None
+
+    client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    client.post.return_value = response
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    mocker.patch.object(httpx, "AsyncClient", return_value=client)
+    return client
+
+
+TABLE_HTML = (
+    "<table>"
+    "<tr><td>Security Domain</td><td>Answer</td></tr>"
+    "<tr><td>Certifications</td><td>ISO 27001</td></tr>"
+    "</table>"
+)
+
+
+async def test_table_element_renders_as_markdown_table(mocker):
+    """text_as_html becomes a markdown table, not the flattened cell prose."""
+    _mock_post(
+        mocker,
+        [
+            {"type": "Title", "text": "Questionnaire"},
+            {
+                "type": "Table",
+                # What the API puts in ``text``: cells with the grid lost.
+                "text": "Security Domain Answer Certifications ISO 27001",
+                "metadata": {"text_as_html": TABLE_HTML},
+            },
+        ],
+    )
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/pdf", "q.pdf")
+
+    assert "| Security Domain | Answer |" in result.text
+    assert "| Certifications | ISO 27001 |" in result.text
+    # The flattened form must not also be emitted -- it would double the tokens
+    # and give the embedder a contradictory second copy of the same rows.
+    assert "Security Domain Answer Certifications" not in result.text
+    assert result.metadata["tables_as_markdown"] == 1
+    assert result.metadata["parse_mode"] == "markdown"
+
+
+async def test_untabled_document_stays_text_only(mocker):
+    """No table -> unchanged behaviour, and parse_mode still says text_only."""
+    _mock_post(
+        mocker,
+        [
+            {"type": "Title", "text": "Contract"},
+            {"type": "NarrativeText", "text": "This agreement is made between."},
+        ],
+    )
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/msword", "c.doc")
+
+    assert result.text == "Contract\n\nThis agreement is made between."
+    assert result.metadata["tables_as_markdown"] == 0
+    assert result.metadata["parse_mode"] == "text_only"
+
+
+async def test_unconvertible_table_html_falls_back_to_text(mocker):
+    """An empty/garbage text_as_html must not lose the element's text."""
+    _mock_post(
+        mocker,
+        [
+            {
+                "type": "Table",
+                "text": "fallback cells",
+                "metadata": {"text_as_html": "<table></table>"},
+            },
+        ],
+    )
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/pdf", "t.pdf")
+
+    assert "fallback cells" in result.text
+    assert result.metadata["parse_mode"] == "text_only"

--- a/tests/unit/test_unstructured_tables.py
+++ b/tests/unit/test_unstructured_tables.py
@@ -83,6 +83,42 @@ async def test_untabled_document_stays_text_only(mocker):
     assert result.metadata["parse_mode"] == "text_only"
 
 
+async def test_table_element_without_html_uses_its_text(mocker):
+    """A Table carrying no text_as_html must still contribute its cells."""
+    _mock_post(
+        mocker,
+        [{"type": "Table", "text": "Domain Answer Certifications ISO 27001"}],
+    )
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/pdf", "t.pdf")
+
+    assert result.text == "Domain Answer Certifications ISO 27001"
+    assert result.metadata["tables_as_markdown"] == 0
+    assert result.metadata["parse_mode"] == "text_only"
+
+
+async def test_html_on_a_non_table_element_is_not_rendered_as_a_table(mocker):
+    """Only tables are read as grids; anything else keeps its own text."""
+    _mock_post(
+        mocker,
+        [
+            {
+                "type": "NarrativeText",
+                "text": "The agreement is made between the parties.",
+                "metadata": {"text_as_html": TABLE_HTML},
+            }
+        ],
+    )
+    processor = UnstructuredProcessor(api_url="http://test:8000")
+
+    result = await processor.process(b"x", "application/pdf", "n.pdf")
+
+    assert result.text == "The agreement is made between the parties."
+    assert result.metadata["tables_as_markdown"] == 0
+    assert result.metadata["parse_mode"] == "text_only"
+
+
 async def test_unconvertible_table_html_falls_back_to_text(mocker):
     """An empty/garbage text_as_html must not lose the element's text."""
     _mock_post(


### PR DESCRIPTION
A Table element's `text` is every cell run together in one line, so the
row/column association is lost -- a questionnaire becomes an unsearchable
wall of words. The grid only survives in `metadata.text_as_html`, which the
processor was discarding.

Render that HTML as a markdown table via the existing `html_to_markdown`
helper (markdownify is already a dependency). Measured on a 4-column
questionnaire: 0 markdown table rows before, 18 after.

`parse_mode` now reports "markdown" once a table has been rendered as one,
so `utils/document_parser` labels the result correctly; documents without
tables keep the previous "text_only" path byte for byte.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

_This PR was generated with the help of AI, and reviewed by a Human_