### PR TITLE
refactor(client): centralise OCS envelope parsing and name 997

### DIFF
--- a/nextcloud_mcp_server/client/collectives.py
+++ b/nextcloud_mcp_server/client/collectives.py
@@ -24,7 +24,12 @@ class OCSError(Exception):
     def __init__(self, status_code: int, message: str):
         self.status_code = status_code
         self.message = message
-        super().__init__(f"OCS error {status_code}: {message}")
+        # No status prefix here: server-side failures arrive already described
+        # by ``describe_ocs_failure``, which names the code (and, for 997, what
+        # it actually means). Re-prefixing produced "OCS error 404: OCS API
+        # error (code 404): ..." in logs and tracebacks. ``status_code`` stays
+        # available for the internally-raised cases that carry a bare message.
+        super().__init__(message)
 
 
 class CollectivesClient(BaseNextcloudClient):

--- a/nextcloud_mcp_server/client/collectives.py
+++ b/nextcloud_mcp_server/client/collectives.py
@@ -40,7 +40,7 @@ class CollectivesClient(BaseNextcloudClient):
     # Sourced from the shared OCS module so a new call site cannot pick up a
     # drifted copy of the header set -- omitting OCS-APIRequest is what makes
     # Nextcloud answer 997, the failure this module exists to make legible.
-    _OCS_HEADERS: dict[str, str] = OCS_REQUEST_HEADERS
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
 
     _OCS_HEADERS_JSON: dict[str, str] = {
         **OCS_REQUEST_HEADERS,

--- a/nextcloud_mcp_server/client/collectives.py
+++ b/nextcloud_mcp_server/client/collectives.py
@@ -4,6 +4,10 @@ import logging
 from typing import Any
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+from nextcloud_mcp_server.client.ocs import (
+    describe_ocs_failure,
+    parse_ocs_envelope,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,18 +42,23 @@ class CollectivesClient(BaseNextcloudClient):
     }
 
     def _unwrap_ocs(self, response_json: dict[str, Any]) -> Any:
-        """Unwrap OCS envelope, validating the status before returning data."""
-        ocs = response_json.get("ocs")
-        if ocs is None:
-            raise OCSError(500, "Response is not an OCS envelope")
-        meta = ocs.get("meta", {})
-        status_code = meta.get("statuscode", 200)
-        if status_code >= 400:
-            message = meta.get("message", "OCS error")
-            raise OCSError(status_code, message)
-        if "data" not in ocs:
+        """Unwrap OCS envelope, validating the status before returning data.
+
+        Raises ``OCSError``, which ``server/collectives`` catches in a dozen
+        places. Parsing and failure wording come from :mod:`.ocs`; the
+        ``>= 400`` rule stays local because it is looser than the documented
+        100/200 success codes and retightening it here would be a behaviour
+        change smuggled into a refactor.
+        """
+        envelope = parse_ocs_envelope(response_json)
+        if envelope.status_code >= 400:
+            raise OCSError(
+                envelope.status_code,
+                describe_ocs_failure(envelope.status_code, envelope.message),
+            )
+        if not envelope.has_data:
             raise OCSError(500, "OCS response missing 'data' field")
-        return ocs["data"]
+        return envelope.data
 
     # Collectives
 

--- a/nextcloud_mcp_server/client/collectives.py
+++ b/nextcloud_mcp_server/client/collectives.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
 from nextcloud_mcp_server.client.ocs import (
+    OCS_REQUEST_HEADERS,
     describe_ocs_failure,
     parse_ocs_envelope,
 )
@@ -31,13 +32,13 @@ class CollectivesClient(BaseNextcloudClient):
 
     app_name = "collectives"
 
-    _OCS_HEADERS: dict[str, str] = {
-        "OCS-APIRequest": "true",
-        "Accept": "application/json",
-    }
+    # Sourced from the shared OCS module so a new call site cannot pick up a
+    # drifted copy of the header set -- omitting OCS-APIRequest is what makes
+    # Nextcloud answer 997, the failure this module exists to make legible.
+    _OCS_HEADERS: dict[str, str] = OCS_REQUEST_HEADERS
 
     _OCS_HEADERS_JSON: dict[str, str] = {
-        **_OCS_HEADERS,
+        **OCS_REQUEST_HEADERS,
         "Content-Type": "application/json",
     }
 

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -32,6 +32,7 @@ from httpx import HTTPStatusError, RequestError, Response
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
 from nextcloud_mcp_server.client.ocs import (
+    OCS_REQUEST_HEADERS,
     describe_ocs_failure,
     parse_ocs_envelope,
 )
@@ -111,10 +112,9 @@ class MailClient(BaseNextcloudClient):
 
     # The OCS-APIRequest header authenticates the OCS routes and exempts the
     # direct routes from CSRF, so both families use the same headers.
-    _API_HEADERS = {
-        "OCS-APIRequest": "true",
-        "Accept": "application/json",
-    }
+    # Shared with the other OCS clients -- see collectives for why the header
+    # set has a single home.
+    _API_HEADERS = OCS_REQUEST_HEADERS
 
     app_name = "mail"
 

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -68,6 +68,11 @@ def _ocs_response(response: Response) -> Any:
             f"Unexpected response format: expected dict, got {type(body).__name__}"
         )
 
