### PR TITLE
fix: honor X-Forwarded-For from configured proxies (#1284)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1534,8 +1534,8 @@ INFO     172.16.0.7:44832 - "POST /mcp HTTP/1.1" 401
 The server reads `X-Forwarded-For` / `X-Forwarded-Proto`, but only from proxies it
 has been told to trust — the default trust list is `127.0.0.1`, so a proxy on
 another host or container is ignored and its headers are discarded. Name the proxy
-with `FORWARDED_ALLOW_IPS` (a comma-separated list of IP addresses, CIDR networks,
-or `*`):
+with `FORWARDED_ALLOW_IPS` (a comma-separated list of IP addresses and CIDR
+networks, or `*` on its own to trust everything):
 
 ```bash
 # Environment variable
@@ -1569,6 +1569,10 @@ per-IP rate limiting. With an explicit list, the header is walked from the right
 past each trusted hop, which cannot be spoofed past a proxy that appends honestly.
 Use `*` only where the server is unreachable except through the proxy, and prefer a
 CIDR even then.
+
+`*` is a wildcard **only as the entire value**. Anywhere else it is inert — it
+matches nothing, so `10.0.0.0/8,*` trusts the `/8` alone, narrowing the list
+rather than widening it. Startup warns when a `*` is used this way.
 
 Entries that are not valid IP addresses or networks (a hostname, or a CIDR with
 host bits set such as `10.0.0.1/8`) are never matched. Startup reports the trust

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1521,6 +1521,67 @@ the logs after changing configuration if a setting does not seem to apply.
 
 ---
 
+## Running Behind a Reverse Proxy
+
+When a proxy (nginx, Traefik, Caddy, an ingress controller, Envoy) sits in front of
+the server, every log line shows the *proxy's* address instead of the client's:
+
+```
+WARNING  /mcp request WITHOUT Authorization header from Address(host='172.16.0.7', port=44832)
+INFO     172.16.0.7:44832 - "POST /mcp HTTP/1.1" 401
+```
+
+The server reads `X-Forwarded-For` / `X-Forwarded-Proto`, but only from proxies it
+has been told to trust — the default trust list is `127.0.0.1`, so a proxy on
+another host or container is ignored and its headers are discarded. Name the proxy
+with `FORWARDED_ALLOW_IPS` (a comma-separated list of IP addresses, CIDR networks,
+or `*`):
+
+```bash
+# Environment variable
+FORWARDED_ALLOW_IPS=172.16.0.7
+```
+
+```toml
+# settings.toml — equivalent, and what the Helm chart mounts as a ConfigMap
+[default]
+forwarded_allow_ips = "172.16.0.7"
+```
+
+The address to trust is the one the server currently logs — the proxy as seen from
+the server, not the proxy's public address. Examples:
+
+| Deployment | Value |
+|------------|-------|
+| docker compose, proxy in the same network | the proxy container's IP, e.g. `172.16.0.7` |
+| Kubernetes, nginx-ingress or Envoy Gateway | the cluster **pod** CIDR, e.g. `10.42.0.0/16` |
+| Proxy on the same host (`--net=host`, local dev) | `127.0.0.1` (already the default) |
+
+This affects more than log readability: rate limiting on OAuth dynamic client
+registration is keyed on the client address, so while the real address is unknown
+every client behind the proxy shares a single bucket.
+
+### Prefer a CIDR over `*`
+
+`*` trusts *any* source and takes the **left-most** `X-Forwarded-For` entry, which
+is attacker-controlled — a client can then claim any address it likes and evade
+per-IP rate limiting. With an explicit list, the header is walked from the right
+past each trusted hop, which cannot be spoofed past a proxy that appends honestly.
+Use `*` only where the server is unreachable except through the proxy, and prefer a
+CIDR even then.
+
+Entries that are not valid IP addresses or networks (a hostname, or a CIDR with
+host bits set such as `10.0.0.1/8`) are never matched. Startup reports the trust
+list and warns about such entries:
+
+```
+INFO     Trusting X-Forwarded-* headers from: 10.0.0.1/8
+WARNING  FORWARDED_ALLOW_IPS entries are not IP addresses or networks and will
+         only ever match a client address literally: 10.0.0.1/8
+```
+
+---
+
 ## CLI Configuration
 
 Some configuration options can also be provided via CLI arguments. CLI arguments take precedence over environment variables.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1575,9 +1575,8 @@ host bits set such as `10.0.0.1/8`) are never matched. Startup reports the trust
 list and warns about such entries:
 
 ```
-INFO     Trusting X-Forwarded-* headers from: 10.0.0.1/8
-WARNING  FORWARDED_ALLOW_IPS entries are not IP addresses or networks and will
-         only ever match a client address literally: 10.0.0.1/8
+INFO [2026-08-11 18:40:33] nextcloud_mcp_server.cli - Trusting X-Forwarded-* headers from: 10.0.0.1/8
+WARNING [2026-08-11 18:40:33] nextcloud_mcp_server.cli - FORWARDED_ALLOW_IPS entries are not IP addresses or networks and will only ever match a client address literally: 10.0.0.1/8
 ```
 
 ---

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -311,16 +311,16 @@ def run(
     )
 
 
-def _is_trusted_proxy_token(token: str) -> bool:
+def _is_ip_or_network(token: str) -> bool:
     """Whether uvicorn will parse ``token`` as an IP address or network.
 
-    Mirrors ``uvicorn.middleware.proxy_headers._TrustedHosts.__init__``
-    exactly, including its strict network parsing — anything it cannot parse is
-    kept as a string literal there, so "10.0.0.1/8" (host bits set) is a
-    literal, not the /8 the operator meant.
+    Mirrors the per-entry half of
+    ``uvicorn.middleware.proxy_headers._TrustedHosts.__init__``, including its
+    strict network parsing — anything it cannot parse is kept as a string
+    literal there, so "10.0.0.1/8" (host bits set) is a literal, not the /8 the
+    operator meant. The wildcard is deliberately not accepted here; it is not a
+    per-entry concern (see ``_log_forwarded_allow_ips``).
     """
-    if token == "*":
-        return True
     if "/" in token:
         try:
             ipaddress.ip_network(token)
@@ -346,9 +346,19 @@ def _log_forwarded_allow_ips(value: str | None) -> None:
     if not value:
         return
 
-    tokens = [token.strip() for token in value.split(",")]
-    unparsed = [t for t in tokens if t and not _is_trusted_proxy_token(t)]
     logger.info("Trusting X-Forwarded-* headers from: %s", value)
+
+    # uvicorn's trust-everything switch is an exact match on the whole raw
+    # value (``_TrustedHosts.always_trust``), so a "*" is only a wildcard when
+    # it is the entire setting. Anywhere else — even alone but padded, and
+    # notably in "10.0.0.0/8,*" — it parses as neither address nor network and
+    # becomes an inert literal, quietly narrowing the list rather than widening
+    # it. Verified against uvicorn 0.51.0. So it gets no special case below.
+    if value == "*":
+        return
+
+    tokens = [token.strip() for token in value.split(",")]
+    unparsed = [t for t in tokens if t and not _is_ip_or_network(t)]
     if unparsed:
         logger.warning(
             "FORWARDED_ALLOW_IPS entries are not IP addresses or networks and "

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 from importlib.metadata import version
 from typing import TYPE_CHECKING
@@ -285,13 +286,65 @@ def run(
         include_trace_context=settings.log_include_trace_context,
     )
 
+    _log_forwarded_allow_ips(settings.forwarded_allow_ips)
+
     uvicorn.run(
         app=app,
         host=host,
         port=port,
         log_level=log_level,
         log_config=uvicorn_log_config,
+        # None reproduces uvicorn's own resolution (FORWARDED_ALLOW_IPS env,
+        # else 127.0.0.1), so passing it unconditionally only ever adds the
+        # settings.toml source on top. See GH #1284.
+        forwarded_allow_ips=settings.forwarded_allow_ips,
     )
+
+
+def _is_trusted_proxy_token(token: str) -> bool:
+    """Whether uvicorn will parse ``token`` as an IP address or network.
+
+    Mirrors ``uvicorn.middleware.proxy_headers._TrustedHosts.__init__``
+    exactly, including its strict network parsing — anything it cannot parse is
+    kept as a string literal there, so "10.0.0.1/8" (host bits set) is a
+    literal, not the /8 the operator meant.
+    """
+    if token == "*":
+        return True
+    if "/" in token:
+        try:
+            ipaddress.ip_network(token)
+        except ValueError:
+            return False
+        return True
+    try:
+        ipaddress.ip_address(token)
+    except ValueError:
+        return False
+    return True
+
+
+def _log_forwarded_allow_ips(value: str | None) -> None:
+    """Report the effective proxy trust list, warning about unusable entries.
+
+    uvicorn silently demotes an entry it cannot parse to a string literal,
+    which then matches no real client — its own source calls this out as
+    something that "may lead to unexpected / difficult to debug behaviour". A
+    typo therefore looks configured while leaving GH #1284's symptom (every
+    request logged as the proxy's IP) fully in place, so say so at startup.
+    """
+    if not value:
+        return
+
+    tokens = [token.strip() for token in value.split(",")]
+    unparsed = [t for t in tokens if t and not _is_trusted_proxy_token(t)]
+    logger.info("Trusting X-Forwarded-* headers from: %s", value)
+    if unparsed:
+        logger.warning(
+            "FORWARDED_ALLOW_IPS entries are not IP addresses or networks and "
+            "will only ever match a client address literally: %s",
+            ", ".join(unparsed),
+        )
 
 
 def _init_worker_observability(settings: Settings) -> None:

--- a/nextcloud_mcp_server/cli.py
+++ b/nextcloud_mcp_server/cli.py
@@ -1,5 +1,6 @@
 import ipaddress
 import logging
+import logging.config
 from importlib.metadata import version
 from typing import TYPE_CHECKING
 
@@ -285,6 +286,15 @@ def run(
         log_level=settings.log_level,
         include_trace_context=settings.log_include_trace_context,
     )
+
+    # Apply the config now rather than leaving it to uvicorn.run(). Anything we
+    # log before that call otherwise escapes this pipeline: the MCP SDK's
+    # configure_logging() has already run logging.basicConfig() with a rich
+    # handler, so a startup line would render as rich text even under
+    # LOG_FORMAT=json — and would vanish entirely if that side effect ever went
+    # away. dictConfig is idempotent (disable_existing_loggers is False), so
+    # uvicorn re-applying the same dict internally is a no-op.
+    logging.config.dictConfig(uvicorn_log_config)
 
     _log_forwarded_allow_ips(settings.forwarded_allow_ips)
 

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -353,6 +353,11 @@ _DEFAULTS: dict[str, Any] = {
     "log_format": "text",
     "log_level": "INFO",
     "log_include_trace_context": True,
+    # Reverse-proxy trust list for X-Forwarded-For (GH #1284). Passed to
+    # uvicorn; None keeps uvicorn's own resolution (which itself falls back to
+    # 127.0.0.1). Declared here so the key is settable from settings.toml, not
+    # only as the env var uvicorn already reads on its own.
+    "forwarded_allow_ips": None,
     # Document processing (no master switch: each optional processor has its own
     # ENABLE_* flag, and parsing on read is the caller's per-call decision)
     "document_processor": "unstructured",
@@ -1400,6 +1405,15 @@ class Settings:
     log_format: str = "text"  # "json" or "text"
     log_level: str = "INFO"
     log_include_trace_context: bool = True
+
+    # Comma-separated hosts/CIDRs whose X-Forwarded-For/-Proto headers uvicorn
+    # trusts, or "*" (GH #1284). Behind a reverse proxy this is what makes
+    # request.client the real client rather than the proxy — it feeds the access
+    # log, app.py's missing-Authorization warning, and the DCR rate-limit bucket
+    # in auth/oauth_routes.py. None means "leave uvicorn's own resolution alone"
+    # (its FORWARDED_ALLOW_IPS env read, defaulting to 127.0.0.1), so declaring
+    # the setting changes nothing until an operator sets it.
+    forwarded_allow_ips: str | None = None
 
     # Tag-based file exclusion (issue #710): comma-separated list of
     # Nextcloud system tag names. Files/folders carrying any of these tags

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -91,6 +91,12 @@ otel_traces_sampler_arg = 1.0
 log_format = "text"
 log_level = "INFO"
 log_include_trace_context = true
+# Comma-separated hosts/CIDRs whose X-Forwarded-For/-Proto headers are trusted,
+# so logs and per-client rate limiting see the real client rather than your
+# reverse proxy. Unset means uvicorn's default of 127.0.0.1 only. "*" trusts
+# everything and is spoofable -- prefer the proxy's address or CIDR, and note
+# that "*" only works as the entire value. See docs/configuration.md.
+# forwarded_allow_ips = "10.42.0.0/16"
 
 # --- Document processing ---
 # No master switch: PDF extraction is built in, each optional processor below has

--- a/tests/unit/test_cli_forwarded_allow_ips.py
+++ b/tests/unit/test_cli_forwarded_allow_ips.py
@@ -12,9 +12,10 @@ import logging
 
 import pytest
 from click.testing import CliRunner
+from uvicorn.middleware.proxy_headers import _TrustedHosts
 
 from nextcloud_mcp_server.cli import (
-    _is_trusted_proxy_token,
+    _is_ip_or_network,
     _log_forwarded_allow_ips,
     run,
 )
@@ -25,10 +26,10 @@ pytestmark = pytest.mark.unit
 
 @pytest.mark.parametrize(
     "token",
-    ["*", "127.0.0.1", "192.168.1.5", "10.0.0.0/8", "::1", "fd00::/8"],
+    ["127.0.0.1", "192.168.1.5", "10.0.0.0/8", "::1", "fd00::/8"],
 )
 def test_parseable_tokens(token):
-    assert _is_trusted_proxy_token(token) is True
+    assert _is_ip_or_network(token) is True
 
 
 @pytest.mark.parametrize(
@@ -37,11 +38,33 @@ def test_parseable_tokens(token):
         "proxy.internal",  # hostname: uvicorn compares against an IP string
         "10.0.0.1/8",  # host bits set — uvicorn's ip_network() is strict
         "10.0.0.256",
+        "*",  # only a wildcard as the whole value, never as one entry
         "",
     ],
 )
 def test_unparseable_tokens(token):
-    assert _is_trusted_proxy_token(token) is False
+    assert _is_ip_or_network(token) is False
+
+
+@pytest.mark.parametrize(
+    ("value", "trusts_a_public_address"),
+    [
+        ("*", True),
+        ("10.0.0.0/8,*", False),
+        (" * ", False),
+    ],
+)
+def test_wildcard_semantics_match_uvicorn(value, trusts_a_public_address):
+    """Pin the behavior `_log_forwarded_allow_ips` mirrors, against real uvicorn.
+
+    `_TrustedHosts.always_trust` is an exact match on the whole raw value, so a
+    "*" that is not the entire setting parses as neither address nor network
+    and becomes an inert literal — narrowing the list instead of widening it.
+    """
+    hosts = _TrustedHosts(value)
+
+    assert hosts.always_trust is (value == "*")
+    assert ("203.0.113.9" in hosts) is trusts_a_public_address
 
 
 def test_warns_only_about_the_bad_entries(caplog):
@@ -57,10 +80,30 @@ def test_warns_only_about_the_bad_entries(caplog):
 
 def test_no_warning_when_all_entries_parse(caplog):
     with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
-        _log_forwarded_allow_ips("10.0.0.0/8,192.168.1.5,*")
+        _log_forwarded_allow_ips("10.0.0.0/8,192.168.1.5")
 
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]
     assert "Trusting X-Forwarded-* headers from" in caplog.text
+
+
+def test_bare_wildcard_is_not_flagged(caplog):
+    """The one form uvicorn honors as trust-everything."""
+    with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
+        _log_forwarded_allow_ips("*")
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert "Trusting X-Forwarded-* headers from: *" in caplog.text
+
+
+@pytest.mark.parametrize("value", ["10.0.0.0/8,*", " * "])
+def test_inert_wildcard_is_flagged(value, caplog):
+    """A "*" that isn't the whole value silently narrows the list — say so."""
+    with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
+        _log_forwarded_allow_ips(value)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "*" in warnings[0].getMessage()
 
 
 @pytest.mark.parametrize("value", [None, ""])

--- a/tests/unit/test_cli_forwarded_allow_ips.py
+++ b/tests/unit/test_cli_forwarded_allow_ips.py
@@ -11,8 +11,14 @@ from __future__ import annotations
 import logging
 
 import pytest
+from click.testing import CliRunner
 
-from nextcloud_mcp_server.cli import _is_trusted_proxy_token, _log_forwarded_allow_ips
+from nextcloud_mcp_server.cli import (
+    _is_trusted_proxy_token,
+    _log_forwarded_allow_ips,
+    run,
+)
+from nextcloud_mcp_server.config import Settings
 
 pytestmark = pytest.mark.unit
 
@@ -64,3 +70,38 @@ def test_silent_when_unset(value, caplog):
         _log_forwarded_allow_ips(value)
 
     assert not caplog.records
+
+
+def test_run_configures_logging_before_reporting(mocker):
+    """The startup report must not out-run the log config that formats it.
+
+    `uvicorn.run()` applies `log_config` itself, but only once it is called —
+    anything logged before that lands wherever the MCP SDK's `basicConfig()`
+    rich handler left the root logger, i.e. rich text even under
+    LOG_FORMAT=json. `caplog` attaches its own handler, so the tests above
+    cannot see that ordering; this one asserts it directly.
+    """
+    calls: list[str] = []
+    mocker.patch("nextcloud_mcp_server.cli.set_override")  # keep dynaconf pristine
+    mocker.patch("nextcloud_mcp_server.cli.get_app")
+    mocker.patch(
+        "nextcloud_mcp_server.cli.get_settings",
+        return_value=Settings(forwarded_allow_ips="10.0.0.0/8"),
+    )
+    mocker.patch(
+        "logging.config.dictConfig", side_effect=lambda _cfg: calls.append("dictConfig")
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.cli._log_forwarded_allow_ips",
+        side_effect=lambda _v: calls.append("report"),
+    )
+    uvicorn_run = mocker.patch(
+        "nextcloud_mcp_server.cli.uvicorn.run",
+        side_effect=lambda **_kw: calls.append("uvicorn.run"),
+    )
+
+    result = CliRunner().invoke(run, [])
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["dictConfig", "report", "uvicorn.run"]
+    assert uvicorn_run.call_args.kwargs["forwarded_allow_ips"] == "10.0.0.0/8"

--- a/tests/unit/test_cli_forwarded_allow_ips.py
+++ b/tests/unit/test_cli_forwarded_allow_ips.py
@@ -1,0 +1,66 @@
+"""Unit tests for the proxy trust-list startup report (GH #1284).
+
+``cli._log_forwarded_allow_ips`` exists because uvicorn silently demotes any
+entry it cannot parse to a string literal that matches no real client, so a
+typo'd CIDR looks configured while every request keeps getting logged as the
+proxy's address.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from nextcloud_mcp_server.cli import _is_trusted_proxy_token, _log_forwarded_allow_ips
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["*", "127.0.0.1", "192.168.1.5", "10.0.0.0/8", "::1", "fd00::/8"],
+)
+def test_parseable_tokens(token):
+    assert _is_trusted_proxy_token(token) is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "proxy.internal",  # hostname: uvicorn compares against an IP string
+        "10.0.0.1/8",  # host bits set — uvicorn's ip_network() is strict
+        "10.0.0.256",
+        "",
+    ],
+)
+def test_unparseable_tokens(token):
+    assert _is_trusted_proxy_token(token) is False
+
+
+def test_warns_only_about_the_bad_entries(caplog):
+    with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
+        _log_forwarded_allow_ips("10.42.0.0/16, proxy.internal ,192.168.1.5")
+
+    assert "10.42.0.0/16, proxy.internal ,192.168.1.5" in caplog.text
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "proxy.internal" in warnings[0].getMessage()
+    assert "192.168.1.5" not in warnings[0].getMessage()
+
+
+def test_no_warning_when_all_entries_parse(caplog):
+    with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
+        _log_forwarded_allow_ips("10.0.0.0/8,192.168.1.5,*")
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert "Trusting X-Forwarded-* headers from" in caplog.text
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_silent_when_unset(value, caplog):
+    """Unset is the default; uvicorn's own 127.0.0.1 resolution applies."""
+    with caplog.at_level(logging.INFO, logger="nextcloud_mcp_server.cli"):
+        _log_forwarded_allow_ips(value)
+
+    assert not caplog.records

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -229,6 +229,32 @@ class TestGetSettings:
         assert settings.pod_namespace == "tenant-example"
         assert settings.pod_name == "backend-7c95d96fd9-mh2d7"
 
+    @patch.dict(
+        os.environ,
+        {"FORWARDED_ALLOW_IPS": "10.42.0.0/16,192.168.1.5"},
+        clear=True,
+    )
+    def test_get_settings_forwarded_allow_ips_from_env(self):
+        """FORWARDED_ALLOW_IPS must reach settings (GH #1284).
+
+        The env var is uvicorn's own, and uvicorn reads it directly — but only
+        a _DEFAULTS + _FIELD_MAP entry makes it settable from settings.toml
+        too, which is how the helm chart carries non-secret config.
+        """
+        _reload_config()
+        settings = get_settings()
+        assert settings.forwarded_allow_ips == "10.42.0.0/16,192.168.1.5"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_forwarded_allow_ips_unset_by_default(self):
+        """None means "don't touch uvicorn's own resolution" (127.0.0.1).
+
+        Defaulting to anything wider would silently make client IPs spoofable,
+        and the DCR rate limiter in auth/oauth_routes.py keys on them.
+        """
+        _reload_config()
+        assert get_settings().forwarded_allow_ips is None
+
     @patch.dict(os.environ, {}, clear=True)
     def test_pyroscope_disabled_by_default(self):
         """Profiling is opt-in: default off with no server address."""


### PR DESCRIPTION
Fixes #1284.

## Problem

Behind a reverse proxy, every log line shows the proxy's address rather than the client's:

```
WARNING  /mcp request WITHOUT Authorization header from Address(host='172.16.0.7', port=44832)
INFO     172.16.0.7:44832 - "POST /mcp HTTP/1.1" 401
```

The cause is a uvicorn default, not our parsing. `ProxyHeadersMiddleware` is already active (`proxy_headers=True` is uvicorn's default and we never disabled it), but `cli.py` never passed `forwarded_allow_ips`, so it resolved to `127.0.0.1` — a proxy on another host or container is untrusted and its `X-Forwarded-For` is discarded.

Nothing in this codebase parses XFF itself; `request.client` is just the ASGI scope that middleware would have rewritten. So one trust-list value fixes every consumer at once:

- `uvicorn.access` log lines
- `app.py`'s missing-Authorization warning
- **`auth/oauth_routes.py` DCR rate limiting, which is keyed on `request.client.host`** — today every client behind a proxy shares a single bucket

## Change

`forwarded_allow_ips` becomes a first-class setting, passed through to uvicorn.

The env var alone already worked (uvicorn reads `FORWARDED_ALLOW_IPS` itself). What was missing is the `settings.toml` path — which is how the Helm chart carries non-secret config, and avoids restating an entire `extraEnv` list to add one key. The env name matches uvicorn's own for free: dynaconf runs with `envvar_prefix=False`, so the field name uppercases to exactly `FORWARDED_ALLOW_IPS`.

**Default stays unset**, reproducing uvicorn's own resolution — purely additive, nothing changes until an operator opts in.

Deliberately *not* defaulted to `*`: `_TrustedHosts.always_trust` takes the **left-most**, attacker-controlled XFF entry, whereas an explicit list walks right-to-left past trusted hops. Given DCR rate limiting keys on the client address, a spoofable default would be a regression. The docs say this too.

Startup now reports the effective trust list and warns about entries uvicorn cannot parse as an IP or network. That is not decoration: uvicorn silently keeps such entries as string literals that match no real client — its own source notes this "may lead to unexpected / difficult to debug behaviour" — so a typo'd CIDR would look configured while leaving the reported symptom fully in place.

## Verification

Unit tests cover the settings resolution and the trust-token parsing (which mirrors uvicorn's own strict semantics — e.g. `10.0.0.1/8`, with host bits set, is a literal rather than the `/8` the operator meant).

Since unit tests can't prove the middleware path, verified end-to-end against a real server boot with the value coming **only** from `settings.toml` (no env var set), probing with a forged header:

| `settings.toml` | access log |
|---|---|
| `forwarded_allow_ips = "127.0.0.1"` (the caller) | `203.0.113.7:0 - "POST /mcp HTTP/1.1" 400` — header honored |
| `forwarded_allow_ips = "10.42.0.0/16"` (not the caller) | `127.0.0.1:55064 - "POST /mcp HTTP/1.1" 400` — header ignored |

## Test coverage note

Per CLAUDE.md's e2e + Pact gate: this adds no API surface — no MCP tool, no `/api/v1/*` route, no cross-service boundary. It is a server-runtime config knob, so the gate does not apply and no contract test is warranted.

## Follow-ups (not this PR)

- `helm-charts`: optional first-class `forwardedAllowIps` value. Already usable without a chart change via `.Values.settings.content`, which is rendered verbatim into the mounted `settings.toml`.
- Set it for our own deployments once this ships.

---

_This PR was generated with the help of AI, and reviewed by a Human_
