### PR TITLE
fix(auth): report an empty JWKS as no_signing_keys, not unknown

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,7 +106,7 @@ most consequential changes are silent — see the alerts below.
     Derived from `reason`, not set independently, so the two cannot drift.
   - `reason`: `expired`, `inactive`, `bad_signature`, `bad_issuer`,
     `bad_audience`, `not_allowlisted`, `not_configured`, `network_error`,
-    `unknown` — `none` when valid
+    `no_signing_keys`, `unknown` — `none` when valid
   - `client_id`: read from the *unverified* token, so length-clamped and capped
     at 50 distinct values (`_other` beyond), on a budget of its own
 
@@ -437,7 +437,7 @@ sum by (client_id, method, reason) (
 
 Split by who is at fault: `result="invalid"` is the caller's token (expired,
 revoked, wrong audience); `result="error"` is ours (`not_configured`,
-`network_error`) and should page:
+`network_error`, `no_signing_keys`) and should page:
 ```promql
 sum by (reason) (increase(mcp_oauth_token_validations_total{result="error"}[15m])) > 0
 ```
@@ -449,6 +449,16 @@ allowlist path: an empty allowlist is `not_configured` (ours, pageable) while a
 client merely absent from a populated one is `not_allowlisted` (theirs):
 ```promql
 sum(increase(mcp_oauth_token_validations_total{reason="not_configured"}[5m])) > 0
+```
+
+`reason="no_signing_keys"` is the same shape of total outage and belongs on the
+same alert: the JWKS was fetched and parsed but contains no usable key, so every
+JWT is unverifiable. It is a configuration fault rather than an outage — most
+often an IdP provider left on symmetric (HS256) signing, which makes Authentik
+and Keycloak serve an empty key set. The rejection detail carries the JWKS URI,
+so the log line names the endpoint to look at:
+```promql
+sum(increase(mcp_oauth_token_validations_total{reason="no_signing_keys"}[5m])) > 0
 ```
 
 **MCP client fleet — who is connected, at which protocol version**:

--- a/nextcloud_mcp_server/auth/unified_verifier.py
+++ b/nextcloud_mcp_server/auth/unified_verifier.py
@@ -641,7 +641,9 @@ class UnifiedTokenVerifier(TokenVerifier):
     # took the default, which put the single most total failure mode in the
     # system (no validator configured at all) on the *client's* side of the
     # split, contradicting the documented contract.
