### PR TITLE
fix(sharing): reject shareType/shareWith pairings that silently misfire

### DIFF
--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -37,13 +37,19 @@ def validate_share_with(share_type: int, share_with: str | None) -> None:
 
     if share_type == ShareType.PUBLIC_LINK:
         if has_recipient:
+            # Deliberately names no alternative *call* here. This message is
+            # shared between direct client callers and the MCP tool, which
+            # surfaces it verbatim, and the two layers have different names for
+            # the same operation -- pointing an agent at a callable that does
+            # not exist on its side is worse than not suggesting one. The tool
+            # appends its own suggestion when it translates this.
             raise ValueError(
                 f"shareType {ShareType.PUBLIC_LINK} (public link) must not carry "
                 f"shareWith: Nextcloud ignores the recipient and publishes the "
                 f"file to anyone holding the URL, so it would NOT be shared with "
                 f"{share_with!r}. Use shareType {ShareType.USER} (user) or "
-                f"{ShareType.GROUP} (group) to share with a recipient, or "
-                f"create_public_link() for an anonymous link."
+                f"{ShareType.GROUP} (group) to share with a recipient, or omit "
+                f"shareWith to create an anonymous public link."
             )
         return
 

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -110,7 +110,11 @@ class SharingClient(BaseNextcloudClient):
             Share data including share ID
 
         Raises:
-            ValueError: If the ``share_type``/``share_with`` pairing is invalid
+            PublicLinkRecipientError: If a public link carries a recipient. A
+                ``ValueError`` subclass, so existing ``except ValueError``
+                handlers keep working; catch it specifically to react to just
+                that case.
+            ValueError: If a recipient-typed share is missing its recipient.
             HTTPStatusError: If the request fails
         """
         validate_share_with(share_type, share_with)

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -109,8 +109,11 @@ class SharingClient(BaseNextcloudClient):
         # Omit shareWith entirely for a public link rather than sending an empty
         # value: validate_share_with has already established there is no
         # recipient, and OCS treats a present-but-empty field inconsistently.
-        if share_with:
-            payload["shareWith"] = share_with
+        # Send it trimmed, matching the value validation just accepted -- an
+        # untrimmed " alice " would otherwise reach OCS as a different recipient
+        # id than the one that was checked.
+        if share_with and share_with.strip():
+            payload["shareWith"] = share_with.strip()
 
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
@@ -176,7 +179,7 @@ class SharingClient(BaseNextcloudClient):
         """
         data: dict[str, Any] = {
             "path": path,
-            "shareType": 3,
+            "shareType": ShareType.PUBLIC_LINK,
             "permissions": permissions,
         }
         if expire_date is not None:

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -3,9 +3,60 @@
 import logging
 from typing import Any
 
+from nextcloud_mcp_server.models.sharing import ShareType
+
 from .base import BaseNextcloudClient, retry_on_429
 
 logger = logging.getLogger(__name__)
+
+
+def validate_share_with(share_type: int, share_with: str | None) -> None:
+    """Check the ``shareType``/``shareWith`` pairing before it reaches the wire.
+
+    The case worth guarding is a public link that carries a recipient.
+    Nextcloud does not reject it: it ignores ``shareWith`` and returns a
+    perfectly valid anonymous link. The caller is then told the share
+    succeeded and reasonably believes the file went to the named person, when
+    it was actually published to anyone holding the URL. A silent success with
+    the wrong audience is worse than an error, which is why this is checked
+    client-side rather than left to the server.
+
+    The inverse — a recipient-typed share with no ``shareWith`` — does fail
+    server-side, but as a generic OCS 400 that names neither the field nor what
+    belongs in it.
+
+    Args:
+        share_type: OCS ``shareType`` value (see :class:`ShareType`).
+        share_with: Recipient identifier, if any.
+
+    Raises:
+        ValueError: If a public link carries a recipient, or a recipient-typed
+            share is missing one.
+    """
+    has_recipient = bool(share_with and share_with.strip())
+
+    if share_type == ShareType.PUBLIC_LINK:
+        if has_recipient:
+            raise ValueError(
+                f"shareType {ShareType.PUBLIC_LINK} (public link) must not carry "
+                f"shareWith: Nextcloud ignores the recipient and publishes the "
+                f"file to anyone holding the URL, so it would NOT be shared with "
+                f"{share_with!r}. Use shareType {ShareType.USER} (user) or "
+                f"{ShareType.GROUP} (group) to share with a recipient, or "
+                f"create_public_link() for an anonymous link."
+            )
+        return
+
+    # Everything that is not a public link addresses someone. Unknown types are
+    # treated as recipient-typed rather than rejected outright -- Nextcloud may
+    # add share types we do not know about, and refusing them here would break
+    # a caller that is otherwise correct.
+    if not has_recipient:
+        raise ValueError(
+            f"shareType {share_type} requires a non-empty shareWith recipient "
+            "(user id, group id, email address, federated user@remote, circle "
+            "id, Talk conversation token or Deck card id, depending on the type)"
+        )
 
 
 class SharingClient(BaseNextcloudClient):
