### PR TITLE
fix(webdav): escape caller values in SEARCH predicates

### DIFF
--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -293,6 +293,32 @@ def _validate_destination_precondition(
         )
 
 
+def like_predicate(prop_element: str, value: str) -> str:
+    """Build a ``<d:like>`` SEARCH predicate with *value* XML-escaped.
+
+    Every caller-supplied literal in a SEARCH body goes through here. A value
+    containing ``&``, ``<`` or ``>`` -- "Costs & Revenue%" is the everyday case
+    -- otherwise produces malformed XML that Sabre/DAV rejects with 400, and
+    the search fails rather than returning nothing.
+
+    It exists as a shared builder rather than an escaping call each site
+    remembers to make: the same predicate was being assembled in five places,
+    two of which had no escaping at all. Routing construction through one
+    function makes the escaping structural instead of a convention.
+
+    Args:
+        prop_element: Namespaced property element, e.g. ``"d:displayname"`` or
+            ``"oc:tags"``. Not caller-supplied -- callers pass a literal.
+        value: The match value, including any ``%`` wildcards. Escaped here.
+    """
+    return (
+        "<d:like>"
+        f"<d:prop><{prop_element}/></d:prop>"
+        f"<d:literal>{xml_escape(value)}</d:literal>"
+        "</d:like>"
+    )
+
+
 def _write_precondition_header(if_match: Optional[str]) -> dict[str, str]:
     """Pick the single conditional header for a fail-closed PUT.
 
@@ -1737,14 +1763,7 @@ class WebDAVClient(BaseNextcloudClient):
             # Find files starting with "report"
             results = await find_by_name("report%")
         """
