### PR TITLE
feat(deck): add card dependency tools

### DIFF
--- a/docs/deck.md
+++ b/docs/deck.md
@@ -35,6 +35,8 @@
 | `deck_remove_label_from_card` | Remove a label from a card |
 | `deck_assign_user_to_card` | Assign a user to a card |
 | `deck_unassign_user_from_card` | Remove a user assignment from a card |
+| `deck_assign_dependent_card` | Mark a card as depending on another card ("Add dependent card") |
+| `deck_remove_dependent_card` | Remove a dependency between two cards |
 
 ### Deck Resources
 | Resource | Description |

--- a/nextcloud_mcp_server/client/deck.py
+++ b/nextcloud_mcp_server/client/deck.py
@@ -456,6 +456,39 @@ class DeckClient(BaseNextcloudClient):
             json=json_data,
         )
 
+    async def assign_dependent_card(
+        self, board_id: int, stack_id: int, card_id: int, dependent_card_id: int
+    ) -> DeckCard:
+        """Record that ``card_id`` depends on ``dependent_card_id``.
+
+        Mirrors Deck's "Add dependent card" card action. The dependency is
+        directional: it is stored on ``card_id`` and surfaces in that card's
+        ``dependentCards`` list. The caller needs read access to the dependent
+        card. Returns the updated (depending) card.
+        """
+        headers = self._get_deck_headers()
+        response = await self._make_request(
+            "POST",
+            f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/dependentCards/{dependent_card_id}",
+            headers=headers,
+        )
+        return DeckCard(**response.json())
+
+    async def remove_dependent_card(
+        self, board_id: int, stack_id: int, card_id: int, dependent_card_id: int
+    ) -> DeckCard:
+        """Remove the dependency of ``card_id`` on ``dependent_card_id``.
+
+        Returns the updated (depending) card.
+        """
+        headers = self._get_deck_headers()
+        response = await self._make_request(
+            "DELETE",
+            f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/dependentCards/{dependent_card_id}",
+            headers=headers,
+        )
+        return DeckCard(**response.json())
+
     async def reorder_card(
         self,
         board_id: int,

--- a/nextcloud_mcp_server/models/deck.py
+++ b/nextcloud_mcp_server/models/deck.py
@@ -92,6 +92,7 @@ class DeckCard(BaseModel):
     createdAt: Optional[int] = None
     labels: Optional[List[DeckLabel]] = None
     assignedUsers: Optional[List[Union[DeckUser, DeckAssignedUser]]] = None
+    dependentCards: Optional[List[int]] = None  # IDs of cards this card depends on
     attachments: Optional[List[Any]] = None  # Define a proper Attachment model later
     attachmentCount: Optional[int] = None
     deletedAt: Optional[int] = None

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -1845,6 +1845,83 @@ def configure_deck_tools(mcp: FastMCP):
             board_id=board_id,
         )
 
+    # Card Dependency Tools
+    @mcp.tool(
+        title="Add Dependent Card to Deck Card",
+        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+    )
+    @require_scopes("deck.write")
+    @instrument_tool
+    async def deck_assign_dependent_card(
+        ctx: Context,
+        board_id: int,
+        stack_id: int,
+        card_id: int,
+        dependent_card_id: int,
+    ) -> CardOperationResponse:
+        """Mark a Nextcloud Deck card as depending on another card.
+
+        Mirrors Deck's "Add dependent card" action. The dependency is
+        directional and stored on ``card_id``: it surfaces in that card's
+        ``dependentCards`` list (visible via deck_get_card). You need read
+        access to the dependent card.
+
+        Args:
+            board_id: The ID of the board containing the depending card
+            stack_id: The ID of the stack containing the depending card
+            card_id: The ID of the card that depends on another card
+            dependent_card_id: The ID of the card that card_id depends on
+        """
+        client = await get_client(ctx)
+        await client.deck.assign_dependent_card(
+            board_id, stack_id, card_id, dependent_card_id
+        )
+        return CardOperationResponse(
+            success=True,
+            message=f"Card {dependent_card_id} added as a dependency of card {card_id}",
+            card_id=card_id,
+            stack_id=stack_id,
+            board_id=board_id,
+        )
+
+    @mcp.tool(
+        title="Remove Dependent Card from Deck Card",
+        annotations=ToolAnnotations(
+            destructiveHint=True, idempotentHint=True, openWorldHint=True
+        ),
+    )
+    @require_scopes("deck.write")
+    @instrument_tool
+    async def deck_remove_dependent_card(
+        ctx: Context,
+        board_id: int,
+        stack_id: int,
+        card_id: int,
+        dependent_card_id: int,
+    ) -> CardOperationResponse:
+        """Remove a dependency between two Nextcloud Deck cards.
+
+        Removes the dependency of ``card_id`` on ``dependent_card_id`` that was
+        created by deck_assign_dependent_card.
+
+        Args:
+            board_id: The ID of the board containing the depending card
+            stack_id: The ID of the stack containing the depending card
+            card_id: The ID of the card that depends on another card
+            dependent_card_id: The ID of the dependency to remove
+        """
+        client = await get_client(ctx)
+        await client.deck.remove_dependent_card(
+            board_id, stack_id, card_id, dependent_card_id
+        )
+        return CardOperationResponse(
+            success=True,
+            message=f"Card {dependent_card_id} removed as a dependency of card {card_id}",
+            card_id=card_id,
+            stack_id=stack_id,
+            board_id=board_id,
+        )
+
     # Card Comment Tools
 
     @mcp.tool(

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -8,6 +8,7 @@ from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.capabilities import require_capability
 from nextcloud_mcp_server.client import NextcloudClient
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.deck import (
@@ -1851,6 +1852,7 @@ def configure_deck_tools(mcp: FastMCP):
         annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
     )
     @require_scopes("deck.write")
+    @require_capability("deck", min_version="1.18.0")
     @instrument_tool
     async def deck_assign_dependent_card(
         ctx: Context,
@@ -1891,6 +1893,7 @@ def configure_deck_tools(mcp: FastMCP):
         ),
     )
     @require_scopes("deck.write")
