### PR TITLE
fix: declare phantom runtime dependencies (#1285)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
         run: uv run --frozen ruff check
       - name: Type check
         run: uv run --frozen ty check -- nextcloud_mcp_server
+      # Fails if a module is imported at runtime but not declared in
+      # [project.dependencies] (#1285). Config in pyproject.toml [tool.deptry].
+      - name: Check for undeclared dependencies
+        run: uv run --frozen deptry .
 
   unit-test:
     runs-on: ubuntu-latest

--- a/nextcloud_mcp_server/observability/tracing.py
+++ b/nextcloud_mcp_server/observability/tracing.py
@@ -12,9 +12,9 @@ This module provides:
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
+from importlib.metadata import version
 from typing import Any
 
-from importlib_metadata import version
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.logging import LoggingInstrumentor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,16 @@ keywords = ["nextcloud", "mcp", "model-context-protocol", "llm", "ai", "claude",
 dependencies = [
     "mcp[cli] (>=1.29,<1.30)",
     "httpx (>=0.28.1,<0.29.0)",
+    # Imported directly at runtime. Each was previously reachable only because
+    # some other dependency happened to pull it in — the accident that broke
+    # #1285 when the resolver stopped doing so. Declared explicitly so the
+    # install closure no longer depends on a transitive coincidence.
+    "anyio>=4.0", # structured concurrency, used throughout
+    "uvicorn>=0.30", # cli.py serves the ASGI app
+    "cryptography>=42.0", # auth/storage.py token encryption
+    "lxml>=5.0", # client/calendar.py CalDAV XML parsing
+    "botocore>=1.35.0", # providers/bedrock.py exception types
+    "numpy>=1.26", # vector/pca.py, vector/visualization.py
     "pillow (>=10.3.0,<12.0.0)", # Compatible with fastembed
     "icalendar (>=7.2.0,<7.3.0)",
     "pythonvcard4>=0.2.0",
@@ -114,6 +124,22 @@ extend-select = ["I", "PLC0415", "G004"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["PLC0415"]
 
+# Guard against undeclared ("phantom") dependencies — a module imported at
+# runtime but absent from [project.dependencies], which only works while some
+# transitive dep happens to pull it in. That is how #1285 shipped: tracing.py
+# imported the `importlib-metadata` backport, present only because
+# opentelemetry-api depended on it. package-smoke can't catch this — it proves
+# only that one resolution happened to work, not that we declare what we need.
+# DEP001 (missing) and DEP003 (relying on a transitive dep) are enforced —
+# #1285 was a DEP003. DEP002 (declared but unused) and DEP004 are noisy here
+# (re-exports, plugin-only deps like pyroscope-io) and stay off.
+[tool.deptry]
+ignore = ["DEP002", "DEP004"]
+
+[tool.deptry.per_rule_ignores]
+# Optional local-OCR extra, imported inside a try/except ImportError.
+DEP001 = ["pytesseract"]
+
 [build-system]
 requires = ["uv_build>=0.12.1,<0.13.0"]
 build-backend = "uv_build"
@@ -125,6 +151,7 @@ module-root = ""
 [dependency-groups]
 dev = [
     "commitizen>=4.8.2",
+    "deptry>=0.20.0",
     "ipython>=9.2.0",
     "playwright>=1.49.1",
     "pytest>=8.3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -592,6 +592,36 @@ wheels = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e7/b554568a84197c0a4177b51c9880b55e9861de08d9acfd914a08148a1faa/deptry-0.25.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:30d64d4df1c08bc69de56cb0b4ec1f4cd9fa2e42582347d5b1eb25fd0e401745", size = 1846779, upload-time = "2026-03-18T23:22:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/38cf5ab4b81fcb1c58909ab0fe1ccc62b36f61c5f7d213a7d0474f620925/deptry-0.25.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:87bcd90f99a98bb059c7580bc315c3f87d97fe2db725530030bc974176834735", size = 1758420, upload-time = "2026-03-18T23:22:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/fb/234c333d5dfcc810bb3ca5b3b420355bdd759901c75e41f0441a9871a1cd/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f31eb5c520651b102568dd91f738222b250a3e44c9e95d4941322109b8d40a", size = 1870345, upload-time = "2026-03-18T23:22:29.734Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/cb63e5210d1ba36cf68cdc0e4fdea73e48f80ac3b7680228816f39ff696a/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df88952a2bab7517ef23cb304b979199b28449e5d9db2e9ba9bc27a286ac852b", size = 1922759, upload-time = "2026-03-18T23:22:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8c/e079c44ed98464930e83ca54ea5d40fec522d234e8428e06a1be7f6c7a9a/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e6f7b8fa72932e51e86799b10dcd29381b2132dc799c790dca3b28ab08dffb28", size = 2049576, upload-time = "2026-03-18T23:22:12.797Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f2/6a89ad9e5e8e9d37def57a28020d6d7fbcf900b2e5f4dfbbace349cdca91/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e3fa3321078e11cd1ac3f10ce3ff0547731c53f9253b87c757a8749c76fe8fa9", size = 2144676, upload-time = "2026-03-18T23:22:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/b3358690a1a47381d995c3d3587798ab2cd086baf4b839e35183599aa2e1/deptry-0.25.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:03c032c32492fde434736954fbcaff09c02bf207b0f793b77e9040300e34b344", size = 1715518, upload-time = "2026-03-18T23:22:20.486Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1939,10 +1969,13 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "authlib" },
     { name = "boto3" },
+    { name = "botocore" },
     { name = "caldav" },
     { name = "click" },
+    { name = "cryptography" },
     { name = "dynaconf" },
     { name = "fastembed", version = "0.7.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "fastembed", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -1950,9 +1983,12 @@ dependencies = [
     { name = "icalendar" },
     { name = "jinja2" },
     { name = "langchain-text-splitters" },
+    { name = "lxml" },
     { name = "markdownify" },
     { name = "mcp", extra = ["cli"] },
     { name = "mistralai" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -1973,6 +2009,7 @@ dependencies = [
     { name = "recurring-ical-events" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -1987,6 +2024,7 @@ postgres = [
 [package.dev-dependencies]
 dev = [
     { name = "commitizen" },
+    { name = "deptry" },
     { name = "ipython" },
     { name = "pact-python" },
     { name = "playwright" },
@@ -2009,19 +2047,24 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.14.0" },
+    { name = "anyio", specifier = ">=4.0" },
     { name = "authlib", specifier = ">=1.6.5" },
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "botocore", specifier = ">=1.35.0" },
     { name = "caldav", specifier = ">=3.0.1,<4.0" },
     { name = "click", specifier = ">=8.1.8" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "dynaconf", specifier = ">=3.2.13,<4.0" },
     { name = "fastembed", specifier = ">=0.7.3" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "icalendar", specifier = ">=7.2.0,<7.3.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langchain-text-splitters", specifier = ">=1.0.0" },
+    { name = "lxml", specifier = ">=5.0" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.29,<1.30" },
     { name = "mistralai", specifier = ">=2.4.5" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=2.8.1" },
     { name = "opentelemetry-api", specifier = ">=1.28.2" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.28.2" },
@@ -2045,12 +2088,14 @@ requires-dist = [
     { name = "recurring-ical-events", specifier = ">=3.8.0,<4.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "starlette", specifier = "<1.0" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["postgres", "observability"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=4.8.2" },
+    { name = "deptry", specifier = ">=0.20.0" },
     { name = "ipython", specifier = ">=9.2.0" },
     { name = "pact-python", specifier = ">=3.4.0" },
     { name = "playwright", specifier = ">=1.49.1" },
@@ -3773,6 +3818,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #1285.

## The bug

`uvx nextcloud-mcp-server run --transport stdio` crashed at import:

```
File ".../nextcloud_mcp_server/observability/tracing.py", line 17, in <module>
    from importlib_metadata import version
ModuleNotFoundError: No module named 'importlib_metadata'
```

`tracing.py` imported the third-party **`importlib-metadata` backport**, not the
stdlib `importlib.metadata`. That package was never declared in
`[project.dependencies]` — it was only present because `opentelemetry-api`
happened to pull it in. Once the resolver stopped doing so, install broke.

`cli.py` and `api/management.py` already used the stdlib module, and
`requires-python = ">=3.11"` means the backport is never needed, so the fix
removes the dependency entirely rather than declaring it.

## The rest of the same bug

A repo-wide audit found six more imports in the same shape — used
unconditionally at runtime, present only via someone else's dependency:

| Package | Imported by | Was pulled in by |
|---|---|---|
| `anyio` | 64 sites across `client/`, `vector/`, `auth/` | mcp / httpx |
| `uvicorn` | `cli.py` (module level) | mcp[cli] |
| `cryptography` | `auth/storage.py` | pyjwt[crypto] |
| `lxml` | `client/calendar.py` | caldav |
| `botocore` | `providers/bedrock.py` | boto3 |
| `numpy` | `vector/pca.py`, `vector/visualization.py` | qdrant-client / fastembed |

Each is one resolver change away from reproducing #1285 — `cli.py`'s
module-level `import uvicorn` is the exact same shape as the import that broke.
All six are now declared.

## Why `package-smoke` didn't catch it

```yaml
- run: uv run --isolated --no-project --with . nextcloud-mcp-server --help
```

That job does walk the crashing import chain — but it can only ever prove *"the
versions this run happened to resolve work"*, never *"this package declares what
it needs"*. It was green the whole time the bug was shipping.

So the linting job now runs [`deptry`](https://deptry.com/), which checks the
declaration rather than one resolution:

- **DEP001** — imported but not declared anywhere
- **DEP003** — imported but only available as a *transitive* dependency (this is
  what #1285 was; note DEP001 alone would **not** have caught it)
- DEP002/DEP004 stay off — noisy here (re-exports, plugin-only deps like
  `pyroscope-io`)

Config lives in `[tool.deptry]` in `pyproject.toml`, with one documented
exception: `pytesseract`, an optional local-OCR import already guarded by
`try/except ImportError`.

## Verification

- Reverting just the `tracing.py` line makes `deptry` fail with DEP003 on
  `importlib_metadata` — the guard reproduces the reported bug.
- `uv run --isolated --no-project --with . nextcloud-mcp-server run --help`
  starts cleanly, with `importlib-metadata` no longer in the closure.
- `ruff` / `ruff format` / `ty` clean; 3388 unit tests pass.

## Test coverage note

No API surface changed (no MCP tools, no `/api/v1/*` routes, no cross-service
boundary), so no new e2e/contract tests are required. The regression guard for
this class of bug is the `deptry` CI step rather than a test — a unit test cannot
observe the install closure it runs inside.

---

_This PR was generated with the help of AI, and reviewed by a Human_