-        where_conditions = f"""
-            <d:like>
-                <d:prop>
-                    <d:displayname/>
-                </d:prop>
-                <d:literal>{xml_escape(pattern)}</d:literal>
-            </d:like>
-        """
+        where_conditions = like_predicate("d:displayname", pattern)
 
         return await self.search_files(
             scope=scope, where_conditions=where_conditions, limit=limit
@@ -1813,14 +1832,7 @@ class WebDAVClient(BaseNextcloudClient):
         # Escape so a caller-supplied MIME type can't break the SEARCH XML or
         # inject elements. All current callers pass literal strings, but this
         # keeps the boundary safe for any future user-supplied value.
-        where_conditions = f"""
-            <d:like>
-                <d:prop>
-                    <d:getcontenttype/>
-                </d:prop>
-                <d:literal>{xml_escape(mime_type)}</d:literal>
-            </d:like>
-        """
+        where_conditions = like_predicate("d:getcontenttype", mime_type)
 
         # fileid is required by callers like NextcloudClient.find_files_by_tag
         # that dedupe results by id; the default property set in search_files
@@ -1909,14 +1921,7 @@ class WebDAVClient(BaseNextcloudClient):
             results = await find_by_tag("vector-index", scope="Documents")
         """
         # Use LIKE for tag matching since tags can be comma-separated
-        where_conditions = f"""
-            <d:like>
-                <d:prop>
-                    <oc:tags/>
-                </d:prop>
-                <d:literal>%{xml_escape(tag_name)}%</d:literal>
-            </d:like>
-        """
+        where_conditions = like_predicate("oc:tags", f"%{tag_name}%")
 
         # Request tag property along with standard properties
         properties = [

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -10,6 +10,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.client.webdav import like_predicate
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.links import with_links
@@ -794,28 +795,10 @@ def configure_webdav_tools(mcp: FastMCP):
         conditions = []
 
         if name_pattern:
-            conditions.append(
-                f"""
-                <d:like>
-                    <d:prop>
-                        <d:displayname/>
-                    </d:prop>
-                    <d:literal>{name_pattern}</d:literal>
-                </d:like>
-            """
-            )
+            conditions.append(like_predicate("d:displayname", name_pattern))
 
         if mime_type:
-            conditions.append(
-                f"""
-                <d:like>
-                    <d:prop>
-                        <d:getcontenttype/>
-                    </d:prop>
-                    <d:literal>{mime_type}</d:literal>
-                </d:like>
-            """
-            )
+            conditions.append(like_predicate("d:getcontenttype", mime_type))
 
         if only_favorites:
             conditions.append(

--- a/tests/client/webdav/test_webdav_search.py
+++ b/tests/client/webdav/test_webdav_search.py
@@ -290,3 +290,40 @@ async def test_search_scope_with_ampersand_does_not_400(nc_client: NextcloudClie
             await nc_client.webdav.delete_resource(test_dir)
         except Exception as e:
             logger.warning("Failed to cleanup test directory %s: %s", test_dir, e)
+
+
+async def test_search_with_xml_special_chars_in_pattern(nc_client: NextcloudClient):
+    """A name pattern containing ``&`` must search, not 400.
+
+    Regression for the unescaped ``<d:literal>``: an unescaped ``&`` makes the
+    SEARCH body malformed, and Sabre/DAV rejects the whole request. The failure
+    mode is what makes it worth an integration test -- the search errors rather
+    than returning no matches, so a caller cannot tell "nothing matched" from
+    "your query was rejected".
+    """
+    test_dir = f"mcp_search_amp_{uuid.uuid4().hex[:8]}"
+    await nc_client.webdav.create_directory(test_dir)
+    try:
+        await nc_client.webdav.write_file(
+            f"{test_dir}/Costs & Revenue.txt", b"quarterly", "text/plain"
+        )
+
+        results = await nc_client.webdav.find_by_name(
+            "%Costs & Revenue%", scope=test_dir
+        )
+
+        assert [r["name"] for r in results] == ["Costs & Revenue.txt"]
+    finally:
+        await nc_client.webdav.delete_resource(test_dir)
+
+
+async def test_search_with_xml_special_chars_in_mime_type(nc_client: NextcloudClient):
+    """The mime_type predicate is escaped too, on the same code path.
+
+    No real MIME type contains ``&``, so this asserts the request is *accepted*
+    and simply matches nothing -- the behaviour an unescaped literal replaces
+    with a 400.
+    """
+    results = await nc_client.webdav.find_by_type("text/<nonexistent & odd>")
+
+    assert results == []

--- a/tests/unit/client/test_webdav.py
+++ b/tests/unit/client/test_webdav.py
@@ -9,6 +9,7 @@ from httpx import HTTPStatusError
 from nextcloud_mcp_server.client.webdav import (
     WebDAVClient,
     _normalize_etag,
+    like_predicate,
 )
 
 
@@ -1615,3 +1616,35 @@ async def test_list_directory_survives_a_non_numeric_fileid(mocker):
 
     by_name = {item["name"]: item for item in items}
     assert by_name["notes.txt"]["file_id"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "escaped"),
+    [
+        ("Costs & Revenue%", "Costs &amp; Revenue%"),
+        ("<draft>%", "&lt;draft&gt;%"),
+        ("a > b", "a &gt; b"),
+    ],
+)
+def test_like_predicate_escapes_the_literal(value, escaped):
+    """Every caller-supplied literal is escaped by construction."""
+    predicate = like_predicate("d:displayname", value)
+
+    # Well-formed once namespaced (raised ParseError when unescaped).
+    ET.fromstring(f"<root xmlns:d='DAV:'>{predicate}</root>")
+    assert escaped in predicate
+    assert value not in predicate
+
+
+@pytest.mark.unit
+def test_like_predicate_keeps_wildcards_intact():
+    """``%`` is SEARCH syntax, not XML -- escaping must leave it alone."""
+    predicate = like_predicate("oc:tags", "%vector-index%")
+
+    root = ET.fromstring(
+        f"<root xmlns:d='DAV:' xmlns:oc='http://owncloud.org/ns'>{predicate}</root>"
+    )
+    literal = root.find(".//{DAV:}literal")
+    assert literal is not None
+    assert literal.text == "%vector-index%"

--- a/tests/unit/server/test_webdav_search_escaping.py
+++ b/tests/unit/server/test_webdav_search_escaping.py
@@ -1,0 +1,86 @@
+"""The SEARCH predicates ``nc_webdav_search_files`` builds must be escaped.
+
+The client's ``find_by_*`` helpers escaped their literals; this tool did not,
+so a ``name_pattern`` or ``mime_type`` containing ``&``/``<``/``>`` produced a
+malformed SEARCH body that Sabre/DAV rejects with 400. The search then failed
+outright rather than matching nothing, which is the confusing part -- the same
+bug class as the folder-name-with-``&`` indexing gap and the empty-``<d:where>``
+500.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from nextcloud_mcp_server.server.webdav import configure_webdav_tools
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def search_tool():
+    mcp = FastMCP("test")
+    configure_webdav_tools(mcp)
+    return mcp._tool_manager.get_tool("nc_webdav_search_files")
+
+
+async def _captured_where(tool, mocker, **kwargs) -> str:
+    """Call the tool with a stubbed client and return the SEARCH where-clause."""
+    client = mocker.MagicMock()
+    client.webdav.search_files = mocker.AsyncMock(return_value=[])
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_client",
+        mocker.AsyncMock(return_value=client),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.webdav.get_excluded_file_paths",
+        mocker.AsyncMock(return_value=set()),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=mocker.MagicMock(enable_login_flow=False),
+    )
+
+    await tool.fn(ctx=mocker.MagicMock(), **kwargs)
+
+    return client.webdav.search_files.call_args.kwargs["where_conditions"]
+
+
+async def test_name_pattern_with_ampersand_yields_well_formed_xml(search_tool, mocker):
+    where = await _captured_where(
+        search_tool, mocker, scope="Docs", name_pattern="Costs & Revenue%"
+    )
+
+    # Raised ParseError on the bare '&' before the fix.
+    ET.fromstring(f"<root xmlns:d='DAV:'>{where}</root>")
+    assert "&amp;" in where
+    assert "Costs & Revenue" not in where
+
+
+async def test_mime_type_with_angle_brackets_yields_well_formed_xml(
+    search_tool, mocker
+):
+    where = await _captured_where(
+        search_tool, mocker, scope="Docs", mime_type="text/<odd>"
+    )
+
+    ET.fromstring(f"<root xmlns:d='DAV:'>{where}</root>")
+    assert "&lt;odd&gt;" in where
+
+
+async def test_combined_filters_stay_well_formed(search_tool, mocker):
+    """Both predicates are escaped when AND-ed together."""
+    where = await _captured_where(
+        search_tool,
+        mocker,
+        scope="Docs",
+        name_pattern="A & B%",
+        mime_type="text/<x>",
+    )
+
+    root = ET.fromstring(f"<root xmlns:d='DAV:'>{where}</root>")
+    assert root.find(".//{DAV:}and") is not None
+    assert len(root.findall(".//{DAV:}like")) == 2