+    # These shape checks are not redundant with parse_ocs_envelope: it reports
+    # a malformed body as a 500 envelope, whereas this client's contract is to
+    # raise RequestError for a body that is not an OCS response at all. Callers
+    # distinguish "the server said no" from "that was not OCS", so the checks
+    # stay ahead of the shared parser.
     ocs = body.get("ocs")
     if not isinstance(ocs, dict):
         raise RequestError(
@@ -114,7 +119,7 @@ class MailClient(BaseNextcloudClient):
     # direct routes from CSRF, so both families use the same headers.
     # Shared with the other OCS clients -- see collectives for why the header
     # set has a single home.
-    _API_HEADERS = OCS_REQUEST_HEADERS
+    _API_HEADERS = dict(OCS_REQUEST_HEADERS)
 
     app_name = "mail"
 

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -31,6 +31,10 @@ from urllib.parse import quote
 from httpx import HTTPStatusError, RequestError, Response
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+from nextcloud_mcp_server.client.ocs import (
+    describe_ocs_failure,
+    parse_ocs_envelope,
+)
 
 # Nextcloud's primary blue. Shared with the nc_mail_create_tag tool so the two
 # defaults cannot drift into creating differently-coloured tags for the same
@@ -63,24 +67,25 @@ def _ocs_response(response: Response) -> Any:
             f"Unexpected response format: expected dict, got {type(body).__name__}"
         )
 
-    ocs = body.get("ocs")
-    if not isinstance(ocs, dict):
+    if not isinstance(body.get("ocs"), dict):
         raise RequestError(
-            f"Unexpected OCS format: expected dict, got {type(ocs).__name__}"
+            f"Unexpected OCS format: expected dict, got "
+            f"{type(body.get('ocs')).__name__}"
         )
 
-    meta = ocs.get("meta", {})
-    if not isinstance(meta, dict):
-        meta = {}
-    status_code = int(meta.get("statuscode", 200) or 200)
+    # Parsing and failure wording are shared with the other OCS clients; the
+    # >= 400 rule and the HTTPStatusError contract stay local, since callers
+    # here branch on status_code and a stricter rule would be a behaviour
+    # change rather than a refactor.
+    envelope = parse_ocs_envelope(body)
 
-    if status_code >= 400:
-        message = meta.get("message", "Unknown OCS error")
+    if envelope.status_code >= 400:
+        message = describe_ocs_failure(envelope.status_code, envelope.message)
         # Synthesise a Response-like object so callers can check status_code
-        synthetic = Response(status_code=status_code, text=message)
+        synthetic = Response(status_code=envelope.status_code, text=message)
         raise HTTPStatusError(message, request=response.request, response=synthetic)
 
-    return ocs.get("data")
+    return envelope.data
 
 
 class MailClient(BaseNextcloudClient):

--- a/nextcloud_mcp_server/client/mail.py
+++ b/nextcloud_mcp_server/client/mail.py
@@ -68,10 +68,10 @@ def _ocs_response(response: Response) -> Any:
             f"Unexpected response format: expected dict, got {type(body).__name__}"
         )
 
