### PR TITLE
fix(ingest): dead-letter documents whose mime type has no processor

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -237,7 +237,10 @@ success, so partial extractions and in-flight batch-OCR polls never inflate them
 - `astrolabe_document_bytes_processed_total` - Source bytes parsed
 - `astrolabe_document_parse_duration_seconds` - Parse latency per document
 - `astrolabe_document_parse_failed_total{reason}` - Hard failures
-  (`timeout` | `oom` | `error` | `oversize`)
+  (`timeout` | `oom` | `error` | `oversize` | `unreadable` | `unsupported_type`).
+  `unsupported_type` means no registered processor claims the document's mime
+  type — a property of what this deployment has enabled, not of the document, so
+  it is answered by enabling a processor (or excluding the type), not by a retry.
 
 Corpus shape, recorded before the oversize gate so the over-cap tail is visible:
 

--- a/nextcloud_mcp_server/document_processors/escalation.py
+++ b/nextcloud_mcp_server/document_processors/escalation.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from nextcloud_mcp_server.config import get_document_processor_config
+
 # Cheapest-first. ``ocr`` is the single configurable OCR tier: the backend (direct
 # Mistral vs the embedding gateway, which can route Mistral, surya, etc.) and the
 # model are chosen by ``document_ocr_provider`` + ``document_ocr_model``. ``llm`` is
@@ -42,10 +44,11 @@ def escalation_tiers_signature(settings: Any) -> str:
     at runtime — flip it and previously dead-lettered documents become retryable.
 
     Derived purely from settings (not the live ``ProcessorRegistry``) so it is
-    identical across the API/scanner and worker roles: the *registered* processor
-    set is build-constant, so the only runtime variables are the OCR-enabled gate
-    (``document_ocr_enabled`` — the single OCR-tier toggle) and the tier-1 engine
-    pin (``document_tier1_engine``). Enabling OCR changes the signature, so the
+    identical across the API/scanner and worker roles: the built-in processor set
+    is build-constant, so the runtime variables are the OCR-enabled gate
+    (``document_ocr_enabled`` — the single OCR-tier toggle), the tier-1 engine
+    pin (``document_tier1_engine``) and the configured *optional* processors
+    (below). Enabling OCR changes the signature, so the
     pathological-but-OCR-recoverable documents dead-lettered while OCR was off are
     re-attempted automatically.
 
@@ -74,16 +77,30 @@ def escalation_tiers_signature(settings: Any) -> str:
     ``150`` must not change the fingerprint (and ``:d`` would raise on a float,
     breaking the dead-letter key for the whole tenant).
 
