### PR TITLE
feat(webdav): read and post comments on files (#1308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For Kubernetes, see [cbcoutinho/helm-charts](https://github.com/cbcoutinho/helm-
 | **Notes** | 7 | Full CRUD, keyword search, semantic search |
 | **Calendar** | 20+ | Events, todos (tasks), recurring events, attendees, availability |
 | **Contacts** | 8 | Full CardDAV support, address books |
-| **Files (WebDAV)** | 12 | Filesystem access, OCR/document processing |
+| **Files (WebDAV)** | 14 | Filesystem access, OCR/document processing, file comments |
 | **Deck** | 15 | Boards, stacks, cards, labels, assignments |
 | **Cookbook** | 13 | Recipe management, URL import (schema.org) |
 | **Tables** | 5 | Row operations on Nextcloud Tables |

--- a/docs/webdav.md
+++ b/docs/webdav.md
@@ -11,6 +11,8 @@
 | `nc_webdav_delete_resource` | Delete files or directories |
 | `nc_webdav_move_resource` | Move or rename files and directories |
 | `nc_webdav_copy_resource` | Copy files and directories |
+| `nc_webdav_list_comments` | Read the comments on a file |
+| `nc_webdav_create_comment` | Comment on a file, mentioning people to notify them |
 
 ### WebDAV File System Access
 
@@ -73,6 +75,33 @@ await nc_webdav_copy_resource("document.txt", "Backup/document.txt")
 # Copy a directory
 await nc_webdav_copy_resource("Projects/ProjectA", "Projects/ProjectA_Backup")
 ```
+
+### File Comments
+
+Comments annotate a file in place — review requests, hand-offs, context that
+does not belong in the file itself. They are the same comments the Nextcloud
+web UI shows in a file's sidebar.
+
+```python
+# Ask a colleague to review; @-mentioning them sends the notification
+await nc_webdav_create_comment(
+    "Reports/q3.pdf", 'numbers updated, please review @"alice"'
+)
+
+# Read the thread, newest first
+await nc_webdav_list_comments("Reports/q3.pdf")
+
+# Page through a long thread
+await nc_webdav_list_comments("Reports/q3.pdf", limit=20, offset=20)
+```
+
+Mention a user by their Nextcloud user ID: `@alice`, or `@"user id with spaces"`.
+Nextcloud parses the mention out of the message when it stores the comment and
+sends the notification itself.
+
+A comment is capped at **1000 characters** (measured after trimming whitespace,
+counting Unicode code points — Nextcloud's own rule). Longer content belongs in
+the file, with a short pointer comment.
 
 ### Safe Writes: Concurrent Edits and Locks
 

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -186,6 +186,61 @@ def _normalize_etag(raw: Optional[str]) -> Optional[str]:
     return raw.strip('"') if raw is not None else None
 
 
+#: The ownCloud/Nextcloud DAV property namespace.
+_OC_NS = "http://owncloud.org/ns"
+
+#: Collection holding one file's comments, addressed by file id.
+_COMMENTS_PATH = "/remote.php/dav/comments/files"
+
+
+def _dav_props_ok(response_elem: ET.Element) -> dict[str, str]:
+    """Return a multistatus response's ``200 OK`` properties, keyed by local name.
+
+    A response carries one ``propstat`` block per status: the 200 one holds the
+    values, while a 404 one lists the properties the server does *not* have.
+    Folding those in would fabricate empty values for them.
+    """
+    props: dict[str, str] = {}
+    for propstat in response_elem.findall("{DAV:}propstat"):
+        # "HTTP/1.1 200 OK" -> the code is the second token. Matching the token
+        # rather than a " 200 " substring keeps a reason-phrase-less status line
+        # (legal per RFC 9110) working.
+        status = (propstat.findtext("{DAV:}status") or "").split()
+        if len(status) < 2 or status[1] != "200":
+            continue
+        prop = propstat.find("{DAV:}prop")
+        if prop is None:
+            continue
+        for child in prop:
+            props[str(child.tag).rsplit("}", 1)[-1]] = (child.text or "").strip()
+    return props
+
+
+def _parse_comment_props(props: dict[str, str]) -> dict[str, Any] | None:
+    """Shape one comment's DAV properties into the dict ``FileComment`` consumes.
+
+    Returns None for a row without a usable id — one malformed comment should
+    cost the caller that comment, not the whole thread.
+    """
+    try:
+        comment_id = int(props["id"])
+    except (KeyError, ValueError):
+        logger.warning("Skipping comment with unusable id %r", props.get("id"))
+        return None
+    return {
+        "id": comment_id,
+        "message": props.get("message", ""),
+        "actor_id": props.get("actorId", ""),
+        "actor_type": props.get("actorType", ""),
+        "actor_display_name": props.get("actorDisplayName") or None,
+        # Raw DAV date (RFC 1123), like every other timestamp this client
+        # surfaces -- see FileInfo.last_modified.
+        "creation_datetime": props.get("creationDateTime") or None,
+        "verb": props.get("verb", ""),
+        "is_unread": props.get("isUnread", "").lower() == "true",
+    }
+
+
 def _destination_precondition_header(
     destination_webdav_path: str, if_destination_match: str
 ) -> dict[str, str]:
@@ -1957,6 +2012,86 @@ class WebDAVClient(BaseNextcloudClient):
                 if text:
                     return text
         return None
+
+    async def list_comments(
+        self, file_id: int, *, limit: int = 20, offset: int = 0
+    ) -> list[dict[str, Any]]:
+        """Return comments on a file, newest first.
+
+        A ``REPORT`` carrying ``oc:filter-comments`` rather than a ``PROPFIND``:
+        the report is the only form that takes ``limit``/``offset``, and a
+        Depth-1 PROPFIND on the collection would return the entire thread.
+
+        Args:
+            file_id: Nextcloud file ID (see :meth:`get_fileid`).
+            limit: Maximum comments to return.
+            offset: How many of the newest comments to skip.
+
+        Returns:
+            One dict per comment, in the shape ``FileComment`` expects.
+        """
+        body = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            f'<oc:filter-comments xmlns:oc="{_OC_NS}">'
+            f"<oc:limit>{int(limit)}</oc:limit>"
+            f"<oc:offset>{int(offset)}</oc:offset>"
+            "</oc:filter-comments>"
+        )
+        response = await self._make_request(
+            "REPORT",
+            f"{_COMMENTS_PATH}/{int(file_id)}",
+            content=body,
+            headers={"Depth": "0", "Content-Type": "application/xml"},
+        )
+
+        root = ET.fromstring(response.content)
+        comments = []
+        for response_elem in root.findall("{DAV:}response"):
+            props = _dav_props_ok(response_elem)
+            if not props:
+                continue
+            comment = _parse_comment_props(props)
+            if comment is not None:
+                comments.append(comment)
+
+        logger.debug("Found %s comment(s) on file %s", len(comments), file_id)
+        return comments
+
+    async def create_comment(self, file_id: int, message: str) -> int | None:
+        """Post a comment on a file and return the new comment's ID.
+
+        Nextcloud answers ``201`` with an **empty body**, naming the new comment
+        only in the ``Content-Location`` header — so the ID is read from there
+        rather than by fetching the comment back.
+
+        Mentions are the server's business: it parses ``@"username"`` out of the
+        message when storing it and sends the notification itself.
+
+        Args:
+            file_id: Nextcloud file ID (see :meth:`get_fileid`).
+            message: Comment text. The caller is expected to have checked it
+                against Nextcloud's 1000-character limit.
+
+        Returns:
+            The new comment's ID, or None if the server named no location.
+        """
+        response = await self._make_request(
+            "POST",
+            f"{_COMMENTS_PATH}/{int(file_id)}",
+            json={"actorType": "users", "verb": "comment", "message": message},
+        )
+
+        location = response.headers.get("Content-Location", "")
+        comment_id = location.rstrip("/").rsplit("/", 1)[-1]
+        try:
+            return int(comment_id)
+        except ValueError:
+            logger.warning(
+                "Comment created on file %s but Content-Location %r carries no id",
+                file_id,
+                location,
+            )
+            return None
 
     async def _get_file_info_by_id(self, file_id: int) -> Dict[str, Any]:
         """Get file information by Nextcloud file ID using WebDAV.

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -186,9 +186,6 @@ def _normalize_etag(raw: Optional[str]) -> Optional[str]:
     return raw.strip('"') if raw is not None else None
 
 
-#: The ownCloud/Nextcloud DAV property namespace.
-_OC_NS = "http://owncloud.org/ns"
-
 #: Collection holding one file's comments, addressed by file id.
 _COMMENTS_PATH = "/remote.php/dav/comments/files"
 
@@ -2030,9 +2027,13 @@ class WebDAVClient(BaseNextcloudClient):
         Returns:
             One dict per comment, in the shape ``FileComment`` expects.
         """
+        # The owncloud namespace stays inside the request body, never a
+        # standalone string constant -- same reason as get_fileid, which matches
+        # oc properties by local name rather than naming the URL (see
+        # _dav_props_ok). A bare URL literal also trips Sonar's python:S5332.
         body = (
             '<?xml version="1.0" encoding="utf-8"?>'
-            f'<oc:filter-comments xmlns:oc="{_OC_NS}">'
+            '<oc:filter-comments xmlns:oc="http://owncloud.org/ns">'
             f"<oc:limit>{int(limit)}</oc:limit>"
             f"<oc:offset>{int(offset)}</oc:offset>"
             "</oc:filter-comments>"
@@ -2041,7 +2042,11 @@ class WebDAVClient(BaseNextcloudClient):
             "REPORT",
             f"{_COMMENTS_PATH}/{int(file_id)}",
             content=body,
-            headers={"Depth": "0", "Content-Type": "application/xml"},
+            headers={
+                "Depth": "0",
+                "Content-Type": "text/xml",
+                "OCS-APIRequest": "true",
+            },
         )
 
         root = ET.fromstring(response.content)
@@ -2079,6 +2084,7 @@ class WebDAVClient(BaseNextcloudClient):
             "POST",
             f"{_COMMENTS_PATH}/{int(file_id)}",
             json={"actorType": "users", "verb": "comment", "message": message},
+            headers={"OCS-APIRequest": "true"},
         )
 
         location = response.headers.get("Content-Location", "")

--- a/nextcloud_mcp_server/models/__init__.py
+++ b/nextcloud_mcp_server/models/__init__.py
@@ -73,9 +73,12 @@ from .tables import (
 from .webdav import (
     CopyResourceResponse,
     CreateDirectoryResponse,
+    CreateFileCommentResponse,
     DeleteResourceResponse,
     DirectoryListing,
+    FileComment,
     FileInfo,
+    ListFileCommentsResponse,
     MoveResourceResponse,
     ReadFileResponse,
     SearchFilesResponse,
@@ -148,4 +151,7 @@ __all__ = [
     "MoveResourceResponse",
     "CopyResourceResponse",
     "SearchFilesResponse",
+    "FileComment",
+    "ListFileCommentsResponse",
+    "CreateFileCommentResponse",
 ]

--- a/nextcloud_mcp_server/models/webdav.py
+++ b/nextcloud_mcp_server/models/webdav.py
@@ -184,6 +184,57 @@ class CopyResourceResponse(StatusResponse):
     )
 
 
+class FileComment(BaseModel):
+    """A single comment on a file."""
+
+    id: int = Field(description="Comment ID")
+    message: str = Field(description="Comment text, mentions included as typed")
+    actor_id: str = Field(description="User ID of the comment's author")
+    actor_type: str = Field(description="Actor type, normally 'users'")
+    actor_display_name: Optional[str] = Field(
+        None, description="Display name of the comment's author"
+    )
+    creation_datetime: Optional[str] = Field(
+        None, description="When the comment was posted (RFC 1123 date)"
+    )
+    verb: str = Field(description="Comment verb, normally 'comment'")
+    is_unread: bool = Field(
+        default=False, description="Whether the comment is unread by you"
+    )
+
+
+class ListFileCommentsResponse(BaseResponse):
+    """Response model for listing the comments on a file."""
+
+    results: List[FileComment] = Field(description="Comments, newest first")
+    count: int = Field(
+        description=(
+            "Number of comments in this page. Nextcloud does not report a "
+            "thread total — a full page means there may be more, so page with "
+            "`offset`."
+        )
+    )
+    path: str = Field(description="Path of the commented file")
+    file_id: int = Field(description="Nextcloud file ID the comments belong to")
+    limit: int = Field(description="Page size that was requested")
+    offset: int = Field(description="Number of newest comments that were skipped")
+
+
+class CreateFileCommentResponse(BaseResponse):
+    """Response model for posting a comment on a file."""
+
+    path: str = Field(description="Path of the commented file")
+    file_id: int = Field(description="Nextcloud file ID the comment was posted on")
+    comment_id: Optional[int] = Field(
+        None,
+        description=(
+            "ID of the created comment. None if the server did not name the new "
+            "comment's location — the comment was still posted."
+        ),
+    )
+    message: str = Field(description="The comment text that was posted")
+
+
 class SearchFilesResponse(BaseResponse):
     """Response model for WebDAV search operations."""
 

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -44,6 +44,7 @@ from nextcloud_mcp_server.models.deck import (
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 from nextcloud_mcp_server.utils.message_splitter import (
+    COMMENT_MAX_LENGTH,
     measured_length,
     split_message,
 )
@@ -73,12 +74,12 @@ def _validate_positive_length(
         raise ValueError(f"{name} must be positive, got {value}")
 
 
-# Nextcloud core caps a comment at IComment::MAX_MESSAGE_LENGTH, checked in
-# OC\Comments\Comment::setMessage AFTER trim(), in UTF-8 code points, with a
-# strict ">" so exactly 1000 is legal. Deck adds no check of its own: its
-# CommentService::create translates the overflow into a 400, but its update()
-# has no such catch and leaks a masked 500 (see _comment_http_error).
-_COMMENT_MAX_LENGTH: Final[int] = 1000
+# Nextcloud's core comment cap (see COMMENT_MAX_LENGTH). Deck adds no check of
+# its own: its CommentService::create translates the overflow into a 400, but
+# its update() has no such catch and leaks a masked 500 (see
+# _comment_http_error). Aliased rather than re-declared so the many references
+# below -- and their tests -- keep reading the same value as file comments.
+_COMMENT_MAX_LENGTH: Final[int] = COMMENT_MAX_LENGTH
 
 # Ceiling on overflow="split". Ten comments is already a wall of text on a card;
 # past that the content wants to be a note or a file attachment, not an

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -45,6 +45,7 @@ from nextcloud_mcp_server.models.deck import (
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 from nextcloud_mcp_server.utils.message_splitter import (
     COMMENT_MAX_LENGTH,
+    is_blank_comment,
     measured_length,
     split_message,
 )
@@ -96,13 +97,10 @@ def _validate_comment_message_not_blank(message: str) -> None:
     Deck would happily store one, but a blank row in an activity log is noise
     nobody asked for and almost always signals a bug in the caller.
 
-    Uses Python's broad ``str.strip()`` on purpose, unlike
-    :func:`measured_length`, which must mirror PHP's narrower ``trim()``
-    charlist exactly. This guard is our own policy rather than a restatement of
-    the server's rule, and a comment of nothing but ideographic spaces is just
-    as useless as one of nothing but spaces -- so do not "align" it.
+    Blankness is deliberately the *union* of our rule and the server's -- see
+    :func:`is_blank_comment` for why neither trim charlist alone is enough.
     """
-    if not message.strip():
+    if is_blank_comment(message):
         raise ValueError("Comment message must not be empty or whitespace-only")
 
 

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -15,8 +15,11 @@ from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.links import with_links
 from nextcloud_mcp_server.models import (
     CopyResourceResponse,
+    CreateFileCommentResponse,
     DirectoryListing,
+    FileComment,
     FileInfo,
+    ListFileCommentsResponse,
     MoveResourceResponse,
     ReadFileResponse,
     SearchFilesResponse,
@@ -28,8 +31,13 @@ from nextcloud_mcp_server.server.tag_exclusion import (
     get_excluded_file_paths,
     is_path_excluded,
 )
+from nextcloud_mcp_server.utils.message_splitter import (
+    COMMENT_MAX_LENGTH,
+    measured_length,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle / lazy-import guard
+    from nextcloud_mcp_server.client import NextcloudClient
     from nextcloud_mcp_server.document_processors.source import DocumentSource
 
 logger = logging.getLogger(__name__)
@@ -137,6 +145,34 @@ async def _raw_response(
         parsing_metadata=parsing_metadata,
         etag=etag,
     )
+
+
+async def _resolve_commented_file(client: "NextcloudClient", path: str) -> int:
+    """Resolve ``path`` to the file ID the comments collection is keyed by.
+
+    Shared by both comment tools so the excluded-tag guard and the
+    does-it-exist check cannot drift between reading and writing comments.
+
+    Raises:
+        ToolError: If the path is excluded by tag, resolves to nothing, or
+            resolves to something that is not a numeric file id.
+    """
+    excluded = await get_excluded_file_paths(client.webdav)
+    if is_path_excluded(path, excluded):
+        raise ToolError(f"Access denied: {path!r} is tagged with an excluded tag")
+
+    file_id = await client.webdav.get_fileid(path)
+    if file_id is None:
+        raise ToolError(f"File not found: {path!r}")
+    try:
+        return int(file_id)
+    except ValueError:
+        # Nextcloud always reports a numeric oc:fileid; anything else means the
+        # PROPFIND response shape changed, and a clear refusal beats a
+        # ValueError from deep inside the URL we would have built with it.
+        raise ToolError(
+            f"Unexpected non-numeric file id {file_id!r} for {path!r}"
+        ) from None
 
 
 def configure_webdav_tools(mcp: FastMCP):
@@ -975,4 +1011,110 @@ def configure_webdav_tools(mcp: FastMCP):
             total_found=len(file_infos),
             scope=scope,
             filters_applied={"only_favorites": True},
+        )
+
+    @mcp.tool(
+        title="List File Comments",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("files.read")
+    @instrument_tool
+    async def nc_webdav_list_comments(
+        path: str, ctx: Context, limit: int = 20, offset: int = 0
+    ) -> ListFileCommentsResponse:
+        """Read the comments people have left on a file in NextCloud.
+
+        Comments are how a team annotates a file in place -- review requests,
+        hand-offs, context that does not belong in the file itself.
+
+        Raises ``ToolError`` when the file does not exist, or when
+        ``EXCLUDED_TAGS`` is configured and the file (or an ancestor folder)
+        carries an excluded system tag.
+
+        Args:
+            path: Full path to the file (e.g. "/Documents/report.pdf")
+            limit: Maximum number of comments to return (default: 20)
+            offset: How many of the newest comments to skip, for paging
+
+        Returns:
+            ListFileCommentsResponse with the comments, newest first.
+        """
+        if limit <= 0:
+            raise ValueError(f"limit must be positive, got {limit}")
+        if offset < 0:
+            raise ValueError(f"offset must not be negative, got {offset}")
+
+        client = await get_client(ctx)
+        file_id = await _resolve_commented_file(client, path)
+
+        comments = await client.webdav.list_comments(
+            file_id, limit=limit, offset=offset
+        )
+        return ListFileCommentsResponse(
+            results=[FileComment(**comment) for comment in comments],
+            count=len(comments),
+            path=path,
+            file_id=file_id,
+            limit=limit,
+            offset=offset,
+        )
+
+    @mcp.tool(
+        title="Comment on File",
+        annotations=ToolAnnotations(
+            idempotentHint=False,  # Each call adds another comment
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("files.write")
+    @instrument_tool
+    async def nc_webdav_create_comment(
+        path: str, message: str, ctx: Context
+    ) -> CreateFileCommentResponse:
+        """Post a comment on a file in NextCloud.
+
+        To notify someone, mention them by Nextcloud user ID: ``@username``, or
+        ``@"user id with spaces"``. Nextcloud parses the mention out of the
+        message when it stores the comment and sends the notification itself --
+        nothing else is needed here.
+
+        Raises ``ToolError`` when the file does not exist, or when
+        ``EXCLUDED_TAGS`` is configured and the file (or an ancestor folder)
+        carries an excluded system tag. Raises ``ValueError`` for a blank
+        message, or one over Nextcloud's limit -- nothing is posted in either
+        case.
+
+        Args:
+            path: Full path to the file to comment on
+            message: The comment text (max 1000 characters, measured after
+                trimming whitespace, counting Unicode code points)
+
+        Returns:
+            CreateFileCommentResponse with the new comment's ID.
+        """
+        if not message.strip():
+            raise ValueError("Comment message must not be empty or whitespace-only")
+        length = measured_length(message)
+        if length > COMMENT_MAX_LENGTH:
+            raise ValueError(
+                f"Comment message is {length} characters; Nextcloud's limit is "
+                f"{COMMENT_MAX_LENGTH} (measured after trimming whitespace, "
+                f"counting Unicode code points). It is "
+                f"{length - COMMENT_MAX_LENGTH} characters over. Nothing was "
+                f"posted -- shorten it, or put the content in the file itself "
+                f"and leave a short pointer comment."
+            )
+
+        client = await get_client(ctx)
+        file_id = await _resolve_commented_file(client, path)
+
+        comment_id = await client.webdav.create_comment(file_id, message)
+        return CreateFileCommentResponse(
+            path=path,
+            file_id=file_id,
+            comment_id=comment_id,
+            message=message,
         )

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -33,6 +33,7 @@ from nextcloud_mcp_server.server.tag_exclusion import (
 )
 from nextcloud_mcp_server.utils.message_splitter import (
     COMMENT_MAX_LENGTH,
+    is_blank_comment,
     measured_length,
 )
 
@@ -1095,7 +1096,7 @@ def configure_webdav_tools(mcp: FastMCP):
         Returns:
             CreateFileCommentResponse with the new comment's ID.
         """
-        if not message.strip():
+        if is_blank_comment(message):
             raise ValueError("Comment message must not be empty or whitespace-only")
         length = measured_length(message)
         if length > COMMENT_MAX_LENGTH:

--- a/nextcloud_mcp_server/utils/message_splitter.py
+++ b/nextcloud_mcp_server/utils/message_splitter.py
@@ -48,6 +48,14 @@ MENTION_PATTERN: Final[re.Pattern[str]] = re.compile(r'@(?:"[^"\n]*"|[\w.\-@]+)'
 
 PART_PREFIX_TEMPLATE: Final[str] = "({index}/{total}) "
 
+# Nextcloud core caps a comment at IComment::MAX_MESSAGE_LENGTH, checked in
+# OC\Comments\Comment::setMessage AFTER trim(), in UTF-8 code points, with a
+# strict ">" so exactly 1000 is legal. It is a *core* rule, not a Deck one, so
+# every comment surface (Deck cards, file comments) measures against this one
+# definition -- next to measured_length, which is what makes the measurement
+# agree with the server's.
+COMMENT_MAX_LENGTH: Final[int] = 1000
+
 # The prefix width depends on the part count, which depends on the budget, which
 # depends on the prefix width. The fixed point converges as soon as the digit
 # count stops moving -- three rounds is already generous.

--- a/nextcloud_mcp_server/utils/message_splitter.py
+++ b/nextcloud_mcp_server/utils/message_splitter.py
@@ -87,6 +87,26 @@ def measured_length(message: str) -> int:
     return len(message.strip(_PHP_TRIM_CHARS))
 
 
+def is_blank_comment(message: str) -> bool:
+    """True when a comment carries no content by *either* trim rule.
+
+    The two rules disagree in both directions and each gap posts a useless
+    comment, so blankness is the union of them:
+
+    * Python's ``str.strip()`` also strips every Unicode Zs space -- U+00A0,
+      U+3000 -- which PHP leaves in place. A comment of nothing but ideographic
+      spaces is as useless as one of nothing but spaces, so we reject it even
+      though the server would store it.
+    * PHP's ``trim()`` strips NUL, which Python's does not. ``"\\0"`` is
+      non-blank to Python but measures 0 to the server, which would store an
+      empty comment and report success.
+
+    Shared by every comment surface (Deck cards, file comments) so the two
+    cannot drift into rejecting different things.
+    """
+    return not message.strip() or measured_length(message) == 0
+
+
 def split_message(
     message: str,
     *,

--- a/tests/client/test_webdav_comments_client.py
+++ b/tests/client/test_webdav_comments_client.py
@@ -83,7 +83,12 @@ async def test_list_comments_request_and_parsing(webdav_client, mocker):
     body = make_request.call_args.kwargs["content"]
     assert "<oc:limit>5</oc:limit>" in body
     assert "<oc:offset>10</oc:offset>" in body
-    assert make_request.call_args.kwargs["headers"]["Depth"] == "0"
+    headers = make_request.call_args.kwargs["headers"]
+    assert headers["Depth"] == "0"
+    assert headers["Content-Type"] == "text/xml"
+    # Sent on every WebDAV request in this client; a reverse proxy may enforce
+    # it as a CSRF guard even where the dev stack does not.
+    assert headers["OCS-APIRequest"] == "true"
 
     assert [c["id"] for c in comments] == [7, 6]
     assert comments[0] == {
@@ -149,6 +154,7 @@ async def test_create_comment_payload_and_id(webdav_client, mocker):
         "verb": "comment",
         "message": 'ping @"alice"',
     }
+    assert make_request.call_args.kwargs["headers"]["OCS-APIRequest"] == "true"
 
 
 async def test_create_comment_without_content_location(webdav_client, mocker):

--- a/tests/client/test_webdav_comments_client.py
+++ b/tests/client/test_webdav_comments_client.py
@@ -1,0 +1,160 @@
+"""Unit tests for WebDAVClient file comments — wire format and parsing.
+
+The comments collection (``/remote.php/dav/comments/files/{fileId}``) is the
+only place this client speaks REPORT, and the create path is the only one that
+reads its result out of a response *header*. Both are pinned here.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from nextcloud_mcp_server.client.webdav import WebDAVClient
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def webdav_client(mocker):
+    """WebDAVClient with a mocked underlying httpx client."""
+    return WebDAVClient(mocker.AsyncMock(spec=AsyncClient), "testuser")
+
+
+def _report_response(mocker, xml: str):
+    response = mocker.Mock()
+    response.content = xml.encode()
+    response.raise_for_status = mocker.Mock()
+    return response
+
+
+_TWO_COMMENTS = """<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:response>
+    <d:href>/remote.php/dav/comments/files/42/7</d:href>
+    <d:propstat>
+      <d:prop>
+        <oc:id>7</oc:id>
+        <oc:message>Please review @"alice"</oc:message>
+        <oc:actorId>bob</oc:actorId>
+        <oc:actorType>users</oc:actorType>
+        <oc:actorDisplayName>Bob</oc:actorDisplayName>
+        <oc:creationDateTime>Sat, 15 Aug 2026 08:00:00 GMT</oc:creationDateTime>
+        <oc:verb>comment</oc:verb>
+        <oc:isUnread>true</oc:isUnread>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/comments/files/42/6</d:href>
+    <d:propstat>
+      <d:prop>
+        <oc:id>6</oc:id>
+        <oc:message>Looks good</oc:message>
+        <oc:actorId>alice</oc:actorId>
+        <oc:actorType>users</oc:actorType>
+        <oc:verb>comment</oc:verb>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <oc:actorDisplayName/>
+        <oc:creationDateTime/>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>"""
+
+
+async def test_list_comments_request_and_parsing(webdav_client, mocker):
+    """REPORT with an oc:filter-comments body; 404 propstat blocks ignored."""
+    make_request = mocker.patch.object(
+        WebDAVClient,
+        "_make_request",
+        return_value=_report_response(mocker, _TWO_COMMENTS),
+    )
+
+    comments = await webdav_client.list_comments(42, limit=5, offset=10)
+
+    method, url = make_request.call_args.args
+    assert method == "REPORT"
+    assert url == "/remote.php/dav/comments/files/42"
+    body = make_request.call_args.kwargs["content"]
+    assert "<oc:limit>5</oc:limit>" in body
+    assert "<oc:offset>10</oc:offset>" in body
+    assert make_request.call_args.kwargs["headers"]["Depth"] == "0"
+
+    assert [c["id"] for c in comments] == [7, 6]
+    assert comments[0] == {
+        "id": 7,
+        "message": 'Please review @"alice"',
+        "actor_id": "bob",
+        "actor_type": "users",
+        "actor_display_name": "Bob",
+        "creation_datetime": "Sat, 15 Aug 2026 08:00:00 GMT",
+        "verb": "comment",
+        "is_unread": True,
+    }
+    # The properties the server reported as 404 must not be fabricated as "".
+    assert comments[1]["actor_display_name"] is None
+    assert comments[1]["creation_datetime"] is None
+    assert comments[1]["is_unread"] is False
+
+
+async def test_list_comments_skips_row_without_id(webdav_client, mocker):
+    """One malformed comment costs that comment, not the whole thread."""
+    xml = """<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+      <d:response>
+        <d:href>/remote.php/dav/comments/files/42/</d:href>
+        <d:propstat>
+          <d:prop><oc:message>collection itself, no id</oc:message></d:prop>
+          <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+      </d:response>
+      <d:response>
+        <d:href>/remote.php/dav/comments/files/42/6</d:href>
+        <d:propstat>
+          <d:prop><oc:id>6</oc:id><oc:message>real one</oc:message></d:prop>
+          <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+      </d:response>
+    </d:multistatus>"""
+    mocker.patch.object(
+        WebDAVClient, "_make_request", return_value=_report_response(mocker, xml)
+    )
+
+    comments = await webdav_client.list_comments(42)
+
+    assert [c["id"] for c in comments] == [6]
+
+
+async def test_create_comment_payload_and_id(webdav_client, mocker):
+    """POST the JSON body Nextcloud expects; read the id off Content-Location."""
+    response = mocker.Mock()
+    response.headers = {"Content-Location": "/remote.php/dav/comments/files/42/99"}
+    make_request = mocker.patch.object(
+        WebDAVClient, "_make_request", return_value=response
+    )
+
+    comment_id = await webdav_client.create_comment(42, 'ping @"alice"')
+
+    assert comment_id == 99
+    method, url = make_request.call_args.args
+    assert method == "POST"
+    assert url == "/remote.php/dav/comments/files/42"
+    assert make_request.call_args.kwargs["json"] == {
+        "actorType": "users",
+        "verb": "comment",
+        "message": 'ping @"alice"',
+    }
+
+
+async def test_create_comment_without_content_location(webdav_client, mocker):
+    """No usable location means no id — but the comment was still posted."""
+    response = mocker.Mock()
+    response.headers = {}
+    mocker.patch.object(WebDAVClient, "_make_request", return_value=response)
+
+    assert await webdav_client.create_comment(42, "hi") is None

--- a/tests/server/test_webdav_comments_mcp.py
+++ b/tests/server/test_webdav_comments_mcp.py
@@ -1,0 +1,100 @@
+"""End-to-end tests for the WebDAV file-comment MCP tools (GH #1308).
+
+Exercises the real DAV comments collection through the MCP server: post a
+comment on a file, read it back, and page over it.
+"""
+
+import json
+import logging
+import uuid
+
+import pytest
+from mcp import ClientSession
+
+from nextcloud_mcp_server.client import NextcloudClient
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def commented_file(nc_client: NextcloudClient):
+    """A file to hang comments off, removed afterwards."""
+    path = f"mcp_comments_{uuid.uuid4().hex[:8]}.txt"
+    await nc_client.webdav.write_file(path, b"review me", "text/plain")
+    yield path
+    try:
+        await nc_client.webdav.delete_resource(path)
+    except Exception as e:
+        logger.warning("Failed to cleanup %s: %s", path, e)
+
+
+def _data(result):
+    return json.loads(result.content[0].text)
+
+
+async def test_create_and_list_comment(
+    nc_mcp_client: ClientSession, commented_file: str
+):
+    """A posted comment comes back from the list tool, verbatim."""
+    message = f"Automated check {uuid.uuid4().hex[:8]}"
+
+    created = _data(
+        await nc_mcp_client.call_tool(
+            "nc_webdav_create_comment",
+            arguments={"path": commented_file, "message": message},
+        )
+    )
+    assert created["success"] is True
+    assert created["file_id"] > 0
+    assert created["comment_id"] is not None
+
+    listed = _data(
+        await nc_mcp_client.call_tool(
+            "nc_webdav_list_comments", arguments={"path": commented_file}
+        )
+    )
+    assert listed["count"] == 1
+    comment = listed["results"][0]
+    assert comment["id"] == created["comment_id"]
+    assert comment["message"] == message
+    assert comment["verb"] == "comment"
+    assert comment["actor_type"] == "users"
+    assert comment["actor_id"]
+
+
+async def test_list_comments_paging(nc_mcp_client: ClientSession, commented_file: str):
+    """limit/offset page over the thread, newest first."""
+    for i in range(3):
+        await nc_mcp_client.call_tool(
+            "nc_webdav_create_comment",
+            arguments={"path": commented_file, "message": f"comment {i}"},
+        )
+
+    first_page = _data(
+        await nc_mcp_client.call_tool(
+            "nc_webdav_list_comments", arguments={"path": commented_file, "limit": 2}
+        )
+    )
+    assert first_page["count"] == 2
+    assert first_page["results"][0]["message"] == "comment 2"
+
+    second_page = _data(
+        await nc_mcp_client.call_tool(
+            "nc_webdav_list_comments",
+            arguments={"path": commented_file, "limit": 2, "offset": 2},
+        )
+    )
+    assert second_page["count"] == 1
+    assert second_page["results"][0]["message"] == "comment 0"
+
+
+async def test_comment_on_missing_file_is_refused(nc_mcp_client: ClientSession):
+    """A path that resolves to nothing is a clear refusal, not a raw 404."""
+    result = await nc_mcp_client.call_tool(
+        "nc_webdav_create_comment",
+        arguments={"path": f"no_such_file_{uuid.uuid4().hex}.txt", "message": "hi"},
+    )
+
+    assert result.isError
+    assert "File not found" in result.content[0].text

--- a/tests/unit/test_deck_comment_overflow.py
+++ b/tests/unit/test_deck_comment_overflow.py
@@ -438,7 +438,18 @@ async def test_limit_plus_trailing_whitespace_is_accepted(
     fake_client.deck.create_comment.assert_awaited_once()
 
 
-@pytest.mark.parametrize("message", ["", "   \n\t "])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "   \n\t ",
+        # Non-blank to Python's strip(), but PHP's trim() takes NUL, so Deck
+        # would store an empty comment and report success.
+        "\0",
+        # Blank to Python's strip(), non-blank to PHP's: an ideographic space.
+        "　",
+    ],
+)
 @pytest.mark.parametrize("overflow", ["error", "split"])
 async def test_blank_message_is_rejected_in_both_modes(
     create_comment, fake_client, patch_get_client, message, overflow, ctx

--- a/tests/unit/test_webdav_comment_tools.py
+++ b/tests/unit/test_webdav_comment_tools.py
@@ -104,7 +104,18 @@ async def test_create_comment_at_the_limit_is_accepted(create_comment, fake_clie
     fake_client.webdav.create_comment.assert_awaited_once()
 
 
-@pytest.mark.parametrize("message", ["", "   \n\t "])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "   \n\t ",
+        # Non-blank to Python's strip(), but PHP's trim() takes NUL, so the
+        # server would store an empty comment and report success.
+        "\0",
+        # Blank to Python's strip(), non-blank to PHP's: an ideographic space.
+        "　",
+    ],
+)
 async def test_create_comment_rejects_blank(create_comment, fake_client, message):
     with pytest.raises(ValueError, match="must not be empty"):
         await create_comment("/report.pdf", message, _ctx())

--- a/tests/unit/test_webdav_comment_tools.py
+++ b/tests/unit/test_webdav_comment_tools.py
@@ -1,0 +1,188 @@
+"""Tool-layer tests for the WebDAV file-comment tools (GH #1308).
+
+These register the WebDAV tools on a fresh ``FastMCP`` and invoke each tool's
+underlying function directly with a mocked client, covering the wiring the
+client-layer tests cannot: that the excluded-tag guard and the message
+validation run *before* anything is posted, and that a missing file is a clear
+refusal rather than a 404 from the comments collection.
+
+Fixture shape mirrors ``tests/unit/test_webdav_tools_exclusion.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from nextcloud_mcp_server.server.webdav import configure_webdav_tools
+from nextcloud_mcp_server.utils.message_splitter import COMMENT_MAX_LENGTH
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def basicauth_mode():
+    """Pin ``require_scopes`` to the BasicAuth pass-through path.
+
+    See test_webdav_tools_exclusion.py — without this the outcome depends on
+    the ambient ``MCP_DEPLOYMENT_MODE``.
+    """
+    with patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=SimpleNamespace(enable_login_flow=False),
+    ):
+        yield
+
+
+@pytest.fixture
+def fake_client(mocker):
+    """A NextcloudClient-shaped mock, installed as the tools' ``get_client``."""
+    client = SimpleNamespace(webdav=AsyncMock())
+    client.webdav.get_fileid.return_value = "42"
+
+    async def fake_get_client(_ctx):
+        return client
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_client", side_effect=fake_get_client
+    )
+    return client
+
+
+@pytest.fixture(autouse=True)
+def no_excluded_tags(mocker):
+    """Default: no tags are excluded. Individual tests override the return."""
+
+    async def fake(*_, **__):
+        return set()
+
+    return mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_excluded_file_paths", side_effect=fake
+    )
+
+
+@pytest.fixture
+def tools() -> dict:
+    mcp = FastMCP(name="test-webdav-comment-tools")
+    configure_webdav_tools(mcp)
+    return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+
+@pytest.fixture
+def create_comment(tools):
+    """Resolved outside ``pytest.raises`` blocks so only the call can throw."""
+    return tools["nc_webdav_create_comment"].fn
+
+
+@pytest.fixture
+def list_comments(tools):
+    return tools["nc_webdav_list_comments"].fn
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(request_context=SimpleNamespace())
+
+
+async def test_create_comment_posts_and_returns_id(create_comment, fake_client):
+    fake_client.webdav.create_comment.return_value = 99
+
+    result = await create_comment("/report.pdf", 'ping @"alice"', _ctx())
+
+    assert (result.file_id, result.comment_id) == (42, 99)
+    assert result.message == 'ping @"alice"'
+    fake_client.webdav.create_comment.assert_awaited_once_with(42, 'ping @"alice"')
+
+
+async def test_create_comment_at_the_limit_is_accepted(create_comment, fake_client):
+    """Nextcloud's check is a strict ``>``, so exactly the limit is legal."""
+    fake_client.webdav.create_comment.return_value = 1
+
+    await create_comment("/report.pdf", "x" * COMMENT_MAX_LENGTH, _ctx())
+
+    fake_client.webdav.create_comment.assert_awaited_once()
+
+
+@pytest.mark.parametrize("message", ["", "   \n\t "])
+async def test_create_comment_rejects_blank(create_comment, fake_client, message):
+    with pytest.raises(ValueError, match="must not be empty"):
+        await create_comment("/report.pdf", message, _ctx())
+
+    fake_client.webdav.create_comment.assert_not_awaited()
+
+
+async def test_create_comment_rejects_over_length(create_comment, fake_client):
+    """The error states the exact overage, so an agent needn't guess how much to cut."""
+    with pytest.raises(ValueError, match="5 characters over"):
+        await create_comment("/report.pdf", "x" * (COMMENT_MAX_LENGTH + 5), _ctx())
+
+    fake_client.webdav.create_comment.assert_not_awaited()
+
+
+async def test_create_comment_refuses_excluded_path(
+    create_comment, fake_client, no_excluded_tags
+):
+    no_excluded_tags.side_effect = None
+    no_excluded_tags.return_value = {"private"}  # stored without leading slash
+
+    with pytest.raises(ToolError, match="excluded tag"):
+        await create_comment("/private/report.pdf", "hi", _ctx())
+
+    fake_client.webdav.create_comment.assert_not_awaited()
+
+
+async def test_create_comment_on_missing_file(create_comment, fake_client):
+    fake_client.webdav.get_fileid.return_value = None
+
+    with pytest.raises(ToolError, match="File not found"):
+        await create_comment("/gone.pdf", "hi", _ctx())
+
+    fake_client.webdav.create_comment.assert_not_awaited()
+
+
+async def test_list_comments_maps_to_models(list_comments, fake_client):
+    fake_client.webdav.list_comments.return_value = [
+        {
+            "id": 7,
+            "message": "Please review",
+            "actor_id": "bob",
+            "actor_type": "users",
+            "actor_display_name": "Bob",
+            "creation_datetime": "Sat, 15 Aug 2026 08:00:00 GMT",
+            "verb": "comment",
+            "is_unread": True,
+        }
+    ]
+
+    result = await list_comments("/report.pdf", _ctx(), limit=5, offset=10)
+
+    assert result.count == 1
+    assert result.results[0].actor_display_name == "Bob"
+    assert (result.file_id, result.limit, result.offset) == (42, 5, 10)
+    fake_client.webdav.list_comments.assert_awaited_once_with(42, limit=5, offset=10)
+
+
+@pytest.mark.parametrize(
+    ("limit", "offset", "match"),
+    [(0, 0, "limit must be positive"), (5, -1, "offset must not be negative")],
+)
+async def test_list_comments_rejects_bad_paging(
+    list_comments, fake_client, limit, offset, match
+):
+    with pytest.raises(ValueError, match=match):
+        await list_comments("/report.pdf", _ctx(), limit=limit, offset=offset)
+
+    fake_client.webdav.list_comments.assert_not_awaited()
+
+
+async def test_list_comments_refuses_excluded_path(
+    list_comments, fake_client, no_excluded_tags
+):
+    no_excluded_tags.side_effect = None
+    no_excluded_tags.return_value = {"private"}  # stored without leading slash
+
+    with pytest.raises(ToolError, match="excluded tag"):
+        await list_comments("/private/report.pdf", _ctx())
+
+    fake_client.webdav.list_comments.assert_not_awaited()


### PR DESCRIPTION
Closes #1308.

Nextcloud file comments are how a team annotates a file in place — review
requests, hand-offs — and an `@mention` in one is what sends the notification.
Neither was reachable over MCP.

## What this adds

Two tools on the existing webdav surface (rather than a separate `comments`
app: comments only exist for files here, and the webdav module already carries
the fileid resolver, the excluded-tag guard, and the `files.read`/`files.write`
scopes):

| Tool | Wire |
|---|---|
| `nc_webdav_list_comments(path, limit=20, offset=0)` | `REPORT oc:filter-comments` on `/remote.php/dav/comments/files/{fileId}` |
| `nc_webdav_create_comment(path, message)` | `POST` JSON to the same collection; new id read from `Content-Location` |

Both take a **path** — consistent with every other tool in the module — and
resolve it through the existing `WebDAVClient.get_fileid()`. Both run the
excluded-tag guard the neighbouring file tools use, and a path that resolves to
nothing is a clear `ToolError` rather than a raw 404 from the comments
collection.

Mentions need nothing on our side: Nextcloud parses `@"username"` out of the
message when it stores the comment and sends the notification itself. Verified
end to end against the dev stack — posting `please review @"alice"` produced a
`comments`/`mention` notification row for alice.

`REPORT` rather than `PROPFIND` (as the issue sketched) because it is the only
form that takes `limit`/`offset`; a `Depth: 1` PROPFIND returns the entire
thread.

## Drive-by

The 1000-character comment cap moves from `server/deck.py` to
`utils/message_splitter.py` as `COMMENT_MAX_LENGTH`. It is core’s
`IComment::MAX_MESSAGE_LENGTH`, not a Deck rule, so both comment surfaces now
measure against one definition using the PHP-`trim()`-accurate
`measured_length`. `deck.py` keeps its `_COMMENT_MAX_LENGTH` name as an alias,
so nothing there (or in its tests) moves.

## Test coverage

- **Unit — client wire format** (`tests/client/test_webdav_comments_client.py`):
  the REPORT body/headers, multistatus parsing including a `404` propstat block
  (whose properties must not be fabricated as `""`), a row with no usable id
  being skipped rather than killing the thread, the POST payload, and the
  `Content-Location` → id read plus its absent case.
- **Unit — tool layer** (`tests/unit/test_webdav_comment_tools.py`): excluded-tag
  refusal, missing file, blank/over-length message — each asserting that
  *nothing was posted* — plus exactly-at-the-limit being accepted (core’s check
  is a strict `>`) and the paging arguments threading through.
- **End-to-end** (`tests/server/test_webdav_comments_mcp.py`, `integration`):
  through `nc_mcp_client` against a live stack — post a comment and read it back
  verbatim, page over a thread newest-first, and refuse a missing file.
- **Contract (Pact): not applicable.** This is a Nextcloud DAV boundary, not a
  cross-service provider/consumer one — no new pact interaction exists to write.

## Verification

```
uv run pytest -m unit -n auto -q                       # 3507 passed
uv run pytest tests/server/test_webdav_comments_mcp.py # 3 passed (live stack)
uv run pytest tests/server/test_annotations.py         # ADR-017 gate
uv run pytest -m smoke -q
```

---

_This PR was generated with the help of AI, and reviewed by a Human_