### PR TITLE
fix(auth): don't dispose shared storage in the per-session MCP lifespan

### DIFF
--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -1766,15 +1766,22 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                 )
             finally:
                 logger.info("Shutting down MCP server")
-                # Dispose the RefreshTokenStorage engine so pooled
-                # psycopg connections drain cleanly on SIGTERM instead
-                # of leaking server-side slots until the Postgres
-                # idle-timeout fires (ADR-026, PR #798 round-4).
-                if refresh_token_storage is not None:
-                    try:
-                        await refresh_token_storage.close()
-                    except Exception as e:
-                        logger.warning("Error disposing refresh-token storage: %s", e)
+                # NOTE: refresh_token_storage is deliberately NOT closed here.
+                # This lifespan is per MCP *session*, but the storage was built
+                # once at startup (setup_oauth_config) and is handed to the
+                # process-lifetime background tasks — user_manager_task and
+                # credential_cleanup_task both hold this very object
+                # (see the token_storage wiring in starlette_lifespan). Closing
+                # it nulls the shared engine, so the first client session to end
+                # killed new-user discovery for the rest of the pod's life:
+                # every later poll raised
+                # AssertionError('RefreshTokenStorage.initialize() not called')
+                # and a newly provisioned user got no scanner until a restart.
+                # Nothing is leaked by leaving it open: under NullPool
+                # (ADR-026) there is no idle pool to drain and _db() closes each
+                # connection in its own finally. Whoever creates the storage
+                # closes it — app_lifespan_basic still closes the instance it
+                # builds itself.
                 # OAuth client cleanup (if it has a close method)
                 if oauth_client and hasattr(oauth_client, "close"):
                     try:

--- a/tests/unit/test_session_lifespan_storage_ownership.py
+++ b/tests/unit/test_session_lifespan_storage_ownership.py
@@ -34,7 +34,31 @@ pytestmark = pytest.mark.unit
 SESSION_LIFESPANS = {"oauth_lifespan", "app_lifespan_basic"}
 
 # Storage objects owned elsewhere: built at startup or by the process lifespan.
-FOREIGN_STORAGE = {"refresh_token_storage", "basic_auth_storage", "storage_from_state"}
+FOREIGN_STORAGE = {"refresh_token_storage", "basic_auth_storage"}
+
+# The same objects reached through app.state rather than by local name --
+# starlette_lifespan publishes basic_auth_storage as app.state.storage, so
+# `app.state.storage.close()` is the same mistake spelled differently.
+FOREIGN_STORAGE_ATTRS = {"storage"}
+
+
+def _closed_receiver(node: ast.Call) -> str | None:
+    """Name of the object a ``<obj>.close()`` call disposes, else None.
+
+    Matches a bare local (``refresh_token_storage.close()``) and an attribute
+    chain ending in a known state slot (``app.state.storage.close()``). It is
+    deliberately syntactic: an alias (``s = refresh_token_storage; s.close()``)
+    slips past, since the point is to pin the invariant at the shapes the
+    codebase actually uses, not to reimplement data-flow analysis.
+    """
+    if not (isinstance(node.func, ast.Attribute) and node.func.attr == "close"):
+        return None
+    receiver = node.func.value
+    if isinstance(receiver, ast.Name) and receiver.id in FOREIGN_STORAGE:
+        return receiver.id
+    if isinstance(receiver, ast.Attribute) and receiver.attr in FOREIGN_STORAGE_ATTRS:
+        return ast.unparse(receiver)
+    return None
 
 
 def _app_tree() -> ast.Module:
