### PR TITLE
fix(calendar): give CalDAV writes ETag concurrency control

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -810,8 +810,15 @@ class CalendarClient:
         outer_comp_filter = cdav.CompFilter(name="VCALENDAR") + inner_comp_filter
         filter_element = cdav.Filter() + outer_comp_filter
 
+        # Ask for the ETag alongside the calendar data. The REPORT is the hot
+        # path for "list events in a range", and objects built from it are
+        # already loaded -- so without getetag here, surfacing an ETag per event
+        # would fall back to one PROPFIND *each*, turning a single REPORT into
+        # 1 + N requests.
         data = cdav.CalendarData()
-        query = cdav.CalendarQuery() + [dav.Prop() + data] + filter_element
+        query = (
+            cdav.CalendarQuery() + [dav.Prop() + data + dav.GetEtag()] + filter_element
+        )
 
         body = etree.tostring(
             query.xmlelement(), encoding="utf-8", xml_declaration=True
@@ -821,17 +828,24 @@ class CalendarClient:
 
         # Parse response (same pattern as AsyncCalendar.search)
         objects = []
-        response_data = response.expand_simple_props([cdav.CalendarData()])
+        response_data = response.expand_simple_props(
+            [cdav.CalendarData(), dav.GetEtag()]
+        )
         for href, props in response_data.items():
             if href == str(calendar.url):
                 continue
             cal_data = props.get(cdav.CalendarData.tag)
             if cal_data:
+                etag = props.get(dav.GetEtag.tag)
                 obj = AsyncEvent(
                     client=calendar.client,
                     url=calendar.url.join(href),  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]  # url is always set for calendars
                     data=cal_data,
                     parent=calendar,
+                    # caldav's ``etag`` property reads straight from ``props``,
+                    # so seeding it here is what keeps _object_etag off the
+                    # PROPFIND fallback.
+                    props={dav.GetEtag.tag: etag} if etag else None,
                 )
                 objects.append(obj)
 

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -967,6 +967,32 @@ class CalendarClient:
 
         return props.get(dav.GetEtag.tag) or ""
 
+    async def _collection_etags(self, calendar: Any) -> dict[str, str]:
+        """Map decoded href path -> ETag for every object in *calendar*.
+
+        One ``PROPFIND`` (Depth 1, ``getetag`` only) instead of one per object.
+        Mirrors the lightweight ctag/etag PROPFIND the contacts client already
+        uses. Returns ``{}`` on failure -- an ETag is a token for the caller,
+        not a reason to fail the listing that produced it.
+        """
+        body = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<d:propfind xmlns:d="DAV:"><d:prop><d:getetag/></d:prop></d:propfind>'
+        )
+
+        try:
+            response = await self._dav_client.request(
+                str(calendar.url), "PROPFIND", body, {"Depth": "1"}
+            )
+            return {
+                unquote(urlsplit(href).path): etag
+                for href, props in response.expand_simple_props([dav.GetEtag()]).items()
+                if (etag := props.get(dav.GetEtag.tag))
+            }
+        except Exception as e:
+            logger.debug("Collection etag PROPFIND failed for %s: %s", calendar.url, e)
+            return {}
+
     async def _conditional_put(
         self, obj: Any, ical: str, etag: str, *, kind: str, uid: str
     ) -> str:
@@ -1156,6 +1182,13 @@ class CalendarClient:
         # Get all todos including completed ones (filtering is done client-side)
         todos = await calendar.todos(include_completed=True)  # type: ignore[misc]  # ty: ignore[invalid-await]  # dual-mode
 
+        # caldav's todos() REPORT asks for calendar-data only, so none of these
+        # objects carry an etag and _object_etag would PROPFIND once per todo --
+        # measured at 1 + N against a live instance. Its ``props`` argument
+        # cannot carry getetag (it expects calendar-data-shaped elements only),
+        # so fetch them all in a single collection PROPFIND instead: 1 + 1.
+        etags = await self._collection_etags(calendar)
+
         result = []
         for todo in todos:
             # Only load if data not already present from REPORT response
@@ -1166,8 +1199,9 @@ class CalendarClient:
             else:
                 continue
             if todo_dict:
-                todo_dict["href"] = str(todo.url)
-                todo_dict["etag"] = await self._object_etag(todo)
+                href = str(todo.url)
+                todo_dict["href"] = href
+                todo_dict["etag"] = etags.get(unquote(urlsplit(href).path), "")
 
                 # Apply filters if provided
                 if not filters or self._todo_matches_filters(todo_dict, filters):

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -993,6 +993,11 @@ class CalendarClient:
             response = await self._dav_client.request(
                 str(calendar.url), "PROPFIND", body, {"Depth": "1"}
             )
