### PR TITLE
fix(providers): detect embedding dimension for OpenAI/Mistral models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1075,6 +1075,12 @@ OPENAI_EMBEDDING_MODEL=text-embedding-3-small  # default
 # OPENAI_BASE_URL=https://models.github.ai/inference  # optional
 ```
 
+There is no dimension setting: the vector size is read from the model itself.
+Known OpenAI models use a built-in lookup; any other model (a local
+llama.cpp / LM Studio / vLLM endpoint behind `OPENAI_BASE_URL`) is probed with
+a single test embedding at startup. The same applies to Ollama, Bedrock and
+Mistral. The model must therefore be reachable when vector sync starts.
+
 #### Mistral
 
 Hosted Mistral embeddings. Requires a Mistral API key from

--- a/nextcloud_mcp_server/providers/mistral.py
+++ b/nextcloud_mcp_server/providers/mistral.py
@@ -223,6 +223,19 @@ class MistralProvider(Provider):
         )
         return result, tokens
 
+    async def _detect_dimension(self) -> None:
+        """Detect the embedding dimension by embedding a probe string.
+
+        Same startup hook as the OpenAI/Ollama/Bedrock providers: Qdrant needs
+        the vector size before the first real embed, and a model outside
+        MISTRAL_EMBEDDING_DIMENSIONS is only knowable by asking the API.
+        """
+        if self._dimension is None and self.supports_embeddings:
+            logger.debug(
+                "Detecting embedding dimension for model %s...", self.embedding_model
+            )
+            await self.embed("test")
+
     def get_dimension(self) -> int:
         if not self.supports_embeddings:
             raise NotImplementedError(_NO_EMBEDDING_MODEL_MSG)

--- a/nextcloud_mcp_server/providers/openai.py
+++ b/nextcloud_mcp_server/providers/openai.py
@@ -250,6 +250,22 @@ class OpenAIProvider(Provider):
         )
         return embeddings, tokens
 
+    async def _detect_dimension(self) -> None:
+        """Detect the embedding dimension by embedding a probe string.
+
+        Qdrant collection init needs the vector size at startup, before any
+        real embed. Models outside OPENAI_EMBEDDING_DIMENSIONS — every model on
+        an OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, ...) — are
+        only knowable by asking the service, so the vector-sync bootstrap calls
+        this hook (``vector/qdrant_client.py``) the same way it does for
+        Ollama/Bedrock. ``embed()`` caches the dimension it observes.
+        """
+        if self._dimension is None and self.supports_embeddings:
+            logger.debug(
+                "Detecting embedding dimension for model %s...", self.embedding_model
+            )
+            await self.embed("test")
+
     def get_dimension(self) -> int:
         """
         Get embedding dimension.

--- a/tests/unit/providers/test_mistral.py
+++ b/tests/unit/providers/test_mistral.py
@@ -144,6 +144,23 @@ async def test_mistral_get_dimension_unknown_model_detected(mock_mistral_client)
 
 
 @pytest.mark.unit
+async def test_mistral_detect_dimension_hook(mock_mistral_client):
+    """_detect_dimension() resolves an unknown model's size at startup."""
+    mock_mistral_client.embeddings.create_async = AsyncMock(
+        return_value=_make_response([[0.1] * 512])
+    )
+
+    provider = MistralProvider(api_key="test-key", embedding_model="custom-mistral")
+
+    await provider._detect_dimension()
+    assert provider.get_dimension() == 512
+
+    # Idempotent: a second call does not re-probe the API.
+    await provider._detect_dimension()
+    assert mock_mistral_client.embeddings.create_async.await_count == 1
+
+
+@pytest.mark.unit
 async def test_mistral_no_embeddings_disabled(mock_mistral_client):
     """Setting embedding_model=None disables the embedding capability."""
     provider = MistralProvider(api_key="test-key", embedding_model=None)

--- a/tests/unit/providers/test_openai.py
+++ b/tests/unit/providers/test_openai.py
@@ -169,6 +169,32 @@ async def test_openai_unknown_dimension_detected(mock_openai_client):
 
 
 @pytest.mark.unit
+async def test_openai_detect_dimension_hook(mock_openai_client):
+    """_detect_dimension() resolves an unknown model's size at startup.
+
+    Vector-sync bootstrap calls this before any embed (discussion #1302: a
+    self-hosted OpenAI-compatible model failed startup with "dimension not
+    detected yet").
+    """
+    mock_embedding_data = MagicMock()
+    mock_embedding_data.embedding = [0.1] * 384
+    mock_embedding_data.index = 0
+
+    mock_response = MagicMock()
+    mock_response.data = [mock_embedding_data]
+    mock_openai_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+    provider = OpenAIProvider(api_key="test-key", embedding_model="bekko8")
+
+    await provider._detect_dimension()
+    assert provider.get_dimension() == 384
+
+    # Idempotent: a second call does not re-probe the service.
+    await provider._detect_dimension()
+    assert mock_openai_client.embeddings.create.await_count == 1
+
+
+@pytest.mark.unit
 async def test_openai_github_models_api(mock_openai_client):
     """Test OpenAI provider with GitHub Models API configuration."""
     # Mock response


### PR DESCRIPTION
## Problem

Reported in discussion #1302: pointing the server at a self-hosted embedding
model on an OpenAI-compatible endpoint refuses to start.

```
RuntimeError: Cannot start vector sync - Qdrant initialization failed:
Embedding dimension not detected yet for model <model>.
Call embed() first or use a known model.
```

Qdrant collection init needs the vector size *before* the first real embed, so
`vector/qdrant_client.py` calls `provider._detect_dimension()` when the provider
exposes that hook. `OllamaProvider` and `BedrockProvider` have it;
`OpenAIProvider` and `MistralProvider` did not — they only had a hardcoded
dimension table (`text-embedding-3-*`, `mistral-embed`) plus detect-on-first-embed,
which happens too late. So every model outside those tables — i.e. anything served
by a local llama.cpp / LM Studio / vLLM endpoint behind `OPENAI_BASE_URL` — failed
at startup, with no configuration escape hatch.

## Change

- `providers/openai.py`, `providers/mistral.py`: add `_detect_dimension()` — one
  probe embedding, cached; a no-op for models already in the static table and on
  any subsequent call.
- Unit tests for both hooks (resolves the dimension, does not re-probe).
- `docs/configuration.md`: state that there is no dimension setting, that the
  size is read from the model, and that the model must therefore be reachable
  when vector sync starts.

No new configuration surface: the dimension is a property of the model, and a
hand-entered wrong value would silently mis-size the collection.

`GatewayProvider` overrides `_detect_dimension()` (reads `GET /v1/models`) and is
unaffected.

## Test coverage

No API surface changes (no MCP tool, no `/api/v1/*` route, no cross-service
contract), so the e2e + contract gate does not apply. Covered by unit tests:

```
uv run pytest tests/unit/providers/test_openai.py tests/unit/providers/test_mistral.py \
              tests/unit/providers/test_gateway_provider.py -q   # 58 passed
```

Closes the startup failure reported in #1302.

---

_This PR was generated with the help of AI, and reviewed by a Human_