-    if not isinstance(body.get("ocs"), dict):
+    ocs = body.get("ocs")
+    if not isinstance(ocs, dict):
         raise RequestError(
-            f"Unexpected OCS format: expected dict, got "
-            f"{type(body.get('ocs')).__name__}"
+            f"Unexpected OCS format: expected dict, got {type(ocs).__name__}"
         )
 
     # Parsing and failure wording are shared with the other OCS clients; the

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -31,6 +31,11 @@ from typing import Any, NamedTuple
 #: Headers Nextcloud's CSRF check requires on every OCS request. Omitting
 #: ``OCS-APIRequest`` yields ``meta.statuscode: 997``, not a 4xx, which is why
 #: it is easy to misdiagnose.
+#:
+#: Used by the three clients this module serves (sharing, collectives, mail).
+#: The same literal still appears inline elsewhere -- deck, groups, tables,
+#: users, and the DAV calls in webdav that send it for unrelated reasons --
+#: which is a wider sweep than this module's scope.
 OCS_REQUEST_HEADERS: dict[str, str] = {
     "OCS-APIRequest": "true",
     "Accept": "application/json",
@@ -91,7 +96,13 @@ def parse_ocs_envelope(payload: Any) -> OCSEnvelope:
     if not isinstance(meta, dict):
         meta = {}
 
-    raw_status = meta.get("statuscode", 200)
+    # ``or 200`` covers falsy-but-present values (``0``, ``""``, ``None``) the
+    # same way the mail client did before this module existed. Without it an
+    # empty statuscode parses to 500, which crosses mail's ``>= 400`` gate and
+    # turns a response that used to succeed into a raised error. A genuinely
+    # non-numeric value still falls through to 500 -- an unreadable status is
+    # not something to report as success.
+    raw_status = meta.get("statuscode") or 200
     try:
         status_code = int(raw_status)
     except (TypeError, ValueError):

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -108,6 +108,13 @@ def parse_ocs_envelope(payload: Any) -> OCSEnvelope:
     except (TypeError, ValueError):
         status_code = 500
 
+    # One fallback string for all three clients. They previously differed --
+    # sharing "Unknown error", collectives "OCS error", mail "Unknown OCS
+    # error" -- and consolidating is deliberate rather than incidental: this is
+    # the text shown only when the server sent no message at all, so a
+    # per-client variant conveys nothing a caller can act on. Called out
+    # explicitly because the statuscode default next to it was preserved
+    # exactly, and the difference in treatment should not look accidental.
     message = meta.get("message") or "Unknown error"
     return OCSEnvelope(status_code, str(message), ocs.get("data"), "data" in ocs)
 

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -1,0 +1,108 @@
+"""Shared handling for Nextcloud's OCS response envelope.
+
+Every OCS endpoint wraps its payload the same way::
+
+    {"ocs": {"meta": {"status": "ok", "statuscode": 200, "message": "OK"},
+             "data": {...}}}
+
+Two properties of that envelope bite callers who only check the HTTP status:
+
+* **The v1 trap.** ``/ocs/v1.php`` answers *every* request with HTTP 200 and
+  puts the real outcome in ``meta.statuscode``, where success is ``100``.
+  ``/ocs/v2.php`` mirrors the OCS code onto the HTTP status and uses ``200``.
+  Both codes therefore mean success, depending only on which route was called.
+
+* **997 is not a server error.** Nextcloud returns it when the request was
+  unauthenticated *or* when it omitted the mandatory ``OCS-APIRequest: true``
+  header that its CSRF check requires on every OCS call. Reported as a generic
+  failure it sends the reader hunting for a server fault that is not there, so
+  it gets named explicitly here.
+
+This module deliberately does **not** raise. Three clients parse this envelope
+and each raises a different type that its callers already catch --
+``OCSError`` (collectives, caught in a dozen places in ``server/collectives``),
+``HTTPStatusError`` (mail), and ``RuntimeError`` (sharing). Centralising the
+*parsing* and the *wording* is safe; centralising the raising would change
+three caller contracts at once.
+"""
+
+from typing import Any, NamedTuple
+
+#: Headers Nextcloud's CSRF check requires on every OCS request. Omitting
+#: ``OCS-APIRequest`` yields ``meta.statuscode: 997``, not a 4xx, which is why
+#: it is easy to misdiagnose.
+OCS_REQUEST_HEADERS: dict[str, str] = {
+    "OCS-APIRequest": "true",
+    "Accept": "application/json",
+}
+
+#: Success codes: ``100`` from OCS v1, ``200`` from v2.
+OCS_SUCCESS_STATUS_CODES = frozenset({100, 200})
+
+#: "Unauthorised" in OCS's vocabulary -- bad credentials *or* a missing
+#: ``OCS-APIRequest`` header.
+OCS_STATUS_UNAUTHENTICATED = 997
+
+_UNAUTHENTICATED_HINT = (
+    "unauthenticated — either the credentials were rejected, or the request "
+    "omitted the 'OCS-APIRequest: true' header that Nextcloud's CSRF check "
+    "requires on OCS routes"
+)
+
+
+class OCSEnvelope(NamedTuple):
+    """The parts of an OCS envelope callers act on."""
+
+    status_code: int
+    message: str
+    data: Any
+    has_data: bool
+
+    @property
+    def is_success(self) -> bool:
+        """True when the OCS code is a documented success (100 or 200).
+
+        This is stricter than the ``< 400`` test the collectives and mail
+        clients apply. They keep their own comparison for now rather than being
+        silently retightened by a refactor -- converging on one rule needs
+        evidence about which sub-400 codes real endpoints return.
+        """
+        return self.status_code in OCS_SUCCESS_STATUS_CODES
+
+
+def parse_ocs_envelope(payload: Any) -> OCSEnvelope:
+    """Pull ``(statuscode, message, data)`` out of an OCS response body.
+
+    Tolerates every malformed shape seen in practice -- a non-dict body, a
+    missing or non-dict ``ocs`` / ``meta``, a non-numeric statuscode -- by
+    reporting ``500`` with a description, rather than raising a ``KeyError`` or
+    ``TypeError`` that tells the caller nothing about what the server said.
+    """
+    if not isinstance(payload, dict):
+        return OCSEnvelope(
+            500, f"Response is not a JSON object: {type(payload).__name__}", None, False
+        )
+
+    ocs = payload.get("ocs")
+    if not isinstance(ocs, dict):
+        return OCSEnvelope(500, "Response is not an OCS envelope", None, False)
+
+    meta = ocs.get("meta")
+    if not isinstance(meta, dict):
+        meta = {}
+
+    raw_status = meta.get("statuscode", 200)
+    try:
+        status_code = int(raw_status)
+    except (TypeError, ValueError):
+        status_code = 500
+
+    message = meta.get("message") or "Unknown error"
+    return OCSEnvelope(status_code, str(message), ocs.get("data"), "data" in ocs)
+
+
+def describe_ocs_failure(status_code: int, message: str) -> str:
+    """Render an OCS failure, naming 997's two causes rather than guessing."""
+    if status_code == OCS_STATUS_UNAUTHENTICATED:
+        return f"OCS API error (code {status_code}): {_UNAUTHENTICATED_HINT}"
+    return f"OCS API error (code {status_code}): {message}"

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -280,9 +280,7 @@ class SharingClient(BaseNextcloudClient):
         response.raise_for_status()
         data = response.json()
 
-        _ocs_data(data)
-
-        share_data = data["ocs"]["data"]
+        share_data = _ocs_data(data)
         # The API returns a list with a single share, extract the first element
         if isinstance(share_data, list) and len(share_data) > 0:
             return share_data[0]
@@ -318,10 +316,8 @@ class SharingClient(BaseNextcloudClient):
         response.raise_for_status()
         data = response.json()
 
-        _ocs_data(data)
-
         # Handle both single share and list of shares
-        shares_data = data["ocs"]["data"]
+        shares_data = _ocs_data(data)
         if isinstance(shares_data, dict):
             return [shares_data]
         return shares_data if shares_data else []
@@ -354,7 +350,7 @@ class SharingClient(BaseNextcloudClient):
         response.raise_for_status()
         result = response.json()
 
-        _ocs_data(result)
+        share_data = _ocs_data(result)
 
         logger.info("Updated share %s", share_id)
-        return result["ocs"]["data"]
+        return share_data

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -6,6 +6,7 @@ from typing import Any
 from nextcloud_mcp_server.models.sharing import ShareType
 
 from .base import BaseNextcloudClient, retry_on_429
+from .ocs import OCS_REQUEST_HEADERS, describe_ocs_failure, parse_ocs_envelope
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,20 @@ def validate_share_with(share_type: int, share_with: str | None) -> None:
         )
 
 
