### PR TITLE
fix(webdav): give an unfiltered SEARCH an explicit match-all predicate

### DIFF
--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -1508,8 +1508,16 @@ class WebDAVClient(BaseNextcloudClient):
         # Build property list
         prop_xml = "\n".join([self._property_to_xml(prop) for prop in properties])
 
-        # Build where clause
-        where_xml = where_conditions if where_conditions else ""
+        # Build where clause. An *empty* ``<d:where>`` is not a match-all:
+        # Nextcloud answers it with ``500`` and a Sabre ``TypeError`` document
+        # (verified against 32.0.14). So an unfiltered search -- "everything
+        # under this folder", the most obvious call an MCP client can make --
+        # needs an explicit predicate that holds for every row instead.
+        # ``displayname LIKE '%'`` is that predicate, and reuses the operator
+        # the filtered callers already build.
+        where_xml = (where_conditions or "").strip() or (
+            "<d:like><d:prop><d:displayname/></d:prop><d:literal>%</d:literal></d:like>"
+        )
 
         # Build order by clause
         orderby_xml = ""

--- a/tests/server/test_webdav_search_mcp.py
+++ b/tests/server/test_webdav_search_mcp.py
@@ -205,6 +205,30 @@ async def test_nc_webdav_search_files_basic(
         assert name.endswith(".md"), f"Expected .md file, got {name}"
 
 
+async def test_nc_webdav_search_files_unfiltered(
+    nc_mcp_client: ClientSession, search_test_files: str
+):
+    """An unfiltered search returns the scope's contents instead of erroring.
+
+    Regression: with no ``name_pattern`` / ``mime_type`` / ``only_favorites``
+    the SEARCH body carried an empty ``<d:where>``, which Nextcloud answers
+    with ``500 TypeError`` (confirmed on 32.0.14) — so "list everything under
+    this folder" failed outright.
+    """
+    result = await nc_mcp_client.call_tool(
+        "nc_webdav_search_files",
+        arguments={"scope": search_test_files},
+    )
+
+    assert not result.isError, f"unfiltered search failed: {result.content[0].text}"
+
+    files = normalize_search_response(json.loads(result.content[0].text))
+    logger.info("Unfiltered search returned %s files", len(files))
+
+    # The fixture writes 8 files into the scope; all of them match.
+    assert len(files) >= 8, f"Expected the scope's 8 files, got {len(files)}"
+
+
 async def test_nc_webdav_search_files_combined(
     nc_mcp_client: ClientSession, search_test_files: str
 ):

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -1121,6 +1121,52 @@ def test_build_search_xml_escapes_angle_brackets_in_scope():
 
 
 @pytest.mark.unit
+def test_build_search_xml_unfiltered_emits_a_predicate():
+    """An unfiltered SEARCH must still carry a predicate inside ``<d:where>``.
+
+    Regression: ``nc_webdav_search_files`` with no ``name_pattern`` /
+    ``mime_type`` / ``only_favorites`` passes ``where_conditions=None``, which
+    rendered as an *empty* ``<d:where></d:where>``. Nextcloud 34 answers that
+    with an internal type error (HTTP 500), so "search everything under this
+    folder" -- the most obvious call an MCP client can make -- failed outright
+    rather than returning the folder's contents.
+    """
+    client = WebDAVClient(AsyncMock(), "testuser")
+
+    body = client._build_search_xml(
+        scope="Documents",
+        where_conditions=None,
+        properties=["displayname"],
+        order_by=None,
+        limit=None,
+    )
+
+    where = ET.fromstring(body).find(".//{DAV:}where")
+    assert where is not None
+    # The empty element is what Nextcloud rejects; any child predicate is fine.
+    assert len(where) > 0, "unfiltered SEARCH emitted an empty <d:where>"
+
+
+@pytest.mark.unit
+def test_build_search_xml_keeps_supplied_conditions():
+    """The match-all fallback must not displace a caller's own predicate."""
+    client = WebDAVClient(AsyncMock(), "testuser")
+    condition = "<d:eq><d:prop><oc:favorite/></d:prop><d:literal>1</d:literal></d:eq>"
+
+    body = client._build_search_xml(
+        scope="",
+        where_conditions=condition,
+        properties=["displayname"],
+        order_by=None,
+        limit=None,
+    )
+
+    where = ET.fromstring(body).find(".//{DAV:}where")
+    assert where is not None
+    assert [child.tag for child in where] == ["{DAV:}eq"]
+
+
+@pytest.mark.unit
 async def test_find_by_name_escapes_special_chars_in_pattern(mocker):
     # The filename pattern is embedded in a <d:literal>; '&'/'<'/'>' must be
     # escaped or the SEARCH body is malformed and Sabre 400s — the same bug class


### PR DESCRIPTION
## Problem

`nc_webdav_search_files` called with only a `scope` — no `name_pattern`,
`mime_type`, or `only_favorites` — passed `where_conditions=None` into
`_build_search_xml`, which rendered an **empty `<d:where></d:where>`**.
Nextcloud rejects that body:

```
HTTP 500
<d:error><s:exception>TypeError</s:exception>
  <s:message>A type error occurred...</s:message></d:error>
```

So "search everything under this folder" — the most obvious call an MCP client
can make — failed outright rather than returning the folder's contents.
Directory listing and direct reads were unaffected.

Verified against the dev stack's **Nextcloud 32.0.14**, so this is not limited
to recent releases. The defect was independently reported against a downstream
fork; the fix here was written from the diagnosis, not adopted from it.

## Fix

Emit `displayname LIKE '%'` when no condition is supplied, reusing the operator
the filtered callers already build. It lives at the single construction site, so
`search_files`, `search_files_all` and both paging fallbacks are covered rather
than just the tool-level path. A whitespace-only `where_conditions` now takes the
same branch instead of producing an effectively-empty predicate.

## Test coverage

- `test_build_search_xml_unfiltered_emits_a_predicate` — unit; fails on the
  unfixed tree with `assert 0 > 0: unfiltered SEARCH emitted an empty <d:where>`.
- `test_build_search_xml_keeps_supplied_conditions` — unit; the fallback must not
  displace a caller's own predicate.
- `test_nc_webdav_search_files_unfiltered` — integration, through the MCP tool
  against a live Nextcloud. Confirmed to fail without the fix (container rebuilt
  from the unfixed source returned the 500 `TypeError` through the tool) and pass
  with it.

No API surface is added or changed, so no new contract-test obligation; the
existing WebDAV integration tier gained the end-to-end case.

Verification run: 3474 unit passed · 6 smoke passed · 10 webdav-search
integration passed · ruff, ruff format, ty clean.

Deck: board 12 card #1042.

---

_This PR was generated with the help of AI, and reviewed by a Human_