-    _OUR_FAULT_REASONS = frozenset({"not_configured", "network_error", "unknown"})
+    _OUR_FAULT_REASONS = frozenset(
+        {"not_configured", "network_error", "no_signing_keys", "unknown"}
+    )
 
     def _reject(
         self,
@@ -823,6 +825,26 @@ class UnifiedTokenVerifier(TokenVerifier):
         except jwt.InvalidTokenError as e:
             # Covers signature failures, malformed tokens and bad `iat`.
             return self._note(chain, "jwt", "bad_signature", token, str(e))
+        except jwt.PyJWKSetError as e:
+            # The JWKS was fetched and parsed fine but carries no usable signing
+            # key, so every JWT is unverifiable. That is an IdP/operator
+            # misconfiguration, not an outage and not a bad token — most often
+            # a provider left on symmetric (HS256) signing, which serves an
+            # empty key set: Authentik and Keycloak both publish JWKS keys only
+            # for asymmetric signing keys.
+            #
+            # Separate from PyJWKClientError below because PyJWKSetError is NOT
+            # a subclass of it (both derive straight from PyJWTError), so it
+            # otherwise fell through to the generic handler and surfaced as
+            # "unknown" — indistinguishable from a real internal bug, and the
+            # operator got a bare 401 with the cause only in our logs.
+            return self._note(
+                chain,
+                "jwt",
+                "no_signing_keys",
+                token,
+                f"{e} (JWKS: {getattr(self.jwks_client, 'uri', 'unknown')})",
+            )
         except jwt.PyJWKClientError as e:
             # Fetching the signing key failed — the JWKS endpoint is down, slow
             # or unreachable. Nothing is wrong with the caller's token. This is

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -186,7 +186,7 @@ oauth_token_validations_total = Counter(
     #         reason in _reject(), never set independently
     # reason: none (valid) | expired | inactive | bad_signature | bad_issuer
     #         | bad_audience | not_allowlisted | not_configured
-    #         | network_error | unknown
+    #         | network_error | no_signing_keys | unknown
     ["method", "result", "reason", "client_id"],
 )
 

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1296,7 +1296,9 @@ class TestRejectionObservability:
             "The JWK Set did not contain any keys"
         )
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(
+            logging.WARNING, logger="nextcloud_mcp_server.auth.unified_verifier"
+        ):
             assert await verifier._verify_jwt_signature(self._jwt_for()) is None
 
         assert any(

--- a/tests/unit/test_unified_verifier.py
+++ b/tests/unit/test_unified_verifier.py
@@ -1257,6 +1257,68 @@ class TestRejectionObservability:
 
         assert metric_sample(self.VALIDATIONS, labels) - before == 1
 
+    async def test_empty_jwks_is_no_signing_keys_not_unknown(
+        self, base_settings, metric_sample
+    ):
+        """An IdP publishing no keys is a misconfiguration, not an unknown error.
+
+        `PyJWKSetError` derives straight from `PyJWTError`, NOT from the
+        `PyJWKClientError` the outage clause catches, so it used to fall through
+        to the generic handler as "unknown" — indistinguishable from a real
+        internal bug. The operator saw a bare 401 and had to read server logs to
+        find out their provider was signing with HS256.
+        """
+        labels = {
+            "method": "jwt",
+            "result": "error",
+            "reason": "no_signing_keys",
+            "client_id": "mistral-client",
+        }
+        before = metric_sample(self.VALIDATIONS, labels)
+
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        verifier.jwks_client.uri = "https://idp.example/jwks"
+        verifier.jwks_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKSetError(
+            "The JWK Set did not contain any keys"
+        )
+
+        assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert metric_sample(self.VALIDATIONS, labels) - before == 1
+
+    async def test_empty_jwks_rejection_names_the_endpoint(self, base_settings, caplog):
+        """The log must point at the JWKS URI — that is the thing to go fix."""
+        verifier = UnifiedTokenVerifier(base_settings)
+        verifier.jwks_client = MagicMock()
+        verifier.jwks_client.uri = "https://idp.example/application/o/nc/jwks/"
+        verifier.jwks_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKSetError(
+            "The JWK Set did not contain any keys"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert await verifier._verify_jwt_signature(self._jwt_for()) is None
+
+        assert any(
+            "https://idp.example/application/o/nc/jwks/" in r.message
+            for r in caplog.records
+        )
+
+    async def test_real_pyjwt_raises_pyjwksseterror_on_an_empty_key_set(
+        self, base_settings
+    ):
+        """Pin the upstream behaviour the clause above depends on.
+
+        If PyJWT ever re-parents `PyJWKSetError` under `PyJWKClientError`, or
+        changes which error an empty key set raises, this fix silently reverts
+        to reporting "network_error"/"unknown" — so assert against the real
+        library rather than only our mock of it.
+        """
+        assert not issubclass(jwt.PyJWKSetError, jwt.PyJWKClientError)
+
+        with pytest.raises(jwt.PyJWKSetError):
+            jwt.PyJWKSet.from_dict({"keys": []})
+
     def test_empty_verified_client_id_falls_back(self, base_settings, metric_sample):
         """An empty verified id recovers azp/aud rather than recording nothing.
 


### PR DESCRIPTION
## Problem

An IdP that publishes no usable signing key makes **every** JWT unverifiable. That is a specific, common, and fixable operator misconfiguration — but it was being reported as `reason="unknown"`, the same bucket as a genuine internal bug, and the caller got a bare 401.

Seen in the wild at cbcoutinho/astrolabe#324, on an Authentik-backed deployment:

```
Token rejected (jwt/unknown, our fault) for client E2x6qDM9…: The JWK Set did not contain any keys
```

The user had to paste server logs into an issue before anyone could tell them what was wrong — and the answer ("your provider is signing with HS256") was nowhere in the message.

## Why it slipped through

There is already a clause classifying JWKS failures (`network_error`, added for the outage case). It never fired here, because PyJWT raises **`PyJWKSetError`** for an empty key set, and that is *not* a subclass of the `PyJWKClientError` that clause catches — both derive straight from `PyJWTError`:

```python
>>> issubclass(jwt.PyJWKSetError, jwt.PyJWKClientError)
False
```

So it fell past both specific handlers into `except Exception` → `unknown`.

## Change

A sibling clause ahead of the outage one, with its own reason:

- **`no_signing_keys`** — the JWKS was fetched and parsed fine, but carries no usable key. Not an outage, not a bad token: a configuration fault. The most common cause is a provider left on symmetric (HS256) signing; Authentik and Keycloak publish JWKS keys only for *asymmetric* signing keys.
- The rejection detail now carries **the JWKS URI**, so the log line names the endpoint to go and look at.
- `no_signing_keys` joins `_OUR_FAULT_REASONS`. Like `not_configured`, it rejects every token, so it belongs on the pageable side of the fault split.

`metrics.py` names itself the canonical vocabulary and prescribes the update order, so all three places are updated: the label comment, `_OUR_FAULT_REASONS`, and `docs/observability.md` — plus an alert query alongside the existing `not_configured` one.

## Tests

Three cases, mirroring the existing `test_jwks_outage_is_a_network_error_not_unknown`:

- the metric records `jwt`/`error`/`no_signing_keys` rather than `unknown`
- the rejection log names the JWKS URI (that string is the actionable part)
- **the upstream premise itself** — that `PyJWKSetError` is not a `PyJWKClientError`, and that an empty key set raises it — asserted against the real library, not our mock. If PyJWT ever re-parents that exception, this fix silently reverts to `unknown`; this test fails instead.

Verified the tests actually fail without the fix (reverted the verifier change, ran them, restored): both the metric and log-content assertions fail, so they're pinning the behaviour rather than passing vacuously.

`tests/unit` 3228 passed; ruff + `ty` clean.

## Not addressed here

The downstream deployment still has two further walls, tracked separately — `ALLOWED_MGMT_CLIENT` needing the IdP's client id, and #1326 (token `sub` used as the Nextcloud UID). This PR only makes the *first* failure explain itself.

---

_This PR was generated with the help of AI, and reviewed by a Human_
