### PR TITLE
feat(vector): meter chunks_ingested at indexing

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -267,6 +267,10 @@ again, so a period sum measures *churn*:
 - `pages_ocr` - Pages that hit the OCR tier specifically, billed separately
   from CPU-cheap parsing. Mode-independent.
 - `bytes_ingested` / `bytes_stored` - Source size and persisted chunk-text size.
+  Monitor-only since Deck #1036 — both price at zero.
+- `chunks_ingested` - Chunks produced by this indexing pass. The **billed**
+  ingestion dimension, sharing its unit with the `chunks_stored` retention stock
+  below so indexing and storage are directly comparable on an invoice.
 
 **Retention stock** — emitted once per UTC day (`record_storage_stock`,
 `vector/metrics_publisher.py`):

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -489,6 +489,11 @@ async def record_indexing_usage(
       Qdrant payload excerpts, recorded for *every* embedded document. Reflects
       the indexed footprint and so includes chunk-overlap duplication; it is
       therefore typically larger than ``bytes_ingested`` for text content.
+    - ``chunks_ingested`` — the number of chunks this indexing pass produced,
+      recorded for every embedded document. This is the **billed** ingestion
+      dimension (Deck #1036): it shares its unit with the ``chunks_stored``
+      retention meter, so an invoice's indexing and storage lines are directly
+      comparable. ``bytes_ingested`` is retained as a monitor-only signal.
 
     Best-effort and flag-gated: a metering failure is logged and never breaks
     indexing. ``chunk_count`` is the empty-batch no-op guard — a document that
@@ -574,6 +579,12 @@ async def record_indexing_usage(
         events.append(
             UsageEvent(metric="bytes_stored", value=bytes_stored, metadata=metadata)
         )
+    # chunks_ingested (Deck #1036): the billed ingestion dimension, in the same
+    # unit as the chunks_stored retention meter. No guard — the chunk_count == 0
+    # early return above already established it's positive.
+    events.append(
+        UsageEvent(metric="chunks_ingested", value=chunk_count, metadata=metadata)
+    )
 
     try:
         store = await UsageEventStore.shared()

--- a/tests/unit/test_processor_metering.py
+++ b/tests/unit/test_processor_metering.py
@@ -115,6 +115,7 @@ async def test_parsed_file_records_pages_and_tokens(store_spy):
         "pages_embedded": 12,
         "bytes_ingested": 204800,
         "bytes_stored": 178000,
+        "chunks_ingested": 110,
     }
     # Intentional ordering: tokens (recorded for every doc) before pages (the
     # conditional parsing cost). Asserted so a refactor can't silently reverse
@@ -158,6 +159,7 @@ async def test_text_doc_records_tokens_and_bytes_no_pages(store_spy):
         "tokens_embedded": 512,
         "bytes_ingested": 7100,
         "bytes_stored": 8200,
+        "chunks_ingested": 4,
     }
     assert "pages_embedded" not in by_metric
 
@@ -185,6 +187,7 @@ async def test_zero_pages_skips_pages(store_spy):
         "tokens_embedded": 99,
         "bytes_ingested": 2048,
         "bytes_stored": 1100,
+        "chunks_ingested": 4,
     }
 
 
@@ -211,6 +214,7 @@ async def test_negative_pages_skips_pages(store_spy):
         "tokens_embedded": 99,
         "bytes_ingested": 2048,
         "bytes_stored": 1100,
+        "chunks_ingested": 4,
     }
 
 
@@ -234,7 +238,7 @@ async def test_nonpositive_bytes_skip_byte_rows(store_spy):
 
     by_metric = {e.metric: e.value for e in _events(store_spy)}
     # Only tokens_embedded survives — neither byte row is written.
-    assert by_metric == {"tokens_embedded": 99}
+    assert by_metric == {"tokens_embedded": 99, "chunks_ingested": 4}
 
 
 @pytest.mark.unit
@@ -330,6 +334,7 @@ async def test_ocr_tier_records_pages_ocr(store_spy):
         "pages_ocr": 8,
         "bytes_ingested": 51200,
         "bytes_stored": 41000,
+        "chunks_ingested": 20,
     }
     # pipeline_tier is threaded into the billing metadata for CP attribution.
     for e in events:
@@ -361,6 +366,7 @@ async def test_fast_tier_does_not_record_pages_ocr(store_spy):
         "pages_embedded",
         "bytes_ingested",
         "bytes_stored",
+        "chunks_ingested",
     }
 
 
@@ -391,6 +397,7 @@ async def test_keyword_mode_meters_bytes_not_tokens(store_spy):
         "pages_embedded": 5,
         "bytes_ingested": 40960,
         "bytes_stored": 30500,
+        "chunks_ingested": 12,
     }
     assert "tokens_embedded" not in by_metric
     # Every event carries the keyword mode so the CP can attribute it separately.
@@ -419,4 +426,4 @@ async def test_hybrid_zero_tokens_still_skips_tokens_row(store_spy):
     )
     metrics = {e.metric for e in _events(store_spy)}
     assert "tokens_embedded" not in metrics
-    assert metrics == {"bytes_ingested", "bytes_stored"}
+    assert metrics == {"bytes_ingested", "bytes_stored", "chunks_ingested"}


### PR DESCRIPTION
Pricing model v21 bills ingestion **per chunk** rather than per source GiB, so
indexing and retention share a unit and the two chunk lines on an invoice are
directly comparable. Catalog side shipped in homelab-terraform#580 (Deck #1036);
this is the data-plane half.

## What changed

`record_indexing_usage` appends one more event:

```python
events.append(
    UsageEvent(metric="chunks_ingested", value=chunk_count, metadata=metadata)
)
```

No guard — the `chunk_count == 0` early return already established it is
positive. The event inherits the same `metadata` as every other row, so it
carries `index_mode` and splits hybrid/keyword in the CP rollup for free.

`bytes_ingested` keeps firing as a monitor-only signal; it prices at zero in
the catalog now.

## Rollout

The event is **inert** until the control plane maps the metric and
`CHUNK_METERING_ENABLED` is set — the rollup silently skips a metric its
catalog doesn't know. Order is: catalog (done) → this → CP mapping + flag on
dev → verify a dev invoice → prod flag.

## Test coverage

No new API surface — the metric is a string written to the tenant's own
`usage_events`, and nothing crosses a service boundary here — so no pact change
is needed in this repo. The consumer/provider pair for this dimension is
CP ↔ web and lands in the sibling PR.

`tests/unit/test_processor_metering.py` covers it throughout: every exact-dict
assertion now pins `chunks_ingested` to the pass's chunk count, including the
keyword-mode, zero-token and non-positive-bytes cases.

---

_This PR was generated with the help of AI, and reviewed by a Human_
