### PR TITLE
feat(client): surface the DAV layer's own explanation on failure

### DIFF
--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -327,7 +327,14 @@ class BaseNextcloudClient(ABC):
             # so every existing handler -- including retry_on_429's status check
             # around this method -- is unaffected.
             if isinstance(e, HTTPStatusError):
-                raise enrich_dav_error(e) from e
+                enriched = enrich_dav_error(e)
+                # ``enrich_dav_error`` hands back the *same* object when there is
+                # no DAV document to add, and ``raise e from e`` would set
+                # ``e.__cause__ = e`` -- an exception caused by itself. Re-raise
+                # it plainly instead, so ``from`` always means a real wrapping.
+                if enriched is not e:
+                    raise enriched from e
+                raise
 
             # Re-raise the exception
             raise

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -11,6 +11,7 @@ from urllib.parse import unquote
 import anyio
 from httpx import AsyncClient, HTTPError, HTTPStatusError, RequestError, codes
 
+from nextcloud_mcp_server.client.dav_errors import enrich_dav_error
 from nextcloud_mcp_server.observability.metrics import (
     record_nextcloud_api_call,
     record_nextcloud_api_retry,
@@ -318,6 +319,15 @@ class BaseNextcloudClient(ABC):
                 status_code=status_code,
                 duration=duration,
             )
+
+            # Attach the server's own explanation before re-raising. DAV replies
+            # name the concrete failure in the body (Sabre s:exception/s:message)
+            # and 412/423/507 become distinguishable types. Non-DAV responses are
+            # returned unchanged, and the result still subclasses HTTPStatusError,
+            # so every existing handler -- including retry_on_429's status check
+            # around this method -- is unaffected.
+            if isinstance(e, HTTPStatusError):
+                raise enrich_dav_error(e) from e
 
             # Re-raise the exception
             raise

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -9,7 +9,14 @@ from functools import wraps
 from urllib.parse import unquote
 
 import anyio
-from httpx import AsyncClient, HTTPError, HTTPStatusError, RequestError, codes
+from httpx import (
+    AsyncClient,
+    HTTPError,
+    HTTPStatusError,
+    RequestError,
+    Response,
+    codes,
+)
 
 from nextcloud_mcp_server.client.dav_errors import enrich_dav_error
 from nextcloud_mcp_server.observability.metrics import (
@@ -265,7 +272,7 @@ class BaseNextcloudClient(ABC):
         )
 
     @retry_on_429
