### PR TITLE
fix(build): add .containerignore so podman produces a complete image

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,33 @@
+# Build context for podman/buildah. Docker reads only .dockerignore; podman
+# reads .containerignore in preference to it. This file exists because the two
+# engines disagree about re-inclusion patterns, and under podman that
+# disagreement silently produces a broken image.
+#
+# .dockerignore re-includes sources with `!nextcloud_mcp_server/**/*.py`. Once
+# `*` has excluded everything, BuildKit keeps descending into excluded
+# directories in case a later `!` pattern matches inside; buildah does not, so
+# the glob never fires for nested packages. `podman build` therefore ships an
+# image containing no subpackage except auth/ -- which survives only because
+# `!nextcloud_mcp_server/auth/static/*` names it literally -- and the container
+# dies at startup with:
+#
+#   ModuleNotFoundError: No module named 'nextcloud_mcp_server.alembic'
+#
+# Re-including the package directory itself, rather than globbing into it, is
+# handled the same way by both engines.
+#
+# Keep this equivalent to .dockerignore rather than relaxing it into a plain
+# denylist: the Dockerfile is single-stage, so whatever `COPY . .` pulls in
+# stays in the shipped image. A denylist measured 13 MB / 757 files against
+# .dockerignore's 5 MB / 206.
+
+*
+
+!pyproject.toml
+!README.md
+!uv.lock
+
+!nextcloud_mcp_server
+
+**/__pycache__
+**/*.pyc


### PR DESCRIPTION
`podman build .` reports success and produces an image that cannot start. I hit
this building the image for my own deployment, and the failure surfaces only at
runtime:

```
ModuleNotFoundError: No module named 'nextcloud_mcp_server.alembic'
```

`alembic` is just the first import to fail. The image is missing **every**
subpackage except `auth/`.

## The bug

`.dockerignore` excludes everything and then re-includes sources:

```
*
!nextcloud_mcp_server/**/*.py
```

BuildKit keeps descending into an already-excluded directory in case a later `!`
pattern matches inside it. Buildah — podman's build engine — does not, so that
glob never fires for nested packages. `auth/` survives only because
`!nextcloud_mcp_server/auth/static/*` names the directory literally.

Measured on this tree, same Dockerfile, same context, only the engine changed:

| engine | `.py` files under `nextcloud_mcp_server/` | subpackages present |
|---|---|---|
| docker | **197** | all 15 |
| podman | **37** | `auth/` only |

Because the Dockerfile is single-stage, `COPY . .` is what lands in `/src`, and
the second `uv sync --no-editable` builds the wheel from that. A truncated
context therefore produces a truncated wheel, with no error at build time.

CI publishes via docker/buildx, so the released image is unaffected and this
never shows up upstream — only for people building the repo themselves.

## The fix

Podman reads `.containerignore` in preference to `.dockerignore`; docker does not
read `.containerignore` at all. I verified that directly rather than assuming it:
with the two files pointing at deliberately different file sets, each engine
followed its own. So this adds a podman-only build context and **cannot** change
the CI build or the published image.

Re-including the package directory itself, instead of globbing into it, is
handled identically by both engines.

The file deliberately mirrors `.dockerignore` rather than relaxing into a plain
denylist. Since the build is single-stage, whatever the context carries stays in
the shipped image — a denylist measured 13 MB / 757 files against
`.dockerignore`'s 5 MB / 206.

## Verification

With `.containerignore` in place, both engines produce an identical context:

| | docker | podman |
|---|---|---|
| context size | 5 MB | 5 MB |
| total files | 206 | 206 |
| package `.py` files | 197 | 197 |
| top-level entries | `README.md nextcloud_mcp_server pyproject.toml uv.lock` | same |

And a full `podman build` now yields a working image: all 15 subpackages present
under `site-packages/nextcloud_mcp_server/`, `import nextcloud_mcp_server.app`
succeeds, and the entrypoint runs.

No Python changes, so the usual `ruff`/`ty`/`pytest` gates have nothing to act
on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