+    The *optional* processor set is included for the same reason (Deck #1016): a
+    document whose mime type no registered processor claims fails
+    ``unsupported_type``, which is terminal — so without this, enabling
+    ``docling``/``unstructured``/``tesseract``/``custom`` later would never
+    re-drive the documents dead-lettered while they were off. Taken from
+    ``get_document_processor_config()`` (settings, via the same ``ENABLE_*``
+    flags app startup registers from) rather than from the live registry, so the
+    scanner and worker roles agree even though only the worker imports the parse
+    stack. The built-in PDF tiers are build-constant and covered by ``t1``/``ocr``.
+
     TODO: when a future setting can make a previously-terminal document parseable,
     fold it in here so raising it auto-retries existing dead-letters. Known
     remaining candidate: a new escalation tier becoming toggleable (e.g. the
     reserved ``llm`` rung in ``TIER_LADDER``).
     """
+    optional_processors = ",".join(
+        sorted(get_document_processor_config()["processors"])
+    )
     return (
         f"ocr={int(bool(settings.document_ocr_enabled))};"
         f"t1={settings.document_tier1_engine};"
         f"maxmb={settings.document_max_pdf_size_mb:g};"
-        f"mdpages={settings.document_markdown_max_pages:g}"
+        f"mdpages={settings.document_markdown_max_pages:g};"
+        f"procs={optional_processors}"
     )
 
 

--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -29,6 +29,36 @@ logger = logging.getLogger(__name__)
 
 PDF_MIME_TYPE = "application/pdf"
 
+# parse_failed_reason for "no registered processor claims this mime type".
+UNSUPPORTED_TYPE_REASON = "unsupported_type"
+
+
+def _unsupported_type_result(
+    content_type: str, registered: list[str]
+) -> ProcessingResult:
+    """Permanent, non-raising failure for a mime type nothing can parse.
+
+    Returned rather than raised (Deck #1016): a ``ProcessorError`` from dispatch
+    unwinds past the ingest caller's ``if not result.success:`` block -- the one
+    that owns dead-lettering -- and lands in the generic retry handler, which
+    treats the fault as transient and lets the next scan re-queue the document.
+    Forever, because "nothing is registered for this type" never changes on its
+    own. Failing gracefully instead routes it to the dead-letter marker, whose
+    signature covers the configured processor set (see
+    ``escalation.escalation_tiers_signature``) so enabling a processor later
+    re-drives the document.
+    """
+    return ProcessingResult(
+        text="",
+        metadata={"parse_failed_reason": UNSUPPORTED_TYPE_REASON},
+        processor="registry",
+        success=False,
+        error=(
+            f"No processor found for type: {content_type}. "
+            f"Registered processors: {', '.join(registered)}"
+        ),
+    )
+
 
 @dataclass
 class _LadderState:
@@ -180,10 +210,14 @@ class ProcessorRegistry:
             progress_callback: Optional async callback for progress updates
 
         Returns:
-            ProcessingResult with extracted text and metadata
+            ProcessingResult with extracted text and metadata. A mime type no
+            registered processor claims comes back as ``success=False`` /
+            ``parse_failed_reason="unsupported_type"`` rather than raising, so
+            callers dead-letter it instead of retrying forever (Deck #1016).
 
         Raises:
-            ProcessorError: If no processor found or processing fails
+            ProcessorError: If a named ``processor_name`` is unknown, or the
+                selected processor fails
         """
         # Forced processor bypasses tiering.
         if processor_name:
@@ -206,10 +240,7 @@ class ProcessorRegistry:
 
         processor = self.find_processor(content_type)
         if not processor:
-            raise ProcessorError(
-                f"No processor found for type: {content_type}. "
-                f"Registered processors: {', '.join(self.list_processors())}"
-            )
+            return _unsupported_type_result(content_type, self.list_processors())
         return await self._run_processor(
             processor, content, content_type, filename, options, progress_callback
         )
@@ -826,10 +857,7 @@ class ProcessorRegistry:
 
         processor = self.find_processor(source.content_type)
         if not processor:
-            raise ProcessorError(
-                f"No processor found for type: {source.content_type}. "
-                f"Registered processors: {', '.join(self.list_processors())}"
-            )
+            return _unsupported_type_result(source.content_type, self.list_processors())
         return await self._run_processor_source(
             processor, source, options, progress_callback
         )

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1790,9 +1790,11 @@ def record_document_dead_lettered(reason: str) -> None:
     Args:
         reason: ``timeout`` | ``oom`` | ``error`` (the terminal parse failure
             reason carried from the isolated worker), ``oversize`` (rejected by
-            the pre-parse size guard, which no tier can ever parse), or
+            the pre-parse size guard, which no tier can ever parse),
             ``unreadable`` (the bytes are not a document the engine can open --
-            no tier will do better, so it is terminal on the first attempt).
+            no tier will do better, so it is terminal on the first attempt), or
+            ``unsupported_type`` (no registered processor claims the mime type --
+            a config property of the deployment, not a fault of the document).
     """
     document_dead_lettered_total.labels(reason=reason).inc()
 

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1735,11 +1735,17 @@ def record_document_parse_failed(reason: str) -> None:
     """Record a hard parse failure from the isolated worker.
 
     Args:
-        reason: ``timeout`` | ``oom`` | ``error`` (from the isolated worker), or
+        reason: ``timeout`` | ``oom`` | ``error`` (from the isolated worker);
             ``unreadable`` -- the engine could not open the bytes as a document
             at all, i.e. the file's content does not match the mime type its
             extension claimed. Distinguished from ``error`` on purpose: it means