+            # Depth 1 includes the collection's own href. Unlike the REPORT
+            # parser, this does not skip it: nothing ever looks the collection
+            # up (only object hrefs are queried), and a collection ctag in the
+            # map is inert. Left in rather than filtered so this stays a plain
+            # transcription of the response.
             return {
                 unquote(urlsplit(href).path): etag
                 for href, props in response.expand_simple_props([dav.GetEtag()]).items()

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -696,9 +696,17 @@ class CalendarClient:
             # (floating / TZID / UTC). RFC 4791 <C:expand> would normalize
             # everything to UTC and erase the original timezone context.
             do_expand = bool(start_datetime and end_datetime)
+            # The REPORT above asks for getetag, so the objects carry their own.
+            fallback_etags: dict[str, str] = {}
         else:
             events = await calendar.events()  # type: ignore[misc]  # ty: ignore[invalid-await]  # dual-mode
             do_expand = False
+            # caldav's events() asks for calendar-data only (verified: .etag is
+            # None on every object it returns), so without this the unfiltered
+            # listing would pay one PROPFIND per event -- the same 1 + N the
+            # date-range path and list_todos were fixed for. One batched
+            # collection PROPFIND covers the whole result set.
+            fallback_etags = await self._collection_etags(calendar)
 
         result = []
         for event in events:
@@ -715,8 +723,9 @@ class CalendarClient:
             href = str(event.url)
             # One ETag per stored object: expanded recurrence instances are
             # views of the same resource, so a conditional write against any of
-            # them targets that one object.
-            etag = await self._object_etag(event)
+            # them targets that one object. Both sources are per-listing, never
+            # per-event -- see the branch above.
+            etag = event.etag or fallback_etags.get(unquote(urlsplit(href).path), "")
             event_dicts = self._expand_event_occurrences(
                 cal, start_datetime, end_datetime, do_expand
             )
@@ -1187,7 +1196,8 @@ class CalendarClient:
         # measured at 1 + N against a live instance. Its ``props`` argument
         # cannot carry getetag (it expects calendar-data-shaped elements only),
         # so fetch them all in a single collection PROPFIND instead: 1 + 1.
-        etags = await self._collection_etags(calendar)
+        # Skipped entirely for an empty calendar -- there is nothing to key.
+        etags = await self._collection_etags(calendar) if todos else {}
 
         result = []
         for todo in todos:

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -21,6 +21,7 @@ from icalendar import Todo as ICalTodo
 from lxml import etree  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 from ..config import get_nextcloud_ssl_verify
+from .dav_errors import dav_error_from_response
 
 logger = logging.getLogger(__name__)
 
@@ -712,12 +713,16 @@ class CalendarClient:
                 continue
 
             href = str(event.url)
+            # One ETag per stored object: expanded recurrence instances are
+            # views of the same resource, so a conditional write against any of
+            # them targets that one object.
+            etag = await self._object_etag(event)
             event_dicts = self._expand_event_occurrences(
                 cal, start_datetime, end_datetime, do_expand
             )
             for event_dict in event_dicts:
                 event_dict["href"] = href
-                event_dict["etag"] = ""
+                event_dict["etag"] = etag
                 result.append(event_dict)
 
                 if len(result) >= limit:
@@ -850,7 +855,7 @@ class CalendarClient:
         return {
             "uid": event_uid,
             "href": str(event.url),
-            "etag": "",
+            "etag": await self._object_etag(event),
             "status_code": 201,
         }
 
@@ -861,7 +866,17 @@ class CalendarClient:
         event_data: dict[str, Any],
         etag: str = "",
     ) -> dict[str, Any]:
-        """Update an existing calendar event."""
+        """Update an existing calendar event.
+
+        Args:
+            etag: The ETag the caller last read. The write is refused with
+                :class:`DavPreconditionFailed` if the event changed since. When
+                omitted, the ETag observed during this call's own read is used,
+                which still closes the read-modify-write window opened here.
+
+        Raises:
+            DavPreconditionFailed: If the event changed since ``etag`` was read.
+        """
         await self._ensure_calendar_home()
         calendar = self._get_calendar(calendar_name)
 
@@ -871,17 +886,24 @@ class CalendarClient:
         )
         await _maybe_await(event.load(only_if_unloaded=True))
 
+        # The caller's ETag wins: it is their concurrency assertion, covering
+        # the whole read-modify-write cycle rather than just our own read.
+        # Matches the rule the contacts client already follows.
+        if not etag:
+            etag = await self._object_etag(event)
+
         # Merge updates into existing iCal data
         updated_ical = self._merge_ical_properties(event.data, event_data)  # type: ignore[arg-type]
-        event.data = updated_ical  # type: ignore[misc]
 
-        await _maybe_await(event.save())
+        new_etag = await self._conditional_put(
+            event, updated_ical, etag, kind="event", uid=event_uid
+        )
 
         logger.debug("Updated event %s", event_uid)
         return {
             "uid": event_uid,
             "href": str(event.url),
-            "etag": "",
+            "etag": new_etag,
             "status_code": 200,
         }
 