### PR DESCRIPTION
## Problem

`nc_webdav_search_files` interpolated `name_pattern` and `mime_type` straight into `<d:literal>`:

```python
<d:literal>{name_pattern}</d:literal>
```

A value containing `&`, `<` or `>` — `"Costs & Revenue%"` is the everyday case — produces a malformed SEARCH body that Sabre/DAV rejects with **400**. So the search *fails* rather than matching nothing, and the caller cannot tell "nothing matched" from "your query was rejected".

The tell was an asymmetry: the client's `find_by_name` / `find_by_type` / `find_by_tag` all escaped their literals, while `server/webdav.py` never imported `xml_escape` at all.

## Fix

Patching the two server sites would have left the next predicate free to repeat the mistake. Instead predicate construction moves into a single `like_predicate()` builder in the client layer, used by all five sites (three client, two server).

The escaping is now **structural** — a predicate cannot be built without going through it — rather than a convention each site remembers.

`%` wildcards pass through untouched: they are SEARCH syntax, not XML.

## Same bug class as two already-fixed defects

- Card #409 — WebDAV SEARCH 400s on folder names with `&` (scope escaping)
- Card #1042 — empty `<d:where>` 500

All three are a malformed body that Sabre rejects wholesale. This closes the last unescaped path.

## Verification

Against Nextcloud 32.0.14: searching `%Costs & Revenue%` returns the matching file, and a `mime_type` containing `&`/`<`/`>` is accepted and matches nothing rather than 400ing.

Unit tests were confirmed to **fail** against the unescaped form (`ParseError: not well-formed`) before passing with the fix — the tool-level tests, the escaping tests, and 27 WebDAV integration tests all green.

No API surface change (an existing tool's inputs are now handled correctly), so no new contract-test obligation.

Deck: board 12 card #1044, raised by the review bot on #1332 as an out-of-scope observation.

---

_This PR was generated with the help of AI, and reviewed by a Human_