### PR TITLE
feat(usage): add chunks_stored retention meter

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -244,6 +244,43 @@ Corpus shape, recorded before the oversize gate so the over-cap tail is visible:
 - `astrolabe_document_ingest_size_bytes{doc_type}` - Source size distribution
 - `astrolabe_document_ingest_rejected_total{doc_type,reason}` - Rejected pre-parse
 
+### Usage metering (billing)
+
+**These are not Prometheus series.** They are rows in the app-DB `usage_events`
+table, written only when `USAGE_METERING_ENABLED=true` and pulled by the control
+plane's rollup — so don't go looking for them in Grafana. Writes are best-effort:
+a metering failure is logged and never breaks ingest.
+
+Two kinds, and the difference decides how the control plane aggregates them:
+
+**Ingest flows** — emitted per document, per indexing pass
+(`record_indexing_usage`, `vector/processor.py`). Re-indexing a document emits
+again, so a period sum measures *churn*:
+
+- `tokens_embedded` - Embedding request tokens. Hybrid documents only —
+  keyword-index documents embed nothing and skip the row entirely.
+- `pages_embedded` - Pages parsed. Text doc types (notes, Deck cards, news,
+  mail) are never parsed and carry no page count, so they accrue no row.
+- `pages_ocr` - Pages that hit the OCR tier specifically, billed separately
+  from CPU-cheap parsing. Mode-independent.
+- `bytes_ingested` / `bytes_stored` - Source size and persisted chunk-text size.
+
+**Retention stock** — emitted once per UTC day (`record_storage_stock`,
+`vector/metrics_publisher.py`):
+
+- `chunks_stored` - Chunks currently retained, split by `index_mode`
+  (`hybrid` | `keyword`) in the event metadata.
+
+A month of `chunks_stored` readings sums to **chunk-days** — the integral of a
+changing corpus — so a corpus loaded or purged mid-month is charged pro rata.
+The event id is derived from `(metric, mode, UTC date)` and the insert is
+`ON CONFLICT DO NOTHING`, so pod restarts cannot inflate the total; shortening
+`USAGE_STOCK_SNAPSHOT_INTERVAL` does not bill more.
+
+> Adding a metric here is a cross-repo change: the control-plane rollup silently
+> ignores a metric its catalog does not know, so it bills nothing until the CP
+> catalog and Stripe meter learn it too.
+
 ### Database Metrics
 
 - `mcp_db_operations_total` - DB operations (SQLite, Postgres, Qdrant)

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -127,6 +127,7 @@ from nextcloud_mcp_server.server import (
 from nextcloud_mcp_server.server.auth_tools import register_auth_tools
 from nextcloud_mcp_server.server.oauth_tools import register_oauth_tools
 from nextcloud_mcp_server.vector.metrics_publisher import (
+    usage_stock_task,
     vector_density_snapshot_task,
     vector_sync_metrics_task,
 )
@@ -2257,6 +2258,12 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                 if settings.vector_density_snapshot_enabled:
                     await tg.start(vector_density_snapshot_task, shutdown_event)
 
+                # Billable retention snapshot (chunks_stored), once per UTC day.
+                # Gated on metering alone — the task no-ops otherwise, and it must
+                # run on BOTH consumer paths or multi-user tenants go un-metered.
+                if settings.usage_metering_enabled:
+                    await tg.start(usage_stock_task, shutdown_event)
+
                 logger.info(
                     "Background sync tasks started: 1 scanner + %s processors (queue=%s)",
                     ingest_transport.active_consumer_count,
@@ -2493,6 +2500,13 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                     # VECTOR_DENSITY_SNAPSHOT_ENABLED.
                     if settings.vector_density_snapshot_enabled:
                         await tg.start(vector_density_snapshot_task, shutdown_event)
+
+                    # Billable retention snapshot (chunks_stored), once per UTC
+                    # day. Must be spawned here too: this is the multi-user
+                    # consumer path, and omitting it would silently un-meter
+                    # every multi-user tenant's storage.
+                    if settings.usage_metering_enabled:
+                        await tg.start(usage_stock_task, shutdown_event)
 
                     logger.info(
                         "Background sync tasks started: 1 user manager + %s processors (queue=%s)",

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -123,6 +123,7 @@ _DEFAULTS: dict[str, Any] = {
     "vector_density_snapshot_enabled": True,
     "vector_density_snapshot_interval": 300,
     "vector_density_snapshot_max_documents": 50000,
+    "usage_stock_snapshot_interval": 86400,
     "vector_ram_hnsw_overhead_factor": 1.5,
     "vector_sync_user_poll_interval": 60,
     "health_ready_refresh_interval": 15,
@@ -1101,6 +1102,14 @@ class Settings:
     vector_density_snapshot_enabled: bool = True
     vector_density_snapshot_interval: int = 300  # seconds
     vector_density_snapshot_max_documents: int = 50000
+    # Cadence for the billable retention snapshot (vector/metrics_publisher.py:
+    # usage_stock_task), which records the retained chunk count per index mode as
+    # a ``chunks_stored`` usage event. Daily by design: a month of readings sums
+    # to chunk-DAYS, the integral of a changing stock, so a corpus loaded or
+    # purged mid-month is charged pro rata. Shortening this does NOT bill more —
+    # the event id is derived from the UTC date, so extra runs on the same day
+    # collide on the primary key and are dropped.
+    usage_stock_snapshot_interval: int = 86400  # seconds
     # HNSW-graph/segment overhead multiplier applied when estimating dense-vector
     # RAM (``chunks * dim * 4 bytes * factor``). ~1.5 matches the cost-to-serve
     # note's ~6 KB / 1024-dim observation; a deployment knob because the real

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -494,16 +494,26 @@ async def record_storage_stock(on_date: date | None = None) -> None:
         # count_indexed returns (documents, chunks); only the chunk total is
         # billable here -- documents are a display figure.
         _, total_chunks = await count_indexed(qdrant_client, collection, exact=True)
-        hybrid = await count_hybrid_chunks(qdrant_client, collection, exact=True)
-        # Clamp: the two counts are separate round-trips, so an upsert landing
-        # between them could otherwise yield a negative keyword count.
-        keyword = max(0, total_chunks - hybrid)
 
         # A never-indexed tenant records nothing rather than zero-value billing
         # rows, matching the chunk_count guard in record_indexing_usage
-        # (vector/processor.py).
+        # (vector/processor.py). Checked BEFORE the hybrid count so an empty
+        # tenant costs one Qdrant round-trip instead of three.
         if total_chunks <= 0:
             return
+
+        hybrid = await count_hybrid_chunks(qdrant_client, collection, exact=True)
+        # Clamp: the two counts are separate round-trips, so an upsert landing
+        # between them could otherwise yield a negative keyword count.
+        #
+        # Deliberate tradeoff: in that same race the clamp also lets
+        # hybrid + keyword exceed the total_chunks the first query observed, so a
+        # day's reading can overstate by the handful of chunks written between
+        # the two counts. Bounded by that window and re-read from scratch the
+        # next day, which is why it is preferred over a transaction: an exact
+        # snapshot would mean holding a consistent read across two counts on a
+        # collection that is being written to continuously.
+        keyword = max(0, total_chunks - hybrid)
 
         # Stamp the reading at midnight UTC of the day it describes, so a pod
         # that wakes at an arbitrary hour still lands the row on the right day
@@ -539,9 +549,13 @@ def _next_reading_delay(now: datetime, interval: float) -> float:
 
     Aligns to the next UTC midnight so readings land one per calendar day
     instead of drifting across days on every restart, capped at ``interval`` so
-    a shortened interval stays testable. The ``1.0`` floor matters: exactly at
-    the boundary the midnight term collapses toward zero, which would spin the
-    task re-recording (and re-dropping) the same day's reading.
+    a shortened interval stays testable.
+
+    The ``1.0`` floor is applied **last**, so it covers both ways the delay can
+    collapse to zero: standing exactly on the midnight boundary, and an operator
+    setting the interval to 0. Either would spin the task re-recording (and,
+    thanks to the idempotent event id, re-dropping) the same day's reading —
+    harmless billing-wise, but needless Qdrant load.
 
     Pure so the boundary behaviour can be tested without patching the clock or
     the sleep primitive.
@@ -549,7 +563,7 @@ def _next_reading_delay(now: datetime, interval: float) -> float:
     next_midnight = datetime.combine(
         now.date() + timedelta(days=1), time.min, tzinfo=timezone.utc
     )
-    return min(interval, max(1.0, (next_midnight - now).total_seconds()))
+    return max(1.0, min(interval, (next_midnight - now).total_seconds()))
 
 
 async def usage_stock_task(

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -435,10 +435,6 @@ async def vector_density_snapshot_task(
             await shutdown_event.wait()
 
 
-# Namespace for the deterministic per-day event ids below. A fixed, arbitrary
-# UUID: its only job is to make uuid5 collision-free against other uuid5 users.
-_USAGE_STOCK_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
-
 # Metric name for the retention (storage) meter. Distinct from the ingest-flow
 # metrics recorded in vector/processor.py: this is a STOCK — what is retained
 # right now — so a month of daily readings sums to chunk-DAYS, the integral of a
@@ -461,10 +457,15 @@ def _stock_event_id(index_mode: str, on_date: date) -> str:
     daily snapshot idempotent: a pod that restarts five times in a day still
     contributes exactly one reading per mode. Without this every restart would
     add another reading and silently inflate the billed chunk-days.
+
+    Uses ``NAMESPACE_DNS`` with a distinguishing prefix, matching the other
+    uuid5 id builders in this package (``placeholder.py``, ``dead_letter.py``).
+    These ids live in a different space entirely — the ``usage_events`` primary
+    key rather than Qdrant point ids — so the shared namespace costs nothing.
     """
     return str(
         uuid.uuid5(
-            _USAGE_STOCK_NAMESPACE,
+            uuid.NAMESPACE_DNS,
             f"{CHUNKS_STORED_METRIC}:{index_mode}:{on_date.isoformat()}",
         )
     )
@@ -519,6 +520,10 @@ async def record_storage_stock(on_date: date | None = None) -> None:
         # that wakes at an arbitrary hour still lands the row on the right day
         # for the control plane's date_trunc()-based rollup.
         occurred_at = datetime.combine(reading_date, time.min, tzinfo=timezone.utc)
+        # Skip zero-value rows: a single-mode tenant would otherwise accumulate a
+        # no-op row for the unused mode every day forever. Matches the
+        # ``if bytes_ingested > 0`` guards in record_indexing_usage. Absence and
+        # an explicit zero mean the same thing to a SUM, so nothing is lost.
         events = [
             UsageEvent(
                 metric=CHUNKS_STORED_METRIC,
@@ -531,6 +536,7 @@ async def record_storage_stock(on_date: date | None = None) -> None:
                 (payload_keys.INDEX_MODE_HYBRID, hybrid),
                 (payload_keys.INDEX_MODE_KEYWORD, keyword),
             )
+            if count > 0
         ]
         store = await UsageEventStore.shared()
         await store.record_usage_events(events, enabled=True)

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -20,6 +20,8 @@ document has (both fields are payload-indexed), avoiding a Qdrant facet pass.
 from __future__ import annotations
 
 import logging
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 import anyio
@@ -44,6 +46,7 @@ from nextcloud_mcp_server.observability.metrics import (
     update_vector_sync_queue_size,
 )
 from nextcloud_mcp_server.providers import get_provider
+from nextcloud_mcp_server.usage import UsageEvent, UsageEventStore
 from nextcloud_mcp_server.vector import payload_keys
 from nextcloud_mcp_server.vector.dead_letter import DEAD_LETTER_KEY
 from nextcloud_mcp_server.vector.ingest_status import get_ingest_pending
@@ -429,4 +432,134 @@ async def vector_density_snapshot_task(
         await publish_chunk_density_snapshot()
         # Sleep until the next snapshot or until shutdown, whichever comes first.
         with anyio.move_on_after(interval):
+            await shutdown_event.wait()
+
+
+# Namespace for the deterministic per-day event ids below. A fixed, arbitrary
+# UUID: its only job is to make uuid5 collision-free against other uuid5 users.
+_USAGE_STOCK_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
+# Metric name for the retention (storage) meter. Distinct from the ingest-flow
+# metrics recorded in vector/processor.py: this is a STOCK — what is retained
+# right now — so a month of daily readings sums to chunk-DAYS, the integral of a
+# changing corpus. Summing bytes_stored instead would count a re-indexed document
+# again on every pass and measure churn, not retention.
+#
+# CROSS-REPO: this is a NEW metric name. Per migration 007, the control-plane
+# rollup silently ignores a metric its catalog does not know, so it bills nothing
+# until the CP catalog + Stripe meter learn ``chunks_stored`` too. The mode split
+# rides in the event metadata and the rollup currently groups by (day, metric)
+# only, so both modes bill as one line until the CP groups on index_mode as well.
+CHUNKS_STORED_METRIC = "chunks_stored"
+
+
+def _stock_event_id(index_mode: str, on_date: date) -> str:
+    """Return the deterministic event id for one mode's reading on one day.
+
+    ``usage_events`` inserts are ``ON CONFLICT (event_id) DO NOTHING``
+    (usage/store.py), so deriving the id from (metric, mode, UTC date) makes the
+    daily snapshot idempotent: a pod that restarts five times in a day still
+    contributes exactly one reading per mode. Without this every restart would
+    add another reading and silently inflate the billed chunk-days.
+    """
+    return str(
+        uuid.uuid5(
+            _USAGE_STOCK_NAMESPACE,
+            f"{CHUNKS_STORED_METRIC}:{index_mode}:{on_date.isoformat()}",
+        )
+    )
+
+
+async def record_storage_stock(on_date: date | None = None) -> None:
+    """Record one day's retained-chunk count, split by index mode.
+
+    Counts are **exact** (unlike the every-few-seconds gauges, which trade
+    accuracy for cost): this runs once a day and the figure is billable.
+
+    Keyword chunks are derived as ``total - hybrid`` rather than counted
+    separately — one fewer Qdrant round-trip, and the two figures cannot drift
+    apart into a total that disagrees with its own parts.
+
+    Never raises: metering is best-effort and must not disturb the ingest
+    pipeline (same contract as ``publish_vector_sync_metrics``).
+    """
+    settings = get_settings()
+    if not settings.usage_metering_enabled:
+        return
+
+    reading_date = on_date or datetime.now(timezone.utc).date()
+    try:
+        qdrant_client = await get_qdrant_client()
+        collection = settings.get_collection_name()
+        _, total = await count_indexed(qdrant_client, collection, exact=True)
+        hybrid = await count_hybrid_chunks(qdrant_client, collection, exact=True)
+        # Clamp: the two counts are separate round-trips, so an upsert landing
+        # between them could otherwise yield a negative keyword count.
+        keyword = max(0, total - hybrid)
+
+        # A never-indexed tenant records nothing rather than zero-value billing
+        # rows, matching the chunk_count guard in _record_indexing_usage.
+        if total <= 0:
+            return
+
+        # Stamp the reading at midnight UTC of the day it describes, so a pod
+        # that wakes at an arbitrary hour still lands the row on the right day
+        # for the control plane's date_trunc()-based rollup.
+        occurred_at = datetime.combine(reading_date, time.min, tzinfo=timezone.utc)
+        events = [
+            UsageEvent(
+                metric=CHUNKS_STORED_METRIC,
+                value=count,
+                metadata={"index_mode": mode},
+                occurred_at=occurred_at,
+                event_id=_stock_event_id(mode, reading_date),
+            )
+            for mode, count in (
+                (payload_keys.INDEX_MODE_HYBRID, hybrid),
+                (payload_keys.INDEX_MODE_KEYWORD, keyword),
+            )
+        ]
+        store = await UsageEventStore.shared()
+        await store.record_usage_events(events, enabled=True)
+        logger.info(
+            "Recorded retention snapshot for %s: %d hybrid + %d keyword chunks",
+            reading_date.isoformat(),
+            hybrid,
+            keyword,
+        )
+    except Exception as exc:  # noqa: BLE001 — metering must not break ingest
+        logger.warning("Failed to record storage-stock usage events: %s", exc)
+
+
+async def usage_stock_task(
+    shutdown_event: anyio.Event,
+    *,
+    task_status: TaskStatus = anyio.TASK_STATUS_IGNORED,
+) -> None:
+    """Record the billable retention snapshot once per UTC day.
+
+    Spawned only when usage metering and vector sync are both on (see app
+    startup wiring). Takes a reading immediately on start so a fresh pod is
+    represented on the day it comes up, then aligns to the **UTC day boundary**
+    rather than sleeping a fixed interval from process start: a restart-driven
+    drift would otherwise walk the reading across days, and two readings landing
+    in one calendar day would be dropped by the idempotent event id anyway.
+    """
+    settings = get_settings()
+    interval = settings.usage_stock_snapshot_interval
+    logger.info("Usage stock snapshot task started (interval=%ss)", interval)
+    task_status.started()
+
+    while not shutdown_event.is_set():
+        await record_storage_stock()
+        # Sleep to the next UTC midnight, capped at the configured interval so a
+        # shortened interval stays testable and the daily default still aligns.
+        now = datetime.now(timezone.utc)
+        until_midnight = (
+            datetime.combine(
+                now.date() + timedelta(days=1), time.min, tzinfo=timezone.utc
+            )
+            - now
+        ).total_seconds()
+        with anyio.move_on_after(min(interval, max(1.0, until_midnight))):
             await shutdown_event.wait()

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -498,7 +498,8 @@ async def record_storage_stock(on_date: date | None = None) -> None:
         keyword = max(0, total - hybrid)
 
         # A never-indexed tenant records nothing rather than zero-value billing
-        # rows, matching the chunk_count guard in _record_indexing_usage.
+        # rows, matching the chunk_count guard in record_indexing_usage
+        # (vector/processor.py).
         if total <= 0:
             return
 
@@ -531,6 +532,24 @@ async def record_storage_stock(on_date: date | None = None) -> None:
         logger.warning("Failed to record storage-stock usage events: %s", exc)
 
 
+def _next_reading_delay(now: datetime, interval: float) -> float:
+    """Seconds to sleep before the next reading.
+
+    Aligns to the next UTC midnight so readings land one per calendar day
+    instead of drifting across days on every restart, capped at ``interval`` so
+    a shortened interval stays testable. The ``1.0`` floor matters: exactly at
+    the boundary the midnight term collapses toward zero, which would spin the
+    task re-recording (and re-dropping) the same day's reading.
+
+    Pure so the boundary behaviour can be tested without patching the clock or
+    the sleep primitive.
+    """
+    next_midnight = datetime.combine(
+        now.date() + timedelta(days=1), time.min, tzinfo=timezone.utc
+    )
+    return min(interval, max(1.0, (next_midnight - now).total_seconds()))
+
+
 async def usage_stock_task(
     shutdown_event: anyio.Event,
     *,
@@ -552,14 +571,6 @@ async def usage_stock_task(
 
     while not shutdown_event.is_set():
         await record_storage_stock()
-        # Sleep to the next UTC midnight, capped at the configured interval so a
-        # shortened interval stays testable and the daily default still aligns.
-        now = datetime.now(timezone.utc)
-        until_midnight = (
-            datetime.combine(
-                now.date() + timedelta(days=1), time.min, tzinfo=timezone.utc
-            )
-            - now
-        ).total_seconds()
-        with anyio.move_on_after(min(interval, max(1.0, until_midnight))):
+        delay = _next_reading_delay(datetime.now(timezone.utc), interval)
+        with anyio.move_on_after(delay):
             await shutdown_event.wait()

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -491,16 +491,18 @@ async def record_storage_stock(on_date: date | None = None) -> None:
     try:
         qdrant_client = await get_qdrant_client()
         collection = settings.get_collection_name()
-        _, total = await count_indexed(qdrant_client, collection, exact=True)
+        # count_indexed returns (documents, chunks); only the chunk total is
+        # billable here -- documents are a display figure.
+        _, total_chunks = await count_indexed(qdrant_client, collection, exact=True)
         hybrid = await count_hybrid_chunks(qdrant_client, collection, exact=True)
         # Clamp: the two counts are separate round-trips, so an upsert landing
         # between them could otherwise yield a negative keyword count.
-        keyword = max(0, total - hybrid)
+        keyword = max(0, total_chunks - hybrid)
 
         # A never-indexed tenant records nothing rather than zero-value billing
         # rows, matching the chunk_count guard in record_indexing_usage
         # (vector/processor.py).
-        if total <= 0:
+        if total_chunks <= 0:
             return
 
         # Stamp the reading at midnight UTC of the day it describes, so a pod

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -7,7 +7,7 @@ that fixes the queue gauge reading 0 on the multi-user consumer path.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -787,43 +787,47 @@ class TestUsageStockTask:
 
         assert recorded == 1
 
-    async def test_sleep_is_never_zero(self, monkeypatch) -> None:
-        """Guards against a busy-loop at the UTC day boundary.
 
-        The sleep is ``min(interval, max(1.0, until_midnight))``. Exactly at
-        midnight ``until_midnight`` collapses toward 0, so without the 1.0 floor
+class TestNextReadingDelay:
+    """The day-boundary sleep, tested as a pure function.
+
+    Extracted from the task loop so the boundary behaviour can be asserted
+    without patching the clock or anyio's sleep primitive.
+    """
+
+    DAY = 86400.0
+
+    def test_aligns_to_next_utc_midnight(self) -> None:
+        # 21:00 UTC -> 3h to midnight, so the reading lands on the next
+        # calendar day rather than drifting by a fixed interval.
+        now = datetime(2026, 8, 9, 21, 0, tzinfo=timezone.utc)
+
+        assert mp._next_reading_delay(now, self.DAY) == 3 * 3600
+
+    def test_floors_at_one_second_on_the_boundary(self) -> None:
+        """Guards against a busy-loop exactly at the UTC day boundary.
+
+        At 23:59:59.5 the midnight term collapses toward 0; without the floor
         the task would spin recording (and re-dropping) the same day's reading.
         """
-        deadlines: list[float] = []
-        original = anyio.move_on_after
+        now = datetime(2026, 8, 9, 23, 59, 59, 500_000, tzinfo=timezone.utc)
 
-        def _capture(delay, **kwargs):
-            deadlines.append(delay)
-            return original(0, **kwargs)  # don't actually sleep
+        assert mp._next_reading_delay(now, self.DAY) == 1.0
 
-        shutdown = anyio.Event()
-        calls = 0
+    def test_capped_by_the_configured_interval(self) -> None:
+        # A shortened interval must win over the day boundary, so the cadence
+        # stays testable/tunable.
+        now = datetime(2026, 8, 9, 0, 0, tzinfo=timezone.utc)
 
-        async def _fake_record() -> None:
-            nonlocal calls
-            calls += 1
-            if calls >= 2:
-                shutdown.set()
+        assert mp._next_reading_delay(now, 60.0) == 60.0
 
-        monkeypatch.setattr(
-            mp, "record_storage_stock", AsyncMock(side_effect=_fake_record)
-        )
-        # A large interval so the day-boundary term is the one that binds.
-        monkeypatch.setattr(
-            mp,
-            "get_settings",
-            lambda: SimpleNamespace(usage_stock_snapshot_interval=86400),
-        )
-        monkeypatch.setattr(mp.anyio, "move_on_after", _capture)
+    def test_never_zero_across_the_whole_day(self) -> None:
+        # Sweep every minute: no clock position may produce a zero-length sleep.
+        base = datetime(2026, 8, 9, tzinfo=timezone.utc)
+        delays = [
+            mp._next_reading_delay(base + timedelta(minutes=m), self.DAY)
+            for m in range(0, 1440)
+        ]
 
-        await mp.usage_stock_task(shutdown)
-
-        assert deadlines, "expected at least one sleep"
-        assert all(d >= 1.0 for d in deadlines)
-        # And never longer than the configured interval.
-        assert all(d <= 86400 for d in deadlines)
+        assert all(d >= 1.0 for d in delays)
+        assert all(d <= self.DAY for d in delays)

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -733,6 +733,9 @@ class TestRecordStorageStock:
         await mp.record_storage_stock(on_date=date(2026, 8, 9))
 
         store.record_usage_events.assert_not_awaited()
+        # ...and bails before the hybrid count, so a never-indexed tenant costs
+        # one Qdrant round-trip rather than three.
+        mp.count_hybrid_chunks.assert_not_awaited()
 
     async def test_no_op_when_metering_disabled(self, monkeypatch, store) -> None:
         self._stub(monkeypatch, total=1000, hybrid=400, enabled=False)
@@ -820,6 +823,14 @@ class TestNextReadingDelay:
         now = datetime(2026, 8, 9, 0, 0, tzinfo=timezone.utc)
 
         assert mp._next_reading_delay(now, 60.0) == 60.0
+
+    def test_floors_a_zero_interval(self) -> None:
+        # An operator setting USAGE_STOCK_SNAPSHOT_INTERVAL=0 must not hot-loop
+        # the task against Qdrant. The floor is applied after the cap so it
+        # covers a zero interval as well as the midnight boundary.
+        now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+        assert mp._next_reading_delay(now, 0.0) == 1.0
 
     def test_never_zero_across_the_whole_day(self) -> None:
         # Sweep every minute: no clock position may produce a zero-length sleep.

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -752,7 +752,26 @@ class TestRecordStorageStock:
         await mp.record_storage_stock(on_date=date(2026, 8, 9))
 
         events = store.record_usage_events.await_args.args[0]
-        assert [e.value for e in events] == [140, 0]
+        # Clamped to 0, and the zero row is then skipped by the guard below.
+        assert [e.value for e in events] == [140]
+
+    async def test_single_mode_tenant_writes_no_zero_row(
+        self, monkeypatch, store
+    ) -> None:
+        """A 100%-hybrid tenant must not accrue a keyword row every day forever.
+
+        Absence and an explicit zero are identical to a SUM, so the row would be
+        permanent no-op storage. Mirrors the zero-value guards in
+        record_indexing_usage.
+        """
+        self._stub(monkeypatch, total=500, hybrid=500)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        events = store.record_usage_events.await_args.args[0]
+        assert [(e.metadata["index_mode"], e.value) for e in events] == [
+            ("hybrid", 500)
+        ]
 
     async def test_qdrant_failure_does_not_raise(self, monkeypatch, store) -> None:
         self._stub(monkeypatch, total=10, hybrid=4)

--- a/tests/unit/vector/test_metrics_publisher.py
+++ b/tests/unit/vector/test_metrics_publisher.py
@@ -7,6 +7,7 @@ that fixes the queue gauge reading 0 on the multi-user consumer path.
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -640,3 +641,189 @@ class TestPublishDeadLetteredGauge:
         )
 
         gauge.assert_not_called()
+
+
+class TestRecordStorageStock:
+    """The billable retention snapshot (chunks_stored).
+
+    Distinct from the gauges above: this writes to usage_events, so the
+    properties that matter are billing properties -- exact counts, a correct
+    keyword derivation, and idempotency across pod restarts.
+    """
+
+    @pytest.fixture
+    def store(self, monkeypatch) -> AsyncMock:
+        store = AsyncMock()
+        monkeypatch.setattr(mp.UsageEventStore, "shared", AsyncMock(return_value=store))
+        return store
+
+    def _stub(self, monkeypatch, *, total: int, hybrid: int, enabled: bool = True):
+        settings = SimpleNamespace(
+            usage_metering_enabled=enabled,
+            get_collection_name=lambda: _COLLECTION,
+        )
+        monkeypatch.setattr(mp, "get_settings", lambda: settings)
+        monkeypatch.setattr(
+            mp, "get_qdrant_client", AsyncMock(return_value=AsyncMock())
+        )
+        monkeypatch.setattr(mp, "count_indexed", AsyncMock(return_value=(0, total)))
+        monkeypatch.setattr(mp, "count_hybrid_chunks", AsyncMock(return_value=hybrid))
+
+    async def test_records_both_modes_with_keyword_derived(
+        self, monkeypatch, store
+    ) -> None:
+        self._stub(monkeypatch, total=1000, hybrid=400)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        events = store.record_usage_events.await_args.args[0]
+        assert [(e.metric, e.metadata["index_mode"], e.value) for e in events] == [
+            ("chunks_stored", "hybrid", 400),
+            # 1000 - 400: derived, never counted separately, so the parts always
+            # sum to the total.
+            ("chunks_stored", "keyword", 600),
+        ]
+
+    async def test_counts_are_exact_not_approximate(self, monkeypatch, store) -> None:
+        # A billing figure must not use the gauges' exact=False shortcut.
+        self._stub(monkeypatch, total=10, hybrid=4)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        assert mp.count_indexed.await_args.kwargs["exact"] is True
+        assert mp.count_hybrid_chunks.await_args.kwargs["exact"] is True
+
+    async def test_event_id_is_stable_across_restarts(self, monkeypatch, store) -> None:
+        """The property that stops restarts inflating the billed chunk-days.
+
+        Two runs on the same UTC day must produce identical event ids, so the
+        second insert hits ON CONFLICT (event_id) DO NOTHING.
+        """
+        self._stub(monkeypatch, total=1000, hybrid=400)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+        first = [e.event_id for e in store.record_usage_events.await_args.args[0]]
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+        second = [e.event_id for e in store.record_usage_events.await_args.args[0]]
+
+        assert first == second
+        # ...and a different day must NOT collide, or we would bill one reading
+        # per corpus forever.
+        await mp.record_storage_stock(on_date=date(2026, 8, 10))
+        next_day = [e.event_id for e in store.record_usage_events.await_args.args[0]]
+        assert set(next_day).isdisjoint(first)
+
+    async def test_stamped_at_utc_midnight_of_the_reading_date(
+        self, monkeypatch, store
+    ) -> None:
+        # The row must land on the day it describes regardless of the hour the
+        # pod happened to wake up, for the CP's date_trunc() rollup.
+        self._stub(monkeypatch, total=10, hybrid=10)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        events = store.record_usage_events.await_args.args[0]
+        assert all(
+            e.occurred_at == datetime(2026, 8, 9, tzinfo=timezone.utc) for e in events
+        )
+
+    async def test_empty_corpus_records_nothing(self, monkeypatch, store) -> None:
+        self._stub(monkeypatch, total=0, hybrid=0)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        store.record_usage_events.assert_not_awaited()
+
+    async def test_no_op_when_metering_disabled(self, monkeypatch, store) -> None:
+        self._stub(monkeypatch, total=1000, hybrid=400, enabled=False)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        store.record_usage_events.assert_not_awaited()
+
+    async def test_keyword_never_negative(self, monkeypatch, store) -> None:
+        # The two counts are separate round-trips; an upsert landing between
+        # them must not produce a negative keyword count.
+        self._stub(monkeypatch, total=100, hybrid=140)
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        events = store.record_usage_events.await_args.args[0]
+        assert [e.value for e in events] == [140, 0]
+
+    async def test_qdrant_failure_does_not_raise(self, monkeypatch, store) -> None:
+        self._stub(monkeypatch, total=10, hybrid=4)
+        monkeypatch.setattr(
+            mp, "count_indexed", AsyncMock(side_effect=RuntimeError("qdrant down"))
+        )
+
+        await mp.record_storage_stock(on_date=date(2026, 8, 9))
+
+        store.record_usage_events.assert_not_awaited()
+
+
+class TestUsageStockTask:
+    async def test_records_immediately_then_honours_shutdown(self, monkeypatch) -> None:
+        # A fresh pod must be represented on the day it comes up rather than
+        # waiting a full interval, so the reading happens before the sleep.
+        shutdown = anyio.Event()
+        recorded = 0
+
+        async def _fake_record() -> None:
+            nonlocal recorded
+            recorded += 1
+            shutdown.set()  # one pass, then stop the loop
+
+        monkeypatch.setattr(
+            mp, "record_storage_stock", AsyncMock(side_effect=_fake_record)
+        )
+        monkeypatch.setattr(
+            mp,
+            "get_settings",
+            lambda: SimpleNamespace(usage_stock_snapshot_interval=0),
+        )
+
+        await mp.usage_stock_task(shutdown)
+
+        assert recorded == 1
+
+    async def test_sleep_is_never_zero(self, monkeypatch) -> None:
+        """Guards against a busy-loop at the UTC day boundary.
+
+        The sleep is ``min(interval, max(1.0, until_midnight))``. Exactly at
+        midnight ``until_midnight`` collapses toward 0, so without the 1.0 floor
+        the task would spin recording (and re-dropping) the same day's reading.
+        """
+        deadlines: list[float] = []
+        original = anyio.move_on_after
+
+        def _capture(delay, **kwargs):
+            deadlines.append(delay)
+            return original(0, **kwargs)  # don't actually sleep
+
+        shutdown = anyio.Event()
+        calls = 0
+
+        async def _fake_record() -> None:
+            nonlocal calls
+            calls += 1
+            if calls >= 2:
+                shutdown.set()
+
+        monkeypatch.setattr(
+            mp, "record_storage_stock", AsyncMock(side_effect=_fake_record)
+        )
+        # A large interval so the day-boundary term is the one that binds.
+        monkeypatch.setattr(
+            mp,
+            "get_settings",
+            lambda: SimpleNamespace(usage_stock_snapshot_interval=86400),
+        )
+        monkeypatch.setattr(mp.anyio, "move_on_after", _capture)
+
+        await mp.usage_stock_task(shutdown)
+
+        assert deadlines, "expected at least one sleep"
+        assert all(d >= 1.0 for d in deadlines)
+        # And never longer than the configured interval.
+        assert all(d <= 86400 for d in deadlines)


### PR DESCRIPTION
## Why

We are moving the price basis off source bytes (a 31x-spread unit across the fleet) onto **chunks**. Auditing the ingest path against that model found the data plane can bill ingestion and OCR, but **cannot bill retention at all**:

- Emitted metrics are `tokens_embedded`, `pages_embedded`, `pages_ocr`, `bytes_ingested`, `bytes_stored` — there is **no chunk counter** on the billable path.
- `bytes_stored` is emitted per document **per indexing pass**, so it is an ingest **flow**. Summing it over a period counts a re-indexed document again on every pass — it measures churn, not what is retained.

Retention is the term that compounds: it is the only cost that keeps accruing after the ingest work is done.

## What

Records the retained chunk count once per UTC day, split by index mode, as a `chunks_stored` usage event. A month of readings sums to **chunk-days** — the integral of a changing stock — so a corpus loaded or purged mid-month is charged pro rata, and the rollup's existing daily-sum semantics are unchanged.

The measurement already existed and was already mode-aware, so this is mostly wiring:

- Reuses `count_indexed()` and `count_hybrid_chunks()` unchanged (the latter already filters on the `index_mode` payload key).
- Keyword chunks are **derived** as `total - hybrid` — one fewer Qdrant round-trip, and the parts always sum to the total.
- Modelled on the existing `vector_density_snapshot_task` slow-cadence pattern; spawned at **both** consumer paths, since omitting the multi-user one would silently un-meter those tenants.

### Idempotency is the load-bearing detail

Event ids are derived from `(metric, mode, UTC date)`. `usage_events` inserts are already `ON CONFLICT (event_id) DO NOTHING`, so a pod that restarts five times in a day still contributes exactly one reading per mode. Without this, restarts would silently multiply the billed chunk-days. Verified against a real SQLite `usage_events` table as well as in unit tests: three identical runs produce 2 rows totalling 1000 chunk-days, not 3000.

Counts are **exact** rather than the gauges' `exact=False` shortcut — this runs once a day and the figure is billable.

## Cross-repo sequencing (no merge-order requirement)

`chunks_stored` is a new metric name, so per migration 007 the control-plane rollup **ignores it until the CP catalog and Stripe meter learn it**. The mode split rides in the event `metadata`, and the rollup currently groups by `(day, metric)` only, so both modes bill as one line until the CP also groups on `index_mode`.

This lands correct and inert: it changes no existing metric, and is gated on `USAGE_METERING_ENABLED`. `metadata` is already `JSONB` on Postgres — explicitly "so the CP can slice on dimensions later" — so the CP side is a rollup query change, not a migration.

## Test coverage

15 new unit tests covering the billing properties: both modes recorded, keyword derived (and never negative if an upsert lands between the two counts), exact counts, empty corpus records nothing, metering-disabled no-ops, Qdrant failure does not raise, the row is stamped at UTC midnight of the day it describes, **event ids stable across restarts but distinct across days**, plus the task loop's immediate-first-reading and its non-zero sleep floor at the day boundary.

**Deviation from plan, flagged deliberately:** the plan called for a Pact contract test. On inspection that is the wrong tool here — every existing test in `tests/contract/` is an HTTP boundary, but the control plane consumes `usage_events` by reading the app DB directly. This is a **schema** contract, not a Pact-able HTTP one. The metric name and metadata shape are asserted in unit tests instead, and the CP-catalog sync requirement is documented at the metric definition. Happy to add a Pact test if you disagree.

Integration verification against a running stack (mixed-mode corpus, then confirming a re-index does not inflate the stock) is still outstanding.

Deck: board 8 #1001. Depends on #1000 for mode-differentiated billing.

---

_This PR was generated with the help of AI, and reviewed by a Human_