@@ -906,6 +928,63 @@ class CalendarClient:
             if match:
                 return int(match.group(1))
         return None
+
+    @staticmethod
+    async def _object_etag(obj: Any) -> str:
+        """Return *obj*'s current strong ETag, or ``""`` if the server withheld one.
+
+        ``load()`` already populates ``{DAV:}getetag`` from the GET response
+        (verified against Nextcloud 32.0.14), so the common path costs no extra
+        request. The PROPFIND is the fallback for an object reached without a
+        load.
+        """
+        etag = obj.etag
+        if etag:
+            return etag
+
+        try:
+            props = await obj.get_properties([dav.GetEtag()])
+        except Exception as e:
+            # An ETag is an optimisation for the caller, not a precondition for
+            # returning the object they asked for. Failing the read because the
+            # concurrency token could not be fetched would be a worse trade.
+            logger.debug("Could not fetch etag for %s: %s", obj.url, e)
+            return ""
+
+        return props.get(dav.GetEtag.tag) or ""
+
+    async def _conditional_put(
+        self, obj: Any, ical: str, etag: str, *, kind: str, uid: str
+    ) -> str:
+        """PUT *ical* over *obj*, guarded by ``If-Match``. Returns the new ETag.
+
+        ``caldav``'s own ``save()`` sends no ``If-Match``, so two concurrent
+        updates silently last-write-win. It also *returns* a 412 rather than
+        raising, so the status is checked here explicitly.
+
+        Raises:
+            DavPreconditionFailed: If the object changed since *etag* was read.
+            HTTPStatusError: For any other refusal.
+        """
+        url = str(obj.url)
+        headers = {"Content-Type": "text/calendar; charset=utf-8"}
+        if etag:
+            headers["If-Match"] = etag
+
+        response = await self._dav_client.put(url, ical, headers)
+        status = response.status
+
+        if status >= 400:
+            logger.warning(
+                "Conditional PUT of %s %s refused with %s", kind, uid, status
+            )
+            raise dav_error_from_response(
+                status, method="PUT", url=url, body=getattr(response, "raw", b"") or b""
+            )
+
+        # Nextcloud returns the new ETag on the write, so the caller can chain
+        # another conditional update without re-reading.
+        return response.headers.get("etag", "")
 
     async def _delete_dav_object(
         self,
@@ -1002,11 +1081,12 @@ class CalendarClient:
         if not event_data:
             raise ValueError(f"Failed to parse event data for {event_uid}")
 
+        etag = await self._object_etag(event)
         event_data["href"] = str(event.url)
-        event_data["etag"] = ""
+        event_data["etag"] = etag
 
         logger.debug("Retrieved event %s", event_uid)
-        return event_data, ""
+        return event_data, etag
 
     async def search_events_across_calendars(
         self,
@@ -1073,7 +1153,7 @@ class CalendarClient:
                 continue
             if todo_dict:
                 todo_dict["href"] = str(todo.url)
-                todo_dict["etag"] = ""
+                todo_dict["etag"] = await self._object_etag(todo)
 
                 # Apply filters if provided
                 if not filters or self._todo_matches_filters(todo_dict, filters):
@@ -1100,7 +1180,7 @@ class CalendarClient:
         return {
             "uid": todo_uid,
             "href": str(todo.url),
-            "etag": "",
+            "etag": await self._object_etag(todo),
             "status_code": 201,
         }
 
@@ -1111,7 +1191,16 @@ class CalendarClient:
         todo_data: dict[str, Any],
         etag: str = "",
     ) -> dict[str, Any]:
-        """Update an existing todo/task."""
+        """Update an existing todo/task.
+
+        Args:
+            etag: The ETag the caller last read. The write is refused with
+                :class:`DavPreconditionFailed` if the todo changed since. When
+                omitted, the ETag observed during this call's own read is used.
+
+        Raises:
+            DavPreconditionFailed: If the todo changed since ``etag`` was read.
+        """
         await self._ensure_calendar_home()
         calendar = self._get_calendar(calendar_name)
 
@@ -1126,6 +1215,10 @@ class CalendarClient:
                 "Loaded todo %s, current data length: %s", todo_uid, len(todo.data)
             )
 
+            # The caller's ETag wins -- see update_event for the reasoning.
+            if not etag:
+                etag = await self._object_etag(todo)
+
             # Merge updates into existing iCal data
             updated_ical = self._merge_ical_todo_properties(
                 todo.data,  # type: ignore[arg-type]
@@ -1133,17 +1226,16 @@ class CalendarClient:
                 todo_uid,
             )
             logger.debug("Merged iCal data length: %s", len(updated_ical))
-            logger.debug("Updated iCal content:\\n%s", updated_ical)
 
