### PR TITLE
fix(migrations): serialize Alembic commands on a process-wide lock

### DIFF
--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -607,12 +607,21 @@ class RefreshTokenStorage:
         from scratch — the second one crashes with "relation already
         exists". On Postgres we acquire a session-level
         :func:`pg_advisory_lock` so the second pod blocks until the
-        first finishes. SQLite serializes writes via its own file lock
-        and needs no extra coordination, so this is a no-op there.
+        first finishes. This is a no-op on SQLite: its file lock serializes
+        individual writes but does not make a multi-statement migration
+        atomic, so a shared-file multi-process SQLite deployment is not a
+        supported topology here.
 
         The lock is held on a separate connection from the engine pool
         so it survives the worker-thread ``to_thread.run_sync`` call
         that actually runs Alembic.
+
+        This does **not** cover racing migrations inside one process —
+        ``initialize()`` runs per MCP session, and each instance takes its
+        own advisory lock. That serialization lives in
+        :data:`nextcloud_mcp_server.migrations._ALEMBIC_COMMAND_LOCK`,
+        which has to be process-wide anyway because Alembic keeps its
+        environment proxies in module globals.
         """
         assert self.engine is not None, "engine must be built before migration lock"
         if is_sqlite_url(self.database_url):

--- a/nextcloud_mcp_server/migrations.py
+++ b/nextcloud_mcp_server/migrations.py
@@ -10,6 +10,7 @@ back to :func:`nextcloud_mcp_server.config.get_database_url`.
 """
 
 import logging
+import threading
 from pathlib import Path
 
 from alembic.config import Config
@@ -20,6 +21,27 @@ from alembic import command
 from nextcloud_mcp_server.config import get_database_url, mask_db_password
 
 logger = logging.getLogger(__name__)
+
+# Alembic's EnvironmentContext is NOT re-entrant across threads: entering it
+# installs the ``config``/``script`` proxies as *module globals* on
+# ``alembic.context`` (``alembic.util.langhelpers._install_proxy``) and exiting
+# ``del``s them again. Two threads running a command concurrently therefore
+# clobber each other's globals — the loser's ``env.py`` blows up with
+# ``AttributeError: module 'alembic.context' has no attribute 'config'`` and the
+# teardown then raises ``KeyError: 'script'``.
+#
+# This bites us because migrations run per MCP session (``app_lifespan_basic``
+# -> ``RefreshTokenStorage.initialize`` -> ``to_thread.run_sync(upgrade_database)``),
+# so a client opening several sessions at once crashes those sessions. The
+# Postgres advisory lock in ``RefreshTokenStorage._migration_lock`` only covers
+# cross-pod races and is a no-op on SQLite, so the serialization has to live
+# here, next to the shared global state it protects.
+#
+# A ``threading.Lock`` (not ``anyio.Lock``, despite the repo default) is the
+# right primitive: these are blocking calls made from worker threads, possibly
+# under different event loops, and the lock is only ever held inside the worker
+# thread — never on an event loop.
+_ALEMBIC_COMMAND_LOCK = threading.Lock()
 
 
 def _coerce_url(database_url: str | Path | None) -> str:
