### PR TITLE
fix(calendar): propagate todo merge failures

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -2451,16 +2451,13 @@ class CalendarClient:
 
         except ValueError:
             # A rejected update — a pairing conflict, or a date string that
-            # won't parse — is the caller's to fix. The fallback below rebuilds
-            # the todo from the *partial* update dict, so swallowing this would
-            # answer "invalid input" by silently dropping every stored property
-            # the caller didn't happen to pass, and reporting success.
+            # won't parse — is the caller's to fix. Rebuilding the todo from
+            # the *partial* update dict would answer "invalid input" by silently
+            # dropping every stored property the caller didn't happen to pass,
+            # and reporting success.
             # ``_merge_ical_properties`` dropped its identical fallback for
             # VEVENT for exactly that reason.
             raise
-        except Exception as e:
-            logger.error("Error merging iCal todo properties: %s", e)
-            return self._create_ical_todo(todo_data, todo_uid)
 
     # ============= Helper Methods - Filtering =============
 

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -1262,6 +1262,53 @@ def test_an_unparseable_date_does_not_silently_rebuild_the_todo():
         )
 
 
+async def test_update_todo_non_value_merge_error_does_not_rebuild_or_save(mocker):
+    """An unexpected merge failure must leave the stored VTODO untouched."""
+    client = _pure_client()
+    raw_ical = client._create_ical_todo(
+        {
+            "summary": "Keep me",
+            "description": "Original details",
+            "categories": "home",
+        },
+        "uid-runtime-failure",
+    )
+    rebuild = mocker.spy(client, "_create_ical_todo")
+
+    todo = mocker.Mock(
+        data=raw_ical,
+        url="https://cloud.example.org/tasks/uid-runtime-failure.ics",
+    )
+    todo.load = mocker.Mock(return_value=None)
+    todo.save = mocker.AsyncMock()
+
+    mocker.patch.object(client, "_ensure_calendar_home", new=mocker.AsyncMock())
+    mocker.patch.object(client, "_get_calendar", return_value=mocker.Mock())
+    mocker.patch.object(
+        client,
+        "_async_object_by_uid",
+        new=mocker.AsyncMock(return_value=todo),
+    )
+
+    failure = RuntimeError("synthetic merge failure")
+    mocker.patch(
+        "nextcloud_mcp_server.client.calendar.Calendar.from_ical",
+        side_effect=failure,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await client.update_todo(
+            "tasks",
+            "uid-runtime-failure",
+            {"summary": "Changed"},
+        )
+
+    assert exc_info.value is failure
+    assert todo.data == raw_ical
+    todo.save.assert_not_awaited()
+    rebuild.assert_not_called()
+
+
 def test_unrelated_todo_update_survives_a_stored_mismatch():
     """The guard must only fire for the pair the caller is actually writing."""
     client = _pure_client()


### PR DESCRIPTION
Fixes #1252.

## Summary

- Remove the catch-all VTODO merge fallback that rebuilt a todo from the partial update payload.
- Let unexpected merge failures propagate through `update_todo` before `todo.data` is replaced or saved.
- Add an async regression test that injects a non-`ValueError` failure and verifies the stored data is unchanged, save is not called, and no rebuild occurs.

## Why

Rebuilding from a partial update silently drops every stored property the caller did not resend while still reporting success. Surfacing the original failure preserves the existing VTODO and matches the event merge behavior.

## Testing

- The new synthetic `RuntimeError` test fails on base `9621ffa` because the exception is swallowed.
- `uv run --frozen pytest tests/unit/client/test_calendar.py -q`: 70 passed
- `uv run --frozen ruff format --check nextcloud_mcp_server/client/calendar.py tests/unit/client/test_calendar.py`
- `uv run --frozen ruff check nextcloud_mcp_server/client/calendar.py tests/unit/client/test_calendar.py`
- `uv run --frozen ty check -- nextcloud_mcp_server`