+def _ocs_data(payload: Any) -> Any:
+    """Validate an OCS envelope and return its ``data``.
+
+    Raises ``RuntimeError`` -- the type this client has always raised and the
+    one its tests assert on. The envelope parsing and the failure wording come
+    from :mod:`.ocs` so every OCS client says the same thing about a given
+    status code, 997 in particular.
+    """
+    envelope = parse_ocs_envelope(payload)
+    if not envelope.is_success:
+        raise RuntimeError(describe_ocs_failure(envelope.status_code, envelope.message))
+    return envelope.data
+
+
 class SharingClient(BaseNextcloudClient):
     """Client for Nextcloud OCS Sharing API operations."""
 
@@ -135,26 +150,20 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
             data=payload,
         )
         response.raise_for_status()
         data = response.json()
 
-        # OCS API v2 uses HTTP-style status codes (200 for success)
-        # OCS API v1 used custom codes (100 for success)
-        ocs_status = data["ocs"]["meta"]["statuscode"]
-        if ocs_status not in (100, 200):
-            ocs_message = data["ocs"]["meta"].get("message", "Unknown error")
-            raise RuntimeError(f"OCS API error (code {ocs_status}): {ocs_message}")
+        share_data = _ocs_data(data)
 
-        share_data = data["ocs"]["data"]
-
-        # Handle case where data might be an empty list on error
-        if not share_data or (isinstance(share_data, list) and len(share_data) == 0):
-            ocs_message = data["ocs"]["meta"].get("message", "Unknown error")
+        # An OK status with no data still means the share was not created.
+        if not share_data:
+            envelope = parse_ocs_envelope(data)
             raise RuntimeError(
-                f"Share creation failed: {ocs_message} (status {ocs_status})"
+                f"Share creation failed: {envelope.message} "
+                f"(status {envelope.status_code})"
             )
 
         logger.info(
@@ -205,24 +214,20 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
             data=data,
         )
         response.raise_for_status()
         result = response.json()
 
