### PR TITLE
fix(auth): consolidate app-password provisioning onto the OAuth token's scopes

### DIFF
--- a/app-hooks/before-starting/26-configure-astrolabe-oauth.sh
+++ b/app-hooks/before-starting/26-configure-astrolabe-oauth.sh
@@ -39,8 +39,13 @@ NC_EXTERNAL_URL="${NC_EXTERNAL_URL%/}"
 CLIENT_ID="astrolabeMcpClientOAuth00000000000"
 REDIRECT_URI="${NC_EXTERNAL_URL}/apps/astrolabe/oauth/callback"
 
-# All scopes the MCP server supports (must match DCR scopes in app.py)
-ALLOWED_SCOPES="openid profile email offline_access notes.read notes.write calendar.read calendar.write todo.read todo.write contacts.read contacts.write cookbook.read cookbook.write deck.read deck.write tables.read tables.write files.read files.write sharing.read sharing.write news.read news.write collectives.read collectives.write semantic.read"
+# Every scope the MCP server can require, i.e. ALL_SUPPORTED_SCOPES in
+# models/auth.py plus the OIDC standard ones. This is a hard ceiling on what any
+# token issued to this client can carry, and a token scope is now required for
+# every tool call (not just for tool visibility) — so a scope omitted here
+# silently removes those tools. mail.* and talk.* were missing for exactly that
+# reason. Keep in sync with models/auth.py, not with a mental list of apps.
+ALLOWED_SCOPES="openid profile email offline_access notes.read notes.write calendar.read calendar.write todo.read todo.write contacts.read contacts.write cookbook.read cookbook.write deck.read deck.write tables.read tables.write files.read files.write sharing.read sharing.write news.read news.write collectives.read collectives.write mail.read mail.write mail.send talk.read talk.write semantic.read"
 
 # Create OAuth client
 CLIENT_JSON=$(php occ oidc:create "Astrolabe" \

--- a/docs/ADR-009-semantic-search-oauth-scope.md
+++ b/docs/ADR-009-semantic-search-oauth-scope.md
@@ -1,6 +1,8 @@
 # ADR-009: Generic `semantic:read` OAuth Scope for Multi-App Vector Search
 
-**Status**: Accepted — implemented (`semantic.read` scope gates the semantic-search tools)
+**Status**: Accepted — implemented (`semantic.read` scope gates the semantic-search tools).
+
+> **Was unreachable in `login_flow` mode until 0.167.0.** `semantic.read` was advertised in DCR and carried by tokens, but it was never added to `ALL_SUPPORTED_SCOPES`, so no provisioning path could put it in the stored app-password grant that Login Flow v2 checked — and `nc_auth_update_scopes` rejected it as invalid. Every semantic call was denied with no supported recovery (GH #1277). Fixed by adding it to the vocabulary and by making a NULL stored grant defer to the token instead of short-circuiting; see ADR-022.
 **Date**: 2025-01-11
 **Depends On**: ADR-007 (Background Vector Sync), ADR-008 (MCP Sampling for Semantic Search)
 

--- a/docs/ADR-022-deployment-mode-consolidation.md
+++ b/docs/ADR-022-deployment-mode-consolidation.md
@@ -1382,3 +1382,45 @@ All tests must pass before the feature is considered complete.
 13. Verify scope enforcement cannot be bypassed via direct API calls
 14. Verify app password encryption and secure storage
 15. Verify rate limiting prevents abuse
+
+## Addendum (0.167.0): a NULL stored grant defers to the token
+
+The original implementation treated a `NULL` `scopes` column as *"legacy app
+password = all allowed"* and returned from `require_scopes` immediately. Every
+branch of the stored-scope check terminated, so **the OAuth token was never
+consulted on the call path** for a provisioned user. Two problems followed.
+
+1. **The two layers disagreed.** `list_tools` filters on token scopes while
+   `tools/call` enforced on stored scopes, so a NULL-scoped session was offered
+   one set of tools and could successfully call a larger one — including tools
+   whose scope the user had explicitly declined at the consent screen.
+2. **The two provisioning paths were not interchangeable.** The Nextcloud-side
+   routes write `NULL` (no enforcement); `nc_auth_provision_access` wrote a
+   snapshot of `ALL_SUPPORTED_SCOPES` (enforced, and frozen at provisioning
+   time). A scope added to the vocabulary later — `semantic.read` — was
+   therefore grantable to nobody who had used the tool, with no supported
+   recovery. See GH #1277.
+
+`NULL` now means **"no additional restriction"**, not "everything allowed": the
+check falls through to the token, which stays the ceiling. The stored list can
+only ever narrow, and `nc_auth_provision_access` writes `NULL` by default so
+both provisioning paths produce identical rows.
+
+```
+effective = token(consent ∩ client allowed_scopes)  ∩  stored (NULL = no restriction)
+```
+
+Do not restore the short-circuit. It reads like a harmless fast path for the
+common case, and it silently disables the layer that honours user consent.
+
+Consequences worth keeping in mind:
+
+- The OIDC client's allowed scopes are now a **hard ceiling on tool calls**, not
+  merely on tool visibility. A scope missing there removes those tools —
+  which is why `mail.*` and `talk.*` had to be added to the Astrolabe client.
+- Where the `oidc` app has `allow_user_settings=yes`, the ceiling is the
+  **per-user consent record**, so the same client can behave differently for
+  two users. Denial messages name both levers for that reason.
+- Background/vector sync still consults **neither** layer — it reads the app
+  password directly (`vector/oauth_sync.py`). Indexing is therefore not
+  scope-limited. That gap is real and tracked separately.

--- a/docs/ADR-022-deployment-mode-consolidation.md
+++ b/docs/ADR-022-deployment-mode-consolidation.md
@@ -1424,3 +1424,11 @@ Consequences worth keeping in mind:
 - Background/vector sync still consults **neither** layer — it reads the app
   password directly (`vector/oauth_sync.py`). Indexing is therefore not
   scope-limited. That gap is real and tracked separately.
+- **Narrowing an unrestricted grant snapshots the vocabulary.** Restrictions are
+  stored as an allow-list, so `nc_auth_update_scopes(remove_scopes=[...])` on a
+  NULL grant has to write a concrete list — which will not contain scopes added
+  to the vocabulary later, even when the token grants them. That is the same
+  staleness this addendum removes elsewhere, accepted here rather than
+  introducing a deny-list as a second scope representation for a rare,
+  explicitly user-driven request. Re-running `nc_auth_provision_access` returns
+  the user to an unrestricted grant.

--- a/docs/login-flow-v2.md
+++ b/docs/login-flow-v2.md
@@ -295,7 +295,7 @@ Scopes are **per-app** and follow an `<app>.<read|write>` pattern. There is no `
 
 The authoritative list is enumerated at runtime by [`scope_authorization.discover_all_scopes()`](../nextcloud_mcp_server/auth/scope_authorization.py) from each tool's `@require_scopes(...)` decorator and exposed via the PRM endpoint (`/.well-known/oauth-protected-resource/mcp`).
 
-Standard OIDC scopes (`openid`, `profile`, `email`) are also accepted and have no effect on tool access.
+Standard OIDC scopes (`openid`, `profile`, `email`) are accepted and grant no app access of their own. `openid` does gate the auth tools themselves (`nc_auth_provision_access` and friends), which is what keeps an unprovisioned user able to provision.
 
 ### How Scopes Are Enforced
 
@@ -308,7 +308,26 @@ async def nc_notes_get_note(note_id: int, ctx: Context):
     ...
 ```
 
-When a client calls `list_tools`, the server returns only tools the user has granted scopes for (dynamic tool filtering). When a client calls a tool whose scope is missing, the server returns:
+Two layers apply, and **both** must permit a scope:
+
+```
+effective = token(consent ∩ client allowed_scopes)  ∩  stored (NULL = no restriction)
+```
+
+**Layer 1 — the OAuth token** is the ceiling. What lands in it is decided entirely by Nextcloud's `oidc` app:
+
+1. the requested scope is filtered down to the client's **allowed scopes** (anything else is dropped silently), then
+2. the admin setting `allow_user_settings` decides who has the final say:
+   - **`no` (the default)** — everything requested is auto-granted, so the ceiling is the client's allowed-scopes list.
+   - **`yes`** — the **per-user consent record** wins. Users pick a subset on the consent page and can re-edit it later in personal settings, so the ceiling is per-user and two people on the same client can differ.
+
+Widening a client re-prompts affected users at their next authorize, but existing refresh tokens keep the scopes they were minted with until re-authorization.
+
+**Layer 2 — the stored app-password scopes** can only *narrow*. Provisioning stores `NULL` by default, meaning "no additional restriction"; an explicit list (via `nc_auth_provision_access(scopes=[...])` or `PATCH /api/v1/users/{id}/scopes`) restricts further. `NULL` is not a grant — it defers to the token.
+
+This distinction decides where a denial is fixed. A missing **stored** scope is fixed with `nc_auth_update_scopes`; a missing **token** scope cannot be — that needs the OIDC client's allowed scopes widened (admin) or the user's consent updated, followed by re-authorization.
+
+When a client calls `list_tools`, the server returns only tools the user's **token** covers (dynamic tool filtering). When a client calls a tool whose scope is missing at either layer, the server returns:
 
 ```http
 HTTP/1.1 403 Forbidden

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -152,6 +152,32 @@ logger = logging.getLogger(__name__)
 HTTPXClientInstrumentor().instrument()
 
 
+def build_dcr_scopes(*, vector_sync_enabled: bool, offline_access_enabled: bool) -> str:
+    """Build the space-separated scope list this server registers via DCR.
+
+    When we register as a resource server (with resource_url) the allowed
+    scopes describe what is AVAILABLE for this resource, not what the server
+    itself needs — external clients then request tokens limited to this list.
+    Every scope any tool requires must appear, and since a token scope is
+    required for every tool call, an omission here makes those tools
+    permanently uncallable.
+
+    Derived from ALL_SUPPORTED_SCOPES rather than hand-maintained: the two were
+    a duplicated pair that silently drifted, leaving mail.send (and every mail
+    scope) ungrantable in OAuth mode despite being in use. semantic.read is
+    subtracted and re-added conditionally so it is advertised only when
+    semantic search is enabled — subtracting is what keeps it from being
+    emitted twice now that it is a member of the vocabulary.
+    """
+    scopes = ["openid", "profile", "email"]
+    scopes += sorted(ALL_SUPPORTED_SCOPES - {"semantic.read"})
+    if vector_sync_enabled:
+        scopes.append("semantic.read")
+    if offline_access_enabled:
+        scopes.append("offline_access")
+    return " ".join(scopes)
+
+
 def initialize_document_processors():
     """Initialize and register document processors based on configuration.
 
@@ -855,31 +881,17 @@ async def load_oauth_client_credentials(
             f"{mcp_server_url}/oauth/callback",  # Unified callback (flow determined by query param)
         ]
 
-        # MCP server DCR: Register with ALL supported scopes
-        # When we register as a resource server (with resource_url), the allowed_scopes
-        # represent what scopes are AVAILABLE for this resource, not what the server needs.
-        # External clients will request tokens with resource=http://localhost:8001/mcp
-        # and the authorization server will limit them to these allowed scopes.
-        #
-        # The PRM endpoint advertises the same scopes dynamically via @require_scopes
-        # decorators, so this list must cover every scope any tool requires. It is
-        # derived from ALL_SUPPORTED_SCOPES rather than hand-maintained: the two were
-        # a duplicated pair that silently drifted, leaving mail.send (and every mail
-        # scope) ungrantable in OAuth mode despite being in use.
-        dcr_scopes = "openid profile email " + " ".join(sorted(ALL_SUPPORTED_SCOPES))
-
         # Add conditional scopes based on server configuration
         dcr_settings = get_settings()
-
-        # semantic.read gates MCP-server-level semantic search tools
-        if dcr_settings.vector_sync_enabled:
-            dcr_scopes = f"{dcr_scopes} semantic.read"
-            logger.info("✓ semantic.read scope enabled for semantic search tools")
-
-        # offline_access enables refresh tokens for background operations
         enable_offline_access = dcr_settings.enable_offline_access
+
+        dcr_scopes = build_dcr_scopes(
+            vector_sync_enabled=dcr_settings.vector_sync_enabled,
+            offline_access_enabled=enable_offline_access,
+        )
+        if dcr_settings.vector_sync_enabled:
+            logger.info("✓ semantic.read scope enabled for semantic search tools")
         if enable_offline_access:
-            dcr_scopes = f"{dcr_scopes} offline_access"
             logger.info("✓ offline_access scope enabled for refresh tokens")
 
         logger.info("MCP server DCR scopes (resource server): %s", dcr_scopes)

--- a/nextcloud_mcp_server/auth/provision_routes.py
+++ b/nextcloud_mcp_server/auth/provision_routes.py
@@ -114,7 +114,10 @@ async def _poll_and_store(provision_id: str) -> None:
             await storage.store_app_password_with_scopes(
                 user_id=effective_user_id,
                 app_password=result.app_password,
-                scopes=None,  # All scopes
+                # No additional restriction — access stays bounded by the
+                # OAuth token, not granted outright. nc_auth_provision_access
+                # writes the same thing so both paths agree.
+                scopes=None,
                 username=result.login_name,
             )
             invalidate_scope_cache(effective_user_id)

--- a/nextcloud_mcp_server/auth/scope_authorization.py
+++ b/nextcloud_mcp_server/auth/scope_authorization.py
@@ -150,9 +150,15 @@ def require_scopes(*required_scopes: str):
                 return await func(*args, **kwargs)
 
             # ── Login Flow v2: Check stored app password scopes ──
-            # In Login Flow v2 multi-user mode, OAuth tokens provide MCP session
-            # identity only. Nextcloud API access uses stored app passwords.
-            # Check if the user has a stored app password with appropriate scopes.
+            # In Login Flow v2 multi-user mode, Nextcloud API access uses stored
+            # app passwords, so the user must be provisioned before any tool can
+            # run. The stored scope list is an *additional* restriction on top of
+            # the OAuth token, not a replacement for it: this block can deny, and
+            # can decline to restrict (NULL), but never grants. Whatever survives
+            # it still has to clear the token check below, so the effective
+            # permission is:
+            #
+            #     token(consent ∩ client allowed_scopes) ∩ stored (NULL = no restriction)
             if get_settings().enable_login_flow and not set(required_scopes).issubset(
                 IDENTITY_ONLY_SCOPES
             ):
@@ -222,29 +228,35 @@ def require_scopes(*required_scopes: str):
                         raise ProvisioningRequiredError(error_msg)
 
                     if stored_scopes == "all":
-                        # NULL scopes in DB = legacy app password = all allowed
+                        # NULL scopes in DB = no *additional* restriction. This
+                        # deliberately does not grant everything: it falls
+                        # through to the token check below, so the OAuth token
+                        # remains the ceiling. Returning here instead was how a
+                        # NULL-scoped user could call tools their token never
+                        # carried — and it made list_tools (which filters on
+                        # token scopes) disagree with tools/call.
                         logger.debug(
-                            "Stored app password scope check passed for %s: all scopes",
+                            "No stored scope restriction for %s - deferring to token scopes",
                             func_name,
                         )
-                        return await func(*args, **kwargs)
+                    else:
+                        # Check stored scopes against required. This layer can
+                        # only narrow: passing it still requires the token to
+                        # carry the scope as well.
+                        stored_set = set(stored_scopes)
+                        missing = set(required_scopes) - stored_set
+                        if missing:
+                            error_msg = (
+                                f"Access denied to {func_name}: "
+                                f"Missing scopes: {', '.join(sorted(missing))}. "
+                                f"Call 'nc_auth_update_scopes' to add permissions."
+                            )
+                            logger.warning(error_msg)
+                            raise InsufficientScopeError(list(missing), error_msg)
 
-                    # Check stored scopes against required
-                    stored_set = set(stored_scopes)
-                    missing = set(required_scopes) - stored_set
-                    if missing:
-                        error_msg = (
-                            f"Access denied to {func_name}: "
-                            f"Missing scopes: {', '.join(sorted(missing))}. "
-                            f"Call 'nc_auth_update_scopes' to add permissions."
+                        logger.debug(
+                            "Stored app password scope check passed for %s", func_name
                         )
-                        logger.warning(error_msg)
-                        raise InsufficientScopeError(list(missing), error_msg)
-
-                    logger.debug(
-                        "Stored app password scope check passed for %s", func_name
-                    )
-                    return await func(*args, **kwargs)
 
             # Extract scopes from access token (strip resource prefix if configured)
             token_scopes = _strip_resource_prefix(set(access_token.scopes or []))
@@ -256,8 +268,15 @@ def require_scopes(*required_scopes: str):
             settings = get_settings()
             enable_offline_access = settings.enable_offline_access
 
-            # In offline access mode, check if Nextcloud scopes require provisioning
-            if enable_offline_access:
+            # In offline access mode, check if Nextcloud scopes require provisioning.
+            # Skipped under Login Flow v2: the two provisioning models are
+            # mutually exclusive, and this branch would send a login-flow user to
+            # 'provision_nextcloud_access' (the Flow 2 tool, only registered when
+            # offline access is on) instead of raising InsufficientScopeError —
+            # which is also the only path that carries a WWW-Authenticate step-up
+            # challenge. Before NULL scopes fell through, login_flow never reached
+            # here.
+            if enable_offline_access and not settings.enable_login_flow:
                 # Check if any required scopes are Nextcloud-specific
                 nextcloud_scopes = [
                     s
@@ -313,6 +332,23 @@ def require_scopes(*required_scopes: str):
                     f"Missing required scopes: {', '.join(sorted(missing_scopes))}. "
                     f"Token has scopes: {', '.join(sorted(token_scopes)) if token_scopes else 'none'}"
                 )
+                if settings.enable_login_flow:
+                    # Name the remedy *and* the non-remedy. These are OAuth
+                    # token scopes, so nc_auth_update_scopes can never grant
+                    # them — and an agent that has seen the stored-scope denial
+                    # will otherwise retry it forever against an "unchanged"
+                    # response. Either lever can be the cause: the admin's
+                    # allowed_scopes on the OIDC client, or the user's own
+                    # consent selection when the OIDC app permits user settings.
+                    error_msg += (
+                        ". These are OAuth token scopes, not stored app-password "
+                        "scopes: 'nc_auth_update_scopes' cannot grant them. The "
+                        "OIDC client must permit the scope (Nextcloud → "
+                        "Administration → OpenID Connect) and it must be included "
+                        "in your consent (Nextcloud → Personal settings, where "
+                        "user scope selection is enabled); then re-authorize to "
+                        "obtain a new token."
+                    )
                 logger.warning(error_msg)
                 raise InsufficientScopeError(list(missing_scopes), error_msg)
 
@@ -608,8 +644,10 @@ async def _get_stored_scopes(user_id: str) -> list[str] | str | None:
     """Look up stored app password scopes for a user (with TTL cache).
 
     Returns:
-        - list[str]: Specific scopes granted
-        - "all": NULL scopes in DB (legacy = all allowed)
+        - list[str]: Specific scopes granted — an additional restriction on
+          top of the OAuth token
+        - "all": NULL scopes in DB = no additional restriction. Callers must
+          still apply the token check; this is not a grant.
         - None: No stored app password (provisioning required)
 
     Raises:

--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -2273,7 +2273,9 @@ class RefreshTokenStorage:
             logger.info(
                 "Stored scoped app password for user %s (scopes=%s, username=%s)",
                 user_id,
-                "all" if scopes is None else len(scopes),
+                # NULL is "no additional restriction", not "all allowed" — the
+                # OAuth token still bounds the session (see require_scopes).
+                "unrestricted" if scopes is None else len(scopes),
                 username or "N/A",
             )
 

--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -2214,7 +2214,9 @@ class RefreshTokenStorage:
         Args:
             user_id: MCP user ID (identity from OAuth token or session)
             app_password: Nextcloud app password to encrypt and store
-            scopes: List of granted scopes (None = all scopes allowed)
+            scopes: Scope restriction to store. None means no additional
+                restriction — access stays bounded by the OAuth token rather
+                than being granted outright (see require_scopes).
             username: Nextcloud loginName from Login Flow v2 response
 
         Raises:

--- a/nextcloud_mcp_server/models/auth.py
+++ b/nextcloud_mcp_server/models/auth.py
@@ -51,7 +51,13 @@ class UpdateScopesResponse(BaseResponse):
     new_scopes: list[str] | None = Field(None, description="Updated scope set")
 
 
-# All supported application-level scopes (frozenset for O(1) membership tests)
+# All supported application-level scopes (frozenset for O(1) membership tests).
+#
+# Every scope named in a ``@require_scopes`` decorator must be a member: a scope
+# outside this set cannot be granted by any provisioning path, so the tool
+# requiring it is permanently unreachable in Login Flow v2 mode. That is how
+# ``semantic.read`` shipped dead (GH #1277) and how ``mail.send`` did before it.
+# ``test_every_tool_scope_is_grantable`` enforces the invariant.
 ALL_SUPPORTED_SCOPES: frozenset[str] = frozenset(
     {
         "notes.read",
@@ -81,5 +87,9 @@ ALL_SUPPORTED_SCOPES: frozenset[str] = frozenset(
         "talk.write",
         "collectives.read",
         "collectives.write",
+        # MCP-server-level rather than a Nextcloud app, but it gates tools the
+        # same way, so it lives in the same vocabulary. Advertised in DCR only
+        # when vector sync is enabled — see app.py.
+        "semantic.read",
     }
 )

--- a/nextcloud_mcp_server/models/auth.py
+++ b/nextcloud_mcp_server/models/auth.py
@@ -30,7 +30,12 @@ class ProvisionStatusResponse(BaseResponse):
     message: str = Field(description="Human-readable status message")
     user_id: str | None = Field(None, description="MCP user ID")
     scopes: list[str] | None = Field(
-        None, description="Granted scopes (None = all scopes)"
+        None,
+        description=(
+            "Stored scope restriction. None means no additional restriction, "
+            "so access is bounded by your OAuth token alone. A list restricts "
+            "further than the token does. Both layers must permit a scope."
+        ),
     )
     username: str | None = Field(None, description="Nextcloud username (loginName)")
 

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -57,7 +57,11 @@ def register_auth_tools(mcp: FastMCP) -> None:
         Args:
             ctx: MCP context
             scopes: Requested application scopes (e.g. ["notes.read", "calendar.write"]).
-                    If not specified, all available scopes are requested.
+                    Omit this to place no additional restriction on the app
+                    password — access is then bounded by your OAuth token alone,
+                    which is what the Nextcloud-side provisioning flow does too.
+                    Pass an explicit list only to grant *less* than your token
+                    allows; both layers must permit a scope for a tool to run.
 
         Returns:
             ProvisionAccessResponse with login URL or status
@@ -79,18 +83,25 @@ def register_auth_tools(mcp: FastMCP) -> None:
                 status="already_provisioned",
                 message=(
                     f"Nextcloud access already provisioned for {user_id}. "
-                    f"Scopes: {existing['scopes'] or 'all'}. "
+                    f"Scopes: {existing['scopes'] or 'no additional restriction (bounded by your OAuth token)'}. "
                     f"Use nc_auth_update_scopes to modify permissions."
                 ),
                 user_id=user_id,
                 requested_scopes=existing["scopes"],
             )
 
-        # Determine scopes
-        requested_scopes = scopes if scopes else list(ALL_SUPPORTED_SCOPES)
+        # Determine scopes. ``None`` (no explicit request) stores NULL, which
+        # means "no additional restriction beyond the OAuth token" — identical
+        # to what the Nextcloud-side provisioning routes write. Snapshotting a
+        # scope list here instead would go stale the moment an admin edits the
+        # OIDC client's allowed scopes, which is what left semantic.read
+        # permanently ungrantable for early adopters (GH #1277).
+        requested_scopes = scopes or None
 
         # Validate requested scopes
-        invalid_scopes = [s for s in requested_scopes if s not in ALL_SUPPORTED_SCOPES]
+        invalid_scopes = [
+            s for s in (requested_scopes or []) if s not in ALL_SUPPORTED_SCOPES
+        ]
         if invalid_scopes:
             return ProvisionAccessResponse(
                 status="error",
@@ -417,9 +428,22 @@ def register_auth_tools(mcp: FastMCP) -> None:
             set(previous_scopes) if previous_scopes else set(ALL_SUPPORTED_SCOPES)
         )
         if set(new_scopes) == previous_scopes_set:
+            # A NULL stored grant already places no restriction, so adding to it
+            # is always a no-op. Say why, and point at the layer that can
+            # actually still be denying the call — otherwise a caller told
+            # "missing scopes, call nc_auth_update_scopes" loops here forever.
+            if previous_scopes is None:
+                message = (
+                    "Your stored grant already places no additional restriction, "
+                    "so there is nothing to add here. If a tool is still denied, "
+                    "the missing scope is on your OAuth token, not this grant — "
+                    "the OIDC client must allow it and you must re-authorize."
+                )
+            else:
+                message = "Requested scopes match current scopes. No changes needed."
             return UpdateScopesResponse(
                 status="unchanged",
-                message="Requested scopes match current scopes. No changes needed.",
+                message=message,
                 previous_scopes=previous_scopes,
                 new_scopes=new_scopes,
             )

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -398,7 +398,19 @@ def register_auth_tools(mcp: FastMCP) -> None:
 
         previous_scopes = existing["scopes"]
 
-        # Compute new scope set
+        # Compute new scope set.
+        #
+        # Narrowing an unrestricted (NULL) grant has to materialise a concrete
+        # list, because the stored layer expresses restrictions as an allow-list
+        # — there is no "everything except X" representation. So the vocabulary
+        # is snapshotted at this point, and a scope added to it later is not in
+        # that frozen list even if the token would grant it. This is the same
+        # staleness that made semantic.read ungrantable (GH #1277), kept here
+        # deliberately: the alternative is a deny-list, a second scope
+        # representation to store, validate and reason about, for a request
+        # ("drop this one capability") that is rare and explicitly user-driven.
+        # The escape hatch is the same as before — re-run
+        # nc_auth_provision_access to return to an unrestricted grant.
         current_set = (
             set(previous_scopes) if previous_scopes else set(ALL_SUPPORTED_SCOPES)
         )

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -90,13 +90,29 @@ def register_auth_tools(mcp: FastMCP) -> None:
                 requested_scopes=existing["scopes"],
             )
 
+        # An empty list is rejected rather than folded into None. Both are
+        # falsy, but they ask for opposite things — "restrict me to nothing"
+        # versus "do not restrict me" — and silently turning the first into the
+        # second widens access instead of denying it. Callers that mean the
+        # latter omit the argument.
+        if scopes is not None and not scopes:
+            return ProvisionAccessResponse(
+                status="error",
+                message=(
+                    "An empty scope list would grant nothing. Omit `scopes` to "
+                    "place no additional restriction beyond your OAuth token, "
+                    "or name the scopes you want."
+                ),
+                success=False,
+            )
+
         # Determine scopes. ``None`` (no explicit request) stores NULL, which
         # means "no additional restriction beyond the OAuth token" — identical
         # to what the Nextcloud-side provisioning routes write. Snapshotting a
         # scope list here instead would go stale the moment an admin edits the
         # OIDC client's allowed scopes, which is what left semantic.read
         # permanently ungrantable for early adopters (GH #1277).
-        requested_scopes = scopes or None
+        requested_scopes = scopes
 
         # Validate requested scopes
         invalid_scopes = [

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -61,7 +61,7 @@ def register_auth_tools(mcp: FastMCP) -> None:
                     password — access is then bounded by your OAuth token alone,
                     which is what the Nextcloud-side provisioning flow does too.
                     Pass an explicit list only to grant *less* than your token
-                    allows; both layers must permit a scope for a tool to run.
+                    allows. Both layers must permit a scope for a tool to run.
 
         Returns:
             ProvisionAccessResponse with login URL or status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,18 @@ from nextcloud_mcp_server.client import NextcloudClient
 
 logger = logging.getLogger(__name__)
 
-# Default scopes for OAuth testing - all app-specific read/write scopes
+# Default scopes for OAuth testing - all app-specific read/write scopes.
+#
+# The OAuth token is the ceiling for every tool call, not just for tool
+# visibility, so a scope missing here makes those tools fail for the "full
+# access" fixture. mail.*, news.*, collectives.* and semantic.read were absent
+# while nothing in tests/server/login_flow/ called those tools — so CI stayed
+# green over a gap that would have broken real deployments (GH #1277).
+#
+# These lanes rely on the OIDC app's `allow_user_settings` defaulting to 'no'
+# (scopes auto-granted, no consent page). If a test ever enables user scope
+# selection, the token ceiling becomes the per-user consent record instead and
+# these constants stop being authoritative.
 DEFAULT_FULL_SCOPES = (
     "openid profile email "
     "notes.read notes.write "
@@ -39,7 +50,11 @@ DEFAULT_FULL_SCOPES = (
     "tables.read tables.write "
     "files.read files.write "
     "sharing.read sharing.write "
-    "talk.read talk.write"
+    "news.read news.write "
+    "collectives.read collectives.write "
+    "mail.read mail.write mail.send "
+    "talk.read talk.write "
+    "semantic.read"
 )
 
 # Read-only scopes (all read scopes across apps) - should match DEFAULT_FULL_SCOPES read portion
@@ -54,7 +69,11 @@ DEFAULT_READ_SCOPES = (
     "tables.read "
     "files.read "
     "sharing.read "
-    "talk.read"
+    "news.read "
+    "collectives.read "
+    "mail.read "
+    "talk.read "
+    "semantic.read"
 )
 
 # Write-only scopes (all write scopes across apps) - should match DEFAULT_FULL_SCOPES write portion
@@ -69,6 +88,9 @@ DEFAULT_WRITE_SCOPES = (
     "tables.write "
     "files.write "
     "sharing.write "
+    "news.write "
+    "collectives.write "
+    "mail.write mail.send "
     "talk.write"
 )
 

--- a/tests/server/login_flow/test_scope_authorization.py
+++ b/tests/server/login_flow/test_scope_authorization.py
@@ -18,11 +18,15 @@ is why a regression that made ``@require_scopes`` a runtime no-op went
 unnoticed. ``test_stored_scopes_enforced_on_tool_call`` closes that gap here;
 tests/unit/test_require_scopes_enforcement.py covers the decorator directly.
 
-Enforcement in login-flow mode keys on the *stored app-password* scopes, not on
-the OAuth token's scopes. Nextcloud app passwords are unscoped — they are
-all-or-nothing against the Nextcloud API — so the per-user scope set stored
-alongside the password is the only thing that can restrict a session, and it
-must hold on the call path.
+Enforcement in login-flow mode has two layers and both must hold on the call
+path. Nextcloud app passwords are unscoped — all-or-nothing against the
+Nextcloud API — so this server applies its own limits:
+
+    token(consent ∩ client allowed_scopes) ∩ stored (NULL = no restriction)
+
+The stored per-user scope set can only narrow; a NULL grant narrows nothing and
+leaves the OAuth token as the ceiling. It used to short-circuit the check
+entirely, which let a NULL-scoped session call tools its token never carried.
 
 Not covered here: WWW-Authenticate challenge headers for step-up auth.
 """
@@ -166,6 +170,68 @@ def _tool_text(result: CallToolResult) -> str:
 
 @pytest.mark.integration
 @pytest.mark.login_flow
+async def test_semantic_tool_callable_after_default_provisioning(
+    nc_mcp_login_flow_client,
+):
+    """A semantic tool must be callable by a default-provisioned user (GH #1277).
+
+    ``semantic.read`` was required by the semantic tools but absent from
+    ALL_SUPPORTED_SCOPES, so the provisioning tool — whose default was that very
+    set — could never grant it, and nc_auth_update_scopes rejected it as
+    invalid. Every semantic call was denied with no supported way to recover.
+
+    nc_get_vector_sync_status is used rather than nc_semantic_search because it
+    needs no indexed content: the assertion here is about authorization, not
+    retrieval.
+    """
+    result = await nc_mcp_login_flow_client.call_tool("nc_get_vector_sync_status", {})
+
+    assert not result.isError, (
+        "nc_get_vector_sync_status was denied for a default-provisioned user: "
+        f"{_tool_text(result)}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.login_flow
+async def test_token_scopes_enforced_on_tool_call(
+    nc_mcp_login_flow_client,
+    nc_mcp_login_flow_client_read_only,
+):
+    """A tool call must be DENIED when the *token* doesn't carry the scope.
+
+    The stored app-password grant is an additional restriction, not a
+    replacement for the token: default provisioning stores NULL ("no additional
+    restriction"), and the OAuth token remains the ceiling. Before that, NULL
+    short-circuited the whole check, so a read-only token could create notes —
+    and list_tools (filtered on token scopes) disagreed with tools/call.
+
+    Depends on nc_mcp_login_flow_client only to guarantee the user is
+    provisioned; the read-only session is what makes the call. The assertion
+    holds whether the stored grant is NULL or an explicit list, since both
+    layers must permit the scope.
+    """
+    result = await nc_mcp_login_flow_client_read_only.call_tool(
+        "nc_notes_create_note",
+        {
+            "title": "token-scope-enforcement-probe",
+            "content": "must never be created",
+            "category": "testing",
+        },
+    )
+
+    assert result.isError, (
+        "nc_notes_create_note succeeded with a read-only token — the token "
+        "layer is not enforcing on the tools/call path"
+    )
+    message = _tool_text(result)
+    assert "notes.write" in message, (
+        f"expected the missing scope to be named in the denial, got: {message}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.login_flow
 async def test_stored_scopes_enforced_on_tool_call(nc_mcp_login_flow_client):
     """A tool call must be DENIED when the stored scopes don't cover it.
 
@@ -226,6 +292,11 @@ async def test_stored_scopes_enforced_on_tool_call(nc_mcp_login_flow_client):
         # would leave every later test denied. Never raise from here — an
         # exception in `finally` would replace whatever the test was actually
         # failing on.
+        #
+        # The fallback cannot restore NULL (the scopes endpoint takes a list),
+        # but it is equivalent for later tests: the full set covers every scope
+        # a token can carry, so `stored ∧ token` reduces to the token either
+        # way — which is exactly what NULL means.
         try:
             await _set_stored_scopes(
                 user_id,

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -54,7 +54,13 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
         )
         assert get_result.isError is False
 
-        # Update
+        # Update, using the etag from the read rather than the one the create
+        # returned. They are usually equal, but the Notes app can settle a
+        # note's etag after responding to the create, and then the stale
+        # create-time etag loses the optimistic-concurrency check with
+        # "modified by someone else" — a real client would refresh, and this
+        # test already has the fresh value in hand.
+        current = json.loads(get_result.content[0].text)
         update_result = await nc_mcp_client.call_tool(
             "nc_notes_update_note",
             arguments={
@@ -62,7 +68,7 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
                 "title": "Updated Smoke Test",
                 "content": "Updated content",
                 "category": "test",
-                "etag": data["etag"],
+                "etag": current["etag"],
             },
         )
         assert update_result.isError is False

--- a/tests/unit/test_auth_tools.py
+++ b/tests/unit/test_auth_tools.py
@@ -309,6 +309,34 @@ async def test_provision_access_rejects_invalid_scopes(mocker):
     assert "not.a.scope" in response.message
 
 
+async def test_provision_access_rejects_empty_scope_list(mocker):
+    """`scopes=[]` must not be folded into "no restriction".
+
+    Both are falsy but they ask for opposite things — "restrict me to nothing"
+    versus "do not restrict me" — so treating them alike widens access instead
+    of denying it.
+    """
+    provision = _capture_registered_tools()["nc_auth_provision_access"]
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(return_value=None)
+    storage.store_login_flow_session = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+
+    response = await provision(MagicMock(), scopes=[])
+
+    assert response.success is False
+    assert "empty scope list" in response.message
+    storage.store_login_flow_session.assert_not_awaited()
+
+
 # ── Updating scopes on an unrestricted (NULL) grant ──
 
 

--- a/tests/unit/test_auth_tools.py
+++ b/tests/unit/test_auth_tools.py
@@ -309,6 +309,95 @@ async def test_provision_access_rejects_invalid_scopes(mocker):
     assert "not.a.scope" in response.message
 
 
+# ── Updating scopes on an unrestricted (NULL) grant ──
+
+
+def _update_scopes_storage(mocker, previous_scopes):
+    """Wire nc_auth_update_scopes against a user with the given stored grant.
+
+    A change (as opposed to a no-op) re-runs Login Flow v2, so the flow client
+    is stubbed too — otherwise the tool reports a connection failure and the
+    assertion under test never runs.
+    """
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(
+        return_value={"scopes": previous_scopes, "app_password": "x"}
+    )
+    storage.store_login_flow_session = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_settings",
+        return_value=MagicMock(nextcloud_host="https://nc", nextcloud_browser_url=None),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_nextcloud_ssl_verify",
+        return_value=False,
+    )
+    flow_client = AsyncMock()
+    flow_client.initiate = AsyncMock(
+        return_value=MagicMock(
+            poll_token="tok",
+            poll_endpoint="https://nc/login/v2/poll",
+            login_url="https://nc/login/v2/flow",
+        )
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.LoginFlowV2Client",
+        return_value=flow_client,
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.auth.elicitation.present_login_url",
+        AsyncMock(return_value="message_only"),
+    )
+    return storage
+
+
+async def test_update_scopes_add_on_unrestricted_grant_is_a_no_op(mocker):
+    """Adding to a NULL grant changes nothing, and must say why.
+
+    The stored layer already places no restriction, so the only thing that can
+    still be denying the call is the OAuth token — which this tool cannot
+    widen. Saying just "unchanged" sends an agent into a retry loop, since the
+    denial that got it here named this very tool.
+    """
+    update = _capture_registered_tools()["nc_auth_update_scopes"]
+    _update_scopes_storage(mocker, None)
+
+    response = await update(MagicMock(), add_scopes=["semantic.read"])
+
+    assert response.status == "unchanged"
+    assert "OAuth token" in response.message
+
+
+async def test_update_scopes_remove_on_unrestricted_grant_materialises_a_list(mocker):
+    """Narrowing a NULL grant necessarily snapshots the vocabulary.
+
+    Restrictions are stored as an allow-list, so "everything except X" can only
+    be written as a concrete list — which then does not include scopes added to
+    the vocabulary later, even when the token grants them. That is the same
+    staleness this change removes elsewhere, accepted here rather than
+    introducing a second (deny-list) representation for a rare, explicitly
+    user-driven request. Locked in so the trade-off is visible if it ever stops
+    being acceptable.
+    """
+    update = _capture_registered_tools()["nc_auth_update_scopes"]
+    _update_scopes_storage(mocker, None)
+
+    response = await update(MagicMock(), remove_scopes=["mail.send"])
+
+    assert response.status != "unchanged"
+    assert response.new_scopes is not None
+    assert "mail.send" not in response.new_scopes
+    assert set(response.new_scopes) == ALL_SUPPORTED_SCOPES - {"mail.send"}
+
+
 # ── Background-sync wake on provisioning ──
 
 

--- a/tests/unit/test_auth_tools.py
+++ b/tests/unit/test_auth_tools.py
@@ -213,16 +213,100 @@ async def test_delete_expired_login_flow_sessions(temp_storage):
 
 
 def test_all_supported_scopes():
-    """Test that ALL_SUPPORTED_SCOPES contains expected scopes."""
+    """Test that ALL_SUPPORTED_SCOPES contains expected scopes.
+
+    Read/write pairing is deliberately not asserted: it is not a property of
+    this set (mail.send pairs with nothing, News is read-only in practice), and
+    the assertion that used to live here matched on ':read'/':write', which
+    stopped matching anything when ADR-024 moved the separator to a dot — so it
+    passed vacuously for months. Coverage of the invariant that actually
+    matters lives in tests/unit/test_scope_vocabulary_drift.py.
+    """
     assert "notes.read" in ALL_SUPPORTED_SCOPES
     assert "notes.write" in ALL_SUPPORTED_SCOPES
     assert "calendar.read" in ALL_SUPPORTED_SCOPES
     assert "files.read" in ALL_SUPPORTED_SCOPES
     assert "deck.read" in ALL_SUPPORTED_SCOPES
-    # Scopes should be in pairs (read/write)
-    read_scopes = [s for s in ALL_SUPPORTED_SCOPES if s.endswith(":read")]
-    write_scopes = [s for s in ALL_SUPPORTED_SCOPES if s.endswith(":write")]
-    assert len(read_scopes) == len(write_scopes)
+    assert "semantic.read" in ALL_SUPPORTED_SCOPES
+
+
+# ── Provisioning defaults ──
+
+
+async def test_provision_access_without_scopes_stores_no_restriction(mocker):
+    """Omitting `scopes` must persist NULL, not a snapshot of the vocabulary.
+
+    NULL is what the Nextcloud-side provisioning routes write, so both paths
+    agree, and the OAuth token stays the single live source of truth. Storing a
+    list here instead goes stale as soon as an admin edits the OIDC client —
+    which is how semantic.read became permanently ungrantable (GH #1277).
+    """
+    provision = _capture_registered_tools()["nc_auth_provision_access"]
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(return_value=None)
+    storage.store_login_flow_session = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_settings",
+        return_value=MagicMock(nextcloud_host="https://nc", nextcloud_browser_url=None),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_nextcloud_ssl_verify",
+        return_value=False,
+    )
+    flow_client = AsyncMock()
+    flow_client.initiate = AsyncMock(
+        return_value=MagicMock(
+            poll_token="tok",
+            poll_endpoint="https://nc/login/v2/poll",
+            login_url="https://nc/login/v2/flow",
+        )
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.LoginFlowV2Client",
+        return_value=flow_client,
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.auth.elicitation.present_login_url",
+        AsyncMock(return_value="message_only"),
+    )
+
+    response = await provision(MagicMock())
+
+    assert response.requested_scopes is None
+    assert (
+        storage.store_login_flow_session.await_args.kwargs["requested_scopes"] is None
+    )
+
+
+async def test_provision_access_rejects_invalid_scopes(mocker):
+    """An explicit list is still validated — and the None default must not make
+    that comprehension blow up on a missing list."""
+    provision = _capture_registered_tools()["nc_auth_provision_access"]
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(return_value=None)
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+
+    response = await provision(MagicMock(), scopes=["notes.read", "not.a.scope"])
+
+    assert response.success is False
+    assert "not.a.scope" in response.message
 
 
 # ── Background-sync wake on provisioning ──

--- a/tests/unit/test_mail_write_tools.py
+++ b/tests/unit/test_mail_write_tools.py
@@ -18,6 +18,7 @@ from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 from nextcloud_mcp_server.models.mail import MailActionResponse, MailTagResponse
 from nextcloud_mcp_server.server import AVAILABLE_APPS
 from nextcloud_mcp_server.server.mail import configure_mail_tools
+from nextcloud_mcp_server.server.semantic import configure_semantic_tools
 
 pytestmark = pytest.mark.unit
 
@@ -191,9 +192,15 @@ def test_every_tool_scope_is_grantable():
     BasicAuth (where ``require_scopes`` short-circuits) — which is how
     ``mail.send`` stayed broken unnoticed. This walks every registered app so
     the next omission fails here rather than in a deployment.
+
+    ``configure_semantic_tools`` is registered explicitly because
+    ``AVAILABLE_APPS`` deliberately excludes it (semantic search is a
+    cross-app feature gated by VECTOR_SYNC_ENABLED, see server/__init__.py).
+    That exclusion was the hole this test had: ``semantic.read`` shipped
+    ungrantable and undetected (GH #1277).
     """
     mcp = FastMCP(name="test-all-tools")
-    for configure in AVAILABLE_APPS.values():
+    for configure in (*AVAILABLE_APPS.values(), configure_semantic_tools):
         configure(mcp)
 
     required = {

--- a/tests/unit/test_scope_authorization_stored.py
+++ b/tests/unit/test_scope_authorization_stored.py
@@ -4,6 +4,7 @@ Tests the third enforcement mode in scope_authorization.py that checks
 application-level scopes stored alongside app passwords.
 """
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,7 @@ from mcp.server.auth.provider import AccessToken
 from mcp.server.fastmcp import Context
 
 from nextcloud_mcp_server.auth.scope_authorization import (
+    InsufficientScopeError,
     ProvisioningRequiredError,
     _get_stored_scopes,
     _scope_cache,
@@ -52,7 +54,11 @@ async def test_get_stored_scopes_with_scopes():
 
 
 async def test_get_stored_scopes_null_scopes():
-    """Test that NULL scopes returns 'all'."""
+    """Test that NULL scopes returns the 'all' sentinel.
+
+    'all' means "this row places no *additional* restriction", not "everything
+    is permitted" — the decorator still applies the token check afterwards.
+    """
     mock_storage = AsyncMock()
     mock_storage.get_app_password_with_scopes.return_value = {
         "app_password": "xxxxx",
@@ -108,13 +114,22 @@ def authenticated_request():
     ``request_context.access_token`` attribute instead (as these tests once
     did) asserts a contract that does not exist at runtime — ``RequestContext``
     has no such field, so the decorator silently allowed every call.
-    The token's own scopes don't matter here: the Login-Flow-v2 branch checks
-    the stored app-password scopes instead.
+
+    The default token carries no scopes, which is enough for the tests that
+    are denied by the *stored* layer before the token is ever consulted. Tests
+    that reach the token check must set their own scopes via ``_token_scopes``.
     """
+    with _token_scopes():
+        yield
+
+
+@contextmanager
+def _token_scopes(*scopes: str):
+    """Put a token carrying ``scopes`` on the auth contextvar."""
     token = AccessToken(
         token="opaque",
         client_id="test-client",
-        scopes=[],
+        scopes=list(scopes),
         expires_at=None,
         resource="alice",
     )
@@ -123,6 +138,24 @@ def authenticated_request():
         yield
     finally:
         auth_context_var.reset(reset)
+
+
+@contextmanager
+def _settings(*, login_flow: bool = True, offline_access: bool = False):
+    """Patch get_settings for the decorator.
+
+    ``enable_offline_access`` must be present: any call that falls through the
+    stored-scope block reads it, so a double without it raises AttributeError
+    instead of the assertion the test is making.
+    """
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=SimpleNamespace(
+            enable_login_flow=login_flow,
+            enable_offline_access=offline_access,
+        ),
+    ):
+        yield
 
 
 def _make_login_flow_ctx() -> MagicMock:
@@ -301,6 +334,166 @@ async def test_decorator_uses_legacy_message_when_user_cancels():
     msg = str(exc_info.value)
     assert "nc_auth_provision_access" in msg
     assert "retry the request" not in msg
+
+
+@contextmanager
+def _stored(scopes):
+    """Patch the stored app-password scopes and the user-id lookup."""
+    with (
+        patch(
+            "nextcloud_mcp_server.auth.scope_authorization._get_stored_scopes",
+            return_value=scopes,
+        ),
+        patch(
+            "nextcloud_mcp_server.auth.token_utils.extract_user_id_from_token",
+            return_value="alice",
+        ),
+    ):
+        yield
+
+
+async def test_null_stored_scopes_defer_to_token_and_allow():
+    """A NULL stored grant restricts nothing, so a token carrying the scope wins.
+
+    This is the GH #1277 case: Astrolabe-provisioned users hold NULL and their
+    token carries semantic.read.
+    """
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.read")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with _settings(), _stored("all"), _token_scopes("notes.read"):
+        assert await fake_tool(ctx=ctx) == "ok"
+
+
+async def test_null_stored_scopes_defer_to_token_and_deny():
+    """NULL is not a grant: a scope the token lacks is still denied.
+
+    Before this behaviour existed, the 'all' sentinel returned early and a
+    NULL-scoped user could call any tool regardless of their token — which
+    also made list_tools (filtered on token scopes) disagree with tools/call.
+    """
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.read")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with (
+        _settings(),
+        _stored("all"),
+        _token_scopes("openid"),
+        pytest.raises(InsufficientScopeError) as exc_info,
+    ):
+        await fake_tool(ctx=ctx)
+
+    assert exc_info.value.missing_scopes == ["notes.read"]
+
+
+async def test_explicit_stored_scopes_still_gated_by_token():
+    """Both layers must permit: a stored grant cannot exceed the token."""
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.write")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with (
+        _settings(),
+        _stored(["notes.read", "notes.write"]),
+        _token_scopes("notes.read"),
+        pytest.raises(InsufficientScopeError) as exc_info,
+    ):
+        await fake_tool(ctx=ctx)
+
+    assert exc_info.value.missing_scopes == ["notes.write"]
+
+
+async def test_explicit_stored_scopes_pass_when_both_layers_allow():
+    """The ordinary success path once both layers permit the scope."""
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.write")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with _settings(), _stored(["notes.write"]), _token_scopes("notes.write"):
+        assert await fake_tool(ctx=ctx) == "ok"
+
+
+async def test_stored_denial_precedes_token_denial():
+    """The stored layer denies first, and names the remedy for *that* layer.
+
+    Locks the ordering so the two denial messages can't swap: only the stored
+    layer is fixable with nc_auth_update_scopes.
+    """
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.write")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with (
+        _settings(),
+        _stored(["notes.read"]),
+        _token_scopes("notes.write"),
+        pytest.raises(InsufficientScopeError) as exc_info,
+    ):
+        await fake_tool(ctx=ctx)
+
+    assert "nc_auth_update_scopes" in str(exc_info.value)
+
+
+async def test_token_denial_message_points_at_the_oidc_client_not_the_stored_grant():
+    """A token-layer denial must say nc_auth_update_scopes will NOT help.
+
+    Without the negative instruction an agent retries that tool forever against
+    an "unchanged" response. Both levers are named because either can be the
+    cause: the client's allowed_scopes, or the user's own consent selection.
+    """
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("semantic.read")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with (
+        _settings(),
+        _stored("all"),
+        _token_scopes("openid"),
+        pytest.raises(InsufficientScopeError) as exc_info,
+    ):
+        await fake_tool(ctx=ctx)
+
+    msg = str(exc_info.value)
+    assert "cannot grant them" in msg
+    assert "consent" in msg
+    assert "re-authorize" in msg
+
+
+async def test_offline_access_branch_skipped_under_login_flow():
+    """Login Flow v2 must not be routed into the Flow-2 provisioning branch.
+
+    That branch names 'provision_nextcloud_access' (wrong tool here) and raises
+    ProvisioningRequiredError, which carries no WWW-Authenticate challenge, so
+    a client loses its step-up path. It became reachable for login_flow only
+    once NULL stored scopes started falling through.
+    """
+    ctx = _make_login_flow_ctx()
+
+    @require_scopes("notes.read")
+    async def fake_tool(ctx: Context):  # noqa: ARG001
+        return "ok"
+
+    with (
+        _settings(offline_access=True),
+        _stored("all"),
+        _token_scopes("openid"),
+        pytest.raises(InsufficientScopeError),
+    ):
+        await fake_tool(ctx=ctx)
 
 
 async def test_decorator_does_not_elicit_when_scopes_only_partially_missing():

--- a/tests/unit/test_scope_vocabulary_drift.py
+++ b/tests/unit/test_scope_vocabulary_drift.py
@@ -1,0 +1,84 @@
+"""Guards against drift between the places that list scopes.
+
+``ALL_SUPPORTED_SCOPES`` is the vocabulary; several other lists must cover it.
+Each has drifted at least once, and every time the symptom was the same: a tool
+that works under BasicAuth and is permanently uncallable in OAuth / Login Flow
+v2, because the scope it requires can never be granted. ``mail.send`` went that
+way, then ``semantic.read`` (GH #1277).
+
+These are cheap set comparisons — the point is that they fail here rather than
+in a deployment.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from nextcloud_mcp_server.app import build_dcr_scopes
+from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
+from tests.conftest import DEFAULT_FULL_SCOPES
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ASTROLABE_OAUTH_HOOK = (
+    REPO_ROOT / "app-hooks" / "before-starting" / "26-configure-astrolabe-oauth.sh"
+)
+
+
+def _hook_allowed_scopes() -> set[str]:
+    """Parse ALLOWED_SCOPES out of the Astrolabe OIDC client setup hook."""
+    match = re.search(
+        r'^ALLOWED_SCOPES="([^"]+)"', ASTROLABE_OAUTH_HOOK.read_text(), re.MULTILINE
+    )
+    assert match, f"ALLOWED_SCOPES not found in {ASTROLABE_OAUTH_HOOK}"
+    return set(match.group(1).split())
+
+
+def test_dcr_advertises_every_supported_scope():
+    """The DCR registration must cover the whole vocabulary."""
+    advertised = set(
+        build_dcr_scopes(vector_sync_enabled=True, offline_access_enabled=True).split()
+    )
+    assert ALL_SUPPORTED_SCOPES <= advertised, (
+        f"not advertised via DCR: {sorted(ALL_SUPPORTED_SCOPES - advertised)}"
+    )
+
+
+def test_dcr_emits_semantic_read_once_when_enabled():
+    """semantic.read is a vocabulary member *and* conditionally appended.
+
+    It must not be emitted twice — the subtraction in build_dcr_scopes is what
+    prevents that, and nothing else would notice if it were dropped.
+    """
+    scopes = build_dcr_scopes(
+        vector_sync_enabled=True, offline_access_enabled=False
+    ).split()
+    assert scopes.count("semantic.read") == 1
+
+
+def test_dcr_omits_semantic_read_when_vector_sync_disabled():
+    """Advertising a scope for tools that are not registered would be a lie."""
+    scopes = build_dcr_scopes(
+        vector_sync_enabled=False, offline_access_enabled=False
+    ).split()
+    assert "semantic.read" not in scopes
+
+
+def test_astrolabe_oidc_client_allows_every_supported_scope():
+    """The Astrolabe OIDC client is a hard ceiling on the tokens it issues.
+
+    A scope missing from its allowed list cannot reach a token, and since the
+    token gates every tool call, those tools silently vanish for Astrolabe
+    users. mail.* and talk.* were missing exactly this way.
+    """
+    missing = ALL_SUPPORTED_SCOPES - _hook_allowed_scopes()
+    assert not missing, f"Astrolabe OIDC client cannot grant: {sorted(missing)}"
+
+
+def test_full_access_test_token_carries_every_supported_scope():
+    """The "full access" OAuth fixture must not be quietly narrower than the
+    vocabulary, or e2e tests pass while real deployments lose those tools."""
+    missing = ALL_SUPPORTED_SCOPES - set(DEFAULT_FULL_SCOPES.split())
+    assert not missing, f"DEFAULT_FULL_SCOPES is missing: {sorted(missing)}"


### PR DESCRIPTION
Fixes #1277.

## The bug

In `login_flow` mode two independent scope grants exist and had drifted:

- **A** — the OAuth token, governed by the OIDC client's `allowed_scopes` and (where the `oidc` app permits user settings) the per-user consent record.
- **B** — the `scopes` column on the user's `app_passwords` row.

`require_scopes` consulted **B only** for non-identity scopes, and every branch there terminated — so the token check was unreachable for a provisioned user.

`semantic.read` is required by `server/semantic.py` but was absent from `ALL_SUPPORTED_SCOPES`, so no provisioning path could put it in B. The denial told users to call `nc_auth_update_scopes`, which then failed with `Invalid scopes: semantic.read`. No supported recovery existed.

The two provisioning paths also wrote different things into B, which is why this was invisible to some deployments and fatal to others:

| Path | Wrote | Effect |
|---|---|---|
| Nextcloud-side routes (`provision_routes.py`, `api/passwords.py`) | `NULL` | `"all"` short-circuit — no enforcement at all |
| `nc_auth_provision_access` | snapshot of `ALL_SUPPORTED_SCOPES` | enforced, and can never contain `semantic.read` |

A second defect fell out of the same short-circuit: `list_tools` filters on **token** scopes while `tools/call` enforced on **stored** scopes, so a NULL-scoped session was offered one set of tools and could successfully call a larger one — including scopes the user had explicitly declined at the consent screen.

## The change

Both paths now write `NULL`, `NULL` means *"no additional restriction"* rather than *"skip the check"*, and the stored list can only narrow:

```
effective = token(consent ∩ client allowed_scopes)  ∩  stored (NULL = no restriction)
```

So the OIDC client's scopes become the single live source of truth — edit them and it takes effect at the next authorize, with no re-provisioning and no snapshot to go stale.

Also in scope:

- **`semantic.read` joins the vocabulary**, so explicit lists and `nc_auth_update_scopes` can carry it. `build_dcr_scopes()` is extracted from `app.py` so the conditional advertisement (and the single-emit property) is testable.
- **The offline-access branch is skipped under `login_flow`.** It became reachable once NULL fell through, and it names `provision_nextcloud_access` (the wrong, Flow-2 tool) while raising `ProvisioningRequiredError` — the one denial that carries no `WWW-Authenticate` step-up challenge.
- **Token-layer denials now say `nc_auth_update_scopes` cannot fix them**, and name both real levers: the client's allowed scopes, and the user's own consent selection. Without the negative instruction an agent retries that tool forever against an `unchanged` response.

## Why the existing guard missed it

`test_every_tool_scope_is_grantable` already asserted this exact invariant — it was written after the identical `mail.send` drift — but it walked `AVAILABLE_APPS`, which deliberately excludes the semantic tools. It now registers them too, and fails against the pre-fix vocabulary.

## Test coverage

- **Unit** — six decorator tests for the two-layer gate (NULL defers and allows; NULL defers and denies; stored ⊇ req but token narrower → denied; both allow → executes; stored denial precedes token denial; offline branch skipped under login_flow). New `test_scope_vocabulary_drift.py` asserts DCR, the Astrolabe OIDC client hook, and the full-access test token each cover `ALL_SUPPORTED_SCOPES`. New provisioning tests assert the NULL default and that validation survives it.
- **e2e** — `tests/server/login_flow/` gains a semantic-tool call (the direct proof #1277 is fixed) and a token-layer denial against a real provisioned row. Neither existed: nothing in that directory called a mail/news/collectives/semantic tool, so CI would have stayed green while those tools broke.
- **Contract** — `/api/v1/scopes` and `/api/v1/users/{id}/scopes` response shapes are unchanged (both derive from the constant), so no new pact is required.
- The vacuous `endswith(":read")` assertion in `test_auth_tools.py` is removed — it matched nothing after ADR-024 moved the separator to a dot.

## Operator action required (0.167.0)

1. **The OIDC client is now a hard ceiling on tool calls**, not just on tool visibility. `26-configure-astrolabe-oauth.sh` was missing `mail.read`, `mail.write`, `mail.send`, `talk.read`, `talk.write` — fixed here, but the hook early-exits when a client already exists, so existing installs need `occ oidc:update` (or delete + recreate) and users must re-consent.
2. Users provisioned via `nc_auth_provision_access` before this release hold an explicit list without `semantic.read`; one `nc_auth_update_scopes(add_scopes=["semantic.read"])` or `PATCH /api/v1/users/{id}/scopes` grants it.
3. No Alembic migration: the schema is untouched, and legacy full-list rows already behave identically under `stored ∧ token`.

Out of scope, flagged for follow-up: background/vector sync consults **neither** layer — it reads the app password directly — so indexing is not scope-limited.

---

_This PR was generated with the help of AI, and reviewed by a Human_
