### PR TITLE
feat(search): link every semantic-search result to its chunk in Astrolabe

### DIFF
--- a/nextcloud_mcp_server/astrolabe_links.py
+++ b/nextcloud_mcp_server/astrolabe_links.py
@@ -96,13 +96,16 @@ def chunk_url(
         "chunk_start": str(chunk_start),
         "chunk_end": str(chunk_end),
     }
+    # `extra` is spread FIRST so the named parameters win a key collision: they
+    # are the typed, documented surface, and an opaque caller-supplied dict
+    # should not be able to quietly redefine `title` or `path`.
     optional = {
+        **(extra or {}),
         "title": title,
         "path": path,
         "page_number": page_number,
         "chunk_index": chunk_index,
         "total_chunks": total_chunks,
-        **(extra or {}),
     }
     # Omit unset values rather than emitting `page_number=None`, which Astrolabe
     # would parseInt into NaN.

--- a/nextcloud_mcp_server/astrolabe_links.py
+++ b/nextcloud_mcp_server/astrolabe_links.py
@@ -8,11 +8,19 @@ generator.
 """
 
 import logging
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from nextcloud_mcp_server.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+# Schemes a browser can follow. Plain http stays allowed deliberately: local and
+# self-hosted Nextcloud instances are routinely served over http (the dev
+# compose stack is http://localhost:8080), so demanding TLS here would strip the
+# link from exactly the deployments that need it. This is a "can a browser open
+# it" check, not a transport-security decision — the base URL is operator
+# configuration, never user input.
+BROWSER_SCHEMES = ("http", "https")
 
 # Astrolabe's app root. The chunk viewer is opened by query parameters on it —
 # the app has no vue-router, so there is no per-document path to link to.
@@ -28,14 +36,19 @@ def astrolabe_browser_base() -> str | None:
     IdP rather than Nextcloud.
 
     Returns None when nothing is configured, and when the configured base URL
-    lacks an http:// or https:// scheme — a bare ``internal:8080`` would
-    otherwise yield a non-clickable link, so the misconfiguration is surfaced as
-    a warning and callers omit the link instead.
+    is not something a browser can open — a bare ``internal:8080`` parses as
+    scheme ``internal-host`` with no host, and would yield a non-clickable link,
+    so the misconfiguration is surfaced as a warning and callers omit the link
+    instead.
     """
     base = (get_settings().nextcloud_browser_url or "").strip()
     if not base:
         return None
