### PR TITLE
feat(providers): request Matryoshka output width via EMBEDDING_DIMENSIONS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,8 +559,11 @@ Known gaps (tracked on board 11):
   (`/search`, `/webhooks` CRUD, `/apps`, `/chunk-context`,
   `/vector-sync/purge`, per-user app-password/session routes) is **unverified**
   pending the ADR-029 phase-4 Bearer-token/provider-state hook.
-- The gateway **embeddings** consumer pact (`/v1/embeddings` + `/v1/models`) is
-  not yet written — only OCR is pacted.
+- The gateway **embeddings** consumer pact covers one interaction: a *truncated*
+  request (`dimensions`), pinning the base64 wire format and the returned width
+  (`test_gateway_embeddings_consumer.py`). The full-width request, batch input,
+  and the 400 for an unsupported width are not pacted. (`/v1/models`, rerank and
+  OCR have their own consumer pacts.)
 - There is **no dedicated `e2e` tier** (no `e2e` marker/dir); full-stack behavior
   is spread across `tests/integration/` + `tests/smoke/`.
 - `can-i-deploy` runs in non-blocking **shadow mode**.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1118,6 +1118,48 @@ its embeddings have no semantic meaning.
 SIMPLE_EMBEDDING_DIMENSION=384  # optional; default 384
 ```
 
+#### Matryoshka Truncation (`EMBEDDING_DIMENSIONS`)
+
+Some embedding models are trained with Matryoshka Representation Learning (MRL):
+information is front-loaded, so a **prefix** of the vector is itself a valid
+embedding. Truncating cuts storage and vector RAM linearly — the dense-vector
+footprint is `chunks × dimension × 4 bytes × HNSW overhead`, so 3072 → 512 is a
+6× reduction.
+
+`EMBEDDING_DIMENSIONS` requests a narrower output width from whichever provider
+is active (OpenAI, Ollama, or the gateway). Unset (the default) leaves the model
+at its full width.
+
+```dotenv
+OPENAI_EMBEDDING_MODEL=text-embedding-3-large
+EMBEDDING_DIMENSIONS=512   # 3072 -> 512
+```
+
+**Only set this for a model documented as MRL-capable.** Nothing upstream
+validates it: Ollama will truncate a non-MRL model (e.g.
+`snowflake-arctic-embed:110m`) just as readily as an MRL one, with no error and
+silent recall loss. Known-capable: `text-embedding-3-small`/`-large`,
+`nomic-embed-text-v1.5`, `amazon.titan-embed-text-v2:0` (256/512/1024),
+`Qwen3-Embedding-*`, `jina-embeddings-v3`, `snowflake-arctic-embed-v2`.
+Fixed-width (do **not** set this): `mistral-embed`, `bge-m3`,
+`text-embedding-ada-002`, `snowflake-arctic-embed` v1.
+
+Behaviour worth knowing:
+
+- **The width is part of the collection identity.** The collection name and the
+  stored `embedding_identity` become `{model}-{dimensions}`, so changing the
+  width behaves exactly like changing the model: a new collection, and a dedup
+  miss that forces a re-embed. Vectors at two widths are different lengths and
+  cannot share a collection.
+- **An endpoint that ignores the parameter is a startup error, not a silent
+  fallback.** Some services accept `dimensions` and return the full width
+  anyway — as the Astrolabe embedding gateway currently does on every backend
+  path. The server refuses to continue rather than index at a width its
+  collection name misreports. Unset `EMBEDDING_DIMENSIONS` to run at full width.
+- Quality retention is model- and corpus-dependent. Published benchmarks
+  (~98–99% at 512-of-1536) are measured on far smaller corpora than a
+  production index; measure recall on your own data before narrowing.
+
 ### Document Chunking Configuration
 
 The server chunks documents before embedding to handle documents larger than the embedding model's context window. Chunk size and overlap can be tuned based on your embedding model and content type.
@@ -1283,6 +1325,7 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | `BEDROCK_EMBEDDING_MODEL` | ⚠️ Optional | - | Bedrock embedding model ID |
 | `BEDROCK_GENERATION_MODEL` | ⚠️ Optional | - | Bedrock generation model ID |
 | `SIMPLE_EMBEDDING_DIMENSION` | ⚠️ Optional | `384` | Dimension for the fallback Simple provider |
+| `EMBEDDING_DIMENSIONS` | ⚠️ Optional | - | Matryoshka output width requested from the active embedding provider (OpenAI/Ollama/gateway). Unset = the model's full width. Only valid for MRL-trained models — nothing upstream validates this, and truncating a non-MRL model silently degrades recall. The width joins the collection name and embedding identity, so changing it forces a new collection and a re-embed; an endpoint that ignores the parameter fails at startup rather than indexing at the wrong width. See *Matryoshka Truncation* above. |
 | `DOCUMENT_CHUNK_SIZE` | ⚠️ Optional | `2048` | Characters per chunk for document embedding |
 | `DOCUMENT_CHUNK_OVERLAP` | ⚠️ Optional | `200` | Overlapping characters between chunks (must be < chunk size) |
 | `DOCUMENT_CHUNK_PAGE_AWARE` | ⚠️ Optional | `true` | Split PDFs on page boundaries first (one chunk per page; oversized pages split within the page). Exact page numbers, clean snippets, and a predictable ~1 chunk/page when chunk size ≥ the largest page. Set `false` for the legacy char-based path. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1138,11 +1138,19 @@ EMBEDDING_DIMENSIONS=512   # 3072 -> 512
 **Only set this for a model documented as MRL-capable.** Nothing upstream
 validates it: Ollama will truncate a non-MRL model (e.g.
 `snowflake-arctic-embed:110m`) just as readily as an MRL one, with no error and
-silent recall loss. Known-capable: `text-embedding-3-small`/`-large`,
-`nomic-embed-text-v1.5`, `amazon.titan-embed-text-v2:0` (256/512/1024),
-`Qwen3-Embedding-*`, `jina-embeddings-v3`, `snowflake-arctic-embed-v2`.
-Fixed-width (do **not** set this): `mistral-embed`, `bge-m3`,
-`text-embedding-ada-002`, `snowflake-arctic-embed` v1.
+silent recall loss.
+
+MRL-capable models: `text-embedding-3-small`/`-large`, `nomic-embed-text-v1.5`,
+`Qwen3-Embedding-*`, `jina-embeddings-v3`, `snowflake-arctic-embed-v2`, and
+`amazon.titan-embed-text-v2:0` (256/512/1024). Fixed-width — do **not** set this:
+`mistral-embed`, `bge-m3`, `text-embedding-ada-002`, `snowflake-arctic-embed` v1.
+
+Being MRL-capable is a property of the *model*; whether this server can request
+it also depends on the provider. `EMBEDDING_DIMENSIONS` is wired through the
+**OpenAI**, **Ollama** and **gateway** providers. The **Bedrock** provider does
+not send it yet, so `amazon.titan-embed-text-v2:0` runs at full width when
+reached directly through Bedrock (it can still be truncated when served via a
+gateway that forwards the parameter).
 
 Behaviour worth knowing:
 

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -189,6 +189,10 @@ _DEFAULTS: dict[str, Any] = {
     "mistral_api_key": None,
     "mistral_embedding_model": "mistral-embed",
     "mistral_base_url": None,
+    # Matryoshka output width requested from the embedding endpoint (None =
+    # the model's full width). Provider-agnostic: only one provider is active
+    # at a time, so a single knob covers openai/ollama/gateway.
+    "embedding_dimensions": None,
     # Simple (fallback) embedding dimension
     "simple_embedding_dimension": 384,
     # Document chunking
@@ -646,6 +650,14 @@ _dynaconf = Dynaconf(
         # 1/(rank + k) with rank 0-indexed, so k=0 divides by zero on the
         # top-ranked point.
         Validator("VECTOR_SEARCH_RRF_K", gte=1),
+        # Matryoshka truncation width. Optional (None = the model's full
+        # width), but a non-positive value would size the Qdrant collection at
+        # zero — catch it here rather than at collection creation.
+        Validator(
+            "EMBEDDING_DIMENSIONS",
+            condition=lambda v: v is None or v >= 1,
+            messages={"condition": "EMBEDDING_DIMENSIONS must be >= 1 when set"},
+        ),
         Validator("SEARCH_RERANK_POOL_SIZE", gte=1),
         Validator("SEARCH_RERANK_MAX_CONCURRENCY", gte=1),
         Validator("SEARCH_RERANK_TIMEOUT_SECONDS", gt=0),
@@ -1197,6 +1209,12 @@ class Settings:
     mistral_api_key: str | None = None
     mistral_embedding_model: str = "mistral-embed"
     mistral_base_url: str | None = None
+
+    # Matryoshka (MRL) output width requested from the embedding endpoint.
+    # None leaves the model at its full width. Only valid for MRL-trained
+    # models — nothing upstream validates this (Ollama happily truncates a
+    # non-MRL model, with silent recall loss), so it is the operator's call.
+    embedding_dimensions: int | None = None
 
     # Simple (fallback) provider — dimension when no real provider configured
     simple_embedding_dimension: int = 384
@@ -1781,6 +1799,29 @@ class Settings:
         # derived from these two methods.
         return self._detect_base_provider()[1]
 
+    def get_embedding_identity(self) -> str:
+        """The active embedding model name, widened by the requested Matryoshka
+        width when one is configured (e.g. ``text-embedding-3-large-512``).
+
+        This — not ``get_embedding_model_name()`` — is what the Qdrant collection
+        name and the stored ``embedding_identity`` are derived from. Vectors of
+        the same model at two different widths are NOT interchangeable: they are
+        different lengths, so a collection cannot hold both, and the cross-user
+        dedup lookup must miss and force a re-embed rather than match a stored
+        full-width chunk against a truncated one. Folding the width into the
+        identity makes a width change behave exactly like a model change, which
+        is already handled correctly everywhere.
+
+        Deliberately separate from ``get_embedding_model_name()``, which stays
+        the bare model name for tracing and for the usage-metering ``model``
+        field — those record which model ran, a question the width does not
+        change.
+        """
+        model = self.get_embedding_model_name()
+        if self.embedding_dimensions is None:
+            return model
+        return f"{model}-{self.embedding_dimensions}"
+
     def get_embedding_provider_family(self) -> str:
         """
         Get the active dense-embedding provider family (a low-cardinality label).
@@ -1846,7 +1887,9 @@ class Settings:
         # omit the dense vector per-point — they share this collection with
         # hybrid documents (per-document index mode), so the name is always
         # keyed on the embedding model.
-        model_name = self.get_embedding_model_name().replace("/", "-").replace(":", "-")
+        # Identity, not bare model name: a Matryoshka width change must land in
+        # a different collection (the vectors are a different length).
+        model_name = self.get_embedding_identity().replace("/", "-").replace(":", "-")
 
         return f"{deployment_id}-{model_name}"
 

--- a/nextcloud_mcp_server/providers/base.py
+++ b/nextcloud_mcp_server/providers/base.py
@@ -1,7 +1,10 @@
 """Unified provider interface for embeddings."""
 
+import logging
 import math
 from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
 
 
 class Provider(ABC):
@@ -11,6 +14,53 @@ class Provider(ABC):
     Use the ``supports_embeddings`` capability property to determine whether a
     provider is usable before calling ``embed``/``embed_batch``.
     """
+
+    # Dimension bookkeeping shared by every provider that learns its vector
+    # width from the wire. Declared as class attributes so the helpers below can
+    # be inherited without each subclass having to re-state them; subclasses
+    # still assign the instance attributes in their own ``__init__``.
+    _dimension: int | None = None
+    _requested_dimensions: int | None = None
+    # Every embedding provider sets this in __init__; declared here so shared
+    # helpers can read it directly rather than via a defensive getattr, which
+    # would silently swallow a future rename.
+    embedding_model: str | None = None
+
+    def _record_dimension(self, observed: int) -> None:
+        """Cache the vector width seen on the wire, enforcing any requested truncation.
+
+        Matryoshka-capable models accept a ``dimensions`` request parameter and
+        return a truncated, re-normalised prefix. Endpoints that do NOT support
+        it ignore the parameter *silently* and return the model's full width with
+        no error — measured 2026-08-15 against the astrolabe embedding gateway on
+        all three of its backend paths, and against Ollama for a non-Matryoshka
+        model (which truncates blindly instead).
+
+        Letting a mismatch through would size the Qdrant collection from a name
+        claiming one width while it holds another, and bill the full vector RAM
+        the truncation was meant to avoid. So it is fatal here, where the cause is
+        still legible, rather than surfacing as a dimension error at first upsert
+        three layers away.
+        """
+        if (
+            self._requested_dimensions is not None
+            and observed != self._requested_dimensions
+        ):
+            raise RuntimeError(
+                f"Requested {self._requested_dimensions}-dimensional embeddings "
+                f"(EMBEDDING_DIMENSIONS) but the endpoint returned {observed}. "
+                "The 'dimensions' parameter was ignored — either the model is not "
+                "Matryoshka-capable, or the service does not forward the parameter "
+                "to its backend. Unset EMBEDDING_DIMENSIONS to index at the "
+                "model's full width."
+            )
+        if self._dimension is None:
+            self._dimension = observed
+            logger.info(
+                "Detected embedding dimension: %d for model %s",
+                observed,
+                self.embedding_model,
+            )
 
     @property
     @abstractmethod

--- a/nextcloud_mcp_server/providers/base.py
+++ b/nextcloud_mcp_server/providers/base.py
@@ -41,6 +41,12 @@ class Provider(ABC):
         the truncation was meant to avoid. So it is fatal here, where the cause is
         still legible, rather than surfacing as a dimension error at first upsert
         three layers away.
+
+        The check runs on EVERY embed, not only the one that first resolves the
+        width. Caching short-circuits after the first call, but the comparison
+        does not: a backend that changes width mid-run — a failover to a
+        different model behind one endpoint, say — is caught instead of quietly
+        mixing widths within a single collection.
         """
         if (
             self._requested_dimensions is not None

--- a/nextcloud_mcp_server/providers/gateway.py
+++ b/nextcloud_mcp_server/providers/gateway.py
@@ -119,6 +119,7 @@ class GatewayProvider(OpenAIProvider):
         embedding_model: str,
         token_provider: GatewayTokenProvider | None = None,
         timeout: float = 120.0,
+        embedding_dimensions: int | None = None,
     ):
         # The gateway exposes its OpenAI-compatible API under the /v1 base path
         # (/v1/embeddings, /v1/models). Callers configure EMBEDDING_GATEWAY_URL
@@ -140,13 +141,16 @@ class GatewayProvider(OpenAIProvider):
             base_url=normalized_base_url,
             embedding_model=embedding_model,
             timeout=timeout,
+            embedding_dimensions=embedding_dimensions,
         )
         self._token_provider = token_provider
         logger.info(
-            "Initialized gateway embedding provider: base_url=%s, model=%s, auth=%s",
+            "Initialized gateway embedding provider: base_url=%s, model=%s, "
+            "auth=%s, requested_dimensions=%s",
             normalized_base_url,
             embedding_model,
             "oidc-m2m" if token_provider else "none",
+            embedding_dimensions,
         )
 
     async def _ensure_bearer(self) -> None:
@@ -175,6 +179,15 @@ class GatewayProvider(OpenAIProvider):
         """
         if self._dimension is not None:
             return  # already known (e.g. an OpenAI model in the static map)
+
+        if self._requested_dimensions is not None:
+            # The catalogue reports each model's FULL width, so it cannot answer
+            # for a truncated request. Fall through to the inherited probe,
+            # which reads the width off an actual embedding — and therefore also
+            # catches a gateway that accepted `dimensions` and ignored it
+            # (measured 2026-08-15: it does, silently, on every backend path).
+            await super()._detect_dimension()
+            return
 
         # ``models`` is a sibling of ``embeddings`` under the gateway's base —
         # derive it from the same base_url the OpenAI client uses for embeds so

--- a/nextcloud_mcp_server/providers/ollama.py
+++ b/nextcloud_mcp_server/providers/ollama.py
@@ -22,6 +22,7 @@ class OllamaProvider(Provider):
         embedding_model: str | None = None,
         verify_ssl: bool = True,
         timeout: httpx.Timeout | None = None,
+        embedding_dimensions: int | None = None,
     ):
         """
         Initialize Ollama provider.
@@ -31,6 +32,15 @@ class OllamaProvider(Provider):
             embedding_model: Model for embeddings (e.g., "nomic-embed-text"). None disables embeddings.
             verify_ssl: Verify SSL certificates (default: True)
             timeout: HTTP timeout configuration
+            embedding_dimensions: Matryoshka output width to request. None (the
+                default) leaves the model at its full width.
+
+        Note: Ollama honours ``dimensions`` on ``/api/embed`` and truncates
+        *and* re-normalises server-side (verified against nomic-embed-text: the
+        256-wide result is the 768-wide prefix rescaled by 1/||prefix||, norm
+        1.0). It does NOT validate that the model is Matryoshka-trained —
+        snowflake-arctic-embed:110m truncates just as happily, with silent
+        recall loss. Only set this for a model documented as MRL-capable.
         """
         self.base_url = base_url.rstrip("/")
         self.embedding_model = embedding_model
@@ -41,12 +51,15 @@ class OllamaProvider(Provider):
 
         self.client = httpx.AsyncClient(verify=verify_ssl, timeout=timeout)
         self._dimension: int | None = None  # Detected dynamically for embeddings
+        self._requested_dimensions = embedding_dimensions
 
         logger.info(
-            "Initialized Ollama provider: %s (embedding_model=%s, verify_ssl=%s)",
+            "Initialized Ollama provider: %s "
+            "(embedding_model=%s, verify_ssl=%s, requested_dimensions=%s)",
             base_url,
             embedding_model,
             verify_ssl,
+            embedding_dimensions,
         )
 
         # Pre-check and auto-load models
@@ -57,6 +70,16 @@ class OllamaProvider(Provider):
     def supports_embeddings(self) -> bool:
         """Whether this provider supports embedding generation."""
         return self.embedding_model is not None
+
+    def _dimension_params(self) -> dict[str, int]:
+        """The ``dimensions`` field for the ``/api/embed`` body, when configured.
+
+        Omitted entirely rather than sent as ``None``: Ollama would treat an
+        explicit null as a requested width of nothing.
+        """
+        if self._requested_dimensions is None:
+            return {}
+        return {"dimensions": self._requested_dimensions}
 
     async def embed(self, text: str) -> list[float]:
         """
@@ -142,16 +165,22 @@ class OllamaProvider(Provider):
             batch = texts[i : i + batch_size]
             response = await self.client.post(
                 f"{self.base_url}/api/embed",
-                json={"model": self.embedding_model, "input": batch},
+                json={
+                    "model": self.embedding_model,
+                    "input": batch,
+                    **self._dimension_params(),
+                },
             )
             response.raise_for_status()
             data = response.json()
             all_embeddings.extend(data["embeddings"])
 
-            # Cache the dimension inline (mirrors OpenAI/Mistral) so it is set
-            # via any embed path, not only an explicit _detect_dimension() call.
-            if self._dimension is None and data["embeddings"]:
-                self._dimension = len(data["embeddings"][0])
+            # Cache the dimension inline (mirrors OpenAI) so it is set via any
+            # embed path, not only an explicit _detect_dimension() call. Also
+            # where a requested truncation is enforced, so an endpoint that
+            # ignored `dimensions` cannot get past the first batch.
+            if data["embeddings"]:
+                self._record_dimension(len(data["embeddings"][0]))
 
             # ``prompt_eval_count`` is assumed to be the batch-level total for a
             # multi-input /api/embed call. Ollama's API docs aren't explicit
@@ -180,13 +209,9 @@ class OllamaProvider(Provider):
             logger.debug(
                 "Detecting embedding dimension for model %s...", self.embedding_model
             )
-            test_embedding = await self.embed("test")
-            self._dimension = len(test_embedding)
-            logger.info(
-                "Detected embedding dimension: %s for model %s",
-                self._dimension,
-                self.embedding_model,
-            )
+            # embed() routes through embed_batch_with_usage(), which records the
+            # observed width (and enforces any requested truncation) already.
+            await self.embed("test")
 
     def get_dimension(self) -> int:
         """

--- a/nextcloud_mcp_server/providers/openai.py
+++ b/nextcloud_mcp_server/providers/openai.py
@@ -8,7 +8,7 @@ Supports:
 
 import logging
 
-from openai import APIConnectionError, APIError, APIStatusError, AsyncOpenAI
+from openai import APIConnectionError, APIError, APIStatusError, AsyncOpenAI, Omit, omit
 
 from ..retry import retry_on_transient
 from .base import Provider
@@ -68,6 +68,7 @@ class OpenAIProvider(Provider):
         base_url: str | None = None,
         embedding_model: str | None = None,
         timeout: float = 120.0,
+        embedding_dimensions: int | None = None,
     ):
         """
         Initialize OpenAI provider.
@@ -78,9 +79,12 @@ class OpenAIProvider(Provider):
             embedding_model: Model for embeddings (e.g., "text-embedding-3-small").
                             None disables embeddings.
             timeout: HTTP timeout in seconds (default: 120)
+            embedding_dimensions: Matryoshka output width to request. None (the
+                            default) leaves the model at its full width.
         """
         self.embedding_model = embedding_model
         self._dimension: int | None = None
+        self._requested_dimensions = embedding_dimensions
 
         # Initialize async client
         self.client = AsyncOpenAI(
@@ -89,22 +93,43 @@ class OpenAIProvider(Provider):
             timeout=timeout,
         )
 
-        # Try to get known dimension without API call
-        if embedding_model and embedding_model in OPENAI_EMBEDDING_DIMENSIONS:
+        # Try to get known dimension without API call. Skipped when a truncation
+        # is requested: the static map records each model's FULL width, so
+        # trusting it would size the collection wrong. Leaving the dimension
+        # unset makes the first embed observe what the endpoint actually
+        # returned — which is also what catches an endpoint that ignored the
+        # parameter (see Provider._record_dimension).
+        if (
+            embedding_model
+            and embedding_dimensions is None
+            and embedding_model in OPENAI_EMBEDDING_DIMENSIONS
+        ):
             self._dimension = OPENAI_EMBEDDING_DIMENSIONS[embedding_model]
 
         logger.info(
             "Initialized OpenAI provider: base_url=%s "
-            "(embedding_model=%s, dimension=%s)",
+            "(embedding_model=%s, dimension=%s, requested_dimensions=%s)",
             base_url or "default",
             embedding_model,
             self._dimension,
+            embedding_dimensions,
         )
 
     @property
     def supports_embeddings(self) -> bool:
         """Whether this provider supports embedding generation."""
         return self.embedding_model is not None
+
+    def _dimensions_arg(self) -> int | Omit:
+        """The ``dimensions`` request argument, when an output width is configured.
+
+        The SDK's ``omit`` sentinel drops the key from the request body entirely
+        — passing ``None`` would serialise an explicit null, which several
+        OpenAI-compatible endpoints reject.
+        """
+        if self._requested_dimensions is None:
+            return omit
+        return self._requested_dimensions
 
     @_retry_transient
     async def embed(self, text: str) -> list[float]:
@@ -129,18 +154,12 @@ class OpenAIProvider(Provider):
         response = await self.client.embeddings.create(
             input=text,
             model=self.embedding_model,
+            dimensions=self._dimensions_arg(),
         )
 
         embedding = response.data[0].embedding
 
-        # Update dimension if not set
-        if self._dimension is None:
-            self._dimension = len(embedding)
-            logger.info(
-                "Detected embedding dimension: %d for model %s",
-                self._dimension,
-                self.embedding_model,
-            )
+        self._record_dimension(len(embedding))
 
         return embedding
 
@@ -208,14 +227,8 @@ class OpenAIProvider(Provider):
             all_embeddings.extend(batch_embeddings)
             total_tokens += batch_tokens
 
-            # Update dimension if not set
-            if self._dimension is None and batch_embeddings:
-                self._dimension = len(batch_embeddings[0])
-                logger.info(
-                    "Detected embedding dimension: %d for model %s",
-                    self._dimension,
-                    self.embedding_model,
-                )
+            if batch_embeddings:
+                self._record_dimension(len(batch_embeddings[0]))
 
         return all_embeddings, total_tokens
 
@@ -233,6 +246,7 @@ class OpenAIProvider(Provider):
         response = await self.client.embeddings.create(
             input=batch,
             model=self.embedding_model,
+            dimensions=self._dimensions_arg(),
         )
         # Sort by index to maintain order
         sorted_data = sorted(response.data, key=lambda x: x.index)

--- a/nextcloud_mcp_server/providers/registry.py
+++ b/nextcloud_mcp_server/providers/registry.py
@@ -70,6 +70,7 @@ def create_provider() -> Provider:
             base_url=settings.embedding_gateway_url,
             embedding_model=settings.embedding_gateway_model,
             token_provider=token_provider,
+            embedding_dimensions=settings.embedding_dimensions,
         )
 
     # 1. Bedrock
@@ -97,6 +98,7 @@ def create_provider() -> Provider:
             api_key=settings.openai_api_key,
             base_url=settings.openai_base_url,
             embedding_model=settings.openai_embedding_model,
+            embedding_dimensions=settings.embedding_dimensions,
         )
 
     # 3. Mistral
@@ -123,6 +125,7 @@ def create_provider() -> Provider:
             base_url=settings.ollama_base_url,
             embedding_model=settings.ollama_embedding_model,
             verify_ssl=settings.ollama_verify_ssl,
+            embedding_dimensions=settings.embedding_dimensions,
         )
 
     # 5. Simple (fallback)

--- a/nextcloud_mcp_server/vector/collection_metadata.py
+++ b/nextcloud_mcp_server/vector/collection_metadata.py
@@ -46,9 +46,11 @@ def build_embedding_identity(settings: Settings | None = None) -> str:
     truth for the identity stamped on chunk points, the collection sentinel, the
     admin backfill, and the cross-user dedup comparison, so all four agree.
 
-    It is the active dense embedding MODEL name: the gateway and query path route
-    on it, matching the collection-name derivation, and a model switch changes it
-    so the dedup lookup misses and forces a re-embed. It is orthogonal to
+    It is the active dense embedding MODEL name, widened by the requested
+    Matryoshka width when one is set (``get_embedding_identity``): the gateway and
+    query path route on it, matching the collection-name derivation, and a model
+    switch — or a width switch, which likewise changes the vector length — changes
+    it so the dedup lookup misses and forces a re-embed. It is orthogonal to
     keyword-vs-hybrid — keyword documents share this collection and carry the same
     model identity (they simply omit the dense vector), so both modes dedup in one
     identity space. The keyword/hybrid distinction is tracked separately by
@@ -56,7 +58,7 @@ def build_embedding_identity(settings: Settings | None = None) -> str:
     identity is written OR compared (Deck #509).
     """
     s = settings or get_settings()
-    return s.get_embedding_model_name()
+    return s.get_embedding_identity()
 
 
 def env_default_metadata(settings: Settings | None = None) -> dict[str, Any]:

--- a/tests/contract/test_gateway_embeddings_consumer.py
+++ b/tests/contract/test_gateway_embeddings_consumer.py
@@ -1,0 +1,114 @@
+"""Consumer contract: nextcloud-mcp-server -> embedding-gateway POST /v1/embeddings.
+
+This is the embeddings half of the gateway boundary; until now only OCR, rerank
+and the model catalogue were pacted, so the endpoint the whole indexing and query
+path depends on had no contract at all.
+
+Two things it pins that nothing else does:
+
+**The wire format is base64, not a float array.** The OpenAI SDK sets
+``encoding_format="base64"`` whenever the caller does not pass one
+(``openai/resources/embeddings.py``: ``if not is_given(encoding_format):
+params["encoding_format"] = "base64"``) and decodes the payload client-side. Every
+embedding this service has ever requested crossed the wire that way, and no test
+said so. A gateway that only implemented the float form would break this client
+while looking OpenAI-compatible.
+
+**``dimensions`` must be honoured, not merely accepted.** Matryoshka-capable
+models return a truncated, re-normalised prefix when asked for a narrower output
+(``EMBEDDING_DIMENSIONS``). Measured 2026-08-15, the gateway accepts the parameter
+and silently ignores it on all three of its backend paths — OpenRouter, Bedrock
+and local — returning the model's full width with ``error: null``. That is the
+failure this interaction exists to catch, so the width is asserted rather than
+left to a type matcher: the expected body is a base64 string of exactly the
+length a 256-float32 vector encodes to, and a provider returning any other width
+fails verification.
+
+Deliberately NOT pinned here: which models support truncation. That is catalogue
+metadata (``GET /v1/models``, see test_gateway_models_consumer.py) and a rejection
+rule the provider owns — a 400 for an unsupported width is a *different*
+interaction under a different provider state, and this client has no branch for
+it beyond failing loudly. Consumer-side handling of a width that comes back wrong
+lives a tier down in tests/unit/providers/test_embedding_dimensions.py.
+
+The gateway is unauthenticated today, so no bearer is sent. See ADR-029.
+"""
+
+import array
+import base64
+
+import pytest
+from pact import match
+
+from nextcloud_mcp_server.providers.gateway import GatewayProvider
+
+pytestmark = pytest.mark.contract
+
+_MODEL = "openrouter/openai/text-embedding-3-small"
+_INPUT = "the quarterly report was filed late"
+_TRUNCATED = 256
+
+# The example the mock server replays, and the exact shape the provider must
+# match. float32 little-endian is what the SDK decodes with
+# ``array.array("f", base64.b64decode(...))``, so 256 dims is 1024 bytes.
+_EXAMPLE_EMBEDDING = base64.b64encode(
+    array.array("f", [0.0123] * _TRUNCATED).tobytes()
+).decode()
+# Length is the assertion: a full-width 1536-dim vector encodes to a very
+# different number of characters, so an ignored ``dimensions`` cannot pass.
+_EXACT_WIDTH = rf"^[A-Za-z0-9+/=]{{{len(_EXAMPLE_EMBEDDING)}}}$"
+
+
+async def test_embeddings_honour_the_requested_output_width(gateway_consumer_pact):
+    """A truncated embedding request returns a vector of exactly that width."""
+    (
+        gateway_consumer_pact.upon_receiving("a truncated embedding request")
+        .given("the gateway serves a Matryoshka-capable embedding model")
+        .with_request("POST", "/v1/embeddings")
+        .with_body(
+            {
+                "input": _INPUT,
+                "model": _MODEL,
+                # Sent by the SDK on every request, not by this client's choice.
+                "encoding_format": "base64",
+                "dimensions": _TRUNCATED,
+            },
+            content_type="application/json",
+        )
+        .will_respond_with(200)
+        .with_body(
+            {
+                "object": match.string("list"),
+                "data": [
+                    {
+                        "object": match.string("embedding"),
+                        "index": match.integer(0),
+                        "embedding": match.regex(
+                            _EXAMPLE_EMBEDDING, regex=_EXACT_WIDTH
+                        ),
+                    }
+                ],
+                "model": match.string(_MODEL),
+                # Read by _embed_batch_request for usage metering; the same
+                # response shape serves the single-input path used here.
+                "usage": {
+                    "prompt_tokens": match.integer(7),
+                    "total_tokens": match.integer(7),
+                },
+            },
+            content_type="application/json",
+        )
+    )
+
+    with gateway_consumer_pact.serve() as srv:
+        provider = GatewayProvider(
+            base_url=str(srv.url),
+            embedding_model=_MODEL,
+            embedding_dimensions=_TRUNCATED,
+        )
+        embedding = await provider.embed(_INPUT)
+
+    # Decoded client-side by the SDK, and accepted by _record_dimension — which
+    # would have raised had the width disagreed with the request.
+    assert len(embedding) == _TRUNCATED
+    assert provider.get_dimension() == _TRUNCATED

--- a/tests/unit/providers/test_embedding_dimensions.py
+++ b/tests/unit/providers/test_embedding_dimensions.py
@@ -1,0 +1,190 @@
+"""Unit tests for the Matryoshka output-width request (``EMBEDDING_DIMENSIONS``).
+
+Three things are worth pinning, and they are all about the *silent* failure mode
+rather than the happy path:
+
+1. The parameter is sent only when configured — an explicit ``dimensions: null``
+   is rejected by several OpenAI-compatible endpoints.
+2. A returned width that disagrees with the requested one is FATAL. Endpoints
+   that do not support truncation ignore the parameter without erroring
+   (measured 2026-08-15 against the astrolabe embedding gateway on all three of
+   its backend paths), which would otherwise size the Qdrant collection from a
+   name claiming one width while it holds another.
+3. The gateway must not answer a truncated request from its ``/v1/models``
+   catalogue, which reports each model's full width.
+
+The complementary risk — truncating a model that is not Matryoshka-trained — is
+not detectable here. Nothing upstream validates it either (Ollama truncates
+``snowflake-arctic-embed:110m`` just as happily as ``nomic-embed-text``), so it
+stays an operator decision; see the note on ``Settings.embedding_dimensions``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from openai import omit
+
+from nextcloud_mcp_server.providers.gateway import GatewayProvider
+from nextcloud_mcp_server.providers.ollama import OllamaProvider
+from nextcloud_mcp_server.providers.openai import OpenAIProvider
+
+pytestmark = pytest.mark.unit
+
+_TRUNCATED = 256
+_FULL = 1536
+
+
+@pytest.fixture
+def mock_openai_client(mocker):
+    mock_client = MagicMock()
+    mock_client.embeddings = MagicMock()
+    mocker.patch(
+        "nextcloud_mcp_server.providers.openai.AsyncOpenAI", return_value=mock_client
+    )
+    return mock_client
+
+
+def _openai_response(dimension: int):
+    datum = MagicMock()
+    datum.embedding = [0.01] * dimension
+    datum.index = 0
+    response = MagicMock()
+    response.data = [datum]
+    response.usage = MagicMock(total_tokens=3)
+    return response
+
+
+def _ollama_response(dimension: int):
+    resp = MagicMock()
+    resp.json = MagicMock(return_value={"embeddings": [[0.01] * dimension]})
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+async def test_openai_sends_dimensions_when_configured(mock_openai_client):
+    """The configured width is sent, and the observed width is what sticks."""
+    mock_openai_client.embeddings.create = AsyncMock(
+        return_value=_openai_response(_TRUNCATED)
+    )
+    provider = OpenAIProvider(
+        api_key="test-key",
+        embedding_model="text-embedding-3-small",
+        embedding_dimensions=_TRUNCATED,
+    )
+
+    embedding = await provider.embed("probe")
+
+    assert len(embedding) == _TRUNCATED
+    assert mock_openai_client.embeddings.create.await_args.kwargs["dimensions"] == (
+        _TRUNCATED
+    )
+    # The observed width wins over the static OPENAI_EMBEDDING_DIMENSIONS entry,
+    # which records the model's full 1536.
+    assert provider.get_dimension() == _TRUNCATED
+
+
+async def test_openai_omits_dimensions_when_unset(mock_openai_client):
+    """Not ``dimensions: None`` — the key must leave the request body entirely.
+
+    ``omit`` is the SDK's sentinel for that; a literal None would serialise as an
+    explicit null, which several OpenAI-compatible endpoints reject.
+    """
+    mock_openai_client.embeddings.create = AsyncMock(
+        return_value=_openai_response(_FULL)
+    )
+    provider = OpenAIProvider(
+        api_key="test-key", embedding_model="text-embedding-3-small"
+    )
+
+    await provider.embed("probe")
+
+    assert mock_openai_client.embeddings.create.await_args.kwargs["dimensions"] is omit
+
+
+async def test_openai_known_model_dimension_not_prefilled_when_truncating(
+    mock_openai_client,
+):
+    """A requested width must not be pre-empted by the static full-width map.
+
+    Pre-filling would let ``get_dimension()`` answer 1536 before any request,
+    sizing the collection at full width for a truncated deployment.
+    """
+    provider = OpenAIProvider(
+        api_key="test-key",
+        embedding_model="text-embedding-3-small",
+        embedding_dimensions=_TRUNCATED,
+    )
+
+    assert provider._dimension is None
+
+
+async def test_openai_raises_when_endpoint_ignores_dimensions(mock_openai_client):
+    """The measured gateway behaviour: parameter accepted, full width returned."""
+    mock_openai_client.embeddings.create = AsyncMock(
+        return_value=_openai_response(_FULL)
+    )
+    provider = OpenAIProvider(
+        api_key="test-key",
+        embedding_model="text-embedding-3-small",
+        embedding_dimensions=_TRUNCATED,
+    )
+
+    with pytest.raises(RuntimeError, match="ignored"):
+        await provider.embed("probe")
+
+
+async def test_ollama_sends_dimensions_when_configured():
+    """Ollama takes ``dimensions`` in the /api/embed body and truncates server-side."""
+    provider = OllamaProvider(
+        base_url="https://ollama:11434", embedding_dimensions=_TRUNCATED
+    )
+    provider.embedding_model = "nomic-embed-text"
+    provider.client.post = AsyncMock(return_value=_ollama_response(_TRUNCATED))
+
+    embeddings, _ = await provider.embed_batch_with_usage(["probe"])
+
+    assert len(embeddings[0]) == _TRUNCATED
+    assert provider.client.post.await_args.kwargs["json"]["dimensions"] == _TRUNCATED
+    assert provider.get_dimension() == _TRUNCATED
+
+
+async def test_ollama_omits_dimensions_when_unset():
+    provider = OllamaProvider(base_url="https://ollama:11434")
+    provider.embedding_model = "nomic-embed-text"
+    provider.client.post = AsyncMock(return_value=_ollama_response(768))
+
+    await provider.embed_batch_with_usage(["probe"])
+
+    assert "dimensions" not in provider.client.post.await_args.kwargs["json"]
+
+
+async def test_ollama_raises_when_endpoint_ignores_dimensions():
+    provider = OllamaProvider(
+        base_url="https://ollama:11434", embedding_dimensions=_TRUNCATED
+    )
+    provider.embedding_model = "nomic-embed-text"
+    provider.client.post = AsyncMock(return_value=_ollama_response(768))
+
+    with pytest.raises(RuntimeError, match="ignored"):
+        await provider.embed_batch_with_usage(["probe"])
+
+
+async def test_gateway_detect_dimension_ignores_catalogue_when_truncating(mocker):
+    """``/v1/models`` reports the model's full width, so it cannot answer for a
+    truncated request — the probe path must be used instead."""
+    provider = GatewayProvider(
+        base_url="https://gateway.example",
+        embedding_model="openrouter/openai/text-embedding-3-small",
+        embedding_dimensions=_TRUNCATED,
+    )
+    catalogue = mocker.patch("httpx.AsyncClient.get")
+    # Patch the wire, not ``embed`` — the width is recorded by embed() itself,
+    # so mocking that away would test nothing.
+    provider.client.embeddings.create = AsyncMock(
+        return_value=_openai_response(_TRUNCATED)
+    )
+
+    await provider._detect_dimension()
+
+    catalogue.assert_not_called()
+    assert provider.get_dimension() == _TRUNCATED

--- a/tests/unit/providers/test_embedding_dimensions.py
+++ b/tests/unit/providers/test_embedding_dimensions.py
@@ -169,6 +169,31 @@ async def test_ollama_raises_when_endpoint_ignores_dimensions():
         await provider.embed_batch_with_usage(["probe"])
 
 
+async def test_width_is_revalidated_on_every_batch_not_just_the_first():
+    """The guard is not a first-call-only check.
+
+    Caching short-circuits once the width is known, but the comparison does not,
+    so a backend that changes width part-way through a run — a failover to a
+    different model behind one endpoint — is caught rather than quietly mixing
+    widths inside one collection. The first batch here is well-formed; the
+    second is not.
+    """
+    provider = OllamaProvider(
+        base_url="https://ollama:11434", embedding_dimensions=_TRUNCATED
+    )
+    provider.embedding_model = "nomic-embed-text"
+    provider.client.post = AsyncMock(
+        side_effect=[_ollama_response(_TRUNCATED), _ollama_response(768)]
+    )
+
+    with pytest.raises(RuntimeError, match="ignored"):
+        await provider.embed_batch_with_usage(["first", "second"], batch_size=1)
+
+    # The width learned from the good batch is still cached; the guard fired on
+    # the comparison, not on a re-detection.
+    assert provider.get_dimension() == _TRUNCATED
+
+
 async def test_gateway_detect_dimension_ignores_catalogue_when_truncating(mocker):
     """``/v1/models`` reports the model's full width, so it cannot answer for a
     truncated request — the probe path must be used instead."""

--- a/tests/unit/providers/test_openai.py
+++ b/tests/unit/providers/test_openai.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from openai import omit
 
 from nextcloud_mcp_server.providers.openai import (
     OPENAI_EMBEDDING_DIMENSIONS,
@@ -50,6 +51,10 @@ async def test_openai_embedding(mock_openai_client):
     mock_openai_client.embeddings.create.assert_called_once_with(
         input="test text",
         model="text-embedding-3-small",
+        # No EMBEDDING_DIMENSIONS configured. ``omit`` is the SDK's absence
+        # sentinel — it drops the key from the request body, unlike None, which
+        # would serialise an explicit null.
+        dimensions=omit,
     )
 
 
@@ -85,6 +90,7 @@ async def test_openai_embedding_batch(mock_openai_client):
     mock_openai_client.embeddings.create.assert_called_once_with(
         input=["text1", "text2"],
         model="text-embedding-3-small",
+        dimensions=omit,
     )
 
 

--- a/tests/unit/providers/test_registry.py
+++ b/tests/unit/providers/test_registry.py
@@ -35,6 +35,7 @@ def _clear_provider_envs(monkeypatch: pytest.MonkeyPatch) -> None:
         "OLLAMA_GENERATION_MODEL",
         "OLLAMA_VERIFY_SSL",
         "SIMPLE_EMBEDDING_DIMENSION",
+        "EMBEDDING_DIMENSIONS",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -66,6 +67,50 @@ def test_registry_picks_simple_with_custom_dimension(clean_provider_env):
     provider = get_provider()
     assert isinstance(provider, SimpleProvider)
     assert provider.get_dimension() == 512
+
+
+@pytest.mark.unit
+def test_registry_threads_embedding_dimensions_to_openai(clean_provider_env):
+    """EMBEDDING_DIMENSIONS must actually reach the constructed provider.
+
+    A setting can be present in _DEFAULTS and the Settings dataclass yet be
+    dropped on the way to the provider — either by an omission in _FIELD_MAP
+    (which silently disabled OCR batch mode, Deck #332) or by a missing kwarg in
+    create_provider(). Neither shows up in a settings-only assertion, so assert
+    on the provider instance.
+    """
+    clean_provider_env.setenv("OPENAI_API_KEY", "test-key")
+    clean_provider_env.setenv("EMBEDDING_DIMENSIONS", "512")
+    _reload_config()
+
+    provider = get_provider()
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._requested_dimensions == 512
+
+
+@pytest.mark.unit
+def test_registry_threads_embedding_dimensions_to_ollama(clean_provider_env, mocker):
+    """Same wire-through, for the other provider that supports truncation."""
+    mocker.patch(
+        "nextcloud_mcp_server.providers.ollama.OllamaProvider._check_model_is_loaded"
+    )
+    clean_provider_env.setenv("OLLAMA_BASE_URL", "http://ollama:11434")
+    clean_provider_env.setenv("EMBEDDING_DIMENSIONS", "256")
+    _reload_config()
+
+    provider = get_provider()
+    assert isinstance(provider, OllamaProvider)
+    assert provider._requested_dimensions == 256
+
+
+@pytest.mark.unit
+def test_registry_leaves_dimensions_unset_by_default(clean_provider_env):
+    """Unset EMBEDDING_DIMENSIONS means full width, not a coerced 0."""
+    clean_provider_env.setenv("OPENAI_API_KEY", "test-key")
+    _reload_config()
+
+    provider = get_provider()
+    assert provider._requested_dimensions is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -186,6 +186,27 @@ class TestGetSettings:
         settings = get_settings()
         assert settings.vector_sync_empty_discovery_delete_threshold == 5
 
+    @patch.dict(os.environ, {"EMBEDDING_DIMENSIONS": "512"}, clear=True)
+    def test_get_settings_embedding_dimensions_from_env(self):
+        """EMBEDDING_DIMENSIONS must reach settings as an int.
+
+        Same _DEFAULTS / _FIELD_MAP omission guard as the settings above — a key
+        declared on the dataclass but missing from the field map is silently
+        ignored, which here would mean indexing at full width while the operator
+        believes truncation is on.
+        """
+        _reload_config()
+        settings = get_settings()
+        assert settings.embedding_dimensions == 512
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_embedding_dimensions_unset_by_default(self):
+        """Unset means the model's full width, not zero."""
+        _reload_config()
+        settings = get_settings()
+        assert settings.embedding_dimensions is None
+        assert settings.get_embedding_identity() == settings.get_embedding_model_name()
+
     @patch.dict(os.environ, {}, clear=True)
     def test_empty_discovery_threshold_default(self):
         """Default is 3 consecutive empty cycles before deletions are believed."""
@@ -667,6 +688,46 @@ class TestCollectionNameWithProviders:
             openai_embedding_model="text-embedding-3-large",
         )
         assert settings.get_collection_name() == "custom-collection"
+
+
+class TestEmbeddingIdentityWithMatryoshkaWidth:
+    """A requested Matryoshka width is part of the embedding identity.
+
+    Vectors of one model at two widths are different lengths, so a collection
+    cannot hold both and a dedup hit across widths would be wrong. Folding the
+    width into the identity makes a width change behave like a model change.
+    """
+
+    def _settings(self, **overrides):
+        return Settings(
+            openai_api_key="test-key",
+            openai_embedding_model="text-embedding-3-large",
+            otel_service_name="my-deployment",
+            **overrides,
+        )
+
+    def test_identity_is_bare_model_at_full_width(self):
+        assert self._settings().get_embedding_identity() == "text-embedding-3-large"
+
+    def test_identity_carries_the_requested_width(self):
+        settings = self._settings(embedding_dimensions=512)
+        assert settings.get_embedding_identity() == "text-embedding-3-large-512"
+
+    def test_collection_name_separates_widths(self):
+        """The dimension-mismatch guard in qdrant_client only fires on a REUSED
+        collection, so the two widths must not resolve to the same name."""
+        full = self._settings().get_collection_name()
+        truncated = self._settings(embedding_dimensions=512).get_collection_name()
+        assert full == "my-deployment-text-embedding-3-large"
+        assert truncated == "my-deployment-text-embedding-3-large-512"
+
+    def test_model_name_stays_bare_for_metering_and_tracing(self):
+        """``get_embedding_model_name`` feeds the usage-metering ``model`` field
+        and the embedding span attribute — both record which model ran, which the
+        width does not change. Widening it there would rewrite a billing
+        dimension's values."""
+        settings = self._settings(embedding_dimensions=512)
+        assert settings.get_embedding_model_name() == "text-embedding-3-large"
 
 
 class TestDynaconfValidators:

--- a/tests/unit/vector/test_sharing_state.py
+++ b/tests/unit/vector/test_sharing_state.py
@@ -27,12 +27,13 @@ _MODEL = "model-x"
 
 
 class _Settings:
-    # The dedup identity is always the dense embedding model name (keyword-vs-
-    # hybrid is tracked per-document via payload_keys.INDEX_MODE, not the identity).
+    # The dedup identity is always the dense embedding model name, widened by
+    # the Matryoshka output width when one is configured (keyword-vs-hybrid is
+    # tracked per-document via payload_keys.INDEX_MODE, not the identity).
     def get_collection_name(self) -> str:
         return _COLLECTION
 
-    def get_embedding_model_name(self) -> str:
+    def get_embedding_identity(self) -> str:
         return _MODEL
 
 


### PR DESCRIPTION
## What

Adds `EMBEDDING_DIMENSIONS` — an optional Matryoshka (MRL) output width requested
from whichever embedding provider is active. Unset (the default) leaves every
model at its full width, so this is a no-op unless an operator opts in.

MRL-trained models front-load information, so a prefix of the vector is itself a
valid embedding. Truncating cuts dense-vector storage and RAM linearly — the
footprint is `chunks × dimension × 4 bytes × hnsw_overhead`
(`observability/metrics.py`), so 3072 → 512 is a 6× reduction on the figure the
storage rate is pinned to.

## Changes

- **`providers/openai.py`** — `dimensions` on both `embeddings.create` calls, via
  the SDK's `omit` sentinel so the key leaves the request body entirely when
  unset (`None` would serialise an explicit null, which several
  OpenAI-compatible endpoints reject). The static `OPENAI_EMBEDDING_DIMENSIONS`
  prefill is skipped when truncating, since that map records full widths.
- **`providers/ollama.py`** — `dimensions` in the `/api/embed` body.
- **`providers/gateway.py`** — inherits the parameter from `OpenAIProvider`; skips
  the `/v1/models` catalogue when truncating, because the catalogue reports each
  model's full width and cannot answer for a truncated request.
- **`providers/base.py`** — `_record_dimension()` replaces the width-caching block
  that `openai.py` and `ollama.py` each duplicated (four call sites → one), and
  adds the guard below.
- **`config.py` / `vector/collection_metadata.py`** — the requested width joins the
  collection name and the stored `embedding_identity` via a new
  `Settings.get_embedding_identity()`.

## Two decisions worth reviewing

**A width mismatch is fatal, not a warning.** Endpoints that do not support
truncation accept `dimensions` and return the model's full width with no error.
Measured against our dev embedding gateway: it silently drops the parameter on
all three of its backend paths (OpenRouter, Bedrock, local). Letting that through
would size the Qdrant collection from a name claiming one width while it holds
another, and bill the full vector RAM the truncation was meant to avoid — so the
provider raises at detection time, with a message naming both widths, rather than
surfacing a dimension error at first upsert three layers away.

**`get_embedding_model_name()` deliberately stays the bare model name.** It is
the single point all identity derivations flowed through, but it also feeds
`record_indexing_usage(model=...)` and the `embedding.model` span attribute —
both record *which model ran*, a question the width does not change, and widening
it there would rewrite a billing dimension's values. The widened identity is a
separate method used only by the collection name and the dedup identity, where
vector length genuinely matters.

## Test coverage

- `tests/unit/providers/test_embedding_dimensions.py` — the parameter is sent only
  when configured; the mismatch guard fires for both providers; the gateway does
  not answer a truncated request from its catalogue.
- `tests/unit/providers/test_registry.py` — wire-through: the setting actually
  reaches the constructed provider. A key present in `_DEFAULTS` and the dataclass
  but dropped from `_FIELD_MAP` is silently ignored (the failure mode that
  disabled OCR batch mode), and a settings-only assertion would not catch it.
- `tests/unit/test_config.py` — env → settings, identity widening, and that the
  metering model name is unaffected.
- `tests/contract/test_gateway_embeddings_consumer.py` — **the first consumer pact
  for `POST /v1/embeddings`.** It pins two things nothing covered before: the wire
  format is **base64**, not a float array (the OpenAI SDK sets
  `encoding_format=base64` on every request and decodes client-side — how every
  embedding this service has ever made crossed the wire), and the returned width,
  via a regex fixing the exact base64 length of a 256-float32 vector, so a
  provider that ignores `dimensions` fails verification rather than passing a
  lenient type match.

Verified end-to-end against live services, not only mocks: Ollama 768 → 256
through our provider, and the guard firing against the dev gateway with the
intended message.

## Scope boundaries

- **Gateway-side support is not in this PR** and is tracked separately. Behaviour
  degrades rather than depending on deploy order: with `EMBEDDING_DIMENSIONS`
  unset — the default — nothing changes, and a gateway that later honours the
  parameter needs no change here.
- **Mistral and Bedrock are not wired.** Both still cache their width inline
  rather than through `_record_dimension()`. `mistral-embed` is fixed-width, so it
  has nothing to gain; Bedrock Titan v2 does support 256/512/1024 and is a
  reasonable follow-up.
- **Nothing validates that a model is MRL-capable**, because nothing upstream does
  either — Ollama truncates `snowflake-arctic-embed:110m` (not MRL-trained) just
  as readily as `nomic-embed-text`, with silent recall loss. `docs/configuration.md`
  lists the known-capable and fixed-width models and says plainly that this is the
  operator's call.

---

_This PR was generated with the help of AI, and reviewed by a Human_