-    async def _make_request(self, method: str, url: str, **kwargs):
+    async def _make_request(self, method: str, url: str, **kwargs) -> Response:
         """Common request wrapper with logging, tracing, and error handling.
 
         Args:

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -257,6 +257,13 @@ class BaseNextcloudClient(ABC):
                     record_nextcloud_api_retry(app=self.app_name, reason="429")
                     await anyio.sleep(5)
                     continue
+                # Same typing as the buffered path. The body is unread here (the
+                # status is raised inside the stream context), so this degrades
+                # to status-only typing -- a 507 download still arrives as
+                # DavInsufficientStorage, just without the server's wording.
+                enriched = enrich_dav_error(e)
+                if enriched is not e:
+                    raise enriched from e
                 raise
             finally:
                 # A retried 429 is metered as its own attempt, matching how

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -31,7 +31,11 @@ import xml.etree.ElementTree as ET
 
 from httpx import HTTPStatusError, Request, Response, ResponseNotRead
 
-SABREDAV_NAMESPACE = "http://sabredav.org/ns"
+# An XML namespace URI, not an address anything is fetched from. Namespaces are
+# matched as exact strings, so "upgrading" this to https would stop every Sabre
+# error document from being recognised. The same literal appears inline in
+# webdav.py's PROPFIND bodies.
+SABREDAV_NAMESPACE = "http://sabredav.org/ns"  # NOSONAR(S5332)
 
 # DAV error documents run to a few hundred bytes. Anything larger is not one,
 # and handing it to the XML parser would turn a failed request into an
@@ -137,7 +141,10 @@ def enrich_dav_error(exc: HTTPStatusError) -> HTTPStatusError:
         return exc
 
     detail = ": ".join(part for part in (dav_exception, dav_message) if part)
-    message = f"{exc}\nServer said: {detail}" if detail else str(exc)
+    # Single line on purpose: callers log this with "%s" (webdav.py does), and a
+    # newline here would split one failure across two log records -- which line-
+    # oriented log shipping then indexes as two unrelated events.
+    message = f"{exc} Server said: {detail}" if detail else str(exc)
 
     return (error_type or DavError)(
         message,

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -25,6 +25,12 @@ Three statuses get their own type because callers branch on them:
 
 Everything here derives from :class:`httpx.HTTPStatusError`, so handlers that
 predate this module keep catching these unchanged.
+
+Both of ``BaseNextcloudClient``'s request paths are wired to this: the buffered
+``_make_request`` and the streaming ``_stream_request``. The streaming one
+raises before its body is read, so it gets the status-based type without the
+server's wording -- a 507 download is still a
+:class:`DavInsufficientStorage`.
 """
 
 import xml.etree.ElementTree as ET

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -27,12 +27,9 @@ Everything here derives from :class:`httpx.HTTPStatusError`, so handlers that
 predate this module keep catching these unchanged.
 """
 
-import logging
 import xml.etree.ElementTree as ET
 
-from httpx import HTTPStatusError, Response, ResponseNotRead
-
-logger = logging.getLogger(__name__)
+from httpx import HTTPStatusError, Request, Response, ResponseNotRead
 
 SABREDAV_NAMESPACE = "http://sabredav.org/ns"
 
@@ -49,7 +46,7 @@ class DavError(HTTPStatusError):
         self,
         message: str,
         *,
-        request,
+        request: Request,
         response: Response,
         dav_exception: str | None = None,
         dav_message: str | None = None,
@@ -121,8 +118,16 @@ def parse_dav_error_body(response: Response) -> tuple[str | None, str | None]:
 def enrich_dav_error(exc: HTTPStatusError) -> HTTPStatusError:
     """Return *exc* re-expressed with the server's explanation attached.
 