-        ocs_status = result["ocs"]["meta"]["statuscode"]
-        if ocs_status not in (100, 200):
-            ocs_message = result["ocs"]["meta"].get("message", "Unknown error")
-            raise RuntimeError(f"OCS API error (code {ocs_status}): {ocs_message}")
+        share_data = _ocs_data(result)
 
-        share_data = result["ocs"]["data"]
-
-        # An empty list/dict means the share was not created despite an OK code.
-        if not share_data or (isinstance(share_data, list) and len(share_data) == 0):
-            ocs_message = result["ocs"]["meta"].get("message", "Unknown error")
+        # An OK status with no data still means the link was not created.
+        if not share_data:
+            envelope = parse_ocs_envelope(result)
             raise RuntimeError(
-                f"Public link creation failed: {ocs_message} (status {ocs_status})"
+                f"Public link creation failed: {envelope.message} "
+                f"(status {envelope.status_code})"
             )
 
         logger.info(
@@ -246,15 +251,12 @@ class SharingClient(BaseNextcloudClient):
         """
         response = await self._client.delete(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
 
-        if data["ocs"]["meta"]["statuscode"] not in (100, 200):
-            raise RuntimeError(
-                f"OCS API error: {data['ocs']['meta'].get('message', 'Unknown error')}"
-            )
+        _ocs_data(data)
 
         logger.info("Deleted share %s", share_id)
 
@@ -273,15 +275,12 @@ class SharingClient(BaseNextcloudClient):
         """
         response = await self._client.get(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
 
-        if data["ocs"]["meta"]["statuscode"] not in (100, 200):
-            raise RuntimeError(
-                f"OCS API error: {data['ocs']['meta'].get('message', 'Unknown error')}"
-            )
+        _ocs_data(data)
 
         share_data = data["ocs"]["data"]
         # The API returns a list with a single share, extract the first element
@@ -314,15 +313,12 @@ class SharingClient(BaseNextcloudClient):
         response = await self._client.get(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             params=params,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
 
-        if data["ocs"]["meta"]["statuscode"] not in (100, 200):
-            raise RuntimeError(
-                f"OCS API error: {data['ocs']['meta'].get('message', 'Unknown error')}"
-            )
+        _ocs_data(data)
 
         # Handle both single share and list of shares
         shares_data = data["ocs"]["data"]
@@ -352,16 +348,13 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.put(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=OCS_REQUEST_HEADERS,
             data=data,
         )
         response.raise_for_status()
         result = response.json()
 
-        if result["ocs"]["meta"]["statuscode"] not in (100, 200):
-            raise RuntimeError(
-                f"OCS API error: {result['ocs']['meta'].get('message', 'Unknown error')}"
-            )
+        _ocs_data(result)
 
         logger.info("Updated share %s", share_id)
         return result["ocs"]["data"]

--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -93,6 +93,11 @@ class SharingClient(BaseNextcloudClient):
 
     app_name = "sharing"
 
+    # Own copy, matching collectives and mail: the module-level dict is shared
+    # by all three clients, so passing it straight through would make any
+    # future in-place edit a cross-client bug.
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
+
     @retry_on_429
     async def create_share(
         self,
@@ -150,7 +155,7 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
             data=payload,
         )
         response.raise_for_status()
@@ -214,7 +219,7 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.post(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
             data=data,
         )
         response.raise_for_status()
@@ -251,7 +256,7 @@ class SharingClient(BaseNextcloudClient):
         """
         response = await self._client.delete(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -275,7 +280,7 @@ class SharingClient(BaseNextcloudClient):
         """
         response = await self._client.get(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -311,7 +316,7 @@ class SharingClient(BaseNextcloudClient):
         response = await self._client.get(
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             params=params,
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -344,7 +349,7 @@ class SharingClient(BaseNextcloudClient):
 
         response = await self._client.put(
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
-            headers=OCS_REQUEST_HEADERS,
+            headers=self._OCS_HEADERS,
             data=data,
         )
         response.raise_for_status()

--- a/tests/unit/client/test_ocs.py
+++ b/tests/unit/client/test_ocs.py
@@ -1,0 +1,123 @@
+"""Unit tests for the shared OCS envelope handling.
+
+Two things are worth pinning here: that the parser survives every malformed
+shape rather than raising a ``KeyError`` the caller cannot act on, and that a
+997 is described by its two real causes instead of being reported as a generic
+server failure.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.client.ocs import (
+    OCS_REQUEST_HEADERS,
+    OCS_STATUS_UNAUTHENTICATED,
+    describe_ocs_failure,
+    parse_ocs_envelope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _envelope(status_code: int, message: str = "OK", data=None) -> dict:
+    return {
+        "ocs": {
+            "meta": {"status": "ok", "statuscode": status_code, "message": message},
+            "data": data,
+        }
+    }
+
+
+@pytest.mark.parametrize("status_code", [100, 200])
+def test_both_documented_success_codes_are_accepted(status_code):
+    """100 is OCS v1's success, 200 is v2's -- which one arrives depends only
+    on the route, so treating either as failure breaks half the API."""
+    envelope = parse_ocs_envelope(_envelope(status_code, data={"id": 1}))
+
+    assert envelope.is_success
+    assert envelope.data == {"id": 1}
+
+
+@pytest.mark.parametrize("status_code", [400, 403, 404, 997, 998])
+def test_non_success_codes_are_reported_as_failures(status_code):
+    assert not parse_ocs_envelope(_envelope(status_code)).is_success
+
+
+def test_997_names_both_of_its_causes():
+    """The whole reason 997 gets special wording.
+
+    Reported generically it sends the reader looking for a server fault that is
+    not there -- the cause is either rejected credentials or a missing
+    ``OCS-APIRequest`` header, and the message has to say both.
+    """
+    described = describe_ocs_failure(
+        OCS_STATUS_UNAUTHENTICATED, "Current user is not logged in"
+    )
+
+    assert "unauthenticated" in described
+    assert "OCS-APIRequest" in described
+    assert str(OCS_STATUS_UNAUTHENTICATED) in described
+
+
+def test_other_failures_keep_the_server_message():
+    """Only 997 is reworded; everything else reports what the server said."""
+    described = describe_ocs_failure(404, "Wrong path, file/folder doesn't exist")
+
+    assert "Wrong path, file/folder doesn't exist" in described
+    assert "OCS-APIRequest" not in described
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        "not json",
+        [],
+        {},
+        {"ocs": None},
+        {"ocs": "nope"},
+        {"ocs": {"meta": {"statuscode": "not-a-number"}}},
+    ],
+)
+def test_unparseable_payloads_report_failure_without_raising(payload):
+    """A body that is not a usable envelope must describe itself, not raise.
+
+    Every caller is already handling a failed request when it gets here, so a
+    ``KeyError``/``TypeError`` from parsing would replace a diagnosable server
+    error with an opaque one.
+    """
+    envelope = parse_ocs_envelope(payload)
+
+    assert not envelope.is_success
+    assert envelope.message
+
+
+@pytest.mark.parametrize("payload", [{"ocs": {}}, {"ocs": {"meta": None}}])
+def test_absent_meta_is_treated_as_success(payload):
+    """An envelope with no usable ``meta`` defaults to 200, i.e. success.
+
+    Deliberate: all three clients did this before the extraction
+    (``meta.get("statuscode", 200)``), and OCS omits ``meta`` only on responses
+    that succeeded. Tightening it to a failure would be a behaviour change
+    smuggled in under a refactor, so it is pinned here rather than left to be
+    "corrected" by someone reading the parser in isolation.
+    """
+    assert parse_ocs_envelope(payload).is_success
+
+
+def test_missing_data_key_is_distinguishable_from_null_data():
+    """``has_data`` separates "no data field" from "data was null".
+
+    The collectives client treats the former as a malformed response; the
+    distinction is lost if callers only test ``data is None``.
+    """
+    absent = parse_ocs_envelope({"ocs": {"meta": {"statuscode": 200}}})
+    present = parse_ocs_envelope(_envelope(200, data=None))
+
+    assert not absent.has_data
+    assert present.has_data
+
+
+def test_request_headers_carry_the_csrf_header():
+    """Shipping the header from one place is what stops a new call site
+    forgetting it and then hitting the 997 it just made confusing."""
+    assert OCS_REQUEST_HEADERS["OCS-APIRequest"] == "true"

--- a/tests/unit/client/test_ocs.py
+++ b/tests/unit/client/test_ocs.py
@@ -166,3 +166,19 @@ def test_collectives_error_string_is_not_double_prefixed():
     assert rendered.count("404") == 1, rendered
     assert not rendered.startswith("OCS error 404:")
     assert exc_info.value.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "meta", [{"statuscode": 404}, {"statuscode": 404, "message": ""}]
+)
+def test_absent_server_message_uses_one_shared_default(meta):
+    """All three clients now share a single "no message" fallback.
+
+    They used to differ ("Unknown error" / "OCS error" / "Unknown OCS error").
+    Consolidating is deliberate -- the text appears only when the server sent no
+    message, so a per-client variant conveys nothing actionable -- but it is
+    pinned here so the change is a decision on record rather than drift.
+    """
+    envelope = parse_ocs_envelope({"ocs": {"meta": meta}})
+
+    assert envelope.message == "Unknown error"

--- a/tests/unit/client/test_ocs.py
+++ b/tests/unit/client/test_ocs.py
@@ -141,3 +141,28 @@ def test_unreadable_statuscode_is_a_failure():
     payload = {"ocs": {"meta": {"statuscode": "not-a-number"}}}
 
     assert parse_ocs_envelope(payload).status_code == 500
+
+
+def test_collectives_error_string_is_not_double_prefixed():
+    """``str(OCSError)`` must not repeat the status code.
+
+    ``describe_ocs_failure`` already names the code, and ``OCSError`` used to
+    prefix it again -- yielding "OCS error 404: OCS API error (code 404): ..."
+    in logs and tracebacks. Nothing caught it because the existing collectives
+    tests assert on ``.message`` and substring matches, never on ``str(e)``.
+    Exercised through the real ``_unwrap_ocs`` failure path rather than by
+    constructing the exception directly, since that is where the two layers
+    meet. Caught in review of #1343.
+    """
+    from nextcloud_mcp_server.client.collectives import CollectivesClient, OCSError
+
+    client = CollectivesClient.__new__(CollectivesClient)
+    payload = {"ocs": {"meta": {"statuscode": 404, "message": "Not found"}}}
+
+    with pytest.raises(OCSError) as exc_info:
+        client._unwrap_ocs(payload)
+
+    rendered = str(exc_info.value)
+    assert rendered.count("404") == 1, rendered
+    assert not rendered.startswith("OCS error 404:")
+    assert exc_info.value.status_code == 404

--- a/tests/unit/client/test_ocs.py
+++ b/tests/unit/client/test_ocs.py
@@ -121,3 +121,23 @@ def test_request_headers_carry_the_csrf_header():
     """Shipping the header from one place is what stops a new call site
     forgetting it and then hitting the 997 it just made confusing."""
     assert OCS_REQUEST_HEADERS["OCS-APIRequest"] == "true"
+
+
+@pytest.mark.parametrize("raw", [0, "", None])
+def test_falsy_statuscode_falls_back_to_success(raw):
+    """A present-but-falsy statuscode defaults to 200, as mail's parser did.
+
+    Without this an empty statuscode resolves to 500, which crosses mail's
+    ``>= 400`` gate and turns a response that previously succeeded into a
+    raised error. Caught in review of #1343.
+    """
+    payload = {"ocs": {"meta": {"statuscode": raw}, "data": {}}}
+
+    assert parse_ocs_envelope(payload).is_success
+
+
+def test_unreadable_statuscode_is_a_failure():
+    """A non-numeric status is not something to report as success."""
+    payload = {"ocs": {"meta": {"statuscode": "not-a-number"}}}
+
+    assert parse_ocs_envelope(payload).status_code == 500


### PR DESCRIPTION
## Problem

The OCS status envelope was re-parsed at **eight sites across three clients** — `sharing.py` alone repeated the same check six times — each with its own navigation, message extraction, and idea of what counts as OK.

Separately, OCS `997` was reported as a generic failure. It means the request was unauthenticated **or** it omitted the `OCS-APIRequest: true` header that Nextcloud's CSRF check requires on every OCS route. Reported generically it sends the reader hunting for a server fault that is not there.

## Fix

New `client/ocs.py` owns the parsing (`parse_ocs_envelope`), the success codes, the shared request headers, and the failure wording (`describe_ocs_failure`).

The parser **tolerates every malformed shape rather than raising** — non-dict body, missing/non-dict `ocs` or `meta`, non-numeric statuscode. Callers reach it while already handling a failure, so a `KeyError` from parsing would replace a diagnosable server error with an opaque one.

## Two things deliberately NOT unified

Both would be behaviour changes wearing a refactor's clothes, and the card explicitly asked to preserve caller contracts:

**Exception types.** The three clients raise different types their callers already catch:

| Client | Raises | Caught by |
|---|---|---|
| collectives | `OCSError` | `server/collectives.py`, 12 sites |
| mail | `HTTPStatusError` (synthetic response) | callers branch on `status_code` |
| sharing | `RuntimeError` | its own tests |

Each keeps its contract; only parsing and wording are shared.

**The success rule.** Sharing requires exactly `100`/`200`; collectives and mail accept anything `< 400`. Retightening the latter could reject a sub-400 code some endpoint actually returns — that needs evidence, not a tidy-up. `OCSEnvelope.is_success` implements the strict rule for sharing, and the two looser sites keep their own comparison with a comment explaining why.

So this PR removes the duplication that is safe to remove and names the divergence instead of papering over it. Converging the rule is a separate, evidence-led change.

## A behaviour I preserved on purpose

An envelope with no usable `meta` still defaults to status `200`, i.e. success — what all three implementations did (`meta.get("statuscode", 200)`). There is now a test pinning it, so it is not "corrected" by someone reading the parser in isolation and assuming a missing status should fail.

That test only exists because I wrote the opposite assertion first and the code told me otherwise.

## Test coverage

20 unit tests in `tests/unit/client/test_ocs.py`: both success codes, failure codes, the 997 wording (and that only 997 is reworded), the unparseable-payload matrix, `has_data` vs null data, and the CSRF header. Existing sharing/collectives/mail suites pass unchanged — 3528 unit tests total — plus the sharing integration tier against a live instance.

No API surface change (client-internal), so no new contract-test obligation.

Deck: board 12 card #1049.

---

_This PR was generated with the help of AI, and reviewed by a Human_
