### PR TITLE
fix(providers): bound Mistral embedding requests at 120s

### DIFF
--- a/nextcloud_mcp_server/providers/mistral.py
+++ b/nextcloud_mcp_server/providers/mistral.py
@@ -29,9 +29,10 @@ BATCH_SIZE = 64
 
 # Request timeout for embedding calls, in milliseconds.
 #
-# Without this the SDK falls back to its own 300 s default (verified in
-# mistralai 2.4.5: ``embeddings.create_async`` resolves the per-call argument,
-# then ``sdk_configuration.timeout_ms``, then a hardcoded ``300000``). Five
+# Without this the SDK falls back to its own 300 s default (verified against
+# mistralai 2.7.0, the locked version: ``embeddings.create_async`` resolves the
+# per-call argument, then ``sdk_configuration.timeout_ms``, then a hardcoded
+# ``300000``). Five
 # minutes is far longer than the 120 s every sibling embedding provider uses
 # (bedrock, ollama, gateway), and an ingest worker blocked that long on one
 # request is indistinguishable from a hung one.

--- a/nextcloud_mcp_server/providers/mistral.py
+++ b/nextcloud_mcp_server/providers/mistral.py
@@ -27,6 +27,20 @@ MISTRAL_EMBEDDING_DIMENSIONS: dict[str, int] = {
 # but we keep this in line with sibling providers (OpenAI=100, Ollama=32).
 BATCH_SIZE = 64
 
+# Request timeout for embedding calls, in milliseconds.
+#
+# Without this the SDK falls back to its own 300 s default (verified in
+# mistralai 2.4.5: ``embeddings.create_async`` resolves the per-call argument,
+# then ``sdk_configuration.timeout_ms``, then a hardcoded ``300000``). Five
+# minutes is far longer than the 120 s every sibling embedding provider uses
+# (bedrock, ollama, gateway), and an ingest worker blocked that long on one
+# request is indistinguishable from a hung one.
+#
+# Set on the client rather than per call: this SDK version reads
+# ``sdk_configuration.timeout_ms`` whenever a call omits its own, so one knob
+# covers every current and future call site.
+EMBED_TIMEOUT_MS = 120_000
+
 _NO_EMBEDDING_MODEL_MSG = "Embedding not supported - no embedding_model configured"
 
 
@@ -81,7 +95,9 @@ class MistralProvider(Provider):
         self.embedding_model = embedding_model
         self._dimension: int | None = None
 
-        self.client = Mistral(api_key=api_key, server_url=base_url)
+        self.client = Mistral(
+            api_key=api_key, server_url=base_url, timeout_ms=EMBED_TIMEOUT_MS
+        )
 
         if embedding_model and embedding_model in MISTRAL_EMBEDDING_DIMENSIONS:
             self._dimension = MISTRAL_EMBEDDING_DIMENSIONS[embedding_model]

--- a/nextcloud_mcp_server/providers/mistral.py
+++ b/nextcloud_mcp_server/providers/mistral.py
@@ -32,10 +32,9 @@ BATCH_SIZE = 64
 # Without this the SDK falls back to its own 300 s default (verified against
 # mistralai 2.7.0, the locked version: ``embeddings.create_async`` resolves the
 # per-call argument, then ``sdk_configuration.timeout_ms``, then a hardcoded
-# ``300000``). Five
-# minutes is far longer than the 120 s every sibling embedding provider uses
-# (bedrock, ollama, gateway), and an ingest worker blocked that long on one
-# request is indistinguishable from a hung one.
+# ``300000``). Five minutes is far longer than the 120 s every sibling
+# embedding provider uses (bedrock, ollama, gateway), and an ingest worker
+# blocked that long on one request is indistinguishable from a hung one.
 #
 # Set on the client rather than per call: this SDK version reads
 # ``sdk_configuration.timeout_ms`` whenever a call omits its own, so one knob

--- a/tests/unit/providers/test_mistral.py
+++ b/tests/unit/providers/test_mistral.py
@@ -7,6 +7,7 @@ from mistralai.client.errors import SDKError
 
 from nextcloud_mcp_server.providers.mistral import (
     BATCH_SIZE,
+    EMBED_TIMEOUT_MS,
     MISTRAL_EMBEDDING_DIMENSIONS,
     MistralProvider,
     _is_transient,
@@ -205,6 +206,7 @@ async def test_mistral_base_url_passed_to_sdk(mocker):
     mock_ctor.assert_called_once_with(
         api_key="test-key",
         server_url="https://example.com/mistral",
+        timeout_ms=EMBED_TIMEOUT_MS,
     )
 
 
@@ -381,3 +383,34 @@ async def test_mistral_embed_batch_retries_on_5xx(mock_mistral_client, monkeypat
     embeddings = await provider.embed_batch(["a", "b"])
     assert embeddings == [[0.1, 0.2], [0.3, 0.4]]
     assert mock_mistral_client.embeddings.create_async.await_count == 2
+
+
+@pytest.mark.unit
+def test_client_is_constructed_with_an_explicit_timeout(mocker):
+    """Embedding calls must be bounded, not left on the SDK's 300 s default.
+
+    The timeout is set on the client rather than per call because this SDK
+    version resolves a call's own ``timeout_ms`` first, then
+    ``sdk_configuration.timeout_ms`` -- so one knob covers every call site,
+    including ones added later.
+    """
+    mock_mistral = mocker.patch("nextcloud_mcp_server.providers.mistral.Mistral")
+
+    MistralProvider(api_key="k")
+
+    assert mock_mistral.call_args.kwargs["timeout_ms"] == EMBED_TIMEOUT_MS
+    # Sized to match every sibling embedding provider (bedrock/ollama/gateway).
+    assert EMBED_TIMEOUT_MS == 120_000
+
+
+@pytest.mark.unit
+async def test_configured_timeout_reaches_the_sdk_configuration(mocker):
+    """The client-level value is what the SDK falls back to per request.
+
+    Guards the reason this is set once rather than at each call: if a future
+    SDK stopped honouring ``sdk_configuration.timeout_ms``, embeddings would
+    silently revert to the 300 s default with nothing else to catch it.
+    """
+    provider = MistralProvider(api_key="k")
+
+    assert provider.client.sdk_configuration.timeout_ms == EMBED_TIMEOUT_MS


### PR DESCRIPTION
## Problem

Mistral embedding calls set no timeout. An ingest worker blocked on a single request for minutes is indistinguishable from a hung one.

## Two corrections to the original report

Card #1043 was filed from a downstream fork's patch. Reading `mistralai` 2.4.5 directly, two of its claims are wrong:

| Claim | Actual |
|---|---|
| SDK default is 60 s | **300 s** — `create_async` resolves the per-call `timeout_ms`, then `sdk_configuration.timeout_ms`, then a hardcoded `300000` |
| Client-level timeouts are ignored for embeddings | **Honoured** — the call falls back to `sdk_configuration.timeout_ms` |

That second point changes the fix. Because client-level config *is* read, setting it once on the constructor covers every call site including future ones, rather than repeating `timeout_ms=` at each `create_async` the way the fork does.

## Fix

`Mistral(..., timeout_ms=EMBED_TIMEOUT_MS)` with `EMBED_TIMEOUT_MS = 120_000`.

120 s is not a new number: it is what every sibling embedding provider already uses — bedrock (`DEFAULT_TIMEOUT_SECONDS = 120`), ollama (`httpx.Timeout(timeout=120, connect=5)`), gateway (`timeout: float = 120.0`).

## Test coverage

Three assertions: the constructor receives it, it lands in `sdk_configuration` (guarding the reason it is set in one place — if a future SDK stopped honouring that fallback, embeddings would silently revert to 300 s), and the value stays aligned with the siblings.

An existing test pinning the exact constructor kwargs was updated to include the new argument rather than loosened to `ANY`.

No API surface change, so no contract-test obligation.

Deck: board 12 card #1043.

---

_This PR was generated with the help of AI, and reviewed by a Human_