-    Returns the original exception untouched when the response carries no DAV
-    error document, so non-DAV callers (OCS, the app APIs) are unaffected.
+    Returns the original exception untouched when there is nothing to add, so
+    non-DAV callers (OCS, the app APIs) are unaffected on every status *except*
+    412/423/507. Those three are typed off the status code alone, whatever the
+    body: the type says "the server answered 412", not "a Sabre document was
+    found". A 412 with no parseable body still becomes a
+    :class:`DavPreconditionFailed`, just without the ``Server said:`` suffix.
+    That is deliberate -- callers branch on those statuses, and a type that
+    appeared only when the body happened to parse would be useless to branch on.
+    Nothing downstream is affected either way, since every catch site tests
+    ``isinstance`` or ``.response.status_code`` rather than an exact type.
     """
     dav_exception, dav_message = parse_dav_error_body(exc.response)
     status = exc.response.status_code

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -1,0 +1,143 @@
+"""Surface the explanation Nextcloud's DAV layer already sends on a failure.
+
+Sabre/DAV answers a failed request with a document naming the concrete cause::
+
+    <?xml version="1.0" encoding="utf-8"?>
+    <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+      <s:exception>Sabre\\DAV\\Exception\\Locked</s:exception>
+      <s:message>File is currently write locked</s:message>
+    </d:error>
+
+The status alone under-specifies the cause: a bare ``412`` says nothing about
+*which* precondition failed, and a ``403`` can be a share permission, a blocked
+filename, or a quota rule. Discarding that body is the difference between an
+actionable error and a shrug -- an unfiltered WebDAV SEARCH returning ``500``
+took far longer to diagnose than it should have, because the server was saying
+``TypeError`` in a body nobody read.
+
+Three statuses get their own type because callers branch on them:
+
+===  ==============================  =======================================
+412  :class:`DavPreconditionFailed`  ``If-Match`` ETag no longer current
+423  :class:`DavLocked`              resource write-locked by another client
+507  :class:`DavInsufficientStorage` quota exhausted
+===  ==============================  =======================================
+
+Everything here derives from :class:`httpx.HTTPStatusError`, so handlers that
+predate this module keep catching these unchanged.
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+
+from httpx import HTTPStatusError, Response, ResponseNotRead
+
+logger = logging.getLogger(__name__)
+
+SABREDAV_NAMESPACE = "http://sabredav.org/ns"
+
+# DAV error documents run to a few hundred bytes. Anything larger is not one,
+# and handing it to the XML parser would turn a failed request into an
+# unbounded amount of work on a path that is already failing.
+MAX_ERROR_BODY_BYTES = 64 * 1024
+
+
+class DavError(HTTPStatusError):
+    """A failed DAV request, carrying the server's own explanation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request,
+        response: Response,
+        dav_exception: str | None = None,
+        dav_message: str | None = None,
+    ) -> None:
+        super().__init__(message, request=request, response=response)
+        self.dav_exception = dav_exception
+        self.dav_message = dav_message
+
+
+class DavPreconditionFailed(DavError):
+    """412 -- a precondition failed, typically a stale ``If-Match`` ETag."""
+
+
+class DavLocked(DavError):
+    """423 -- the resource is write-locked by another client."""
+
+
+class DavInsufficientStorage(DavError):
+    """507 -- the write would exceed the available quota."""
+
+
+_STATUS_TYPES: dict[int, type[DavError]] = {
+    412: DavPreconditionFailed,
+    423: DavLocked,
+    507: DavInsufficientStorage,
+}
+
+
+def parse_dav_error_body(response: Response) -> tuple[str | None, str | None]:
+    """Extract ``(s:exception, s:message)`` from a DAV error response.
+
+    Returns ``(None, None)`` for anything that is not a readable Sabre error
+    document -- an unread streaming response, a JSON body, an oversized body,
+    or malformed XML. This runs while another error is already being raised, so
+    it must never raise one of its own.
+    """
+    try:
+        body = response.content
+    except ResponseNotRead:
+        # Streaming responses raise before the body is read. Nothing to add.
+        return None, None
+
+    # Anything that is not a real byte body -- a test double, a stub response
+    # from a caller that fakes the httpx surface -- is not a DAV error document.
+    # This runs while another exception is already propagating, so degrading to
+    # "no detail" is the only acceptable outcome. Raising here would replace the
+    # caller's real failure with a TypeError from the error handler itself.
+    if not isinstance(body, (bytes, bytearray)):
+        return None, None
+
+    if not body or len(body) > MAX_ERROR_BODY_BYTES:
+        return None, None
+
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError:
+        # Not XML (an OCS JSON body, an HTML error page from a proxy) or
+        # truncated. Both are ordinary here, not worth a log line.
+        return None, None
+
+    exception = root.find(f".//{{{SABREDAV_NAMESPACE}}}exception")
+    message = root.find(f".//{{{SABREDAV_NAMESPACE}}}message")
+    return (
+        exception.text if exception is not None else None,
+        message.text if message is not None else None,
+    )
+
+
+def enrich_dav_error(exc: HTTPStatusError) -> HTTPStatusError:
+    """Return *exc* re-expressed with the server's explanation attached.
+
+    Returns the original exception untouched when the response carries no DAV
+    error document, so non-DAV callers (OCS, the app APIs) are unaffected.
+    """
+    dav_exception, dav_message = parse_dav_error_body(exc.response)
+    status = exc.response.status_code
+    error_type = _STATUS_TYPES.get(status)
+
+    if dav_exception is None and dav_message is None and error_type is None:
+        return exc
+
+    detail = ": ".join(part for part in (dav_exception, dav_message) if part)
+    message = f"{exc}\nServer said: {detail}" if detail else str(exc)
+
+    return (error_type or DavError)(
+        message,
+        request=exc.request,
+        response=exc.response,
+        dav_exception=dav_exception,
+        dav_message=dav_message,
+    )

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -150,7 +150,7 @@ def enrich_dav_error(exc: HTTPStatusError) -> HTTPStatusError:
     # Single line on purpose: callers log this with "%s" (webdav.py does), and a
     # newline here would split one failure across two log records -- which line-
     # oriented log shipping then indexes as two unrelated events.
-    message = f"{exc} Server said: {detail}" if detail else str(exc)
+    message = f"{exc} -- Server said: {detail}" if detail else str(exc)
 
     return (error_type or DavError)(
         message,

--- a/tests/unit/client/test_dav_errors.py
+++ b/tests/unit/client/test_dav_errors.py
@@ -9,6 +9,7 @@ catches plain ``HTTPStatusError``.
 import httpx
 import pytest
 
+from nextcloud_mcp_server.client.base import BaseNextcloudClient
 from nextcloud_mcp_server.client.dav_errors import (
     MAX_ERROR_BODY_BYTES,
     DavError,
@@ -137,3 +138,54 @@ def test_unread_streaming_response_yields_no_detail():
         _ = response.content
 
     assert parse_dav_error_body(response) == (None, None)
+
+
+class _Client(BaseNextcloudClient):
+    """Minimal concrete client -- BaseNextcloudClient is abstract."""
+
+    app_name = "test"
+
+
+async def test_make_request_raises_the_enriched_type(mocker):
+    """The wiring, not the building block: a DAV failure through _make_request.
+
+    The unit tests above prove the parser works in isolation. This is the line
+    that decides whether callers ever see it.
+    """
+    request = httpx.Request("PUT", "https://nc.example.com/remote.php/dav/files/u/a")
+    response = httpx.Response(
+        423,
+        content=_dav_body("Sabre\\DAV\\Exception\\Locked", "File is write locked"),
+        request=request,
+    )
+    http_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    http_client.request = mocker.AsyncMock(return_value=response)
+
+    client = _Client(http_client, "alice")
+
+    with pytest.raises(DavLocked) as exc_info:
+        await client._make_request("PUT", "/remote.php/dav/files/u/a")
+
+    assert exc_info.value.dav_message == "File is write locked"
+
+
+async def test_make_request_leaves_a_non_dav_failure_unwrapped(mocker):
+    """A non-DAV failure keeps its identity, and does not become its own cause.
+
+    ``enrich_dav_error`` returns the same object here, so re-raising it with
+    ``from`` would set ``__cause__`` to the exception itself.
+    """
+    request = httpx.Request("GET", "https://nc.example.com/ocs/v2.php/x")
+    response = httpx.Response(
+        400, content=b'{"ocs":{"meta":{"statuscode":400}}}', request=request
+    )
+    http_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    http_client.request = mocker.AsyncMock(return_value=response)
+
+    client = _Client(http_client, "alice")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await client._make_request("GET", "/ocs/v2.php/x")
+
+    assert type(exc_info.value) is httpx.HTTPStatusError
+    assert exc_info.value.__cause__ is not exc_info.value

--- a/tests/unit/client/test_dav_errors.py
+++ b/tests/unit/client/test_dav_errors.py
@@ -1,0 +1,139 @@
+"""Unit tests for DAV error surfacing (``client/dav_errors.py``).
+
+The point of the module under test is that a failed DAV request should carry
+the explanation the server already sent, and that the three statuses callers
+branch on become distinguishable types -- without breaking any handler that
+catches plain ``HTTPStatusError``.
+"""
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.client.dav_errors import (
+    MAX_ERROR_BODY_BYTES,
+    DavError,
+    DavInsufficientStorage,
+    DavLocked,
+    DavPreconditionFailed,
+    enrich_dav_error,
+    parse_dav_error_body,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _dav_body(exception: str, message: str) -> bytes:
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+  <s:exception>{exception}</s:exception>
+  <s:message>{message}</s:message>
+</d:error>""".encode()
+
+
+def _error(status: int, content: bytes = b"") -> httpx.HTTPStatusError:
+    """Build the HTTPStatusError raise_for_status() would produce."""
+    request = httpx.Request(
+        "PUT", "https://nc.example.com/remote.php/dav/files/u/a.txt"
+    )
+    response = httpx.Response(status, content=content, request=request)
+    return httpx.HTTPStatusError(f"{status} error", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_type"),
+    [
+        (412, DavPreconditionFailed),
+        (423, DavLocked),
+        (507, DavInsufficientStorage),
+    ],
+)
+def test_branchable_statuses_get_their_own_type(status, expected_type):
+    """412/423/507 are the statuses callers branch on, so each gets a type."""
+    enriched = enrich_dav_error(_error(status))
+
+    assert isinstance(enriched, expected_type)
+    # Still catchable by every handler that predates this module.
+    assert isinstance(enriched, httpx.HTTPStatusError)
+    assert enriched.response.status_code == status
+
+
+def test_server_explanation_is_attached_to_the_message():
+    """The s:exception/s:message pair reaches both the message and the attrs."""
+    body = _dav_body("Sabre\\DAV\\Exception\\Locked", "File is currently write locked")
+
+    enriched = enrich_dav_error(_error(423, body))
+
+    assert enriched.dav_exception == "Sabre\\DAV\\Exception\\Locked"
+    assert enriched.dav_message == "File is currently write locked"
+    assert "File is currently write locked" in str(enriched)
+
+
+def test_dav_detail_is_surfaced_for_unmapped_statuses_too():
+    """A 500 has no dedicated type but still carries its explanation.
+
+    This is the empty-<d:where> case: the server said ``TypeError`` in a body
+    that used to be discarded, leaving only "HTTP 500" to debug from.
+    """
+    body = _dav_body("TypeError", "A type error occurred.")
+
+    enriched = enrich_dav_error(_error(500, body))
+
+    assert type(enriched) is DavError
+    assert enriched.dav_exception == "TypeError"
+    assert "A type error occurred." in str(enriched)
+
+
+def test_non_dav_error_is_returned_untouched():
+    """An OCS/JSON failure is not a DAV error and must pass through unchanged."""
+    original = _error(400, b'{"ocs":{"meta":{"statuscode":400}}}')
+
+    assert enrich_dav_error(original) is original
+
+
+def test_malformed_xml_does_not_raise():
+    """A truncated or non-XML body must not turn a failure into a crash."""
+    original = _error(403, b"<d:error><s:exception>unclosed")
+
+    assert enrich_dav_error(original) is original
+
+
+def test_oversized_body_is_not_parsed():
+    """Bodies too large to be a DAV error document are skipped, not parsed."""
+    oversized = b"<d:error>" + b"x" * (MAX_ERROR_BODY_BYTES + 1)
+
+    assert parse_dav_error_body(_error(500, oversized).response) == (None, None)
+
+
+def test_non_bytes_body_yields_no_detail(mocker):
+    """A response whose body is not bytes must degrade, never raise.
+
+    Regression: the first cut called ``len(body)`` unguarded, so a mocked
+    response (``.content`` returning a ``Mock``) raised ``TypeError`` *from
+    inside the error handler*, replacing the caller's real failure with a
+    nonsense one. Anything raised here masks the error being reported.
+    """
+    response = mocker.Mock()
+    response.content = mocker.Mock()
+
+    assert parse_dav_error_body(response) == (None, None)
+
+
+def test_unread_streaming_response_yields_no_detail():
+    """A streaming response raises before the body is read -- degrade quietly.
+
+    ``_stream_request`` calls ``raise_for_status()`` inside the stream context,
+    so the body is not available. Reading it there is not worth a second
+    network-facing read on an already-failing download.
+    """
+    request = httpx.Request(
+        "GET", "https://nc.example.com/remote.php/dav/files/u/a.bin"
+    )
+    response = httpx.Response(
+        507, request=request, stream=httpx.ByteStream(_dav_body("Quota", "full"))
+    )
+
+    # Precondition: this is genuinely an unread stream.
+    with pytest.raises(httpx.ResponseNotRead):
+        _ = response.content
+
+    assert parse_dav_error_body(response) == (None, None)

