### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This project is licensed under the AGPL-3.0 License. See [LICENSE](./LICENSE) fo
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cbcoutinho/nextcloud-mcp-server&type=Date)](https://www.star-history.com/#cbcoutinho/nextcloud-mcp-server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cbcoutinho/nextcloud-mcp-server&type=Date)](https://star-history.dera.page/#cbcoutinho/nextcloud-mcp-server&Date)
 
 ## References
 


### PR DESCRIPTION
The Star History chart at the bottom of the README is currently broken: the service it points to no longer works reliably since GitHub restricted its stargazer API. This change points the chart at a maintained mirror of the project so it renders again, restoring the chart introduced in c73cd4e (PR #1065).