### PR TITLE
fix(auth): read `azp` as the client id when a token has no `client_id`

### DIFF
--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import logging
 import time
+from collections.abc import Mapping
 from typing import Any
 
 import httpx
@@ -227,7 +228,7 @@ class UnifiedTokenVerifier(TokenVerifier):
                 scopes = scope_string.split() if scope_string else []
                 access_token = AccessToken(
                     token=token,
-                    client_id=userinfo.get("client_id", ""),
+                    client_id=self._client_id_from_claims(userinfo),
                     scopes=scopes,
                     expires_at=int(expiry),
                     resource=username,
@@ -562,6 +563,35 @@ class UnifiedTokenVerifier(TokenVerifier):
             True if token appears to be JWT format
         """
         return "." in token and token.count(".") == 2
+
+    @staticmethod
+    def _client_id_from_claims(claims: Mapping[str, Any]) -> str:
+        """The client identity of a *verified* payload.
+
+        Two spellings are in the wild and an IdP generally stamps only one.
+        RFC 9068 (JWT access tokens) puts it in ``client_id`` — that is what the
+        Nextcloud ``oidc`` app emits. Keycloak, Authentik and the rest of the
+        OIDC-Core lineage use ``azp`` (authorized party) instead and never emit
+        ``client_id`` at all.
+
+        Reading only ``client_id`` therefore made every token from an external
+        IdP look like it had no client, so ``ALLOWED_MGMT_CLIENT`` refused it no
+        matter how it was configured (cbcoutinho/astrolabe#324).
+
+        ``aud`` is deliberately NOT consulted here, unlike in
+        :meth:`_claimed_client_id`, which only feeds a log line. The audience
+        says who a token is *for*, not who asked for it; treating it as an
+        identity would let any token minted for an allowlisted audience pass the
+        allowlist regardless of which client obtained it.
+
+        Returns "" when neither claim is a non-empty string — the same
+        fail-closed value the allowlist already rejects.
+        """
+        for key in ("client_id", "azp"):
+            value = claims.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return ""
 
     @staticmethod
     def _claimed_client_id(token: str) -> str | None:
@@ -1062,7 +1092,7 @@ class UnifiedTokenVerifier(TokenVerifier):
 
         return AccessToken(
             token=token,
-            client_id=payload.get("client_id", ""),
+            client_id=self._client_id_from_claims(payload),
             scopes=scopes,
             expires_at=exp,
             resource=username,  # Store username in resource field (RFC 8707)
@@ -1097,7 +1127,7 @@ class UnifiedTokenVerifier(TokenVerifier):
 
         return AccessToken(
             token=token,
-            client_id=userinfo.get("client_id", ""),
+            client_id=self._client_id_from_claims(userinfo),
             scopes=scopes,
             expires_at=int(expiry),
             resource=username,

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -471,6 +471,54 @@ class TestAccessTokenCreation:
         # Should have set a default expiry
         assert result.expires_at > int(time.time())
 
+    def test_create_access_token_reads_azp_when_no_client_id(self, base_settings):
+        """Keycloak et al stamp `azp` and never `client_id`.
+
+        Reading only `client_id` left every external-IdP token looking
+        client-less, so ALLOWED_MGMT_CLIENT rejected it however it was
+        configured (cbcoutinho/astrolabe#324).
+        """
+        verifier = UnifiedTokenVerifier(base_settings)
+
+        payload = {
+            "sub": "testuser",
+            "scope": "openid profile",
+            "exp": int(time.time() + 3600),
+            "azp": "nextcloud",  # no client_id claim at all
+        }
+
+        result = verifier._create_access_token("test-token-123", payload)
+        assert result is not None
+        assert result.client_id == "nextcloud"
+
+    def test_create_access_token_prefers_client_id_over_azp(self, base_settings):
+        """RFC 9068's spelling wins when a token carries both."""
+        verifier = UnifiedTokenVerifier(base_settings)
+
+        payload = {
+            "sub": "testuser",
+            "scope": "openid",
+            "exp": int(time.time() + 3600),
+            "client_id": "rfc9068-client",
+            "azp": "oidc-core-client",
+        }
+
+        result = verifier._create_access_token("test-token-123", payload)
+        assert result is not None
+        assert result.client_id == "rfc9068-client"
+
+    def test_client_id_from_claims_ignores_audience(self, base_settings):
+        """`aud` says who a token is for, not who obtained it.
+
+        Accepting it as an identity would let any token minted for an
+        allowlisted audience through the allowlist.
+        """
+        verifier = UnifiedTokenVerifier(base_settings)
+
+        assert verifier._client_id_from_claims({"aud": "some-allowlisted-id"}) == ""
+        assert verifier._client_id_from_claims({}) == ""
+        assert verifier._client_id_from_claims({"azp": ""}) == ""
+
 
 class TestVerifyTokenFlow:
     """Test complete verify_token flow."""

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -519,6 +519,25 @@ class TestAccessTokenCreation:
         assert verifier._client_id_from_claims({}) == ""
         assert verifier._client_id_from_claims({"azp": ""}) == ""
 
+    def test_client_id_from_claims_falls_through_empty_client_id(self, base_settings):
+        """A present-but-empty `client_id` must not shadow a usable `azp`.
+
+        The guard tests the value, not the key, so an IdP that stamps
+        `client_id: ""` alongside a real `azp` still resolves to a client
+        rather than fail-closing to "".
+        """
+        verifier = UnifiedTokenVerifier(base_settings)
+
+        assert (
+            verifier._client_id_from_claims({"client_id": "", "azp": "nextcloud"})
+            == "nextcloud"
+        )
+        # Non-string claims fall through the same way.
+        assert (
+            verifier._client_id_from_claims({"client_id": 42, "azp": "nextcloud"})
+            == "nextcloud"
+        )
+
 
 class TestVerifyTokenFlow:
     """Test complete verify_token flow."""

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -5,6 +5,7 @@ Tests multi-audience token validation without requiring real network calls or
 IdP connections.
 """
 
+import hashlib
 import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -697,6 +698,39 @@ class TestManagementApiAllowlist:
         ):
             result = await verifier.verify_token_for_management_api("any-token")
             assert result is None
+
+    async def test_cache_hit_resolves_azp_against_allowlist(
+        self, monkeypatch, base_settings
+    ):
+        """The cache-hit path must resolve `azp` too, not just fresh validation.
+
+        This is the hot path in practice — Astrolabe polls the management API
+        often enough that most validations are served from the cache — so an
+        external-IdP token that passed on first validation would otherwise be
+        rejected on every subsequent request.
+        """
+        monkeypatch.setenv("ALLOWED_MGMT_CLIENT", "nextcloud")
+        from nextcloud_mcp_server.config import _reload_config
+
+        _reload_config()
+        verifier = UnifiedTokenVerifier(base_settings)
+        assert verifier._allowed_mgmt_clients == {"nextcloud"}
+
+        # Seed the cache the way _create_access_token_with_cache_key would for a
+        # Keycloak token: `azp`, no `client_id` claim at all.
+        token = "keycloak-token"
+        cache_key = f"mgmt:{hashlib.sha256(token.encode()).hexdigest()}"
+        verifier._token_cache[cache_key] = (
+            {"sub": "alice", "scope": "openid profile", "azp": "nextcloud"},
+            time.time() + 3600,
+        )
+
+        # No _verify_without_audience_check patch: a cache miss would try to
+        # reach the IdP, so reaching the allowlist at all proves the cache hit.
+        result = await verifier.verify_token_for_management_api(token)
+        assert result is not None
+        assert result.client_id == "nextcloud"
+        assert result.resource == "alice"
 
     async def test_cache_hit_also_enforces_allowlist(self, monkeypatch, base_settings):
         """A previously-cached token must still be re-checked against the allowlist."""


### PR DESCRIPTION
## Problem

The management API's `ALLOWED_MGMT_CLIENT` allowlist reads only the `client_id` claim. Two spellings are in the wild and an IdP generally stamps just one:

- **RFC 9068** (JWT access tokens) → `client_id`. This is what the Nextcloud `oidc` app emits, which is why the allowlist has always worked for the "Nextcloud is the IdP" deployment.
- **OIDC Core** → `azp` (authorized party). Keycloak, Authentik and friends use this and emit no `client_id` at all.

So every token from a Nextcloud sitting behind an external IdP looked client-less, and the allowlist refused it however it was configured:

```
Token rejected (allowlist/not_allowlisted, caller's token) for client nextcloud:
client_id '' not in ALLOWED_MGMT_CLIENT
```

Note the shape of that message: the rejection *log* already falls back through `azp` (via `_claimed_client_id`), so it names the client in the same breath as claiming there wasn't one. Only the `AccessToken` construction that the allowlist actually consults was missing the fallback.

## Reproduction

A Keycloak-backed Nextcloud + Astrolabe stack. Every user's search returned 401 from `/api/v1/vector-viz/search`. Downstream report: cbcoutinho/astrolabe#324.

## Fix

Both spellings resolve through one `_client_id_from_claims` helper, applied at all three `AccessToken` construction sites — fresh validation plus both cache-hit paths — so they can't drift apart again.

`aud` is deliberately **not** consulted, unlike in the log-only `_claimed_client_id`. The audience says who a token is *for*, not who obtained it; treating it as an identity would let any token minted for an allowlisted audience pass the allowlist regardless of which client asked for it.

## Verification

- `tests/unit` 3223 passed, including 3 new cases: `azp`-only token resolves, `client_id` wins when both are present, and `aud` is never used as an identity.
- Verified live by patching this line into a running container in the Astrolabe external-IdP e2e lane (Keycloak + `user_oidc`): search goes 401 → 200 and the MCP server resolves the user from `sub`.

---

_This PR was generated with the help of AI, and reviewed by a Human_