@@ -62,13 +86,10 @@ def test_session_lifespan_never_closes_foreign_storage(
 ):
     """A session teardown must not dispose storage owned by the process."""
     offenders = [
-        f"{node.func.value.id}.close() at app.py:{node.lineno}"
+        f"{receiver}.close() at app.py:{node.lineno}"
         for node in ast.walk(lifespan)
         if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "close"
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id in FOREIGN_STORAGE
+        and (receiver := _closed_receiver(node)) is not None
     ]
     assert not offenders, (
         f"{lifespan.name} is per-session but closes process-lifetime storage: "

--- a/tests/unit/test_session_lifespan_storage_ownership.py
+++ b/tests/unit/test_session_lifespan_storage_ownership.py
@@ -1,0 +1,77 @@
+"""Guard: a per-session lifespan must not dispose process-lifetime storage.
+
+``oauth_lifespan`` is entered and exited per MCP *session*, not per process --
+a long-lived pod logs "Starting MCP server in OAuth mode" / "Shutting down MCP
+server" many times a minute. Its ``finally`` used to call
+``refresh_token_storage.close()``, but that object is built once at startup
+(``setup_oauth_config``) and handed to the process-lifetime background tasks:
+``token_storage`` in ``starlette_lifespan`` is the *same* instance that
+``user_manager_task`` and ``credential_cleanup_task`` poll.
+
+``close()`` sets ``engine = None``, so the first client session to end left the
+supervisor asserting
+``RefreshTokenStorage.initialize() not called`` once a minute forever, and a
+newly provisioned user got no scanner until the pod was restarted -- observed
+in production on a multi-user tenant.
+
+The invariant is ownership, not the deletion: whoever *creates* a storage
+closes it. ``app_lifespan_basic`` builds its own instance per session and so
+may still close that one; it must never close ``app.state.storage``, which the
+process lifespan owns.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import nextcloud_mcp_server.app as app_module
+
+pytestmark = pytest.mark.unit
+
+# Session-scoped lifespans. Neither may close storage it did not construct.
+SESSION_LIFESPANS = {"oauth_lifespan", "app_lifespan_basic"}
+
+# Storage objects owned elsewhere: built at startup or by the process lifespan.
+FOREIGN_STORAGE = {"refresh_token_storage", "basic_auth_storage", "storage_from_state"}
+
+
+def _app_tree() -> ast.Module:
+    return ast.parse(Path(inspect.getfile(app_module)).read_text())
+
+
+def _lifespan_nodes() -> list[ast.AsyncFunctionDef]:
+    """Every session-scoped lifespan, including ones nested in get_app()."""
+    return [
+        node
+        for node in ast.walk(_app_tree())
+        if isinstance(node, ast.AsyncFunctionDef) and node.name in SESSION_LIFESPANS
+    ]
+
+
+def test_session_lifespans_are_present():
+    """Guard the guard: a rename would make the scan below vacuously pass."""
+    found = {node.name for node in _lifespan_nodes()}
+    assert found == SESSION_LIFESPANS, f"lifespans missing from app.py: {found}"
+
+
+@pytest.mark.parametrize("lifespan", _lifespan_nodes(), ids=lambda node: node.name)
+def test_session_lifespan_never_closes_foreign_storage(
+    lifespan: ast.AsyncFunctionDef,
+):
+    """A session teardown must not dispose storage owned by the process."""
+    offenders = [
+        f"{node.func.value.id}.close() at app.py:{node.lineno}"
+        for node in ast.walk(lifespan)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "close"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in FOREIGN_STORAGE
+    ]
+    assert not offenders, (
+        f"{lifespan.name} is per-session but closes process-lifetime storage: "
+        f"{offenders}. That nulls the engine the background user manager holds, "
+        "so newly provisioned users get no scanner until the pod restarts."
+    )


### PR DESCRIPTION
## Problem

Newly provisioned users were never picked up by vector sync until the backend
pod was restarted. The backend logged, once a minute and forever:

```
ERROR nextcloud_mcp_server.vector.oauth_sync
[BasicAuth] User manager error: AssertionError('RefreshTokenStorage.initialize() not called')
```

## Root cause

`oauth_lifespan` is entered and exited per MCP **session**, not per process — a
long-lived pod logs `Starting MCP server in OAuth mode` / `Shutting down MCP
server` many times a minute, each inside a request trace. Its `finally` disposed
`refresh_token_storage`.

That object is built once at startup by `setup_oauth_config` (`app.py:1188`) and
handed to the **process-lifetime** background tasks — the `token_storage` wired
in `starlette_lifespan` (`app.py:2335`) is the same instance that
`user_manager_task` and `credential_cleanup_task` poll.

`RefreshTokenStorage.close()` sets `engine = None`, so the first client session
to end permanently killed:

- new-user discovery — a provisioned user never gets a scanner
- the periodic credential-cleanup sweep

Observed timeline on a production pod:

```
09:14:28  Refresh token storage initialized
09:14:30  [BasicAuth] User manager started (poll interval: 60s)   <- clean
11:12:23  Disposed token storage engine                            <- inside a request trace
11:12:24  User manager error: AssertionError(...)                  <- never stops
```

## Fix

Restore the ownership rule: **whoever creates a storage closes it.**
`app_lifespan_basic` builds its own instance per session and still closes that
one; nothing now closes an instance it did not construct.

Nothing leaks by leaving the engine open — under `NullPool` (ADR-026) there is
no idle pool to drain and `_db()` closes each connection in its own `finally`,
so the original rationale (PR #798 round-4) no longer applies. The only
behavioral change is that the engine is not explicitly disposed on SIGTERM;
process exit drops the sockets.

## Test coverage

Adds `tests/unit/test_session_lifespan_storage_ownership.py`, an AST guard
pinning the invariant for both session lifespans. Verified it *fails* on the
pre-fix code:

```
AssertionError: oauth_lifespan is per-session but closes process-lifetime storage:
['refresh_token_storage.close() at app.py:1786'].
```

This is a lifecycle-wiring fix, not API surface: no MCP tool, HTTP route, or
cross-service boundary changes, so the e2e + contract gate doesn't apply. The
regression is invisible to the existing tiers — it only manifests as a stalled
scanner in a long-running multi-session pod — which is why the guard is a source
invariant rather than a behavioral test.

Full unit suite: 3391 passed.

## Follow-up (not in this PR)

`app_lifespan_basic` constructs and `initialize()`s an entire
`RefreshTokenStorage` per MCP session (`app.py:973`), separate from the
process-wide `app.state.storage`. Self-consistent, but a throwaway engine per
session is worth collapsing onto the process-owned instance.

---

_This PR was generated with the help of AI, and reviewed by a Human_