-    if not base.startswith(("http://", "https://")):
+    # Parsed rather than prefix-matched: this also rejects a scheme-only
+    # "https:" (no host) and accepts an uppercase scheme, both of which a
+    # startswith check gets wrong.
+    parsed = urlparse(base)
+    if parsed.scheme not in BROWSER_SCHEMES or not parsed.netloc:
         logger.warning(
             "Cannot build an Astrolabe URL: configured Nextcloud base URL %r is "
             "missing an http:// or https:// scheme.",

--- a/nextcloud_mcp_server/astrolabe_links.py
+++ b/nextcloud_mcp_server/astrolabe_links.py
@@ -1,0 +1,99 @@
+"""Deep links into the Astrolabe Nextcloud app's UI.
+
+The Astrolabe frontend opens its chunk viewer from query parameters on the app
+root (``src/App.vue``'s ``handleUrlParameters``), and strips them via
+``history.replaceState`` once the viewer is open. This module is the only place
+that *builds* such a link; the parser has existed for far longer than any
+generator.
+"""
+
+import logging
+from urllib.parse import urlencode
+
+from nextcloud_mcp_server.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Astrolabe's app root. The chunk viewer is opened by query parameters on it —
+# the app has no vue-router, so there is no per-document path to link to.
+ASTROLABE_APP_PATH = "/index.php/apps/astrolabe/"
+
+
+def astrolabe_browser_base() -> str | None:
+    """Return the browser-reachable Nextcloud base URL, or None.
+
+    Uses ``nextcloud_browser_url`` (``nextcloud_public_url`` →
+    ``nextcloud_public_issuer_url`` → ``nextcloud_host``) so links point at
+    Nextcloud even in external-IdP deployments where the OAuth issuer URL is the
+    IdP rather than Nextcloud.
+
+    Returns None when nothing is configured, and when the configured base URL
+    lacks an http:// or https:// scheme — a bare ``internal:8080`` would
+    otherwise yield a non-clickable link, so the misconfiguration is surfaced as
+    a warning and callers omit the link instead.
+    """
+    base = (get_settings().nextcloud_browser_url or "").strip()
+    if not base:
+        return None
+    if not base.startswith(("http://", "https://")):
+        logger.warning(
+            "Cannot build an Astrolabe URL: configured Nextcloud base URL %r is "
+            "missing an http:// or https:// scheme.",
+            base,
+        )
+        return None
+    return base.rstrip("/")
+
+
+def chunk_url(
+    base: str | None,
+    *,
+    doc_type: str,
+    doc_id: int | str,
+    chunk_start: int | None,
+    chunk_end: int | None,
+    title: str | None = None,
+    path: str | None = None,
+    page_number: int | None = None,
+    chunk_index: int | None = None,
+    total_chunks: int | None = None,
+    extra: dict[str, str] | None = None,
+) -> str | None:
+    """Build a link that opens ``doc_id``'s chunk in the Astrolabe chunk viewer.
+
+    ``base`` comes from :func:`astrolabe_browser_base`; it is a parameter rather
+    than an internal call so a search resolves it once instead of once per
+    result.
+
+    Returns None when there is no base URL, or when either chunk offset is
+    missing — Astrolabe requires ``doc_type``, ``doc_id``, ``chunk_start`` and
+    ``chunk_end`` together, and opens nothing if any is absent, so a link
+    without them would be a dead end rather than a degraded one.
+
+    ``extra`` carries per-doc_type access-recheck identifiers (``board_id``,
+    ``mailbox_id``, ``calendar_uri``) so a stale link gets the same local access
+    check as a live search result.
+    """
+    if not base or chunk_start is None or chunk_end is None:
+        return None
+
+    params: dict[str, str] = {
+        "doc_type": doc_type,
+        "doc_id": str(doc_id),
+        "chunk_start": str(chunk_start),
+        "chunk_end": str(chunk_end),
+    }
+    optional = {
+        "title": title,
+        "path": path,
+        "page_number": page_number,
+        "chunk_index": chunk_index,
+        "total_chunks": total_chunks,
+        **(extra or {}),
+    }
+    # Omit unset values rather than emitting `page_number=None`, which Astrolabe
+    # would parseInt into NaN.
+    params.update({k: str(v) for k, v in optional.items() if v is not None})
+
+    # urlencode quotes the spaces and slashes that real titles and paths carry.
+    return f"{base}{ASTROLABE_APP_PATH}?{urlencode(params)}"

--- a/nextcloud_mcp_server/astrolabe_links.py
+++ b/nextcloud_mcp_server/astrolabe_links.py
@@ -36,10 +36,10 @@ def astrolabe_browser_base() -> str | None:
     IdP rather than Nextcloud.
 
     Returns None when nothing is configured, and when the configured base URL
-    is not something a browser can open — a bare ``internal:8080`` parses as
-    scheme ``internal-host`` with no host, and would yield a non-clickable link,
-    so the misconfiguration is surfaced as a warning and callers omit the link
-    instead.
+    is not something a browser can open — a bare ``internal-host:8080`` parses
+    as scheme ``internal-host`` with no host, and would yield a non-clickable
+    link, so the misconfiguration is surfaced as a warning and callers omit the
+    link instead.
     """
     base = (get_settings().nextcloud_browser_url or "").strip()
     if not base:

--- a/nextcloud_mcp_server/auth/elicitation.py
+++ b/nextcloud_mcp_server/auth/elicitation.py
@@ -10,7 +10,7 @@ from typing import Any
 from mcp.server.fastmcp import Context
 from pydantic import BaseModel, Field
 
-from nextcloud_mcp_server.config import get_settings
+from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base
 from nextcloud_mcp_server.observability.metrics import record_elicitation
 
 logger = logging.getLogger(__name__)
@@ -45,29 +45,15 @@ class ProvisioningRequiredConfirmation(BaseModel):
 def _astrolabe_settings_url() -> str | None:
     """Construct the Astrolabe settings page URL from settings.
 
-    Uses ``nextcloud_browser_url`` (the browser-reachable Nextcloud base URL:
-    ``nextcloud_public_url`` → ``nextcloud_public_issuer_url`` → ``nextcloud_host``)
-    so the link points at Nextcloud even in external-IdP deployments where the
-    OAuth issuer URL is the IdP, not Nextcloud. Returns None if none is set (or
-    set to the empty string), or if the configured base URL is missing an
-    http:// or https:// scheme — in the latter case the caller renders the
-    tool-only fallback message instead of a broken link.
+    Delegates the base-URL resolution and its scheme check to
+    :func:`astrolabe_browser_base`, so that logic lives in one place. Returns
+    None when no browser-reachable Nextcloud URL is configured — the caller then
+    renders the tool-only fallback message instead of a broken link.
     """
-    settings = get_settings()
-    base = (settings.nextcloud_browser_url or "").strip()
-    if not base:
+    base = astrolabe_browser_base()
+    if base is None:
         return None
-    if not base.startswith(("http://", "https://")):
-        # Bare hostname (e.g. "internal:8080") would silently produce a
-        # non-clickable URL. Surface the misconfiguration instead.
-        logger.warning(
-            "Cannot build Astrolabe settings URL: configured Nextcloud base URL "
-            "%r is missing an http:// or https:// scheme. Falling back to the "
-            "tool-only provisioning message.",
-            base,
-        )
-        return None
-    return f"{base.rstrip('/')}{ASTROLABE_SETTINGS_PATH}"
+    return f"{base}{ASTROLABE_SETTINGS_PATH}"
 
 
 async def _run_elicit(

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -96,6 +96,16 @@ class SemanticSearchResult(BaseModel):
     page_count: int | None = Field(
         default=None, description="Total number of pages in PDF document"
     )
+    url: str | None = Field(
+        default=None,
+        description=(
+            "Deep link that opens this exact chunk in the Astrolabe UI. Offer "
+            "it to the user alongside a quotation from `excerpt` so they can "
+            "read the passage in place and check it in context. None when the "
+            "server has no browser-reachable Nextcloud base URL configured, or "
+            "when this chunk carries no character offsets."
+        ),
+    )
     # Context expansion fields (optional, populated when include_context=True)
     has_context_expansion: bool = Field(
         default=False, description="Whether context expansion was performed"

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -13,6 +13,7 @@ from mcp.types import (
 )
 from pydantic import Field
 
+from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base, chunk_url
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import allowed_doc_types
 from nextcloud_mcp_server.config import get_settings
@@ -272,8 +273,16 @@ def configure_semantic_tools(mcp: FastMCP):
                 only — setting it implicitly limits results to files. None/empty = no path filter
                 (default).
 
+        To scope a search to one or more folders, pass `path_prefixes` — that is
+        the supported way to search "just this subdirectory".
+
         Returns:
             SemanticSearchResponse with matching documents ranked by fusion scores.
+
+            Each result carries a `url` that opens that exact chunk in the
+            Astrolabe UI. Offer it alongside anything you quote from `excerpt`
+            so the user can read the passage in place. It is None when the
+            server has no browser-reachable Nextcloud base URL configured.
 
             Verification fields (ADR-019 verify-on-read):
             - verified_chunk_count: chunk rows that passed access checks
@@ -648,6 +657,11 @@ def configure_semantic_tools(mcp: FastMCP):
             )
             search_results = verified_results[:limit]
 
+            # Resolved once per search rather than once per result: it reads
+            # config and logs a warning when the base URL is unusable, and doing
+            # that per row would repeat the warning `limit` times.
+            browser_base = astrolabe_browser_base()
+
             # Convert SearchResult objects to SemanticSearchResult for response.
             # SearchResult.id is `str` (Qdrant keyword-indexed payload), but
             # every currently indexed type uses numeric ids and the MCP response
@@ -681,6 +695,16 @@ def configure_semantic_tools(mcp: FastMCP):
                     algorithm="hybrid",
                     rerank_model=settings.search_rerank_model,
                 )
+                metadata = r.metadata or {}
+                # board_id is the only one of Astrolabe's access-recheck
+                # identifiers the chunk payload carries (see
+                # build_search_result_from_point); the others fall through to
+                # its MCP backstop.
+                link_extra = (
+                    {"board_id": str(metadata["board_id"])}
+                    if metadata.get("board_id")
+                    else None
+                )
                 results.append(
                     SemanticSearchResult(
                         id=narrowed_id,
@@ -689,19 +713,28 @@ def configure_semantic_tools(mcp: FastMCP):
                         rerank_score=r.rerank_score,
                         relevance=relevance,
                         relevance_source=relevance_source,
-                        category=r.metadata.get("category", "") if r.metadata else "",
+                        category=metadata.get("category", ""),
                         excerpt=r.excerpt,
                         score=r.score,
-                        chunk_index=r.metadata.get("chunk_index", 0)
-                        if r.metadata
-                        else 0,
-                        total_chunks=r.metadata.get("total_chunks", 1)
-                        if r.metadata
-                        else 1,
+                        chunk_index=metadata.get("chunk_index", 0),
+                        total_chunks=metadata.get("total_chunks", 1),
                         chunk_start_offset=r.chunk_start_offset,
                         chunk_end_offset=r.chunk_end_offset,
                         page_number=r.page_number,
                         page_end=r.page_end,
+                        url=chunk_url(
+                            browser_base,
+                            doc_type=r.doc_type,
+                            doc_id=narrowed_id,
+                            chunk_start=r.chunk_start_offset,
+                            chunk_end=r.chunk_end_offset,
+                            title=r.title,
+                            path=metadata.get("path"),
+                            page_number=r.page_number,
+                            chunk_index=metadata.get("chunk_index"),
+                            total_chunks=metadata.get("total_chunks"),
+                            extra=link_extra,
+                        ),
                     )
                 )
 
@@ -786,6 +819,7 @@ def configure_semantic_tools(mcp: FastMCP):
                                     chunk_end_offset=result.chunk_end_offset,
                                     page_number=result.page_number,
                                     page_end=result.page_end,
+                                    url=result.url,
                                     # Context expansion fields
                                     has_context_expansion=True,
                                     marked_text=chunk_context.marked_text,

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -699,12 +699,11 @@ def configure_semantic_tools(mcp: FastMCP):
                 # board_id is the only one of Astrolabe's access-recheck
                 # identifiers the chunk payload carries (see
                 # build_search_result_from_point); the others fall through to
-                # its MCP backstop.
-                link_extra = (
-                    {"board_id": str(metadata["board_id"])}
-                    if metadata.get("board_id")
-                    else None
-                )
+                # its MCP backstop. Tested against None rather than falsiness to
+                # match chunk_url's handling of a legitimate 0 — Nextcloud ids
+                # are 1-based, so this is consistency, not a live bug.
+                board_id = metadata.get("board_id")
+                link_extra = None if board_id is None else {"board_id": str(board_id)}
                 results.append(
                     SemanticSearchResult(
                         id=narrowed_id,

--- a/tests/integration/test_semantic_search_chunk_links.py
+++ b/tests/integration/test_semantic_search_chunk_links.py
@@ -1,0 +1,124 @@
+"""Every semantic-search result carries a usable Astrolabe chunk deep-link.
+
+The unit tests pin the URL builder in isolation. What they cannot show is that
+the tool actually reaches it with real values — the link is assembled from
+fields (chunk offsets, metadata) that only a live index populates, and a result
+whose offsets are missing legitimately yields no link at all. So this exercises
+the whole path: index a note, search for it through MCP, and assert the returned
+row carries a link Astrolabe would open.
+"""
+
+import json
+import uuid
+from urllib.parse import parse_qs, urlparse
+
+import anyio
+import pytest
+
+from tests.integration._search_helpers import document_is_searchable
+
+pytestmark = pytest.mark.integration
+
+# Astrolabe's App.vue opens nothing unless all four are present.
+REQUIRED_PARAMS = {"doc_type", "doc_id", "chunk_start", "chunk_end"}
+
+INDEX_TIMEOUT_SECONDS = 180
+POLL_INTERVAL_SECONDS = 5
+
+
+async def test_search_results_carry_an_astrolabe_chunk_link(nc_mcp_client, nc_client):
+    """A freshly indexed note comes back with a link that opens its chunk."""
+    status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
+    if status.isError:
+        pytest.skip("Vector sync not enabled")
+
+    # A nonsense term the seed corpus cannot contain, so the match is ours.
+    unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
+    note = await nc_client.notes.create_note(
+        title=f"Chunk link test {unique_term}",
+        content=f"This note exists to be found by the term {unique_term}.",
+        category="ChunkLinkTest",
+    )
+
+    try:
+        with anyio.move_on_after(INDEX_TIMEOUT_SECONDS) as scope:
+            while not await document_is_searchable(
+                nc_mcp_client, unique_term, note_id=note["id"]
+            ):
+                await anyio.sleep(POLL_INTERVAL_SECONDS)
+        if scope.cancelled_caught:
+            pytest.skip(
+                f"note {note['id']} not indexed within {INDEX_TIMEOUT_SECONDS}s"
+            )
+
+        search = await nc_mcp_client.call_tool(
+            "nc_semantic_search", {"query": unique_term, "limit": 10}
+        )
+        assert not search.isError, search
+        results = json.loads(search.content[0].text)["results"]
+
+        ours = [r for r in results if str(r["id"]) == str(note["id"])]
+        assert ours, f"indexed note {note['id']} missing from its own search"
+        result = ours[0]
+
+        url = result["url"]
+        assert url, (
+            "no chunk link on the result; the mcp service resolves "
+            "nextcloud_browser_url from NEXTCLOUD_PUBLIC_ISSUER_URL, so an "
+            "empty url means the builder was not reached"
+        )
+
+        parsed = urlparse(url)
+        assert parsed.scheme in ("http", "https")
+        assert parsed.path.endswith("/apps/astrolabe/")
+
+        params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+        assert REQUIRED_PARAMS <= set(params), (
+            f"Astrolabe would not open this link: {sorted(params)}"
+        )
+        # The link must point at THIS chunk of THIS document, not merely parse.
+        assert params["doc_id"] == str(note["id"])
+        assert params["doc_type"] == result["doc_type"]
+        assert params["chunk_start"] == str(result["chunk_start_offset"])
+        assert params["chunk_end"] == str(result["chunk_end_offset"])
+    finally:
+        await nc_client.notes.delete_note(note_id=note["id"])
+
+
+async def test_context_expansion_preserves_the_chunk_link(nc_mcp_client, nc_client):
+    """include_context=True rebuilds each result from scratch, which is exactly
+    how rerank_score was once silently dropped. Same corpus, both flavours."""
+    status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
+    if status.isError:
+        pytest.skip("Vector sync not enabled")
+
+    unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
+    note = await nc_client.notes.create_note(
+        title=f"Chunk link context test {unique_term}",
+        content=f"Context expansion should not lose the link for {unique_term}.",
+        category="ChunkLinkTest",
+    )
+
+    try:
+        with anyio.move_on_after(INDEX_TIMEOUT_SECONDS) as scope:
+            while not await document_is_searchable(
+                nc_mcp_client, unique_term, note_id=note["id"]
+            ):
+                await anyio.sleep(POLL_INTERVAL_SECONDS)
+        if scope.cancelled_caught:
+            pytest.skip(
+                f"note {note['id']} not indexed within {INDEX_TIMEOUT_SECONDS}s"
+            )
+
+        search = await nc_mcp_client.call_tool(
+            "nc_semantic_search",
+            {"query": unique_term, "limit": 10, "include_context": True},
+        )
+        assert not search.isError, search
+        results = json.loads(search.content[0].text)["results"]
+
+        ours = [r for r in results if str(r["id"]) == str(note["id"])]
+        assert ours, f"indexed note {note['id']} missing from its own search"
+        assert ours[0]["url"], "context expansion dropped the chunk link"
+    finally:
+        await nc_client.notes.delete_note(note_id=note["id"])

--- a/tests/unit/test_astrolabe_links.py
+++ b/tests/unit/test_astrolabe_links.py
@@ -192,6 +192,24 @@ def test_chunk_url_forwards_extra_access_ids():
     assert _params(url)["board_id"] == "12"
 
 
+def test_chunk_url_named_params_win_a_collision_with_extra():
+    """`extra` is an opaque caller-supplied dict; it must not be able to
+    redefine a named, documented parameter."""
+    url = chunk_url(
+        BASE,
+        doc_type="file",
+        doc_id=1,
+        chunk_start=0,
+        chunk_end=5,
+        title="real title",
+        extra={"title": "hijacked", "board_id": "12"},
+    )
+    assert url is not None
+    params = _params(url)
+    assert params["title"] == "real title"
+    assert params["board_id"] == "12"
+
+
 def test_chunk_url_is_none_without_a_base():
     assert (
         chunk_url(None, doc_type="file", doc_id=1, chunk_start=0, chunk_end=5) is None

--- a/tests/unit/test_astrolabe_links.py
+++ b/tests/unit/test_astrolabe_links.py
@@ -88,6 +88,37 @@ def test_base_is_none_and_warns_when_scheme_missing(caplog):
     )
 
 
+def test_base_allows_plain_http():
+    """Local and self-hosted instances are routinely served over http (the dev
+    compose stack is http://localhost:8080). Demanding TLS would strip the link
+    from exactly the deployments that need it."""
+    fake = _fake_settings(host="http://localhost:8080")
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        assert astrolabe_browser_base() == "http://localhost:8080"
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "https:",  # scheme, no host — a startswith check would let this through
+        "ftp://nc.example.com",  # a browser will not open this as a page
+        "//nc.example.com",  # protocol-relative, meaningless outside a document
+    ],
+)
+def test_base_is_none_for_unopenable_urls(configured):
+    fake = _fake_settings(host=configured)
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        assert astrolabe_browser_base() is None
+
+
+def test_base_accepts_uppercase_scheme():
+    """urlparse normalizes the scheme, so HTTPS:// is a working URL rather than
+    a misconfiguration — a prefix match would have rejected it."""
+    fake = _fake_settings(host="HTTPS://nc.example.com")
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        assert astrolabe_browser_base() == "HTTPS://nc.example.com"
+
+
 # --- chunk_url --------------------------------------------------------------
 
 

--- a/tests/unit/test_astrolabe_links.py
+++ b/tests/unit/test_astrolabe_links.py
@@ -1,0 +1,195 @@
+"""Unit tests for Astrolabe deep-link construction.
+
+The consumer side already exists: Astrolabe's ``src/App.vue`` opens its chunk
+viewer from ``doc_type``/``doc_id``/``chunk_start``/``chunk_end`` on the app
+root, and ``parseInt``s the numeric ones. These tests pin the producer against
+that contract — a link missing one of the four opens nothing at all, so
+"degraded but present" is not an option here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from nextcloud_mcp_server.astrolabe_links import (
+    ASTROLABE_APP_PATH,
+    astrolabe_browser_base,
+    chunk_url,
+)
+
+pytestmark = pytest.mark.unit
+
+BASE = "https://nc.example.com"
+
+
+def _fake_settings(
+    public_url: str | None = None,
+    public_issuer_url: str | None = None,
+    host: str | None = None,
+) -> SimpleNamespace:
+    """Settings-shaped object exposing only what the helper reads.
+
+    ``nextcloud_browser_url`` mirrors the real property's fallback chain
+    (public_url → public_issuer_url → host).
+    """
+    return SimpleNamespace(
+        nextcloud_public_url=public_url,
+        nextcloud_public_issuer_url=public_issuer_url,
+        nextcloud_host=host,
+        nextcloud_browser_url=public_url or public_issuer_url or host,
+    )
+
+
+def _params(url: str) -> dict[str, str]:
+    """Single-valued query parameters of ``url``."""
+    return {k: v[0] for k, v in parse_qs(urlparse(url).query).items()}
+
+
+# --- astrolabe_browser_base -------------------------------------------------
+
+
+def test_base_prefers_public_url_over_issuer_and_host():
+    """In external-IdP mode the issuer is the IdP, not Nextcloud."""
+    fake = _fake_settings(
+        public_url=BASE,
+        public_issuer_url="https://keycloak.example.com/realms/x",
+        host="http://internal:8080",
+    )
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        assert astrolabe_browser_base() == BASE
+
+
+def test_base_strips_trailing_slash():
+    """Otherwise the joined path would carry a doubled slash."""
+    fake = _fake_settings(public_url=f"{BASE}/")
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        assert astrolabe_browser_base() == BASE
+
+
+def test_base_is_none_when_nothing_configured():
+    with patch(
+        "nextcloud_mcp_server.astrolabe_links.get_settings",
+        return_value=_fake_settings(),
+    ):
+        assert astrolabe_browser_base() is None
+
+
+def test_base_is_none_and_warns_when_scheme_missing(caplog):
+    """A bare hostname yields a non-clickable link, so surface it instead."""
+    fake = _fake_settings(host="internal-host:8080")
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        with caplog.at_level("WARNING", logger="nextcloud_mcp_server.astrolabe_links"):
+            result = astrolabe_browser_base()
+    assert result is None
+    assert any("missing an http:// or https://" in r.message for r in caplog.records), (
+        f"expected scheme-missing warning, got {[r.message for r in caplog.records]}"
+    )
+
+
+# --- chunk_url --------------------------------------------------------------
+
+
+def test_chunk_url_full_shape():
+    url = chunk_url(
+        BASE,
+        doc_type="file",
+        doc_id=384194,
+        chunk_start=37636,
+        chunk_end=38594,
+        title="report.pdf",
+        path="/Docs/report.pdf",
+        page_number=22,
+        chunk_index=48,
+        total_chunks=100,
+    )
+    assert url is not None
+    assert url.startswith(f"{BASE}{ASTROLABE_APP_PATH}?")
+    assert _params(url) == {
+        "doc_type": "file",
+        "doc_id": "384194",
+        "chunk_start": "37636",
+        "chunk_end": "38594",
+        "title": "report.pdf",
+        "path": "/Docs/report.pdf",
+        "page_number": "22",
+        "chunk_index": "48",
+        "total_chunks": "100",
+    }
+
+
+def test_chunk_url_escapes_spaces_and_slashes():
+    """Real corpora have spaces in filenames; an unescaped one truncates the
+    query string at the space when the link is pasted or auto-linked."""
+    url = chunk_url(
+        BASE,
+        doc_type="file",
+        doc_id=7,
+        chunk_start=0,
+        chunk_end=10,
+        title="Q3 report & notes.pdf",
+        path="/My Docs/Q3 report & notes.pdf",
+    )
+    assert url is not None
+    assert " " not in url
+    # Escaped on the wire, but round-trips to the original values.
+    assert _params(url)["path"] == "/My Docs/Q3 report & notes.pdf"
+    assert _params(url)["title"] == "Q3 report & notes.pdf"
+
+
+def test_chunk_url_omits_unset_optionals():
+    """`page_number=None` must not become the literal string 'None', which
+    Astrolabe would parseInt into NaN."""
+    url = chunk_url(BASE, doc_type="note", doc_id=1, chunk_start=0, chunk_end=5)
+    assert url is not None
+    assert set(_params(url)) == {"doc_type", "doc_id", "chunk_start", "chunk_end"}
+
+
+def test_chunk_url_forwards_extra_access_ids():
+    """board_id lets a stale link get the same local access re-check as a live
+    search result."""
+    url = chunk_url(
+        BASE,
+        doc_type="deck_card",
+        doc_id=42,
+        chunk_start=0,
+        chunk_end=5,
+        extra={"board_id": "12"},
+    )
+    assert url is not None
+    assert _params(url)["board_id"] == "12"
+
+
+def test_chunk_url_is_none_without_a_base():
+    assert (
+        chunk_url(None, doc_type="file", doc_id=1, chunk_start=0, chunk_end=5) is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("chunk_start", "chunk_end"),
+    [(None, 10), (0, None), (None, None)],
+)
+def test_chunk_url_is_none_without_both_offsets(chunk_start, chunk_end):
+    """Astrolabe requires all four identifying params together and opens
+    nothing if any is absent — a partial link is a dead end, not a degraded
+    one."""
+    assert (
+        chunk_url(
+            BASE,
+            doc_type="file",
+            doc_id=1,
+            chunk_start=chunk_start,
+            chunk_end=chunk_end,
+        )
+        is None
+    )
+
+
+def test_chunk_url_keeps_offset_zero():
+    """0 is falsy but a perfectly valid first-chunk offset."""
+    url = chunk_url(BASE, doc_type="file", doc_id=1, chunk_start=0, chunk_end=0)
+    assert url is not None
+    assert _params(url)["chunk_start"] == "0"
+    assert _params(url)["chunk_end"] == "0"

--- a/tests/unit/test_elicitation.py
+++ b/tests/unit/test_elicitation.py
@@ -39,7 +39,7 @@ def test_astrolabe_settings_url_prefers_public_url():
         public_issuer_url="https://keycloak.example.com/realms/x",
         host="https://internal.example",
     )
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         assert (
             _astrolabe_settings_url()
             == f"https://nc.example.com{ASTROLABE_SETTINGS_PATH}"
@@ -51,7 +51,7 @@ def test_astrolabe_settings_url_prefers_public_issuer():
     fake = _fake_settings(
         public_issuer_url="https://nc.example.com", host="http://internal:8080"
     )
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         assert (
             _astrolabe_settings_url()
             == f"https://nc.example.com{ASTROLABE_SETTINGS_PATH}"
@@ -61,7 +61,7 @@ def test_astrolabe_settings_url_prefers_public_issuer():
 def test_astrolabe_settings_url_strips_trailing_slash_from_public_issuer():
     """Trailing slash on nextcloud_public_issuer_url is normalized."""
     fake = _fake_settings(public_issuer_url="https://nc.example.com/")
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         assert (
             _astrolabe_settings_url()
             == f"https://nc.example.com{ASTROLABE_SETTINGS_PATH}"
@@ -71,7 +71,7 @@ def test_astrolabe_settings_url_strips_trailing_slash_from_public_issuer():
 def test_astrolabe_settings_url_falls_back_to_host():
     """When only nextcloud_host is set, use it (and strip a trailing slash)."""
     fake = _fake_settings(host="https://only-host.example.com/")
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         assert (
             _astrolabe_settings_url()
             == f"https://only-host.example.com{ASTROLABE_SETTINGS_PATH}"
@@ -81,7 +81,7 @@ def test_astrolabe_settings_url_falls_back_to_host():
 def test_astrolabe_settings_url_returns_none_when_unset():
     """No NC URL configured → None (caller renders the tool-only message)."""
     fake = _fake_settings()
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         assert _astrolabe_settings_url() is None
 
 
@@ -89,8 +89,8 @@ def test_astrolabe_settings_url_returns_none_when_scheme_missing(caplog):
     """Bare hostname (no http:// or https://) → None + a warning so the operator
     sees the misconfiguration instead of getting a silently-broken URL."""
     fake = _fake_settings(host="internal-host:8080")
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
-        with caplog.at_level("WARNING", logger="nextcloud_mcp_server.auth.elicitation"):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
+        with caplog.at_level("WARNING", logger="nextcloud_mcp_server.astrolabe_links"):
             assert _astrolabe_settings_url() is None
     assert any(
         "missing an http:// or https://" in rec.message for rec in caplog.records
@@ -105,7 +105,7 @@ async def test_present_provisioning_required_elicits_with_url():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(return_value=SimpleNamespace(action="accept", data=None))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "accepted"
@@ -121,7 +121,7 @@ async def test_present_provisioning_required_without_url():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(return_value=SimpleNamespace(action="accept", data=None))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "accepted"
@@ -139,7 +139,7 @@ async def test_present_provisioning_required_no_elicit_method():
     ctx = _NoElicit()
 
     fake = _fake_settings()
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)  # type: ignore[arg-type]
 
     assert result == "message_only"
@@ -151,7 +151,7 @@ async def test_present_provisioning_required_handles_not_implemented():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(side_effect=NotImplementedError("client lacks elicit"))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "message_only"
@@ -163,7 +163,7 @@ async def test_present_provisioning_required_handles_unexpected_error():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(side_effect=RuntimeError("transport boom"))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "message_only"
@@ -175,7 +175,7 @@ async def test_present_provisioning_required_decline_returns_declined():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(return_value=SimpleNamespace(action="decline", data=None))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "declined"
@@ -187,7 +187,7 @@ async def test_present_provisioning_required_cancel_returns_cancelled():
     ctx = MagicMock()
     ctx.elicit = AsyncMock(return_value=SimpleNamespace(action="cancel", data=None))
 
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         result = await present_provisioning_required(ctx)
 
     assert result == "cancelled"
@@ -210,7 +210,7 @@ _PROVISIONING = "provisioning_required"
 
 async def _run_provisioning(ctx) -> str:
     fake = _fake_settings()
-    with patch("nextcloud_mcp_server.auth.elicitation.get_settings", return_value=fake):
+    with patch("nextcloud_mcp_server.astrolabe_links.get_settings", return_value=fake):
         return await present_provisioning_required(ctx)
 
 


### PR DESCRIPTION
## What

Every `nc_semantic_search` result now carries a `url` that opens that exact
chunk in the Astrolabe UI:

```
http://localhost:8080/index.php/apps/astrolabe/?doc_type=deck_card&doc_id=5
  &chunk_start=0&chunk_end=429&title=4.+Share%2C+comment+and+collaborate%21
  &chunk_index=0&total_chunks=1&board_id=1
```

(real output from the local stack)

## Why

Astrolabe's frontend has long *parsed* this deep link — `App.vue`'s
`handleUrlParameters` reads `doc_type`/`doc_id`/`chunk_start`/`chunk_end`
off the app root and opens the chunk viewer on that passage. **Nothing
anywhere generated one.** An agent answering from a retrieved chunk could
quote the text but had no way to hand the user the passage itself, in
context, to check.

## How

- New `nextcloud_mcp_server/astrolabe_links.py` builds the link from
  `nextcloud_browser_url` (`public_url` → `public_issuer_url` → `host`), so it
  works in external-IdP deployments where the issuer is the IdP rather than
  Nextcloud. No new config knob.
- `url` is `None` rather than broken when there is nothing usable to build
  from: no configured base URL, a base URL missing its `http(s)://` scheme, or
  a chunk with no character offsets. Astrolabe opens nothing unless all four
  identifying parameters are present, so a partial link would be a dead end
  rather than a degraded one.
- `board_id` is forwarded when present, so a stale link gets the same local
  access re-check as a live search result.
- The base-URL resolution and its scheme check move into the new module and are
  now shared with the elicitation settings link, which carried its own copy.
- The tool builds the base URL **once per search**, not once per result.

### Also: the folder filter already existed

The other half of the original request — "filter semantic search to a
subdirectory" — needed no code. `path_prefixes` (and the deprecated
`path_prefix`) has been on the tool since `de6c4b36` / `98189d0f`. Verified
live: same query and `doc_types=["file"]`, scoped to `/Documents` → 2 hits,
`/Photos` → 0, `/_archive` → 0, a nonexistent folder → 0. The gap was
discoverability, so the tool docstring now points at it.

## Test coverage

Per the repo's API-surface gate, this changes MCP surface (an additive field on
`SemanticSearchResult`):

- **Unit** — `tests/unit/test_astrolabe_links.py`: URL shape, escaping of
  spaces/`&` in real titles and paths, omission of unset optionals (so
  Astrolabe never `parseInt`s the string `"None"`), offset `0` surviving the
  falsy check, and each `None` case.
- **e2e** — `tests/integration/test_semantic_search_chunk_links.py`: indexes a
  note, polls until searchable, then asserts the returned link parses and points
  at *that* document and *that* chunk. A second test covers
  `include_context=True`, which rebuilds each result from scratch — exactly how
  `rerank_score` was once silently dropped. Both pass against the local stack.
  There is still no dedicated `e2e` marker in this repo, so these extend the
  `integration` tier (known gap, board 11).
- **Contract** — no new Pact. This tool is not part of the `/api/v1/*` provider
  pact, and the change touches no cross-service boundary. `/api/v1/search` is
  deliberately unchanged: it is consumed by Astrolabe's own UI, which opens
  chunks locally and needs no URL back to itself.
- `tests/unit/server/test_semantic_result_field_parity.py` structurally enforces
  that both construction sites carry the new field.

Full suite: ruff / ruff format / ty clean, 3341 unit + 6 smoke passing.

Deck: board 12, card #991.

---

_This PR was generated with the help of AI, and reviewed by a Human_
