### PR TITLE
test(webdav): pin ASCII-safe Destination header on MOVE/COPY

### DIFF
--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -1017,8 +1017,25 @@ async def test_get_note_attachment_raises_on_truncated_body(mocker):
 
 
 @pytest.mark.unit
-async def test_move_resource_encodes_destination_header(mocker):
-    """The MOVE Destination header must be percent-encoded too (card 309)."""
+@pytest.mark.parametrize("method", ["move_resource", "copy_resource"])
+@pytest.mark.parametrize(
+    ("destination", "expected_suffix"),
+    [
+        # '#' would otherwise be read as a URL fragment and truncate (card 309).
+        ("b/new #1.pdf", "/b/new%20%231.pdf"),
+        # Non-ASCII would otherwise blow up on the ASCII-only header with
+        # "'ascii' codec can't encode characters" (discussion #1337).
+        (
+            "b/30-39 \ud55c\uad6d\ub300\ud559\uad50/x.txt",
+            "/b/30-39%20%ED%95%9C%EA%B5%AD%EB%8C%80%ED%95%99%EA%B5%90/x.txt",
+        ),
+    ],
+)
+async def test_move_copy_encode_destination_header(
+    mocker, method, destination, expected_suffix
+):
+    """MOVE/COPY carry the target in a header, so it needs the same encoding
+    the request URL gets for free from httpx."""
     mock_http_client = AsyncMock()
     client = WebDAVClient(mock_http_client, "testuser")
     client._principal_discovered = True
@@ -1029,36 +1046,14 @@ async def test_move_resource_encodes_destination_header(mocker):
     mock_response.raise_for_status = mocker.Mock()
     mock_http_client.request = AsyncMock(return_value=mock_response)
 
-    await client.move_resource("a/old.pdf", "b/new #1.pdf")
+    await getattr(client, method)("a/old.pdf", destination)
 
     call = mock_http_client.request.call_args
     # Source is the request path; destination is the header.
     assert call[0][1] == "/remote.php/dav/files/testuser/a/old.pdf"
-    destination = call.kwargs["headers"]["Destination"]
-    assert "%23" in destination
-    assert "#" not in destination
-
-
-@pytest.mark.unit
-async def test_copy_resource_encodes_destination_header(mocker):
-    """The COPY Destination header must be percent-encoded too (card 309)."""
-    mock_http_client = AsyncMock()
-    client = WebDAVClient(mock_http_client, "testuser")
-    client._principal_discovered = True
-
-    mock_response = AsyncMock()
-    mock_response.status_code = 201
-    mock_response.headers = {"etag": '"new-etag"'}
-    mock_response.raise_for_status = mocker.Mock()
-    mock_http_client.request = AsyncMock(return_value=mock_response)
-
-    await client.copy_resource("a/old.pdf", "b/new #1.pdf")
-
-    call = mock_http_client.request.call_args
-    assert call[0][1] == "/remote.php/dav/files/testuser/a/old.pdf"
-    destination = call.kwargs["headers"]["Destination"]
-    assert "%23" in destination
-    assert "#" not in destination
+    header = call.kwargs["headers"]["Destination"]
+    header.encode("ascii")  # headers are ASCII-only; unencoded paths raise here
+    assert header.endswith(expected_suffix)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Follow-up to [discussion #1337](https://github.com/cbcoutinho/nextcloud-mcp-server/discussions/1337): `nc_webdav_move_resource` / `nc_webdav_copy_resource` failed with `'ascii' codec can't encode characters` whenever the **destination** path contained non-ASCII characters.

**No product change here — the bug was already fixed in 0.113.0** (`03887355`), which routed every DAV path through `_webdav_path` → `_encode_dav_path` = `quote(path, safe="/")`. MOVE/COPY carry the target in the RFC 4918 `Destination` *header*, which is ASCII-only; before that commit the header got the raw path, while create/list only ever put paths in the request URL, which httpx percent-encodes itself. Hence only MOVE/COPY broke, and only on the destination.

What was missing is coverage of that specific failure mode: the existing tests pinned only `#`, whose failure is a silent truncation (URL fragment), not a hard `UnicodeEncodeError` at the header layer.

## Changes

- Fold `test_move_resource_encodes_destination_header` and `test_copy_resource_encodes_destination_header` — byte-identical apart from the method — into one test parametrized over `move/copy` × (`#`, non-ASCII).
- Assert `header.encode("ascii")` succeeds, the one genuinely new check.

Net −5 lines.

## Test coverage

No API surface added or changed, so the e2e + contract gate does not apply. `uv run pytest -m unit tests/unit/client/test_webdav.py` passes (20 selected on `-k destination`).

Deck: board 12, card 1053.

---

_This PR was generated with the help of AI, and reviewed by a Human_