-            todo.data = updated_ical
-
-            await _maybe_await(todo.save())
+            new_etag = await self._conditional_put(
+                todo, updated_ical, etag, kind="todo", uid=todo_uid
+            )
 
             logger.debug("Updated todo %s", todo_uid)
             return {
                 "uid": todo_uid,
                 "href": str(todo.url),
-                "etag": "",
+                "etag": new_etag,
                 "status_code": 200,
             }
         except Exception as e:

--- a/nextcloud_mcp_server/client/dav_errors.py
+++ b/nextcloud_mcp_server/client/dav_errors.py
@@ -125,6 +125,31 @@ def parse_dav_error_body(response: Response) -> tuple[str | None, str | None]:
     )
 
 
+def dav_error_from_response(
+    status: int, *, method: str, url: str, body: bytes | str = b""
+) -> HTTPStatusError:
+    """Build the typed error for a DAV failure observed outside httpx.
+
+    The CalDAV client talks through the ``caldav`` library rather than
+    ``BaseNextcloudClient._make_request`` (an intentional exception -- it has
+    its own DAV session), and ``caldav``'s ``put`` *returns* a 412 rather than
+    raising. So that path has a status, a URL and a body but no
+    ``HTTPStatusError`` to enrich. This wraps them into the same vocabulary, so
+    a stale-ETag CalDAV write raises the same
+    :class:`DavPreconditionFailed` a WebDAV one would.
+    """
+    if isinstance(body, str):
+        body = body.encode("utf-8", errors="replace")
+
+    request = Request(method, url)
+    response = Response(status, content=body, request=request)
+    return enrich_dav_error(
+        HTTPStatusError(
+            f"{status} error for {method} {url}", request=request, response=response
+        )
+    )
+
+
 def enrich_dav_error(exc: HTTPStatusError) -> HTTPStatusError:
     """Return *exc* re-expressed with the server's explanation attached.
 

--- a/tests/client/calendar/test_etag_concurrency.py
+++ b/tests/client/calendar/test_etag_concurrency.py
@@ -104,3 +104,41 @@ async def test_write_with_the_current_etag_succeeds(
 
     event, _ = await nc_client.calendar.get_event(calendar_name, uid)
     assert event["title"] == "v3"
+
+
+async def test_date_range_listing_costs_one_request(
+    nc_client: NextcloudClient, etag_test_event
+):
+    """Surfacing ETags must not turn one REPORT into 1 + N requests.
+
+    The date-range REPORT is the hot path for "list events in a range". Objects
+    it returns are already loaded, so if the REPORT does not ask for getetag,
+    every event falls through to an individual PROPFIND to find one. Measured
+    against a live instance: 1 REPORT with the getetag prop, versus 1 + N
+    without it.
+    """
+    calendar_name, created = etag_test_event
+    start = datetime.now() - timedelta(days=1)
+    end = datetime.now() + timedelta(days=3)
+
+    calls: list[str] = []
+    dav_client = nc_client.calendar._dav_client
+    original = dav_client.request
+
+    async def counting_request(url, method="GET", body="", headers=None, **kwargs):
+        calls.append(method)
+        return await original(url, method, body, headers or {}, **kwargs)
+
+    dav_client.request = counting_request
+    try:
+        events = await nc_client.calendar.get_calendar_events(
+            calendar_name, start_datetime=start, end_datetime=end
+        )
+    finally:
+        dav_client.request = original
+
+    assert events, "fixture event should fall inside the range"
+    assert calls == ["REPORT"], f"expected a single REPORT, got {calls}"
+    assert all(event.get("etag") for event in events), (
+        "the REPORT must carry an etag for every event"
+    )

--- a/tests/client/calendar/test_etag_concurrency.py
+++ b/tests/client/calendar/test_etag_concurrency.py
@@ -106,6 +106,42 @@ async def test_write_with_the_current_etag_succeeds(
     assert event["title"] == "v3"
 
 
+async def test_unfiltered_event_listing_request_count_does_not_scale(
+    nc_client: NextcloudClient, etag_test_event
+):
+    """The no-date-range branch must not scale requests with the event count.
+
+    ``get_calendar_events`` without a range falls back to caldav's ``events()``,
+    which (verified) leaves ``.etag`` unset on every object it returns -- so this
+    path needed the same treatment as the date-range REPORT, via one batched
+    collection PROPFIND rather than a PROPFIND per event.
+    """
+    calendar_name, _ = etag_test_event
+
+    calls: list[str] = []
+    dav_client = nc_client.calendar._dav_client
+    original = dav_client.request
+
+    async def counting_request(url, method="GET", body="", headers=None, **kwargs):
+        calls.append(method)
+        return await original(url, method, body, headers or {}, **kwargs)
+
+    dav_client.request = counting_request
+    try:
+        events = await nc_client.calendar.get_calendar_events(calendar_name)
+    finally:
+        dav_client.request = original
+
+    assert events, "fixture event should be listed"
+    assert len(calls) <= 2, (
+        f"listing {len(events)} events took {len(calls)} requests ({calls}) -- "
+        "the cost must not scale with the number of events"
+    )
+    assert all(event.get("etag") for event in events), (
+        "every listed event needs an etag to be updatable safely"
+    )
+
+
 async def test_date_range_listing_costs_one_request(
     nc_client: NextcloudClient, etag_test_event
 ):

--- a/tests/client/calendar/test_etag_concurrency.py
+++ b/tests/client/calendar/test_etag_concurrency.py
@@ -142,3 +142,46 @@ async def test_date_range_listing_costs_one_request(
     assert all(event.get("etag") for event in events), (
         "the REPORT must carry an etag for every event"
     )
+
+
+@pytest.mark.parametrize("todo_count", [2, 5])
+async def test_todo_listing_request_count_does_not_scale(
+    nc_client: NextcloudClient, temporary_calendar: str, todo_count: int
+):
+    """Listing todos must cost a fixed number of requests, not one per todo.
+
+    caldav's ``todos()`` REPORT asks for calendar-data only, so surfacing an
+    ETag per todo originally sent ``_object_etag`` to a PROPFIND *each* --
+    measured at 1 + N on a live instance. Its ``props`` argument cannot carry
+    getetag, so the ETags come from one batched collection PROPFIND instead.
+
+    Parametrized over two sizes precisely because a fixed-count assertion is
+    only meaningful if it holds as N changes.
+    """
+    for i in range(todo_count):
+        await nc_client.calendar.create_todo(
+            temporary_calendar, {"summary": f"etag listing probe {i}"}
+        )
+
+    calls: list[str] = []
+    dav_client = nc_client.calendar._dav_client
+    original = dav_client.request
+
+    async def counting_request(url, method="GET", body="", headers=None, **kwargs):
+        calls.append(method)
+        return await original(url, method, body, headers or {}, **kwargs)
+
+    dav_client.request = counting_request
+    try:
+        todos = await nc_client.calendar.list_todos(temporary_calendar)
+    finally:
+        dav_client.request = original
+
+    assert len(todos) >= todo_count
+    assert len(calls) <= 2, (
+        f"listing {len(todos)} todos took {len(calls)} requests ({calls}) -- "
+        "the cost must not scale with the number of todos"
+    )
+    assert all(todo.get("etag") for todo in todos), (
+        "every listed todo needs an etag to be updatable safely"
+    )

--- a/tests/client/calendar/test_etag_concurrency.py
+++ b/tests/client/calendar/test_etag_concurrency.py
@@ -106,8 +106,9 @@ async def test_write_with_the_current_etag_succeeds(
     assert event["title"] == "v3"
 
 
+@pytest.mark.parametrize("extra_events", [0, 3])
 async def test_unfiltered_event_listing_request_count_does_not_scale(
-    nc_client: NextcloudClient, etag_test_event
+    nc_client: NextcloudClient, etag_test_event, extra_events: int
 ):
     """The no-date-range branch must not scale requests with the event count.
 