+    @require_capability("deck", min_version="1.18.0")
     @instrument_tool
     async def deck_remove_dependent_card(
         ctx: Context,

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -1848,7 +1848,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Card Dependency Tools
     @mcp.tool(
         title="Add Dependent Card to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool

--- a/tests/client/deck/test_deck_api.py
+++ b/tests/client/deck/test_deck_api.py
@@ -335,6 +335,60 @@ async def test_deck_get_card(mocker):
     assert "/boards/123/stacks/456/cards/789" in mock_make_request.call_args[0][1]
 
 
+async def test_deck_assign_dependent_card(mocker):
+    """Test that assign_dependent_card POSTs to the right route and parses the card."""
+    mock_response = create_mock_deck_card_response(
+        card_id=789, title="Test Card", stack_id=456, dependentCards=[555]
+    )
+
+    mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    mock_make_request = mocker.patch.object(
+        DeckClient, "_make_request", return_value=mock_response
+    )
+
+    client = DeckClient(mock_client, "testuser")
+    card = await client.assign_dependent_card(
+        board_id=123, stack_id=456, card_id=789, dependent_card_id=555
+    )
+
+    assert isinstance(card, DeckCard)
+    assert card.dependentCards == [555]
+
+    mock_make_request.assert_called_once()
+    assert mock_make_request.call_args[0][0] == "POST"
+    assert (
+        "/boards/123/stacks/456/cards/789/dependentCards/555"
+        in mock_make_request.call_args[0][1]
+    )
+
+
+async def test_deck_remove_dependent_card(mocker):
+    """Test that remove_dependent_card DELETEs the right route and parses the card."""
+    mock_response = create_mock_deck_card_response(
+        card_id=789, title="Test Card", stack_id=456, dependentCards=[]
+    )
+
+    mock_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    mock_make_request = mocker.patch.object(
+        DeckClient, "_make_request", return_value=mock_response
+    )
+
+    client = DeckClient(mock_client, "testuser")
+    card = await client.remove_dependent_card(
+        board_id=123, stack_id=456, card_id=789, dependent_card_id=555
+    )
+
+    assert isinstance(card, DeckCard)
+    assert card.dependentCards == []
+
+    mock_make_request.assert_called_once()
+    assert mock_make_request.call_args[0][0] == "DELETE"
+    assert (
+        "/boards/123/stacks/456/cards/789/dependentCards/555"
+        in mock_make_request.call_args[0][1]
+    )
+
+
 async def test_deck_update_card(mocker):
     """Test that update_card makes the correct API calls."""
     # Mock get_card response (update_card calls get_card first)

--- a/tests/integration/test_deck_dependent_card.py
+++ b/tests/integration/test_deck_dependent_card.py
@@ -4,10 +4,12 @@ Exercises the assign/remove dependent-card endpoints against a live Deck
 instance and verifies the ``dependentCards`` relation on the depending card.
 """
 
+import json
 import logging
 import uuid
 
 import pytest
+from mcp import ClientSession
 
 from nextcloud_mcp_server.client import NextcloudClient
 
@@ -73,3 +75,47 @@ async def test_assign_and_remove_dependent_card(
 
     after_remove = await nc_client.deck.get_card(board_id, stack_id, card_id)
     assert not after_remove.dependentCards
+
+
+async def test_assign_and_remove_dependent_card_via_mcp(
+    nc_mcp_client: ClientSession,
+    nc_client: NextcloudClient,
+    temporary_board_with_card: tuple,
+):
+    """The same round-trip driven through the MCP tools, with the dependency
+    read back via the ``deck_get_card`` tool."""
+    board_data, stack_data, card_data = temporary_board_with_card
+    board_id = board_data["id"]
+    stack_id = stack_data["id"]
+    card_id = card_data["id"]
+
+    # A second card on the same stack to depend on.
+    dependency = await nc_client.deck.create_card(
+        board_id, stack_id, f"Dependency Card {uuid.uuid4().hex[:8]}"
+    )
+    args = {
+        "board_id": board_id,
+        "stack_id": stack_id,
+        "card_id": card_id,
+        "dependent_card_id": dependency.id,
+    }
+
+    async def get_dependent_cards() -> list:
+        result = await nc_mcp_client.call_tool(
+            "deck_get_card",
+            {"board_id": board_id, "stack_id": stack_id, "card_id": card_id},
+        )
+        assert result.isError is False, f"get_card failed: {result.content}"
+        return json.loads(result.content[0].text).get("dependentCards") or []
+
+    # Assign via MCP
+    assign_result = await nc_mcp_client.call_tool("deck_assign_dependent_card", args)
+    assert assign_result.isError is False, f"assign failed: {assign_result.content}"
+    assert json.loads(assign_result.content[0].text)["success"] is True
+    assert await get_dependent_cards() == [dependency.id]
+
+    # Remove via MCP
+    remove_result = await nc_mcp_client.call_tool("deck_remove_dependent_card", args)
+    assert remove_result.isError is False, f"remove failed: {remove_result.content}"
+    assert json.loads(remove_result.content[0].text)["success"] is True
+    assert await get_dependent_cards() == []

--- a/tests/integration/test_deck_dependent_card.py
+++ b/tests/integration/test_deck_dependent_card.py
@@ -1,0 +1,75 @@
+"""Integration tests for Deck card dependencies ("Add dependent card").
+
+Exercises the assign/remove dependent-card endpoints against a live Deck
+instance and verifies the ``dependentCards`` relation on the depending card.
+"""
+
+import logging
+import uuid
+
+import pytest
+
+from nextcloud_mcp_server.client import NextcloudClient
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def board_with_two_cards(nc_client: NextcloudClient):
+    """Create a temporary board with one stack and two cards.
+
+    Yields:
+        tuple: (board_id, stack_id, card_id, dependency_card_id)
+    """
+    unique_suffix = uuid.uuid4().hex[:8]
+    board = None
+    try:
+        board = await nc_client.deck.create_board(
+            f"Dependency Test Board {unique_suffix}", "0000FF"
+        )
+        stack = await nc_client.deck.create_stack(
+            board.id, f"Stack {unique_suffix}", order=1
+        )
+        card = await nc_client.deck.create_card(
+            board.id, stack.id, f"Depending Card {unique_suffix}"
+        )
+        dependency = await nc_client.deck.create_card(
+            board.id, stack.id, f"Dependency Card {unique_suffix}"
+        )
+        yield (board.id, stack.id, card.id, dependency.id)
+    finally:
+        if board:
+            try:
+                await nc_client.deck.delete_board(board.id)
+            except Exception as e:
+                logger.warning("Error cleaning up board: %s", e)
+
+
+async def test_assign_and_remove_dependent_card(
+    nc_client: NextcloudClient, board_with_two_cards: tuple
+):
+    """A card records the dependency, then drops it, on ``dependentCards``."""
+    board_id, stack_id, card_id, dependency_card_id = board_with_two_cards
+
+    # Starts with no dependencies
+    before = await nc_client.deck.get_card(board_id, stack_id, card_id)
+    assert not before.dependentCards
+
+    # Assign: both the returned card and a fresh fetch show the dependency
+    assigned = await nc_client.deck.assign_dependent_card(
+        board_id, stack_id, card_id, dependency_card_id
+    )
+    assert assigned.dependentCards == [dependency_card_id]
+
+    after_assign = await nc_client.deck.get_card(board_id, stack_id, card_id)
+    assert after_assign.dependentCards == [dependency_card_id]
+
+    # Remove: dependency is gone again
+    removed = await nc_client.deck.remove_dependent_card(
+        board_id, stack_id, card_id, dependency_card_id
+    )
+    assert not removed.dependentCards
+
+    after_remove = await nc_client.deck.get_card(board_id, stack_id, card_id)
+    assert not after_remove.dependentCards

--- a/tests/integration/test_deck_dependent_card.py
+++ b/tests/integration/test_deck_dependent_card.py
@@ -11,10 +11,24 @@ import uuid
 import pytest
 from mcp import ClientSession
 
+from nextcloud_mcp_server.capabilities import unmet_capability
 from nextcloud_mcp_server.client import NextcloudClient
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.integration
+
+# Card dependencies first ship in Deck v1.18.0 (Nextcloud 34+). On older
+# instances the API endpoints don't exist and the MCP tools are capability-gated
+# out, so these tests skip rather than fail.
+DECK_DEPENDENCIES_MIN_VERSION = "1.18.0"
+
+
+async def _skip_without_dependency_support(nc_client: NextcloudClient) -> None:
+    reason = await unmet_capability(
+        nc_client, nc_client.username, "deck", DECK_DEPENDENCIES_MIN_VERSION
+    )
+    if reason:
+        pytest.skip(reason)
 
 
 @pytest.fixture
@@ -24,6 +38,7 @@ async def board_with_two_cards(nc_client: NextcloudClient):
     Yields:
         tuple: (board_id, stack_id, card_id, dependency_card_id)
     """
+    await _skip_without_dependency_support(nc_client)
     unique_suffix = uuid.uuid4().hex[:8]
     board = None
     try:
@@ -84,6 +99,7 @@ async def test_assign_and_remove_dependent_card_via_mcp(
 ):
     """The same round-trip driven through the MCP tools, with the dependency
     read back via the ``deck_get_card`` tool."""
+    await _skip_without_dependency_support(nc_client)
     board_data, stack_data, card_data = temporary_board_with_card
     board_id = board_data["id"]
     stack_id = stack_data["id"]

--- a/tests/integration/test_deck_dependent_card.py
+++ b/tests/integration/test_deck_dependent_card.py
@@ -44,8 +44,8 @@ async def board_with_two_cards(nc_client: NextcloudClient):
         if board:
             try:
                 await nc_client.deck.delete_board(board.id)
-            except Exception as e:
-                logger.warning("Error cleaning up board: %s", e)
+            except Exception:
+                logger.warning("Error cleaning up board %s", board.id, exc_info=True)
 
 
 async def test_assign_and_remove_dependent_card(


### PR DESCRIPTION
## What

Adds MCP support for Nextcloud Deck **card dependencies** ("Add dependent card"), a recently added Deck feature that the server did not yet wrap.

Two new tools:

- `deck_assign_dependent_card` — mark a card as depending on another card
- `deck_remove_dependent_card` — remove a dependency between two cards

Existing card reads (`deck_get_card`) now surface a card's dependencies via a new `dependentCards` field.

## Why

Deck exposes card dependencies through its API but the MCP had no way to read or write them.

## How

The dependency is directional and stored on the depending card, mirroring Deck's own behavior (`CardService::assignDependentCard` / `removeDependentCard`):

- `POST   /apps/deck/api/v1.0/boards/{boardId}/stacks/{stackId}/cards/{cardId}/dependentCards/{dependentCardId}`
- `DELETE /apps/deck/api/v1.0/boards/{boardId}/stacks/{stackId}/cards/{cardId}/dependentCards/{dependentCardId}`

Both return the updated card, whose `dependentCards` is an array of dependent card IDs.

### Changes

- `models/deck.py` — add `dependentCards: Optional[List[int]]` to `DeckCard`
- `client/deck.py` — add `assign_dependent_card()` / `remove_dependent_card()`
- `server/deck.py` — add the two MCP tools
- `docs/deck.md` — document the tools
- `tests/client/deck/test_deck_api.py` — unit tests (route + method + parsing)
- `tests/integration/test_deck_dependent_card.py` — integration test covering the full assign/remove cycle

## Testing

- `ruff check`, `ruff format --check`, and `ty check` all pass
- Unit tests pass
- Integration test passes against a live instance (Nextcloud 35 dev + Deck): creates an isolated board/stack/two cards, asserts `dependentCards` after assign and after remove on both the returned card and a fresh fetch, then deletes the board