-            corrupt input, not a failure of ours, so it should not page anyone.
+            corrupt input, not a failure of ours, so it should not page anyone;
+            ``oversize`` -- rejected by the pre-parse size guard, no tier can
+            ever parse it; or ``unsupported_type`` -- no registered processor
+            claims the mime type, which is a property of what this deployment
+            has enabled rather than of the document. Kept in step with
+            ``record_document_dead_lettered`` below: the terminal ones are
+            counted on both.
     """
     document_parse_failed_total.labels(reason=reason).inc()
 

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -1370,6 +1370,9 @@ async def _index_document_inner(
                 EscalateError,
                 escalation_tiers_signature,
             )
+            from nextcloud_mcp_server.document_processors.registry import (  # noqa: PLC0415
+                UNSUPPORTED_TYPE_REASON,
+            )
 
             registry = get_registry()
 
@@ -1427,10 +1430,14 @@ async def _index_document_inner(
                     # (``None`` == terminal). An oversize PDF is rejected by the
                     # pre-parse size guard before any tier runs (no pipeline_tier
                     # stamped on the inline path) and no tier can ever parse it, so
-                    # it is terminal regardless of failing_tier.
+                    # it is terminal regardless of failing_tier. Same for
+                    # ``unsupported_type``: the tier ladder is PDF-only, so a mime
+                    # type no processor claims cannot be parsed by a higher rung
+                    # either -- escalating it would just walk the queues to burn
+                    # the same dispatch failure three times (Deck #1016).
                     next_avail = (
                         None
-                        if reason == "oversize"
+                        if reason in ("oversize", UNSUPPORTED_TYPE_REASON)
                         else registry.next_available_tier(failing_tier, settings)
                     )
                     # #399: a hard parse failure (an isolated-worker timeout/OOM on

--- a/tests/unit/test_escalation_signature.py
+++ b/tests/unit/test_escalation_signature.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from nextcloud_mcp_server.document_processors import escalation as esc_mod
 from nextcloud_mcp_server.document_processors.escalation import (
     escalation_tiers_signature,
 )
@@ -84,6 +85,36 @@ def test_markdown_page_gate_change_changes_signature() -> None:
     assert escalation_tiers_signature(
         _settings(ocr=False, markdown_max_pages=150)
     ) != escalation_tiers_signature(_settings(ocr=False, markdown_max_pages=50))
+
+
+def test_enabling_a_processor_changes_signature(mocker) -> None:
+    # Deck #1016: an unsupported mime type is terminal, so enabling a processor
+    # that claims it (docling/unstructured/tesseract/custom) must re-drive the
+    # documents dead-lettered while it was off -- their etag never changes.
+    before = escalation_tiers_signature(_settings(ocr=False))
+    mocker.patch.object(
+        esc_mod,
+        "get_document_processor_config",
+        lambda: {"processors": {"docling": {}}},
+    )
+    assert escalation_tiers_signature(_settings(ocr=False)) != before
+
+
+def test_processor_set_order_does_not_change_signature(mocker) -> None:
+    # Sorted, so dict ordering (config source, insertion order) cannot spuriously
+    # invalidate every dead letter on the tenant.
+    mocker.patch.object(
+        esc_mod,
+        "get_document_processor_config",
+        lambda: {"processors": {"unstructured": {}, "docling": {}}},
+    )
+    one = escalation_tiers_signature(_settings(ocr=False))
+    mocker.patch.object(
+        esc_mod,
+        "get_document_processor_config",
+        lambda: {"processors": {"docling": {}, "unstructured": {}}},
+    )
+    assert escalation_tiers_signature(_settings(ocr=False)) == one
 
 
 def test_disabling_markdown_changes_signature() -> None:

--- a/tests/unit/test_registry_unsupported_type.py
+++ b/tests/unit/test_registry_unsupported_type.py
@@ -1,0 +1,82 @@
+"""Dispatch of a mime type no registered processor claims (Deck #1016).
+
+The registry used to raise ``ProcessorError`` from dispatch. That raise unwinds
+past the ingest caller's ``if not result.success:`` dead-letter block and lands
+in the generic (transient-fault) retry handler, so the scanner re-queued the
+document every cycle forever — the 12 ``text/html`` documents on the dev tenant.
+"Nothing is registered for this type" is permanent, so dispatch must fail
+gracefully instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nextcloud_mcp_server.document_processors.base import (
+    DocumentProcessor,
+    ProcessingResult,
+)
+from nextcloud_mcp_server.document_processors.registry import ProcessorRegistry
+from nextcloud_mcp_server.document_processors.source import MemoryDocumentSource
+
+pytestmark = pytest.mark.unit
+
+HTML = "text/html; charset=UTF-8"
+
+
+class _PdfOnly(DocumentProcessor):
+    """Stands in for the PDF-only set a production deployment registers."""
+
+    @property
+    def name(self) -> str:
+        return "pypdfium2_fast"
+
+    @property
+    def tier(self) -> str:
+        return "fast"
+
+    @property
+    def supported_mime_types(self) -> set[str]:
+        return {"application/pdf"}
+
+    async def process(
+        self, content, content_type, filename=None, options=None, progress_callback=None
+    ) -> ProcessingResult:  # pragma: no cover - never reached for text/html
+        return ProcessingResult(
+            text="x", metadata={}, processor=self.name, success=True
+        )
+
+    async def health_check(self) -> bool:  # pragma: no cover - not exercised
+        return True
+
+
+def _registry() -> ProcessorRegistry:
+    registry = ProcessorRegistry()
+    registry.register(_PdfOnly(), priority=20)
+    return registry
+
+
+async def test_process_source_unsupported_type_fails_without_raising() -> None:
+    result = await _registry().process_source(
+        MemoryDocumentSource(content=b"<html>", content_type=HTML, filename="m.html")
+    )
+
+    assert result.success is False
+    assert result.metadata["parse_failed_reason"] == "unsupported_type"
+    assert "No processor found" in (result.error or "")
+
+
+async def test_process_bytes_unsupported_type_fails_without_raising() -> None:
+    result = await _registry().process(b"<html>", HTML, filename="m.html")
+
+    assert result.success is False
+    assert result.metadata["parse_failed_reason"] == "unsupported_type"
+
+
+async def test_unknown_forced_processor_still_raises() -> None:
+    """Only *dispatch by mime type* degrades: a caller naming a processor that
+    does not exist is a programming/config error, not a document property."""
+    from nextcloud_mcp_server.document_processors.base import ProcessorError
+
+    with pytest.raises(ProcessorError, match="nope"):
+        await _registry().process(b"x", "application/pdf", processor_name="nope")

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -346,6 +346,34 @@ async def test_oversize_failure_dead_letters_regardless_of_tier(mocker):
     spies.update_ph.assert_not_awaited()
 
 
+async def test_unsupported_mime_type_dead_letters(mocker):
+    """Deck #1016: a non-PDF nothing can parse dead-letters instead of looping.
+
+    Registry dispatch used to raise past the terminal-failure block, so the
+    document was never marked and every scan cycle re-queued it (the 12
+    ``text/html`` documents on the dev tenant, 8 doomed jobs each per 6h). It is
+    terminal at any tier — the tier ladder is PDF-only — so ``fast`` must
+    dead-letter rather than escalate to ``structured``.
+    """
+    spies = _patch_common(mocker, ocr_enabled=False)
+    nc = _nc_client()
+    nc.webdav.read_file = AsyncMock(
+        return_value=(b"<html></html>", "text/html; charset=UTF-8", None)
+    )
+    task = _file_task()
+    task.file_path = "/Export/messages.html"
+
+    result = await processor._index_document(task, nc, MagicMock(), tier="fast")
+
+    assert result is False
+    spies.mark.assert_awaited_once()
+    assert spies.mark.await_args.args[4] == "unsupported_type"  # reason
+    spies.dead_metric.assert_called_once_with("unsupported_type")
+    spies.parse_failed.assert_called_once_with("unsupported_type")
+    spies.escalation.assert_not_called()  # no pointless walk up the queues
+    spies.update_ph.assert_not_awaited()
+
+
 async def test_terminal_failure_without_etag_uses_legacy_mark(mocker):
     """A terminal failure with no etag can't be content-addressed, so fall back to
     the legacy per-user placeholder mark instead of writing an unmatchable marker."""


### PR DESCRIPTION
## Problem

A document whose mime type **no registered processor claims** was re-queued and
re-failed on every scan cycle, forever — never indexed, never dead-lettered.

Registry dispatch raised `ProcessorError`. That raise unwinds past the ingest
caller's `if not result.success:` block — the block that owns
`record_document_parse_failed` / `mark_dead_letter` — and lands in the generic
retry handler, which by design treats a fault as *transient* and deliberately
leaves the document unmarked so the next scan re-picks it. "Nothing is
registered for this type" never changes on its own, so the loop never ends.

Measured on a dev tenant (app v0.169.0): 12 non-PDF documents, a fresh job each
per scan cycle (8 per doc in 6h, 96 failed jobs and growing), each cycle waking
the scale-to-zero fast worker fleet for its 300s cooldown to run doomed jobs.

Same defect class as #918 (Deck #918), but a **different raise site** that
#918's fix does not cover: it happens in dispatch, before any processor runs.

## Change

- **Dispatch fails gracefully.** `process_source()` / `process()` return
  `success=False` + `parse_failed_reason="unsupported_type"` instead of raising,
  so the document takes the existing terminal path and gets a content-addressed,
  tenant-wide dead-letter marker. Fixed once at the dispatch point, not at the
  single ingest call site.
- **Always terminal**, alongside `oversize`: the tier ladder is PDF-only, so a
  mime type nothing claims cannot be parsed by a higher rung — escalating would
  just walk the queues burning the same dispatch failure three times.
- **The marker clears when a processor is added.** `escalation_tiers_signature`
  now covers the configured optional processor set (docling / unstructured /
  tesseract / custom), so enabling one later re-drives the documents
  dead-lettered while it was off — their etag never changes on its own. Read
  from `get_document_processor_config()` (settings) rather than the live
  registry, so the scanner and worker roles still produce the same signature.
- **Distinguishable on metrics**: `unsupported_type` is its own reason label on
  `astrolabe_document_parse_failed_total` / `astrolabe_document_dead_lettered_total`,
  rather than the `other` bucket that made this hard to diagnose.
- A named-but-unknown `processor_name` still raises — that is a config error,
  not a property of the document. Genuine infrastructure faults still raise and
  stay retryable; the generic `except Exception` is untouched.

## Tests

New (all verified to fail before the fix):

- `tests/unit/test_registry_unsupported_type.py` — dispatch by mime type returns
  `unsupported_type` without raising, on both the source- and bytes-based entry
  points; an unknown forced `processor_name` still raises.
- `tests/unit/vector/test_processor_dead_letter.py::test_unsupported_mime_type_dead_letters`
  — the document is dead-lettered with `reason="unsupported_type"` from the
  `fast` tier, with no escalation and no legacy per-user mark.
- `tests/unit/test_escalation_signature.py` — enabling a processor changes the
  signature (which is what re-drives the marker); processor-set ordering does
  not.

"A second scan does not re-queue it" is the existing
`is_dead_lettered` contract, already covered by
`tests/unit/vector/test_dead_letter.py` (etag + `tiers_sig` match ⇒ skip; a
changed `tiers_sig` ⇒ retryable).

Full unit suite green (3492 passed); ruff / ruff format / ty clean.

**API surface:** none added or changed (no MCP tool, no `/api/v1/*` route, no
cross-service boundary), so no new e2e/contract coverage is required.

**Rollout:** the dev tenant's failure loop should decay to zero once deployed —
each affected document is attempted once more, then dead-lettered.

---

_This PR was generated with the help of AI, and reviewed by a Human_
