### PR TITLE
feat(observability): log every MCP tool call with its arguments

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -66,9 +66,9 @@ The Helm chart has moved to a [separate repository](https://github.com/cbcoutinh
   `tool_error` | `protocol_error`
 
 > `mcp_tool_outcomes_total` labels `tool_name` with the tool's **registered MCP
-> name**, whereas `mcp_tool_calls_total` uses the Python `func.__name__`. These
-> differ for the OAuth tools (e.g. `tool_provision_access` vs
-> `provision_nextcloud_access`). Don't join the two on `tool_name`.
+> name**; the other three use the Python `func.__name__` of the decorated
+> function. Every tool function is now named after the tool it registers, so the
+> two agree — keep it that way when adding a tool, or the label silently splits.
 
 ### MCP Client Fleet Metrics
 
@@ -344,6 +344,44 @@ When tracing is enabled, all logs include `trace_id` and `span_id`:
   "span_id": "123456789abc...",
   "note_id": 42
 }
+```
+
+### Tool-Call Logs
+
+Every tool call emits one line, from the single `CallToolRequest` handler
+(`instrument_call_tool_outcomes`) rather than per tool, so coverage is automatic
+for every tool and every transport. Spans carry the same name and arguments, but
+traces are sampled and short-retention — these lines are what answer "which
+tools ran, with what inputs" over a month.
+
+```json
+{
+  "message": "tool call nc_semantic_search success in 3428ms",
+  "logger": "nextcloud_mcp_server.observability.metrics",
+  "mcp_tool": "nc_semantic_search",
+  "mcp_tool_args": "{'query': 'safeguarding policy review', 'limit': 3}",
+  "duration_ms": 3428,
+  "outcome": "success",
+  "mcp_user": "alice",
+  "mcp_client_id": "claude-ai"
+}
+```
+
+| Field | Notes |
+|-------|-------|
+| `mcp_tool` | Registered tool name, or `unknown` if the caller sent a name that is not registered (bounds cardinality for anything aggregating this field) |
+| `mcp_tool_requested` | The raw requested name — present **only** when it differs from `mcp_tool` |
+| `mcp_tool_args` | Arguments as sent on the wire: defaults are absent, `ctx`/`etag` dropped, values whose key looks secret (`password`, `*token*`, `*secret*`, `api_key`, `credential`, `authorization`, `cookie` — substring, case-insensitive) replaced with `[redacted]`, each value capped at 200 chars and the whole field at 1000. Absent when there are no arguments |
+| `duration_ms` | Wall-clock, including the SDK's validation and serialization |
+| `outcome` | `success` \| `tool_error` (`isError=True`, the model sees it) \| `protocol_error` (JSON-RPC error, it does not). Same strings as `mcp_tool_outcomes_total` |
+| `mcp_user`, `mcp_client_id` | From the verified access token; absent in BasicAuth / single-user / stdio, where there is no OAuth identity |
+
+Successful calls log at INFO, the two error outcomes at WARNING. Requires
+`LOG_FORMAT=json` for the fields to be queryable:
+
+```logql
+sum by (mcp_tool) (count_over_time(
+  {namespace="tenant-example"} | json | mcp_tool != "" [1h]))
 ```
 
 ## Dashboards

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -119,9 +119,10 @@ mcp_tool_outcomes_total = Counter(
     "mcp_tool_outcomes_total",
     "How the MCP SDK delivered each tool call: success | tool_error "
     "(CallToolResult.isError, the model sees the message) | protocol_error "
-    "(JSON-RPC error, the model does not). Note tool_name here is the tool's "
-    "*registered* MCP name, which differs from mcp_tool_calls_total's "
-    "func.__name__ for the OAuth tools.",
+    "(JSON-RPC error, the model does not). tool_name here is the tool's "
+    "*registered* MCP name, while mcp_tool_calls_total uses the decorated "
+    "function's __name__. Every tool function is named after the tool it "
+    "registers, so the two agree — test_tool_call_logging.py guards that.",
     ["tool_name", "outcome"],
 )
 

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -18,8 +18,11 @@ import functools
 import logging
 import threading
 import time
+from collections.abc import Mapping
+from typing import Any
 
 from mcp import types
+from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.fastmcp import FastMCP
 from mcp.server.lowlevel.server import request_ctx
 from prometheus_client import (
@@ -1202,6 +1205,106 @@ def record_elicitation(prompt: str, outcome: str, reason: str = "none") -> None:
     mcp_elicitation_total.labels(prompt=prompt, outcome=outcome, reason=reason).inc()
 
 
+# Redaction is by key *substring*, case-insensitively: the arguments reaching
+# the CallToolRequest handler are unvalidated client input (FastMCP registers it
+# with validate_input=False), so a caller can send "password" to a tool that
+# declares no such parameter, and a tool that does take one may call it
+# "access_token" or "clientSecret".
+_SENSITIVE_ARG_SUBSTRINGS = (
+    "password",
+    "token",
+    "secret",
+    "api_key",
+    "apikey",
+    "credential",
+    "authorization",
+    "cookie",
+)
+
+# Arguments that say nothing about how the tool is being used: the injected
+# FastMCP Context and the concurrency etag every update tool carries.
+_UNINTERESTING_ARGS = ("ctx", "etag")
+
+# Per value first, so one huge argument (a file body, a note) cannot fill the
+# whole budget and hide every other argument.
+_MAX_ARG_VALUE_CHARS = 200
+_MAX_ARGS_CHARS = 1000
+
+
+def _sanitize_tool_args(arguments: Mapping[str, Any] | None) -> str | None:
+    """Render tool arguments for a log line or a span attribute.
+
+    Returns ``None`` when there is nothing worth recording, so callers omit the
+    field entirely — OTel rejects None-valued attributes, logging a warning and
+    dropping them.
+    """
+    if not arguments:
+        return None
+
+    parts = []
+    for key, value in arguments.items():
+        if key in _UNINTERESTING_ARGS:
+            continue
+        if any(s in key.lower() for s in _SENSITIVE_ARG_SUBSTRINGS):
+            rendered = repr("[redacted]")
+        else:
+            rendered = repr(value)
+            if len(rendered) > _MAX_ARG_VALUE_CHARS:
+                rendered = rendered[:_MAX_ARG_VALUE_CHARS] + "…"
+        parts.append(f"{key!r}: {rendered}")
+
+    if not parts:
+        return None
+    return ("{" + ", ".join(parts) + "}")[:_MAX_ARGS_CHARS]
+
+
+def _log_tool_call(
+    req: types.CallToolRequest, tool_name: str, outcome: str, started: float
+) -> None:
+    """Emit the one structured line per tool call that Loki queries.
+
+    The spans from ``instrument_tool`` carry the same tool name and arguments,
+    but traces are sampled and short-retention, so they cannot answer "which
+    tools ran, with what inputs, over the last month". Logs are unsampled; that
+    is the whole point of duplicating the information here.
+
+    Field names are prefixed to stay clear of reserved ``LogRecord`` attributes
+    (``name``, ``args``, ``message``), which ``extra=`` may not overwrite.
+    """
+    fields: dict[str, Any] = {
+        "mcp_tool": tool_name,
+        "outcome": outcome,
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+    if req.params.name != tool_name:
+        # Kept out of the metric label to bound cardinality, kept here because a
+        # client sending an unregistered name is exactly what you want to see.
+        fields["mcp_tool_requested"] = req.params.name[:100]
+
+    args = _sanitize_tool_args(req.params.arguments)
+    if args:
+        fields["mcp_tool_args"] = args
+
+    # None in BasicAuth / single-user / stdio, where there is no OAuth identity.
+    # Deliberately not extract_user_id_from_token(): that raises McpError on a
+    # token without a sub claim, which would turn logging into a tool failure.
+    token = get_access_token()
+    if token:
+        if token.resource:
+            fields["mcp_user"] = token.resource
+        fields["mcp_client_id"] = token.client_id
+
+    logger.log(
+        logging.INFO if outcome == "success" else logging.WARNING,
+        "tool call %s %s in %dms",
+        tool_name,
+        outcome,
+        fields["duration_ms"],
+        extra=fields,
+    )
+
+
 def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
     """Wrap the low-level CallToolRequest handler to record how the SDK replied.
 
@@ -1242,6 +1345,7 @@ def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
     async def handler(req: types.CallToolRequest) -> types.ServerResult:
         record_client_session()
         tool_name = _tool_label(req.params.name)
+        started = time.perf_counter()
         try:
             result = await original(req)
         except Exception:
@@ -1250,13 +1354,14 @@ def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
             mcp_tool_outcomes_total.labels(
                 tool_name=tool_name, outcome="protocol_error"
             ).inc()
+            _log_tool_call(req, tool_name, "protocol_error", started)
             raise
         # v1 wraps the result in the ServerResult RootModel; v2 returns the
         # CallToolResult directly.
         is_error = bool(getattr(getattr(result, "root", result), "isError", False))
-        mcp_tool_outcomes_total.labels(
-            tool_name=tool_name, outcome="tool_error" if is_error else "success"
-        ).inc()
+        outcome = "tool_error" if is_error else "success"
+        mcp_tool_outcomes_total.labels(tool_name=tool_name, outcome=outcome).inc()
+        _log_tool_call(req, tool_name, outcome, started)
         return result
 
     server.request_handlers[types.CallToolRequest] = handler
@@ -1989,23 +2094,17 @@ def instrument_tool(func):
         tool_name = func.__name__
         start_time = time.time()
 
-        # Extract tool arguments for tracing (sanitize sensitive fields)
-        # kwargs contains the actual arguments passed to the tool
-        tool_args = {
-            k: v
-            for k, v in kwargs.items()
-            if k not in ("password", "token", "secret", "api_key", "etag", "ctx")
-        }
+        # kwargs is post-validation, so it carries the tool's defaults and the
+        # injected ctx — unlike the raw wire arguments _log_tool_call renders.
+        attributes: dict[str, Any] = {"mcp.tool.name": tool_name}
+        tool_args = _sanitize_tool_args(kwargs)
+        if tool_args:
+            attributes["mcp.tool.args"] = tool_args
 
         # Create trace span with metrics collection
         with trace_operation(
             f"mcp.tool.{tool_name}",
-            attributes={
-                "mcp.tool.name": tool_name,
-                "mcp.tool.args": str(tool_args)[:500]
-                if tool_args
-                else None,  # Limit to 500 chars
-            },
+            attributes=attributes,
             record_exception=True,
         ):
             try:

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -27,6 +27,7 @@ from nextcloud_mcp_server.models.auth import (
     ProvisionStatusResponse,
     UpdateScopesResponse,
 )
+from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ def register_auth_tools(mcp: FastMCP) -> None:
         ),
     )
     @require_scopes("openid")
+    @instrument_tool
     async def nc_auth_provision_access(
         ctx: Context,
         scopes: list[str] | None = None,
@@ -222,6 +224,7 @@ def register_auth_tools(mcp: FastMCP) -> None:
         ),
     )
     @require_scopes("openid")
+    @instrument_tool
     async def nc_auth_check_status(
         ctx: Context,
     ) -> ProvisionStatusResponse:
@@ -371,6 +374,7 @@ def register_auth_tools(mcp: FastMCP) -> None:
         ),
     )
     @require_scopes("openid")
+    @instrument_tool
     async def nc_auth_update_scopes(
         ctx: Context,
         add_scopes: list[str] | None = None,

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -1875,6 +1875,7 @@ def configure_deck_tools(mcp: FastMCP):
     )
     @require_scopes("deck.write")
     @require_capability("deck", min_version="1.18.0")
+    @with_links
     @instrument_tool
     async def deck_assign_dependent_card(
         ctx: Context,
@@ -1916,6 +1917,7 @@ def configure_deck_tools(mcp: FastMCP):
     )
     @require_scopes("deck.write")
     @require_capability("deck", min_version="1.18.0")
+    @with_links
     @instrument_tool
     async def deck_remove_dependent_card(
         ctx: Context,

--- a/nextcloud_mcp_server/server/oauth_tools.py
+++ b/nextcloud_mcp_server/server/oauth_tools.py
@@ -25,6 +25,7 @@ from nextcloud_mcp_server.auth.token_utils import (
     extract_user_id_from_token as extract_user_id_from_token,  # noqa: PLC0414
 )
 from nextcloud_mcp_server.config import cfg, get_settings
+from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
 
@@ -613,7 +614,8 @@ def register_oauth_tools(mcp):
         ),
     )
     @require_scopes("openid")
-    async def tool_provision_access(ctx: Context) -> ProvisioningResult:
+    @instrument_tool
+    async def provision_nextcloud_access(ctx: Context) -> ProvisioningResult:
         user_id = await extract_user_id_from_token(ctx)
         return await _provision_nextcloud_access(ctx, user_id)
 
@@ -628,7 +630,8 @@ def register_oauth_tools(mcp):
         ),
     )
     @require_scopes("openid")
-    async def tool_revoke_access(ctx: Context) -> RevocationResult:
+    @instrument_tool
+    async def revoke_nextcloud_access(ctx: Context) -> RevocationResult:
         user_id = await extract_user_id_from_token(ctx)
         return await _revoke_nextcloud_access(ctx, user_id)
 
@@ -642,7 +645,8 @@ def register_oauth_tools(mcp):
         ),
     )
     @require_scopes("openid")
-    async def tool_check_status(ctx: Context) -> ProvisioningStatus:
+    @instrument_tool
+    async def check_provisioning_status(ctx: Context) -> ProvisioningStatus:
         user_id = await extract_user_id_from_token(ctx)
         return await _check_provisioning_status(ctx, user_id)
 
@@ -659,6 +663,7 @@ def register_oauth_tools(mcp):
         ),
     )
     @require_scopes("openid")
-    async def tool_check_logged_in(ctx: Context) -> str:
+    @instrument_tool
+    async def check_logged_in(ctx: Context) -> str:
         user_id = await extract_user_id_from_token(ctx)
         return await _check_logged_in(ctx, user_id)

--- a/nextcloud_mcp_server/stdio.py
+++ b/nextcloud_mcp_server/stdio.py
@@ -20,6 +20,7 @@ from nextcloud_mcp_server.config_validators import AuthMode, validate_configurat
 from nextcloud_mcp_server.context import BasicAuthLifespanContext
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
 from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.observability.metrics import instrument_call_tool_outcomes
 from nextcloud_mcp_server.server import AVAILABLE_APPS, configure_app_tools
 
 logger = logging.getLogger(__name__)
@@ -105,5 +106,10 @@ def get_stdio_mcp(enabled_apps: list[str] | None = None) -> FastMCP:
                 app_name,
                 list(AVAILABLE_APPS.keys()),
             )
+
+    # Mirrors app.py: the per-tool-call log line, the client-fleet metrics and
+    # the delivery-outcome counter all hang off this wrapper, so the stdio
+    # server is otherwise invisible.
+    instrument_call_tool_outcomes(mcp)
 
     return mcp

--- a/nextcloud_mcp_server/stdio.py
+++ b/nextcloud_mcp_server/stdio.py
@@ -2,7 +2,9 @@
 
 Provides a minimal FastMCP instance suitable for ``mcp.run(transport="stdio")``.
 Only single-user BasicAuth mode is supported.  Background sync, semantic search,
-OAuth, and observability infrastructure are deliberately excluded.
+OAuth, and the observability *plumbing* — the Prometheus HTTP endpoint and the
+OTel tracing setup — are deliberately excluded; the per-tool-call logging and
+metrics are wired in, mirroring ``app.py``, since they cost nothing here.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_instrument_tool.py
+++ b/tests/unit/test_instrument_tool.py
@@ -75,20 +75,27 @@ class TestInstrumentToolDecorator:
     async def test_decorator_sanitizes_sensitive_arguments(
         self, mock_tracer, mock_metrics
     ):
-        """Test that sensitive arguments are excluded from span attributes."""
+        """Sensitive values are redacted; the key stays so you can see it was sent."""
 
         @instrument_tool
         async def example_tool(
-            query: str, password: str, token: str, api_key: str, ctx: object
+            query: str,
+            password: str,
+            access_token: str,
+            client_secret: str,
+            apiKey: str,  # noqa: N803 - deliberately camelCase, as a client would send
+            ctx: object,
         ):
             return {"success": True}
 
-        # Call with sensitive parameters
+        # Call with sensitive parameters. access_token/client_secret/apiKey are
+        # the cases the old exact-match denylist missed entirely.
         await example_tool(
             query="test",
             password="secret123",
-            token="bearer_token",
-            api_key="api_key_123",
+            access_token="bearer_token",
+            client_secret="shh",
+            apiKey="api_key_123",
             ctx=MagicMock(),
         )
 
@@ -96,14 +103,13 @@ class TestInstrumentToolDecorator:
         mock_tracer.assert_called_once()
         attributes = mock_tracer.call_args[1]["attributes"]
 
-        # Check that sensitive fields are NOT in attributes
+        # No secret value survives
         tool_args = attributes["mcp.tool.args"]
-        assert "password" not in tool_args
-        assert "secret123" not in tool_args
-        assert "token" not in tool_args
-        assert "bearer_token" not in tool_args
-        assert "api_key" not in tool_args
-        assert "api_key_123" not in tool_args
+        for secret in ("secret123", "bearer_token", "shh", "api_key_123"):
+            assert secret not in tool_args
+        assert tool_args.count("[redacted]") == 4
+
+        # The injected context is dropped entirely, not redacted
         assert "ctx" not in tool_args
 
         # Check that non-sensitive field IS included
@@ -113,23 +119,27 @@ class TestInstrumentToolDecorator:
     async def test_decorator_limits_argument_string_length(
         self, mock_tracer, mock_metrics
     ):
-        """Test that tool arguments are limited to 500 characters."""
+        """One huge argument is capped so it cannot hide the others."""
 
         @instrument_tool
-        async def example_tool(query: str):
+        async def example_tool(query: str, limit: int):
             return {"results": []}
 
-        # Create a very long query string (>500 chars)
+        # Create a very long query string
         long_query = "x" * 1000
 
-        await example_tool(query=long_query)
+        await example_tool(query=long_query, limit=5)
 
         # Verify arguments were truncated
         mock_tracer.assert_called_once()
         attributes = mock_tracer.call_args[1]["attributes"]
         tool_args = attributes["mcp.tool.args"]
 
-        assert len(tool_args) <= 500
+        assert "x" * 150 in tool_args
+        assert "x" * 300 not in tool_args
+        assert len(tool_args) <= 1000
+        # The argument after the long one is still visible
+        assert "'limit': 5" in tool_args
 
     async def test_decorator_records_success_metrics(self, mock_tracer, mock_metrics):
         """Test that successful tool execution records metrics."""
@@ -213,5 +223,7 @@ class TestInstrumentToolDecorator:
         mock_tracer.assert_called_once()
         attributes = mock_tracer.call_args[1]["attributes"]
 
-        # tool_args should be None when there are no kwargs
-        assert attributes["mcp.tool.args"] is None
+        # The attribute is omitted rather than set to None: OTel rejects
+        # None-valued attributes, warning and dropping them on every call.
+        assert "mcp.tool.args" not in attributes
+        assert attributes["mcp.tool.name"] == "no_args_tool"

--- a/tests/unit/test_tool_call_logging.py
+++ b/tests/unit/test_tool_call_logging.py
@@ -1,0 +1,223 @@
+"""The one structured log line per MCP tool call.
+
+Tool name and arguments also reach Tempo as span attributes, but traces are
+sampled and short-retention. These lines are what answers "which tools ran,
+with what inputs" over a month, so they are asserted field by field: a Loki
+query and a Grafana panel break silently when a field is renamed.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+from mcp import types
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+
+from nextcloud_mcp_server.observability.metrics import (
+    _sanitize_tool_args,
+    instrument_call_tool_outcomes,
+)
+from nextcloud_mcp_server.server import AVAILABLE_APPS, configure_app_tools
+from nextcloud_mcp_server.server.auth_tools import register_auth_tools
+from nextcloud_mcp_server.server.oauth_tools import register_oauth_tools
+
+pytestmark = pytest.mark.unit
+
+LOGGER = "nextcloud_mcp_server.observability.metrics"
+
+
+def _wrap(inner, registered=("nc_semantic_search",)):
+    """Wrap ``inner``, with ``registered`` standing in for the tool registry."""
+    mcp = SimpleNamespace(
+        _mcp_server=SimpleNamespace(request_handlers={types.CallToolRequest: inner}),
+        _tool_manager=SimpleNamespace(
+            get_tool=lambda name: object() if name in registered else None
+        ),
+    )
+    instrument_call_tool_outcomes(mcp)
+    return mcp._mcp_server.request_handlers[types.CallToolRequest]
+
+
+def _request(name: str = "nc_semantic_search", **arguments) -> types.CallToolRequest:
+    return types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name=name, arguments=arguments),
+    )
+
+
+async def _ok(_req):
+    return types.ServerResult(types.CallToolResult(content=[], isError=False))
+
+
+def _line(caplog):
+    """The single tool-call record, or an assertion failure saying so."""
+    records = [r for r in caplog.records if getattr(r, "mcp_tool", None)]
+    assert len(records) == 1, f"expected one tool-call line, got {len(records)}"
+    return records[0]
+
+
+class TestToolCallLine:
+    async def test_success_logs_name_args_duration(self, caplog):
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await _wrap(_ok)(_request(query="safeguarding policy", limit=3))
+
+        record = _line(caplog)
+        assert record.levelno == logging.INFO
+        assert record.mcp_tool == "nc_semantic_search"
+        assert record.outcome == "success"
+        assert isinstance(record.duration_ms, int)
+        assert "'query': 'safeguarding policy'" in record.mcp_tool_args
+        assert "'limit': 3" in record.mcp_tool_args
+        # No unregistered-name noise on the normal path
+        assert not hasattr(record, "mcp_tool_requested")
+
+    async def test_tool_error_logs_at_warning(self, caplog):
+        async def inner(_req):
+            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await _wrap(inner)(_request())
+
+        record = _line(caplog)
+        assert record.outcome == "tool_error"
+        assert record.levelno == logging.WARNING
+
+    async def test_protocol_error_logs_and_still_raises(self, caplog):
+        async def inner(_req):
+            raise McpError(types.ErrorData(code=types.INTERNAL_ERROR, message="boom"))
+
+        handler = _wrap(inner)
+        request = _request()
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            with pytest.raises(McpError):
+                await handler(request)
+
+        record = _line(caplog)
+        assert record.outcome == "protocol_error"
+        assert record.levelno == logging.WARNING
+
+    async def test_no_arguments_omits_the_args_field(self, caplog):
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await _wrap(_ok)(_request())
+
+        assert not hasattr(_line(caplog), "mcp_tool_args")
+
+    async def test_unregistered_name_is_logged_but_not_labelled(self, caplog):
+        """The metric label collapses to "unknown"; the line keeps the typo."""
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await _wrap(_ok)(_request(name="nc_semantic_serach"))
+
+        record = _line(caplog)
+        assert record.mcp_tool == "unknown"
+        assert record.mcp_tool_requested == "nc_semantic_serach"
+
+    async def test_identity_absent_without_a_token(self, caplog):
+        """BasicAuth / single-user / stdio: no OAuth identity, and no crash."""
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await _wrap(_ok)(_request(query="x"))
+
+        record = _line(caplog)
+        assert not hasattr(record, "mcp_user")
+        assert not hasattr(record, "mcp_client_id")
+
+    async def test_identity_from_access_token(self, caplog):
+        token = auth_context_var.set(
+            AuthenticatedUser(
+                AccessToken(
+                    token="opaque",
+                    client_id="claude-ai",
+                    scopes=["openid"],
+                    # This codebase stores the username in `resource`
+                    # (unified_verifier.py), not in `subject`.
+                    resource="alice",
+                )
+            )
+        )
+        try:
+            with caplog.at_level(logging.INFO, logger=LOGGER):
+                await _wrap(_ok)(_request(query="x"))
+        finally:
+            auth_context_var.reset(token)
+
+        record = _line(caplog)
+        assert record.mcp_user == "alice"
+        assert record.mcp_client_id == "claude-ai"
+
+
+def test_every_tool_function_is_named_after_the_tool_it_registers():
+    """Keeps the per-tool metrics joinable with the per-call ones.
+
+    ``mcp_tool_calls_total`` / ``mcp_tool_duration_seconds`` label with
+    ``func.__name__`` (from ``@instrument_tool``), while
+    ``mcp_tool_outcomes_total`` and the log line above use the *registered* MCP
+    name. The four OAuth tools used to disagree — ``tool_provision_access`` vs
+    ``provision_nextcloud_access`` — which silently split every dashboard that
+    joined them. A mismatch is invisible at runtime, so it needs a test.
+    """
+    mcp = FastMCP(name="test-tool-names")
+    for app_name in AVAILABLE_APPS:
+        configure_app_tools(mcp, app_name)
+    register_auth_tools(mcp)
+    register_oauth_tools(mcp)
+
+    mismatched = {
+        tool.name: tool.fn.__name__
+        for tool in mcp._tool_manager.list_tools()
+        if tool.fn.__name__ != tool.name
+    }
+
+    assert not mismatched, (
+        "these tools register under a name that differs from their function "
+        f"name, so their metrics and logs disagree: {mismatched}. Rename the "
+        "function to match the registered name."
+    )
+
+
+class TestSanitizeToolArgs:
+    """Arguments here are raw client input — validate_input=False upstream — so
+    redaction cannot assume the keys a tool actually declares."""
+
+    def test_redacts_by_substring_not_exact_match(self):
+        rendered = _sanitize_tool_args(
+            {
+                "query": "notes",
+                "access_token": "eyJ...",
+                "clientSecret": "shh",
+                "refresh_token": "r",
+                "password": "hunter2",
+            }
+        )
+
+        for secret in ("eyJ...", "shh", "hunter2"):
+            assert secret not in rendered
+        assert rendered.count("[redacted]") == 4
+        assert "'query': 'notes'" in rendered
+
+    def test_redacts_a_secret_the_tool_never_declared(self):
+        """A caller can send any key to any tool; the key still gets caught."""
+        assert "hunter2" not in _sanitize_tool_args({"password": "hunter2"})
+
+    def test_long_value_capped_without_hiding_later_arguments(self):
+        rendered = _sanitize_tool_args({"content": "x" * 5000, "path": "/notes/a.md"})
+
+        assert "x" * 150 in rendered
+        assert "x" * 300 not in rendered
+        assert "'path': '/notes/a.md'" in rendered
+
+    def test_many_arguments_capped_overall(self):
+        rendered = _sanitize_tool_args({f"k{i}": "y" * 150 for i in range(50)})
+
+        assert len(rendered) == 1000
+
+    def test_nothing_worth_logging_returns_none(self):
+        assert _sanitize_tool_args({}) is None
+        assert _sanitize_tool_args(None) is None
+        # ctx and etag are dropped as noise, leaving nothing
+        assert _sanitize_tool_args({"ctx": object(), "etag": "abc"}) is None


### PR DESCRIPTION
Tool calls were invisible in logs. Grepping a deployed tenant for evidence of
a tool call turns up the SDK line `Processing request of type CallToolRequest`
and a `POST /mcp 200` access line — no tool name, no arguments. The name and
args existed only as Tempo spans (`mcp.tool.<name>` / `mcp.tool.args`), and
traces are sampled and short-retention, so "which tools are people using, with
what inputs, over the last month" was unanswerable.

## What this does

Emits **one structured line per tool call** from `instrument_call_tool_outcomes`
— the single `CallToolRequest` handler that every transport funnels through — so
coverage is automatic instead of per-tool:

```json
{
  "message": "tool call nc_semantic_search success in 3428ms",
  "mcp_tool": "nc_semantic_search",
  "mcp_tool_args": "{'query': 'safeguarding policy review', 'limit': 3}",
  "duration_ms": 3428,
  "outcome": "success",
  "mcp_user": "alice",
  "mcp_client_id": "claude-ai"
}
```

Successes log at INFO, `tool_error` / `protocol_error` at WARNING. With
`LOG_FORMAT=json` the fields are top-level, so `| json | mcp_tool != ""` works
in LogQL. `mcp_tool` is the *resolved* registered name (`unknown` for a name
that is not registered, bounding cardinality for anything that aggregates it);
the raw name is kept in `mcp_tool_requested` only when the two differ.

Placed here rather than in `NextcloudFastMCP.call_tool` because this frame is
the only one that can see the `tool_error` vs `protocol_error` split, and
because the capability-gate rejection happens outside `call_tool`'s `try`.

## Also in this PR

- **Widened arg redaction, shared with the span.** The old denylist matched key
  names *exactly* (`password`, `token`, `secret`, `api_key`), so `access_token`,
  `refresh_token` and `client_secret` reached Tempo in the clear. It now matches
  by substring, case-insensitively, and keeps the key visible as `[redacted]`.
  This matters more at the new call site: those arguments are unvalidated client
  input (FastMCP registers the handler with `validate_input=False`), so a caller
  can send a `password` key to a tool that declares no such parameter.
- **Per-value truncation.** One 5 kB argument used to consume the whole 500-char
  budget and hide every other argument; values are now capped individually.
- **`mcp.tool.args` is omitted rather than set to `None`** when a tool takes no
  arguments — OTel rejects `None` attributes, warning and dropping them on every
  such call.
- **stdio server instrumented.** It builds its own `NextcloudFastMCP` and never
  called this wrapper, so it had no tool-call logs, no fleet metrics and no
  outcome counter.
- **The seven uninstrumented auth/oauth tools now carry `@instrument_tool`.** The
  four OAuth closures are renamed to the names they register under
  (`tool_provision_access` → `provision_nextcloud_access`, …) so their
  `func.__name__`-labelled metrics stop disagreeing with the registered-name
  ones; a new registry test guards that for every tool, and the stale warning in
  `docs/observability.md` is gone.
- **`@with_links` on the two Deck dependent-card tools.** Pre-existing: they
  return a linkable model whose `url` was always `None`, and
  `test_links_tool_coverage.py` fails on `master` because of it.

## Testing

- New `tests/unit/test_tool_call_logging.py` — the line's fields per outcome,
  exception still propagating on `protocol_error`, unregistered names, identity
  present/absent, and the sanitizer (substring redaction, per-value and overall
  caps, `None` when there is nothing to record).
- `tests/unit/test_instrument_tool.py` updated for the shared sanitizer.
- Full unit suite green (3485 passed); `ruff`, `ruff format`, `ty` clean;
  `sonar analyze secrets` clean on the diff.
- Verified end-to-end against the docker stack: `pytest -m smoke` produces one
  line per tool call, and a JSON-format run confirms the fields land as
  top-level keys with secrets redacted.

No API surface changes — no new or modified MCP tool, `/api/v1/*` route, or
cross-service boundary — so the e2e + Pact gate does not apply here. The two
renamed OAuth functions keep their registered tool names, so the wire contract
is unchanged.

Deck: board 9 (Platform Observability), card #1015. The Grafana dashboard is a
follow-up PR in `homelab-argocd`.

---

_This PR was generated with the help of AI, and reviewed by a Human_