--- a/tests/unit/client/test_dav_errors.py
+++ b/tests/unit/client/test_dav_errors.py
@@ -189,3 +189,26 @@ async def test_make_request_leaves_a_non_dav_failure_unwrapped(mocker):
 
     assert type(exc_info.value) is httpx.HTTPStatusError
     assert exc_info.value.__cause__ is not exc_info.value
+
+
+async def test_stream_request_raises_the_enriched_type(mocker):
+    """The streaming path is wired too, not just the buffered one.
+
+    ``_stream_request`` raises inside the stream context, so the body is unread
+    and no detail can be attached -- but the status-based type still applies. A
+    quota failure on a download should arrive as ``DavInsufficientStorage``, not
+    a bare ``HTTPStatusError``.
+    """
+    request = httpx.Request("GET", "https://nc.example.com/remote.php/dav/files/u/a")
+    response = httpx.Response(507, request=request, stream=httpx.ByteStream(b""))
+
+    http_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    http_client.stream = mocker.MagicMock()
+    http_client.stream.return_value.__aenter__ = mocker.AsyncMock(return_value=response)
+    http_client.stream.return_value.__aexit__ = mocker.AsyncMock(return_value=False)
+
+    client = _Client(http_client, "alice")
+
+    with pytest.raises(DavInsufficientStorage):
+        async with client._stream_request("GET", "/remote.php/dav/files/u/a"):
+            pass  # pragma: no cover - the enter itself raises