@@ -17,7 +68,7 @@ class SharingClient(BaseNextcloudClient):
     async def create_share(
         self,
         path: str,
-        share_with: str,
+        share_with: str | None = None,
         share_type: int = 0,
         permissions: int = 1,
     ) -> dict[str, Any]:
@@ -25,8 +76,13 @@ class SharingClient(BaseNextcloudClient):
 
         Args:
             path: Path to file/folder to share (relative to user's files)
-            share_with: Username (for user share) or group name (for group share)
-            share_type: Share type (0=user, 1=group, 3=public link)
+            share_with: Recipient identifier — user id, group id, email address,
+                federated ``user@remote``, circle id, Talk conversation token or
+                Deck card id, depending on ``share_type``. Omit it only for a
+                public link (``share_type=3``), which addresses nobody.
+            share_type: OCS share type — see :class:`ShareType`. 0=user
+                (default), 1=group, 3=public link, 4=email, 6=federated,
+                7=circle, 10=Talk conversation, 12=Deck card
             permissions: Share permissions:
                 - 1 = read
                 - 2 = update
@@ -40,17 +96,26 @@ class SharingClient(BaseNextcloudClient):
             Share data including share ID
 
         Raises:
+            ValueError: If the ``share_type``/``share_with`` pairing is invalid
             HTTPStatusError: If the request fails
         """
+        validate_share_with(share_type, share_with)
+
+        payload: dict[str, Any] = {
+            "path": path,
+            "shareType": share_type,
+            "permissions": permissions,
+        }
+        # Omit shareWith entirely for a public link rather than sending an empty
+        # value: validate_share_with has already established there is no
+        # recipient, and OCS treats a present-but-empty field inconsistently.
+        if share_with:
+            payload["shareWith"] = share_with
+
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             headers={"OCS-APIRequest": "true", "Accept": "application/json"},
-            data={
-                "path": path,
-                "shareType": share_type,
-                "shareWith": share_with,
-                "permissions": permissions,
-            },
+            data=payload,
         )
         response.raise_for_status()
         data = response.json()

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -10,6 +10,14 @@ from .base import BaseNextcloudClient, retry_on_429
 logger = logging.getLogger(__name__)
 
 
+class PublicLinkRecipientError(ValueError):
+    """A public-link share was given a recipient it cannot address.
+
+    Its own type, rather than a plain ``ValueError``, so callers can attach a
+    redirect that only fits this case without matching on message text.
+    """
+
+
 def validate_share_with(share_type: int, share_with: str | None) -> None:
     """Check the ``shareType``/``shareWith`` pairing before it reaches the wire.
 
@@ -30,8 +38,8 @@ def validate_share_with(share_type: int, share_with: str | None) -> None:
         share_with: Recipient identifier, if any.
 
     Raises:
-        ValueError: If a public link carries a recipient, or a recipient-typed
-            share is missing one.
+        PublicLinkRecipientError: If a public link carries a recipient.
+        ValueError: If a recipient-typed share is missing one.
     """
     has_recipient = bool(share_with and share_with.strip())
 
@@ -43,7 +51,7 @@ def validate_share_with(share_type: int, share_with: str | None) -> None:
             # the same operation -- pointing an agent at a callable that does
             # not exist on its side is worse than not suggesting one. The tool
             # appends its own suggestion when it translates this.
-            raise ValueError(
+            raise PublicLinkRecipientError(
                 f"shareType {ShareType.PUBLIC_LINK} (public link) must not carry "
                 f"shareWith: Nextcloud ignores the recipient and publishes the "
                 f"file to anyone holding the URL, so it would NOT be shared with "

--- a/nextcloud_mcp_server/models/__init__.py
+++ b/nextcloud_mcp_server/models/__init__.py
@@ -52,6 +52,7 @@ from .notes import (
 # Sharing models
 from .sharing import (
     PublicDownloadLinkResponse,
+    ShareType,
 )
 
 # Tables models
@@ -129,6 +130,7 @@ __all__ = [
     "DeleteAddressBookResponse",
     # Sharing models
     "PublicDownloadLinkResponse",
+    "ShareType",
     # Tables models
     "Table",
     "TableColumn",

--- a/nextcloud_mcp_server/models/sharing.py
+++ b/nextcloud_mcp_server/models/sharing.py
@@ -1,8 +1,31 @@
 """Pydantic models for Nextcloud sharing responses."""
 
+from enum import IntEnum
+
 from pydantic import Field
 
 from .base import BaseResponse
+
+
+class ShareType(IntEnum):
+    """OCS ``shareType`` values.
+
+    An ``IntEnum`` so it stays interchangeable with the bare ints the OCS API
+    and our tool signatures use.
+
+    Every type addresses a named recipient except :attr:`PUBLIC_LINK`, which
+    addresses nobody — see ``validate_share_with`` in the sharing client for
+    why that distinction has to be enforced before the request is sent.
+    """
+
+    USER = 0
+    GROUP = 1
+    PUBLIC_LINK = 3
+    EMAIL = 4
+    FEDERATED = 6
+    CIRCLE = 7
+    TALK_CONVERSATION = 10
+    DECK_CARD = 12
 
 
 class PublicDownloadLinkResponse(BaseResponse):

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -92,8 +93,8 @@ def configure_sharing_tools(mcp: FastMCP):
     @instrument_tool
     async def nc_share_create(
         path: str,
-        share_with: str,
         ctx: Context,
+        share_with: str | None = None,
         share_type: int = 0,
         permissions: int = 1,
     ) -> str:
@@ -104,10 +105,18 @@ def configure_sharing_tools(mcp: FastMCP):
 
         Args:
             path: Path to file/folder to share (relative to your files, e.g., "/document.txt")
-            share_with: Username (for user share) or group name (for group share)
-            share_type: Share type - 0 for user (default), 1 for group, 3 for
-                public link (prefer nc_share_create_public_link for short-lived,
-                read-only download links with managed expiry)
+            share_with: Recipient identifier, required for every share type
+                except a public link: user id, group id, email address,
+                federated "user@remote", circle id, Talk conversation token or
+                Deck card id, matching share_type. Passing a recipient together
+                with share_type=3 is rejected -- a public link addresses nobody,
+                and Nextcloud would silently ignore the recipient and publish
+                the file to anyone holding the URL.
+            share_type: Share type - 0 for user (default), 1 for group, 4 for
+                email, 6 for federated, 7 for circle, 10 for Talk conversation,
+                12 for Deck card. Use 3 for a public link, though
+                nc_share_create_public_link is preferred for short-lived,
+                read-only download links with managed expiry
             permissions: Share permissions (default: 1 for read-only):
                 - 1 = read
                 - 2 = update
@@ -119,14 +128,23 @@ def configure_sharing_tools(mcp: FastMCP):
 
         Returns:
             JSON string with share information including share ID
+
+        Raises:
+            ToolError: If the share_type/share_with pairing is invalid
         """
         client = await get_client(ctx)
-        share_data = await client.sharing.create_share(
-            path=path,
-            share_with=share_with,
-            share_type=share_type,
-            permissions=permissions,
-        )
+        try:
+            share_data = await client.sharing.create_share(
+                path=path,
+                share_with=share_with,
+                share_type=share_type,
+                permissions=permissions,
+            )
+        except ValueError as e:
+            # Surface the pairing rejection as a tool error the caller can read
+            # and act on, rather than an opaque internal failure. The client
+            # layer owns the rule so direct client callers are guarded too.
+            raise ToolError(str(e)) from e
         return json.dumps(share_data, indent=2)
 
     @mcp.tool(

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -143,8 +143,12 @@ def configure_sharing_tools(mcp: FastMCP):
         except ValueError as e:
             # Surface the pairing rejection as a tool error the caller can read
             # and act on, rather than an opaque internal failure. The client
-            # layer owns the rule so direct client callers are guarded too.
-            raise ToolError(str(e)) from e
+            # layer owns the rule so direct client callers are guarded too, and
+            # names no alternative call itself -- the tool that an MCP caller
+            # can actually invoke is only known here.
+            raise ToolError(
+                f"{e} For a public download link, use nc_share_create_public_link."
+            ) from e
         return json.dumps(share_data, indent=2)
 
     @mcp.tool(

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.client.sharing import PublicLinkRecipientError
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models import PublicDownloadLinkResponse
 from nextcloud_mcp_server.observability.metrics import instrument_tool
@@ -140,15 +141,19 @@ def configure_sharing_tools(mcp: FastMCP):
                 share_type=share_type,
                 permissions=permissions,
             )
-        except ValueError as e:
-            # Surface the pairing rejection as a tool error the caller can read
-            # and act on, rather than an opaque internal failure. The client
-            # layer owns the rule so direct client callers are guarded too, and
-            # names no alternative call itself -- the tool that an MCP caller
-            # can actually invoke is only known here.
+        except PublicLinkRecipientError as e:
+            # The redirect fits only this rejection. The client layer names no
+            # tool (its own method names do not exist on the MCP side), and this
+            # is the layer that knows what the caller can actually invoke.
             raise ToolError(
                 f"{e} For a public download link, use nc_share_create_public_link."
             ) from e
+        except ValueError as e:
+            # Every other pairing rejection -- a recipient-typed share with no
+            # recipient. Suggesting the public-link tool here would be a wrong
+            # redirect, which is the failure this whole message path exists to
+            # avoid.
+            raise ToolError(str(e)) from e
         return json.dumps(share_data, indent=2)
 
     @mcp.tool(

--- a/tests/client/test_sharing_client.py
+++ b/tests/client/test_sharing_client.py
@@ -171,3 +171,77 @@ async def test_create_share_raises_on_ocs_failure(sharing_client, mocker):
             share_with="1",
             share_type=12,
         )
+
+
+async def test_create_share_rejects_public_link_with_recipient(sharing_client):
+    """A public link carrying a recipient must be refused before the request.
+
+    Nextcloud accepts this pairing and silently ignores ``shareWith``, handing
+    back a valid anonymous link. The caller is told the share succeeded and
+    believes the file went to the named user, when it was actually published to
+    anyone holding the URL -- so the check has to happen client-side.
+    """
+    with pytest.raises(ValueError, match="must not carry shareWith"):
+        await sharing_client.create_share(
+            path="/Secrets/salaries.xlsx",
+            share_with="alice",
+            share_type=3,
+        )
+
+    # Refused before the wire: nothing was sent.
+    sharing_client._client.post.assert_not_called()
+
+
+@pytest.mark.parametrize("recipient", [None, "", "   "])
+async def test_create_share_requires_recipient_for_user_share(
+    sharing_client, recipient
+):
+    """A recipient-typed share with no usable recipient is refused locally.
+
+    The server does reject this, but as a generic OCS 400 that names neither
+    the field nor what belongs in it. Blank and whitespace-only are treated the
+    same as absent.
+    """
+    with pytest.raises(ValueError, match="requires a non-empty shareWith"):
+        await sharing_client.create_share(
+            path="/Documents/report.md",
+            share_with=recipient,
+            share_type=0,
+        )
+
+    sharing_client._client.post.assert_not_called()
+
+
+async def test_create_share_public_link_omits_share_with(sharing_client, mocker):
+    """A recipient-less public link is allowed and sends no shareWith field."""
+    sharing_client._client.post.return_value = _ok_share_response(mocker, share_id=11)
+
+    await sharing_client.create_share(
+        path="/Public/flyer.pdf",
+        share_type=3,
+    )
+
+    assert sharing_client._client.post.call_args.kwargs["data"] == {
+        "path": "/Public/flyer.pdf",
+        "shareType": 3,
+        "permissions": 1,
+    }
+
+
+async def test_create_share_allows_unknown_share_type_with_recipient(
+    sharing_client, mocker
+):
+    """An unrecognised share type is passed through, not rejected.
+
+    Nextcloud may add share types we do not know about; refusing them here
+    would break an otherwise-correct caller. Only the recipient rule applies.
+    """
+    sharing_client._client.post.return_value = _ok_share_response(mocker, share_id=12)
+
+    await sharing_client.create_share(
+        path="/Documents/report.md",
+        share_with="some-identifier",
+        share_type=99,
+    )
+
+    assert sharing_client._client.post.call_args.kwargs["data"]["shareType"] == 99

--- a/tests/unit/server/test_share_create_validation.py
+++ b/tests/unit/server/test_share_create_validation.py
@@ -69,6 +69,11 @@ async def test_public_link_with_recipient_raises_a_readable_tool_error(
     message = str(exc_info.value)
     assert "must not carry shareWith" in message
     assert "anyone holding the URL" in message
+    # ...and point at a tool this caller can actually invoke. The client-layer
+    # message deliberately names no call, because its own method names do not
+    # exist on the MCP side.
+    assert "nc_share_create_public_link" in message
+    assert "create_public_link()" not in message
 
 
 async def test_missing_recipient_raises_a_tool_error(

--- a/tests/unit/server/test_share_create_validation.py
+++ b/tests/unit/server/test_share_create_validation.py
@@ -1,0 +1,82 @@
+"""Unit tests for how ``nc_share_create`` surfaces an invalid pairing.
+
+The rule itself lives in the client layer (covered in
+``tests/client/test_sharing_client.py``); what is pinned here is the tool's
+translation of that rejection into a ``ToolError``. The caller has to be able to
+*read* why the share was refused -- a public link that quietly published a file
+is the failure this whole path exists to prevent, so an opaque internal error
+would defeat the point.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from nextcloud_mcp_server.client.sharing import validate_share_with
+from nextcloud_mcp_server.server.sharing import configure_sharing_tools
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def share_create_tool():
+    mcp = FastMCP("test")
+    configure_sharing_tools(mcp)
+    return mcp._tool_manager.get_tool("nc_share_create")
+
+
+@pytest.fixture
+def stub_client(mocker):
+    """A client whose sharing layer keeps the real validation."""
+    client = mocker.MagicMock()
+
+    async def create_share(**kwargs):
+        # Apply the real rule rather than a mock that would accept anything, so
+        # the assertions below stay tied to the actual error messages. The valid
+        # path is not exercised here -- it belongs to the client-layer tests.
+        validate_share_with(kwargs.get("share_type", 0), kwargs.get("share_with"))
+        return {"id": 1}
+
+    client.sharing.create_share = create_share
+    mocker.patch(
+        "nextcloud_mcp_server.server.sharing.get_client",
+        mocker.AsyncMock(return_value=client),
+    )
+    # Pin the deployment mode: @require_scopes denies a context without a
+    # verified token only under login-flow, which would otherwise make this
+    # pass locally and fail in CI.
+    mocker.patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=mocker.MagicMock(enable_login_flow=False),
+    )
+    return client
+
+
+async def test_public_link_with_recipient_raises_a_readable_tool_error(
+    share_create_tool, stub_client, mocker
+):
+    with pytest.raises(ToolError) as exc_info:
+        await share_create_tool.fn(
+            path="/Secrets/salaries.xlsx",
+            share_with="alice",
+            share_type=3,
+            ctx=mocker.MagicMock(),
+        )
+
+    # The message must name the consequence, not just say "invalid".
+    message = str(exc_info.value)
+    assert "must not carry shareWith" in message
+    assert "anyone holding the URL" in message
+
+
+async def test_missing_recipient_raises_a_tool_error(
+    share_create_tool, stub_client, mocker
+):
+    with pytest.raises(ToolError, match="requires a non-empty shareWith"):
+        await share_create_tool.fn(
+            path="/Documents/report.md",
+            share_type=0,
+            ctx=mocker.MagicMock(),
+        )

--- a/tests/unit/server/test_share_create_validation.py
+++ b/tests/unit/server/test_share_create_validation.py
@@ -85,3 +85,22 @@ async def test_missing_recipient_raises_a_tool_error(
             share_type=0,
             ctx=mocker.MagicMock(),
         )
+
+
+async def test_missing_recipient_does_not_suggest_the_public_link_tool(
+    share_create_tool, stub_client, mocker
+):
+    """A wrong redirect is the failure this message path exists to avoid.
+
+    The public-link suggestion belongs only to the public-link-with-recipient
+    rejection. Appending it to "you forgot the recipient" would send a caller
+    who wants a *user* share off to create an anonymous link instead.
+    """
+    with pytest.raises(ToolError) as exc_info:
+        await share_create_tool.fn(
+            path="/Documents/report.md",
+            share_type=0,
+            ctx=mocker.MagicMock(),
+        )
+
+    assert "nc_share_create_public_link" not in str(exc_info.value)


### PR DESCRIPTION
Bottom of stack #1336. Independent of the two layers above it — kept at the bottom because it is the smallest and most mergeable, and the whole stack is blocked behind it.

## Problem

`create_share` forwarded any `share_type`/`share_with` combination to OCS unvalidated. The dangerous case is a **public link carrying a recipient**:

Nextcloud does not reject `share_type=3` + `share_with="alice"`. It ignores `shareWith` and returns a perfectly valid anonymous link. The caller is told the share succeeded and reasonably believes the file went to Alice — when it was published to **anyone holding the URL**. A silent success with the wrong audience is worse than an error, which is why this has to be checked before the request is built rather than left to the server.

The inverse — a recipient-typed share with no recipient — does fail server-side, but as a generic OCS 400 naming neither the field nor what belongs in it.

## Fix

- `validate_share_with` rejects both pairings before anything reaches the wire.
- `ShareType` IntEnum for the documented types (0, 1, 3, 4, 6, 7, 10, 12), so call sites stop passing bare ints. The tool docstring previously documented only 0/1/3.
- `shareWith` is omitted from the payload entirely for a public link rather than sent empty.
- **Unknown share types pass through.** Nextcloud may add types we do not know about, and refusing them here would break an otherwise-correct caller. Only the recipient rule applies to them.

The rule lives in the **client layer**, so direct client callers are guarded too, not just the MCP tool. The tool translates the rejection into a `ToolError` the caller can read.

## Test coverage

`tests/client/test_sharing_client.py` — public-link-with-recipient rejection, recipient-typed-without-recipient rejection (parametrized over `None` / `""` / `"   "`), public link omitting `shareWith`, and unknown-type passthrough. The rejection tests assert `post.assert_not_called()`, proving refusal happens before the wire.

No new API surface (an existing tool's signature is tightened), so no new contract-test obligation.

## Out of scope

`nc_share_create` still returns `-> str`. Five of the six tools in `server/sharing.py` do — module-wide pre-existing debt under the CLAUDE.md typed-response migration, not something to fix in the bottom PR of a stack.

Deck: board 12 card #1047.

---

_This PR was generated with the help of AI, and reviewed by a Human_