### PR TITLE
chore(renovate): group pymupdf and pymupdf4llm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
       "allowedVersions": "<12.0.0"
     },
     {
+      "description": "pymupdf and pymupdf4llm are released in lockstep — update them together",
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["pymupdf", "pymupdf4llm"],
+      "groupName": "pymupdf"
+    },
+    {
       "description": "Pin each Nextcloud matrix entry to its own major version",
       "matchDepNames": ["nextcloud-32"],
       "allowedVersions": "/^32\\./"


### PR DESCRIPTION
`pymupdf` and `pymupdf4llm` ship in lockstep (both currently `==1.28.2`), so Renovate opening them as separate PRs — #1269 and #1270 — means always merging two PRs together.

Adds a `packageRules` entry grouping both PyPI packages under `groupName: "pymupdf"`, so future bumps arrive as a single PR.

Validated with `renovate-config-validator`.

Once this lands, the next Renovate run supersedes #1269/#1270 with a single grouped PR.

---

_This PR was generated with the help of AI, and reviewed by a Human_