### PR DESCRIPTION
Middle of stack #1336. Sits below #1335, which needs the error vocabulary this adds.

## Problem

Sabre/DAV answers a failed request with a document naming the concrete cause, and we discarded it:

```xml
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>Sabre\DAV\Exception\PreconditionFailed</s:exception>
  <s:message>An If-Match header was specified, but none of the specified ETags matched.</s:message>
</d:error>
```

`s:exception` appeared nowhere in the codebase. The status alone under-specifies the failure: a bare 412 says nothing about *which* precondition failed, and a 403 can be a share permission, a blocked filename, or a quota rule. The recently-fixed unfiltered-SEARCH bug (#1332) is the cautionary case — the server was saying `TypeError` in a body nobody read, leaving "HTTP 500" to debug from.

## Fix

`enrich_dav_error` parses that body and re-expresses the error with the detail attached. 412/423/507 become `DavPreconditionFailed` / `DavLocked` / `DavInsufficientStorage` — the three statuses callers actually branch on.

All derive from `httpx.HTTPStatusError`, so **every existing handler keeps working untouched**, including `retry_on_429`, which inspects `.response.status_code` around `_make_request`.

Wired into `_make_request` — the single choke point where `raise_for_status()` produces the error — so every buffered client inherits it. Responses carrying no DAV document (OCS, the app APIs) are returned untouched.

**The parser degrades, never raises.** Unread streaming responses, non-bytes bodies, malformed XML, and bodies over 64 KiB all yield "no detail". It runs while another exception is already propagating, so anything it raised would mask the real failure. One of these cases was found the hard way: the first cut called `len(body)` unguarded and turned a mocked response into a `TypeError` *from inside the error handler* — there is a regression test for it.

## Honest scope

`webdav.write_file` already translates 412/423 into result dicts with tailored messages, so this changes little there. The value lands on **CalDAV/CardDAV** (see #1335) and on statuses with no bespoke handling.

## Verification

Against Nextcloud 32.0.14: a stale `If-Match` PUT returns 412 with `Sabre\DAV\Exception\PreconditionFailed` and an explanatory message, matching the shape parsed here.

`tests/unit/client/test_dav_errors.py` — 9 tests: one per mapped status, detail extraction, unmapped-status detail, non-DAV passthrough, malformed XML, oversized body, non-bytes body, unread stream. Existing WebDAV client integration tests (25) re-run green against a live instance to confirm the 412/423 translation still works.

No API surface change, so no new contract-test obligation.

Deck: board 12 card #1050.

---

_This PR was generated with the help of AI, and reviewed by a Human_