@@ -114,7 +136,8 @@ def upgrade_database(
     """Upgrade database to a specific revision (default: latest)."""
     config = get_alembic_config(database_url)
     logger.info("Upgrading database to revision: %s", revision)
-    command.upgrade(config, revision)
+    with _ALEMBIC_COMMAND_LOCK:
+        command.upgrade(config, revision)
     logger.info("Database upgrade completed successfully")
 
 
@@ -124,7 +147,8 @@ def downgrade_database(
     """Downgrade database to a specific revision (default: previous)."""
     config = get_alembic_config(database_url)
     logger.warning("Downgrading database to revision: %s", revision)
-    command.downgrade(config, revision)
+    with _ALEMBIC_COMMAND_LOCK:
+        command.downgrade(config, revision)
     logger.info("Database downgrade completed successfully")
 
 
@@ -171,14 +195,16 @@ def stamp_database(
     """
     config = get_alembic_config(database_url)
     logger.info("Stamping database with revision: %s", revision)
-    command.stamp(config, revision)
+    with _ALEMBIC_COMMAND_LOCK:
+        command.stamp(config, revision)
     logger.info("Database stamped successfully")
 
 
 def show_migration_history(database_url: str | Path | None = None) -> None:
     """Display migration history."""
     config = get_alembic_config(database_url)
-    command.history(config, verbose=True)
+    with _ALEMBIC_COMMAND_LOCK:
+        command.history(config, verbose=True)
 
 
 def create_migration(message: str, autogenerate: bool = False) -> None:
@@ -204,5 +230,6 @@ def create_migration(message: str, autogenerate: bool = False) -> None:
             "Migration will be created with empty upgrade/downgrade functions."
         )
 
-    command.revision(config, message=message, autogenerate=False)
+    with _ALEMBIC_COMMAND_LOCK:
+        command.revision(config, message=message, autogenerate=False)
     logger.info("Migration created successfully. Edit the file to add SQL statements.")

--- a/tests/unit/test_migrations_concurrency.py
+++ b/tests/unit/test_migrations_concurrency.py
@@ -1,0 +1,85 @@
+"""Unit tests pinning the process-wide Alembic command lock.
+
+Migrations run per MCP session (``app_lifespan_basic`` ->
+``RefreshTokenStorage.initialize`` -> ``to_thread.run_sync(upgrade_database)``),
+so a client that opens several sessions at once used to run
+``command.upgrade`` from several worker threads simultaneously. Alembic's
+``EnvironmentContext`` keeps its ``config``/``script`` proxies in *module
+globals* on ``alembic.context``, so the concurrent runs clobbered each other:
+the loser's ``env.py`` raised ``AttributeError: module 'alembic.context' has no
+attribute 'config'`` and teardown then raised ``KeyError: 'script'``, crashing
+the MCP session.
+
+These tests prove the serialization in :mod:`nextcloud_mcp_server.migrations`
+holds so that regression can't come back.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from nextcloud_mcp_server import migrations
+from nextcloud_mcp_server.migrations import get_current_revision, upgrade_database
+
+pytestmark = pytest.mark.unit
+
+CONCURRENT_UPGRADES = 4
+
+
+def test_concurrent_upgrades_do_not_corrupt_alembic_globals(tmp_path):
+    """Several threads upgrading at once all succeed (GH: session crash)."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'tokens.db'}"
+    errors: list[Exception] = []
+    start = threading.Barrier(CONCURRENT_UPGRADES)
+
+    def run_upgrade() -> None:
+        start.wait(timeout=30)
+        try:
+            upgrade_database(db_url, "head")
+        except Exception as exc:
+            # Recorded rather than raised: an exception in a worker thread
+            # would otherwise only print a traceback and still pass the test.
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run_upgrade, name=f"upgrade-{i}")
+        for i in range(CONCURRENT_UPGRADES)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert not any(thread.is_alive() for thread in threads), "upgrade thread hung"
+    assert errors == [], f"concurrent upgrades failed: {errors!r}"
+
+    # The schema is actually at head, not merely crash-free.
+    assert get_current_revision(db_url) is not None
+    with sqlite3.connect(tmp_path / "tokens.db") as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert "refresh_tokens" in tables
+
+
+def test_upgrade_holds_the_shared_alembic_lock(mocker):
+    """``upgrade_database`` runs ``command.upgrade`` under the module lock.
+
+    Guards the specific mistake of dropping the ``with`` while keeping the
+    lock object around — which would look fine but restore the race.
+    """
+    held: list[bool] = []
+
+    def record_lock_state(config: object, revision: str) -> None:
+        held.append(migrations._ALEMBIC_COMMAND_LOCK.locked())
+
+    mocker.patch.object(migrations.command, "upgrade", side_effect=record_lock_state)
+
+    upgrade_database("sqlite+aiosqlite:///:memory:", "head")
+
+    assert held == [True]
+    assert not migrations._ALEMBIC_COMMAND_LOCK.locked(), "lock leaked after upgrade"


### PR DESCRIPTION
MCP sessions intermittently crash at startup on SQLite deployments, killing the
session before it finishes initializing. I hit this on a single-user BasicAuth
instance driven by an MCP client (Hermes Agent) that opens several sessions at
once.

## The bug

Three MCP sessions open inside the same second. Two of them die:

```
INFO  nextcloud_mcp_server.migrations - Upgrading database to revision: head
INFO  nextcloud_mcp_server.migrations - Upgrading database to revision: head
INFO  alembic.runtime.migration - Context impl SQLiteImpl.
INFO  alembic.runtime.migration - Context impl SQLiteImpl.
ERROR mcp.server.streamable_http_manager - Session 4bff5714... crashed
  File "nextcloud_mcp_server/alembic/env.py", line 24, in <module>
    config = context.config
AttributeError: module 'alembic.context' has no attribute 'config'

During handling of the above exception, another exception occurred:
  File "alembic/util/langhelpers.py", line 86, in _remove_proxy
    del globals_[attr_name]
KeyError: 'script'
ERROR mcp.server.streamable_http - SSE response error
  | anyio.BrokenResourceError
```

Alembic's `EnvironmentContext` is not safe to enter twice concurrently in one
process. Entering it installs the `config`/`script` proxies as **module globals**
on `alembic.context` (`alembic.util.langhelpers._install_proxy`); exiting `del`s
them. Two threads inside it clobber each other: the loser's `env.py` finds no
`context.config`, and its own teardown then finds the globals already gone.

Migrations run **per MCP session**:

```
app_lifespan_basic  (app.py:974, runs per session)
  -> RefreshTokenStorage.initialize()
    -> to_thread.run_sync(upgrade_database, ...)   # worker thread
      -> command.upgrade(...)                      # mutates alembic.context globals
```

so a client that opens N sessions at once runs N concurrent `upgrade`s. Nothing
is wrong with the database — the collision is on Python module state.

## Why the existing guard doesn't cover it

`RefreshTokenStorage._migration_lock` takes a `pg_advisory_lock`, added in #798
to stop two **pods** racing migrations during a rolling update. It is a no-op on
SQLite, and each session's storage instance takes its own lock anyway.

That lock does incidentally serialize in-process concurrency on Postgres — which
is why this has only ever been seen on SQLite. I verified that against Postgres
16 — four concurrent `initialize()` calls, with this PR's process lock removed:

| Scenario | Result |
|---|---|
| A: `pg_advisory_lock` intact | **0 errors** — the advisory lock serializes the threads |
| B: `pg_advisory_lock` also neutered | **hangs indefinitely** (killed after 10 min) |

Scenario B's `pg_stat_activity` shows why it's the lock doing the work, not luck:

```
pid | state               | wait_event_type | wait_event    | query
118 | idle in transaction | Client          | ClientRead    | CREATE TABLE alembic_version ...
119 | active              | Lock            | transactionid | CREATE TABLE alembic_version ...
120 | active              | Lock            | transactionid | CREATE TABLE alembic_version ...
121 | active              | Lock            | transactionid | CREATE TABLE alembic_version ...
```

So Postgres deployments are protected today, but only as a side effect of a lock
that exists for an unrelated reason, and only for the one Alembic call that goes
through `initialize()` — `stamp`, `downgrade`, `history` and `revision` are
uncovered on every backend.

## Prior art

063bd06b (shipped inside #813) hit this exact failure on the search hot path:

> concurrent requests ran concurrent Alembic upgrades, which race on Alembic's
> non-thread-safe module-global EnvironmentContext proxy and intermittently raise
> `KeyError: 'script'` → HTTP 500

It was fixed there by caching an initialized storage singleton — correct for that
call site, but it left the underlying hazard in place for every other caller.
This PR fixes the cause instead of the third symptom.

## The fix

A process-wide `threading.Lock` in `migrations.py`, held across every
`command.*` invocation. One thread at a time inside the region that mutates
Alembic's globals.

**Why `threading.Lock` and not `anyio.Lock`,** against the CLAUDE.md default:
these are blocking calls made from worker threads via `to_thread.run_sync`,
potentially under different event loops. An `anyio.Lock` cannot be acquired from
a sync worker thread. The lock is only ever held *inside* the worker thread, so
it never blocks an event loop. The rationale is in a comment at the definition.

Also corrects the `_migration_lock` docstring, which claimed SQLite "serializes
writes via its own file lock and needs no extra coordination" — scenario B above
shows a file lock does not make a multi-statement migration atomic.

## Tests

`tests/unit/test_migrations_concurrency.py`:

- Four threads upgrading a fresh SQLite database concurrently all succeed, and
  the schema really lands at head (`refresh_tokens` exists) rather than merely
  not crashing.
- A guard that `command.upgrade` actually runs *under* the lock, so a future
  refactor can't keep the lock object while dropping the `with`.

Negative control (not committed): swapping the lock for `contextlib.nullcontext()`
makes the first test fail with `KeyError: 'config'` and a duplicate
`CREATE TABLE alembic_version`.

## Not in scope

Every MCP session still constructs its own `RefreshTokenStorage` and re-runs a
now-no-op migration. Serialized, that's correct but redundant; `get_shared_storage()`
already exists as the process-wide singleton. Switching `app_lifespan_basic` to it
would remove the redundancy, but it changes session-shutdown semantics (the
per-session `storage.close()` from #798 round-4), so it belongs in its own PR.

## Verification

Against `uv.lock` on Python 3.11.15:

- `uv run ruff check` — all checks passed
- `uv run ruff format --check` — 557 files already formatted
- `uv run ty check -- nextcloud_mcp_server` — all checks passed
- `uv run pytest -m unit -n auto` — **3535 passed**

`sonar analyze secrets` was not run locally (CLI not installed); no secrets are
added by the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