@@ -115,8 +116,24 @@ async def test_unfiltered_event_listing_request_count_does_not_scale(
     which (verified) leaves ``.etag`` unset on every object it returns -- so this
     path needed the same treatment as the date-range REPORT, via one batched
     collection PROPFIND rather than a PROPFIND per event.
+
+    Parametrized over two sizes deliberately: with only the single fixture
+    event, "at most 2 requests" cannot tell one batched PROPFIND apart from one
+    PROPFIND *per event* -- both total 2 -- so the assertion would pass against
+    the very regression it exists to catch.
     """
     calendar_name, _ = etag_test_event
+
+    tomorrow = datetime.now() + timedelta(days=1)
+    for i in range(extra_events):
+        await nc_client.calendar.create_event(
+            calendar_name,
+            {
+                "title": f"scale probe {i}",
+                "start_datetime": tomorrow.strftime(f"%Y-%m-%dT1{i}:00:00"),
+                "end_datetime": tomorrow.strftime(f"%Y-%m-%dT1{i}:30:00"),
+            },
+        )
 
     calls: list[str] = []
     dav_client = nc_client.calendar._dav_client

--- a/tests/client/calendar/test_etag_concurrency.py
+++ b/tests/client/calendar/test_etag_concurrency.py
@@ -1,0 +1,106 @@
+"""Integration tests for CalDAV ETag concurrency against a live Nextcloud.
+
+The unit tests pin the wiring against mocks. These prove the contract holds
+against the real server: that Nextcloud hands back the ETags we now surface,
+that a conditional write advances them, and -- the point of the whole exercise
+-- that a write carrying a stale ETag is actually *prevented* rather than
+silently clobbering the newer version.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from nextcloud_mcp_server.client import NextcloudClient
+from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def etag_test_event(nc_client: NextcloudClient, temporary_calendar: str):
+    """Create an event and clean it up afterwards."""
+    tomorrow = datetime.now() + timedelta(days=1)
+    result = await nc_client.calendar.create_event(
+        temporary_calendar,
+        {
+            "title": f"etag concurrency {uuid.uuid4().hex[:8]}",
+            "start_datetime": tomorrow.strftime("%Y-%m-%dT10:00:00"),
+            "end_datetime": tomorrow.strftime("%Y-%m-%dT11:00:00"),
+        },
+    )
+
+    yield temporary_calendar, result
+
+    try:
+        await nc_client.calendar.delete_event(temporary_calendar, result["uid"])
+    except Exception as e:
+        logger.warning("Cleanup failed for event %s: %s", result["uid"], e)
+
+
+async def test_reads_surface_a_real_etag(nc_client: NextcloudClient, etag_test_event):
+    """create/get return the server's ETag, not the empty string they used to."""
+    calendar_name, created = etag_test_event
+
+    assert created["etag"], "create_event returned no etag"
+
+    _, read_etag = await nc_client.calendar.get_event(calendar_name, created["uid"])
+
+    assert read_etag == created["etag"]
+
+
+async def test_stale_etag_write_is_refused_and_changes_nothing(
+    nc_client: NextcloudClient, etag_test_event
+):
+    """The lost-update scenario the fix exists to prevent.
+
+    Two writers read the same ETag. The first write wins and advances it. The
+    second, still holding the original, must be refused -- and crucially the
+    first writer's content must survive, which is exactly what last-write-wins
+    used to destroy.
+    """
+    calendar_name, created = etag_test_event
+    uid = created["uid"]
+    _, shared_etag = await nc_client.calendar.get_event(calendar_name, uid)
+
+    # Writer A commits against the shared etag.
+    first = await nc_client.calendar.update_event(
+        calendar_name, uid, {"title": "writer A"}, shared_etag
+    )
+    assert first["etag"] and first["etag"] != shared_etag, (
+        "a successful write must advance the etag"
+    )
+
+    # Writer B still holds the now-stale etag.
+    with pytest.raises(DavPreconditionFailed):
+        await nc_client.calendar.update_event(
+            calendar_name, uid, {"title": "writer B"}, shared_etag
+        )
+
+    # Writer A's content survived.
+    event, _ = await nc_client.calendar.get_event(calendar_name, uid)
+    assert event["title"] == "writer A"
+
+
+async def test_write_with_the_current_etag_succeeds(
+    nc_client: NextcloudClient, etag_test_event
+):
+    """Chaining updates works without re-reading: each write returns the next etag."""
+    calendar_name, created = etag_test_event
+    uid = created["uid"]
+
+    first = await nc_client.calendar.update_event(
+        calendar_name, uid, {"title": "v2"}, created["etag"]
+    )
+    second = await nc_client.calendar.update_event(
+        calendar_name, uid, {"title": "v3"}, first["etag"]
+    )
+
+    assert second["etag"] != first["etag"]
+
+    event, _ = await nc_client.calendar.get_event(calendar_name, uid)
+    assert event["title"] == "v3"

--- a/tests/unit/client/test_calendar_etag_concurrency.py
+++ b/tests/unit/client/test_calendar_etag_concurrency.py
@@ -1,0 +1,137 @@
+"""Unit tests for CalDAV ETag concurrency control.
+
+CalDAV writes used to send no ``If-Match`` and to hand callers a stubbed empty
+ETag, so two concurrent updates silently last-write-win and callers had no
+token to do anything about it. These pin the two halves of the fix: reads
+surface the real ETag, and writes are conditional on it.
+
+``caldav``'s ``put`` *returns* a 412 rather than raising, so the status check in
+``_conditional_put`` is the thing standing between a caller and a silently
+clobbered event.
+"""
+
+import pytest
+from caldav.elements import dav
+
+from nextcloud_mcp_server.client.calendar import CalendarClient
+from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
+
+pytestmark = pytest.mark.unit
+
+ETAG = '"0b406c692bc303debec7507ef061be26"'
+NEW_ETAG = '"6bc8c14c8ab4cc42ef7e537c092b4d8f"'
+
+PRECONDITION_BODY = b"""<?xml version="1.0" encoding="utf-8"?>
+<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
+  <s:exception>Sabre\\DAV\\Exception\\PreconditionFailed</s:exception>
+  <s:message>An If-Match header was specified, but none of the specified ETags matched.</s:message>
+</d:error>"""
+
+
+@pytest.fixture
+def client(mocker):
+    """CalendarClient with its DAV client mocked out."""
+    mocker.patch("nextcloud_mcp_server.client.calendar.AsyncDAVClient")
+    return CalendarClient("https://cloud.example.org", "alice", password="pw")
+
+
+def _put_response(mocker, status: int, etag: str | None = None, raw: bytes = b""):
+    response = mocker.Mock()
+    response.status = status
+    response.headers = {"etag": etag} if etag else {}
+    response.raw = raw
+    return response
+
+
+async def test_object_etag_prefers_the_loaded_property(mocker):
+    """``load()`` already populates getetag, so the common path costs no request."""
+    obj = mocker.Mock()
+    obj.etag = ETAG
+    obj.get_properties = mocker.AsyncMock()
+
+    assert await CalendarClient._object_etag(obj) == ETAG
+    obj.get_properties.assert_not_called()
+
+
+async def test_object_etag_falls_back_to_propfind(mocker):
+    """An object reached without a load still yields an ETag."""
+    obj = mocker.Mock()
+    obj.etag = None
+    obj.get_properties = mocker.AsyncMock(return_value={dav.GetEtag.tag: ETAG})
+
+    assert await CalendarClient._object_etag(obj) == ETAG
+    obj.get_properties.assert_awaited_once()
+
+
+async def test_object_etag_degrades_when_the_server_withholds_one(mocker):
+    """A failed ETag fetch must not fail the read that asked for the object.
+
+    The ETag is an optimisation for the caller. Failing the whole read because
+    the concurrency token could not be fetched is the worse trade.
+    """
+    obj = mocker.Mock()
+    obj.etag = None
+    obj.get_properties = mocker.AsyncMock(side_effect=RuntimeError("PROPFIND failed"))
+
+    assert await CalendarClient._object_etag(obj) == ""
+
+
+async def test_conditional_put_sends_if_match_and_returns_the_new_etag(client, mocker):
+    obj = mocker.Mock()
+    obj.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/e.ics"
+    client._dav_client.put = mocker.AsyncMock(
+        return_value=_put_response(mocker, 204, NEW_ETAG)
+    )
+
+    result = await client._conditional_put(
+        obj, "BEGIN:VCALENDAR", ETAG, kind="event", uid="e"
+    )
+
+    assert result == NEW_ETAG
+    headers = client._dav_client.put.call_args.args[2]
+    assert headers["If-Match"] == ETAG
+
+
+async def test_conditional_put_omits_if_match_without_an_etag(client, mocker):
+    """No ETag means no precondition to assert -- an unconditional write."""
+    obj = mocker.Mock()
+    obj.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/e.ics"
+    client._dav_client.put = mocker.AsyncMock(
+        return_value=_put_response(mocker, 204, NEW_ETAG)
+    )
+
+    await client._conditional_put(obj, "BEGIN:VCALENDAR", "", kind="event", uid="e")
+
+    assert "If-Match" not in client._dav_client.put.call_args.args[2]
+
+
+async def test_conditional_put_raises_typed_error_on_stale_etag(client, mocker):
+    """A 412 is *returned* by caldav, so it must be detected, not awaited-on-raise."""
+    obj = mocker.Mock()
+    obj.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/e.ics"
+    client._dav_client.put = mocker.AsyncMock(
+        return_value=_put_response(mocker, 412, raw=PRECONDITION_BODY)
+    )
+
+    with pytest.raises(DavPreconditionFailed) as exc_info:
+        await client._conditional_put(
+            obj, "BEGIN:VCALENDAR", ETAG, kind="event", uid="e"
+        )
+
+    # The server's own explanation survives the trip through caldav.
+    assert exc_info.value.dav_exception == "Sabre\\DAV\\Exception\\PreconditionFailed"
+    assert "none of the specified ETags matched" in str(exc_info.value)
+
+
+async def test_conditional_put_raises_on_other_refusals(client, mocker):
+    """A non-412 failure still raises rather than being reported as success."""
+    obj = mocker.Mock()
+    obj.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/e.ics"
+    client._dav_client.put = mocker.AsyncMock(return_value=_put_response(mocker, 403))
+
+    with pytest.raises(Exception) as exc_info:
+        await client._conditional_put(
+            obj, "BEGIN:VCALENDAR", ETAG, kind="event", uid="e"
+        )
+
+    assert exc_info.value.response.status_code == 403

--- a/tests/unit/client/test_calendar_etag_concurrency.py
+++ b/tests/unit/client/test_calendar_etag_concurrency.py
@@ -76,6 +76,41 @@ async def test_object_etag_degrades_when_the_server_withholds_one(mocker):
     assert await CalendarClient._object_etag(obj) == ""
 
 
+async def test_collection_etags_degrades_when_the_propfind_fails(client, mocker):
+    """The batched fetch degrades the same way the per-object one does.
+
+    Listings call this before iterating, so a raise here would fail the whole
+    listing over a concurrency token the caller may not even use.
+    """
+    calendar = mocker.Mock()
+    calendar.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/"
+    client._dav_client.request = mocker.AsyncMock(
+        side_effect=RuntimeError("PROPFIND failed")
+    )
+
+    assert await client._collection_etags(calendar) == {}
+
+
+async def test_collection_etags_maps_decoded_href_to_etag(client, mocker):
+    """Keys are decoded paths, matching how callers look objects up."""
+    calendar = mocker.Mock()
+    calendar.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/"
+    response = mocker.Mock()
+    response.expand_simple_props.return_value = {
+        # Percent-encoded on the wire; callers hold the decoded path.
+        "/remote.php/dav/calendars/alice/personal/my%20event.ics": {
+            dav.GetEtag.tag: ETAG
+        },
+        # An object the server reports without an etag is simply absent.
+        "/remote.php/dav/calendars/alice/personal/other.ics": {},
+    }
+    client._dav_client.request = mocker.AsyncMock(return_value=response)
+
+    assert await client._collection_etags(calendar) == {
+        "/remote.php/dav/calendars/alice/personal/my event.ics": ETAG
+    }
+
+
 async def test_conditional_put_sends_if_match_and_returns_the_new_etag(client, mocker):
     obj = mocker.Mock()
     obj.url = "https://cloud.example.org/remote.php/dav/calendars/alice/personal/e.ics"

--- a/tests/unit/client/test_dav_principal_discovery.py
+++ b/tests/unit/client/test_dav_principal_discovery.py
@@ -459,7 +459,13 @@ async def test_caldav_event_operations_use_discovered_home_url(mocker):
     client, dav_client = _calendar_client_with_principal(mocker, "alice_1234")
     fake_calendar = mocker.Mock()
     fake_calendar.save_event = mocker.AsyncMock(
-        return_value=SimpleNamespace(url="https://cloud.example.org/event.ics")
+        # ``etag`` mirrors the real caldav object, whose ``etag`` property is
+        # always present (it reads from ``props``). create_event reads it to
+        # hand the caller a concurrency token.
+        return_value=SimpleNamespace(
+            url="https://cloud.example.org/event.ics",
+            etag='"abc123"',
+        )
     )
     mock_calendar = mocker.patch(
         "nextcloud_mcp_server.client.calendar.AsyncCalendar",


### PR DESCRIPTION
Top of stack #1336. Builds on #1334 for the typed-error vocabulary.

## Problem

Calendar reads returned a stubbed `etag: ""` and writes sent no `If-Match`. Two concurrent updates to the same event **silently last-write-win** — and callers could not have done anything about it, because the only token they were ever handed was the empty string. A 412 was indistinguishable from any other failure.

WebDAV and CardDAV already do this properly (`client/contacts.py:557-571`), so calendar was the odd one out.

## Fix

**Reads surface the real ETag.** `list_events`, `get_event`, `list_todos` and both creates. `load()` already populates `{DAV:}getetag` from the GET response, so the common path costs **no extra request**; the PROPFIND fallback covers an object reached without a load, and a failure there degrades to `""` rather than failing the read that asked for the object.

**Writes are conditional.** `update_event` / `update_todo` PUT with `If-Match`. The caller's ETag wins — it asserts over their whole read-modify-write cycle rather than just our own read — falling back to the ETag observed during this call, matching the rule the contacts client already follows. The write returns the new ETag, so updates chain without a re-read.

Two library facts forced the shape, both established by probing `caldav` 3.2.1 against a live server rather than assumed:

1. `caldav`'s `save()` sends no `If-Match`, so the write goes through the **public** `AsyncDAVClient.put(url, body, headers)` rather than private internals.
2. **`caldav` *returns* a 412 rather than raising**, so the status is checked explicitly. That check is the only thing standing between a caller and a clobbered event.

A refusal raises `DavPreconditionFailed` via `dav_error_from_response`, added here on top of #1334. CalDAV bypasses `_make_request` by design (`CalendarClient` has its own DAV session — CLAUDE.md calls this out as intentional), so it cannot inherit that enrichment automatically; it reuses the vocabulary instead.

## Verification

End to end against Nextcloud 32.0.14 — the lost-update scenario itself: two writers hold the same ETag, the first commits and advances it, the second is **refused**, and the first writer's content **survives**. That last assertion is the one that fails on the old code.

- `tests/unit/client/test_calendar_etag_concurrency.py` — 7 tests: ETag resolution (loaded property / PROPFIND fallback / degradation), `If-Match` presence and absence, typed 412, non-412 refusals.
- `tests/client/calendar/test_etag_concurrency.py` — 3 integration tests against a live instance, including the lost-update case above.
- Full calendar integration tier (72 tests) green.

No new API surface — existing client methods gain honest return values and an enforced precondition — so no new contract-test obligation.

## Deliberately not included

**Conditional DELETE.** `_delete_dav_object` has its own structured-refusal contract (it returns a result dict rather than raising, with tailored messages per status) that a 412 would need to fit. That is a separate change, not a line in this one. Flagging it rather than leaving it to look like an oversight.

Deck: board 12 card #1045.

---

_This PR was generated with the help of AI, and reviewed by a Human_