### PR TITLE
fix(vector): dead-letter documents after repeated index failures

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -663,6 +663,7 @@ ENABLE_SEMANTIC_SEARCH=true           # Enable background indexing
 # Tuning parameters (advanced - only modify if needed)
 VECTOR_SYNC_SCAN_INTERVAL=300         # Scan interval in seconds (default: 5 minutes)
 VECTOR_SYNC_PROCESSOR_WORKERS=3       # Concurrent indexing workers (default: 3)
+VECTOR_SYNC_MAX_INDEX_FAILURES=5      # Failed index attempts before a document is parked
 # Optional per-tier concurrency overrides (unset = inherit PROCESSOR_WORKERS).
 # Precedence: worker --concurrency flag > tier override > PROCESSOR_WORKERS.
 VECTOR_SYNC_FAST_CONCURRENCY=         # Fast-tier worker concurrency (default: unset)
@@ -1313,6 +1314,7 @@ equivalent.** Operators who need a runtime toggle should open an issue.
 | `VECTOR_SYNC_SCAN_INTERVAL` | ⚠️ Optional | `300` | Document scan interval (seconds) |
 | `VECTOR_SYNC_EMPTY_DISCOVERY_DELETE_THRESHOLD` | ⚠️ Optional | `3` | Fail-safe against a flaky/empty tag-discovery read. A scan deletes indexed points whose files a tag-discovery no longer returns; if a Nextcloud intermittently answers the systemtag `REPORT` with an empty result, that would wrongly purge (then re-index) the whole corpus each cycle. This is the number of **consecutive** scan cycles an index mode's discovery must return zero (while Qdrant still holds points for it) before deletions for that mode are believed — a transient empty deletes nothing; a sustained empty (a genuine mass-untag) still deletes once the streak is reached. Worst-case deletion latency for a real mass-untag ≈ `(threshold-1) × VECTOR_SYNC_SCAN_INTERVAL + 1.5 × VECTOR_SYNC_SCAN_INTERVAL`. Set `≤1` to restore immediate deletion. |
 | `VECTOR_SYNC_PROCESSOR_WORKERS` | ⚠️ Optional | `3` | Concurrent indexing workers |
+| `VECTOR_SYNC_MAX_INDEX_FAILURES` | ⚠️ Optional | `5` | Consecutive failed **index** attempts before a document is dead-lettered instead of re-queued by the next scan (GH #1345). A hard *parse* failure at the deepest tier is terminal on its first attempt; an embedding / Qdrant / transport failure is treated as transient at first, so parking it takes this many rounds — otherwise a backend outage would drop every in-flight document. The count is per content-version (`etag` + escalation-tier signature) and is cleared by a successful index, so it bounds only *persistent* failure. Each attempt already costs the in-process retries, so the default spans roughly 5 scan cycles. Must be `>= 1`; `1` parks on the first exhausted-retry round. |
 | `VECTOR_SYNC_FAST_CONCURRENCY` | ⚠️ Optional | unset | Per-tier override for the **fast** ingest worker's concurrency. Unset inherits `VECTOR_SYNC_PROCESSOR_WORKERS`. Must be `>= 1` when set. Resolution precedence: the worker `--concurrency` flag > this tier override > `VECTOR_SYNC_PROCESSOR_WORKERS`. |
 | `VECTOR_SYNC_STRUCTURED_CONCURRENCY` | ⚠️ Optional | unset | Per-tier override for the **structured** ingest worker's concurrency. Unset inherits `VECTOR_SYNC_PROCESSOR_WORKERS`. Must be `>= 1` when set. Same precedence as `VECTOR_SYNC_FAST_CONCURRENCY`. |
 | `VECTOR_SYNC_QUEUE_MAX_SIZE` | ⚠️ Optional | `10000` | Max queued documents |

--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -120,6 +120,10 @@ _DEFAULTS: dict[str, Any] = {
     # Vector sync
     "vector_sync_scan_interval": 300,
     "vector_sync_processor_workers": 3,
+    # Consecutive failed index attempts (embed / Qdrant / transport — NOT a
+    # parse failure, which is terminal on the first try) before a document is
+    # dead-lettered instead of re-queued forever. See vector/dead_letter.py.
+    "vector_sync_max_index_failures": 5,
     # Optional per-tier concurrency overrides (None = fall back to
     # vector_sync_processor_workers). Consumed by the `worker` CLI per --tier.
     "vector_sync_fast_concurrency": None,
@@ -587,6 +591,9 @@ _dynaconf = Dynaconf(
         Validator("QDRANT_INIT_BACKOFF_MAX", gte=0),
         Validator("VECTOR_SYNC_SCAN_INTERVAL", gte=1),
         Validator("VECTOR_SYNC_PROCESSOR_WORKERS", gte=1),
+        # 1 = park on the first exhausted-retry round. 0/negative would park a
+        # document before any attempt was recorded.
+        Validator("VECTOR_SYNC_MAX_INDEX_FAILURES", gte=1),
         # Optional per-tier concurrency overrides (None = fall back to
         # VECTOR_SYNC_PROCESSOR_WORKERS). Like the sibling above they must be
         # >=1 when set — a 0/negative value would otherwise reach
@@ -1107,6 +1114,13 @@ class Settings:
     vector_sync_enabled: bool = False
     vector_sync_scan_interval: int = 300  # seconds (5 minutes)
     vector_sync_processor_workers: int = 3
+    # Consecutive failed index attempts before a document is dead-lettered
+    # (GH #1345). A parse failure is terminal on its first attempt; an
+    # embed/Qdrant/transport failure is transient-until-proven-otherwise, so it
+    # is counted per (doc_id, etag) and only parked once the count is reached.
+    # Each attempt already costs `max_retries` in-process tries, so the default
+    # spans roughly 5 scan cycles before the document stops being re-queued.
+    vector_sync_max_index_failures: int = 5
     # Optional per-tier concurrency overrides for the ingest worker (None = use
     # vector_sync_processor_workers). Only fast/structured are exposed; the
     # CPU-heavy PDF paths are serialized (see document_processors/_native_locks).

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1786,7 +1786,7 @@ def record_document_parse_mode(mode: str) -> None:
 
 
 def record_document_dead_lettered(reason: str) -> None:
-    """Record a document dead-lettered after a terminal parse failure.
+    """Record a document dead-lettered, by parse failure or repeated index failure.
 
     Counts the dead-letter *attempt*: it is incremented alongside the
     ``mark_dead_letter`` call, which is fail-safe (a Qdrant write error is logged,
@@ -1794,13 +1794,22 @@ def record_document_dead_lettered(reason: str) -> None:
     above the live marker count in Qdrant.
 
     Args:
-        reason: ``timeout`` | ``oom`` | ``error`` (the terminal parse failure
-            reason carried from the isolated worker), ``oversize`` (rejected by
-            the pre-parse size guard, which no tier can ever parse),
-            ``unreadable`` (the bytes are not a document the engine can open --
-            no tier will do better, so it is terminal on the first attempt), or
-            ``unsupported_type`` (no registered processor claims the mime type --
-            a config property of the deployment, not a fault of the document).
+        reason: for a **terminal parse failure** — ``timeout`` | ``oom`` |
+            ``error`` (the reason carried from the isolated worker),
+            ``oversize`` (rejected by the pre-parse size guard, which no tier can
+            ever parse), ``unreadable`` (the bytes are not a document the engine
+            can open -- no tier will do better, so it is terminal on the first
+            attempt), or ``unsupported_type`` (no registered processor claims the
+            mime type -- a config property of the deployment, not a fault of the
+            document).
+
+            For a document parked after ``VECTOR_SYNC_MAX_INDEX_FAILURES``
+            consecutive **index** failures (GH #1345), the label is instead a
+            ``vector.processor._drop_reason`` value: ``timeout`` |
+            ``connection`` | ``rate_limit`` | ``server`` | ``qdrant`` |
+            ``other``. ``timeout`` is therefore shared by both paths. The label
+            set is not validated anywhere, so this list is the only contract --
+            keep it in step with ``_drop_reason``.
     """
     document_dead_lettered_total.labels(reason=reason).inc()
 

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -479,8 +479,14 @@ document_parse_failed_total = Counter(
 # changes and it is re-attempted.
 document_dead_lettered_total = Counter(
     "astrolabe_document_dead_lettered_total",
-    "Documents dead-lettered after a terminal parse failure (no escalation tier)",
-    ["reason"],  # reason: timeout | oom | error | oversize | unreadable
+    "Documents dead-lettered by a terminal parse failure (no escalation tier) "
+    "or by repeated index failures",
+    # reason: a parse-failure reason (timeout | oom | error | oversize |
+    # unreadable | unsupported_type) OR a vector.processor._drop_reason value
+    # (timeout | connection | rate_limit | server | qdrant | other) for the
+    # repeated-index-failure path. Keep in step with record_document_dead_lettered's
+    # docstring below and with _drop_reason.
+    ["reason"],
 )
 
 # Documents dropped after exhausting in-process indexing retries (the scanner

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -251,6 +251,14 @@ async def record_index_failure(
     is genuinely per-document (an oversize payload, a chunk the backend always
     rejects) is exactly what parking is for; a backend-wide outage is not.
     Distinguishing them needs cross-document state this function does not have.
+
+    The read-then-write is deliberately NOT compare-and-swap. Two concurrent
+    failures for the same document can both read ``attempts=N`` and both write
+    ``N+1``, undercounting by one — and that is reachable in normal operation,
+    since a file shared by N users produces N tasks for the same ``doc_id``. The
+    consequence is the safe direction: parking is delayed by a round, never
+    triggered early. Qdrant offers no payload-level CAS to close it with, and
+    trading a lost round for that machinery is not worth it.
     """
     settings = get_settings()
     limit = settings.vector_sync_max_index_failures

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -263,6 +263,15 @@ async def record_index_failure(
     early — and the straggler's own next round re-parks it. Qdrant offers no
     payload-level CAS to close either with, and trading a lost round for that
     machinery is not worth it.
+
+    Those two are delays. A third hazard was NOT, and is worth naming because it
+    is the one that actually bit: the count only accumulates while nothing else
+    clears the marker mid-round. ``_index_document`` used to call
+    ``clear_dead_letter`` *before* its final Qdrant upsert, so a persistently
+    failing upsert deleted its own count every round — ``attempts`` was rewritten
+    to 1 forever and the document could never park. The clear now runs only after
+    the upsert succeeds. Any future caller of ``clear_dead_letter`` on a path that
+    can still fail afterwards reintroduces that bug.
     """
     settings = get_settings()
     limit = settings.vector_sync_max_index_failures

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -234,6 +234,23 @@ async def record_index_failure(
     the dead-letter metric), False while it is still being retried. Fail-safe: a
     Qdrant read error counts the attempt as the first, which at worst delays
     parking — it never parks a document early.
+
+    **A Qdrant outage cannot park anything**, and that is load-bearing rather
+    than incidental: the counter lives in the very store whose availability it
+    is judging, so while Qdrant is down both the read and the write here fail
+    and the count cannot advance. Were it kept anywhere else, an outage longer
+    than ``limit × VECTOR_SYNC_SCAN_INTERVAL`` would park every in-flight
+    document, and they would stay parked until their etag changed — i.e. never,
+    for a static corpus. Pinned by
+    ``test_a_qdrant_outage_cannot_park_anything``; do not "fix" the swallowed
+    errors into a fallback that keeps counting.
+
+    Note the asymmetry: a *Qdrant* fault self-protects this way, but a sustained
+    **embedding-backend** outage does not — Qdrant stays healthy, so the count
+    advances normally and documents park after ``limit`` rounds. A failure that
+    is genuinely per-document (an oversize payload, a chunk the backend always
+    rejects) is exactly what parking is for; a backend-wide outage is not.
+    Distinguishing them needs cross-document state this function does not have.
     """
     settings = get_settings()
     limit = settings.vector_sync_max_index_failures

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -19,12 +19,27 @@ loops. A content change (new ``etag``) or a config change that adds an escalatio
 tier (e.g. enabling OCR — new ``tiers_sig``) makes the marker stale and the
 document retryable again.
 
+The same marker point also tracks *non-terminal* failures (GH #1345). A parse
+failure at the deepest tier is terminal on its first attempt, but an embedding /
+Qdrant / transport failure is transient-until-proven-otherwise: parking a document
+on the first one would drop every in-flight document during a backend outage. So
+``record_index_failure`` counts **consecutive** such failures per content-version
+in the marker's ``attempts`` field and only flips ``dead_letter`` to True once
+``VECTOR_SYNC_MAX_INDEX_FAILURES`` is reached. Below that threshold the marker is
+a *soft* one: ``dead_letter=False``, invisible to ``is_dead_lettered``, so the
+scanner keeps retrying. A successful index (or a delete) clears the marker, which
+is what makes the count consecutive rather than cumulative.
+
 The marker carries ``is_placeholder=True`` so the existing search exclusion
 (``get_placeholder_filter``) keeps it out of user-facing results with no extra
-filter, plus ``dead_letter=True`` so the orphan-placeholder sweep and the scanner
-can tell it apart from a volatile in-flight placeholder. Mirrors the fail-safe
-philosophy of ``sharing_state``: a Qdrant error never aborts ingest — a failed
-lookup degrades to "process normally", a failed write is logged, not raised.
+filter, plus ``dead_letter`` (True once terminal) so the orphan-placeholder sweep
+and the scanner can tell it apart from a volatile in-flight placeholder. The sweep
+keys off the *presence* of that field, not its value, so a soft marker is not
+swept away mid-count.
+
+Mirrors the fail-safe philosophy of ``sharing_state``: a Qdrant error never aborts
+ingest — a failed lookup degrades to "process normally", a failed write is logged,
+not raised.
 
 TODO(deck-349): a marker for a file that is dead-lettered and *then* deleted from
 Nextcloud can be orphaned. The processor's delete path clears it, but the
@@ -53,7 +68,14 @@ logger = logging.getLogger(__name__)
 
 # Payload flag distinguishing a durable dead-letter marker from an in-flight
 # placeholder (both carry is_placeholder=True to inherit the search exclusion).
+# True only when the failure is TERMINAL; a soft (still-counting) marker sets it
+# False, so every existing consumer that filters on ``dead_letter=True`` -- the
+# scanner's is_dead_lettered lookup and the dead-lettered-documents gauge --
+# keeps counting only genuinely parked documents, with no new payload index.
 DEAD_LETTER_KEY = "dead_letter"
+
+# Consecutive-failure counter carried on the marker (GH #1345).
+ATTEMPTS_KEY = "attempts"
 
 
 def _generate_dead_letter_id(doc_type: str, doc_id: str) -> str:
@@ -68,6 +90,11 @@ def _generate_dead_letter_id(doc_type: str, doc_id: str) -> str:
 
 def _dead_letter_filter(doc_id: str, doc_type: str) -> Filter:
     """Match the dead-letter marker for one document (tenant-wide, no user_id).
+
+    Matches only a TERMINAL marker (``dead_letter=True``); a soft counting marker
+    is deliberately invisible here so ``is_dead_lettered`` keeps returning False
+    while retries are still wanted. Use ``_generate_dead_letter_id`` to reach a
+    marker of either kind.
 
     Includes ``is_placeholder=True`` (redundant with ``dead_letter=True``, which
     nothing else sets) to inherit the search exclusion. Note both fields must be
@@ -86,23 +113,18 @@ def _dead_letter_filter(doc_id: str, doc_type: str) -> Filter:
     )
 
 
-async def mark_dead_letter(
+async def _upsert_marker(
     doc_id: str,
     doc_type: str,
     etag: str,
     tiers_sig: str,
     reason: str,
     *,
-    file_path: str | None = None,
+    terminal: bool,
+    attempts: int,
+    file_path: str | None,
 ) -> None:
-    """Upsert a durable dead-letter marker for a terminally-failed document.
-
-    Keyed by content (``etag``) + escalation config (``tiers_sig``); the scanner
-    skips re-queuing while both match. ``reason`` is the parse failure reason
-    (``timeout`` | ``oom`` | ``error``). Fail-safe: a Qdrant error is logged, not
-    raised — a missed mark just means the document is retried (the bounded prior
-    behaviour), never a crash.
-    """
+    """Write the (soft or terminal) marker point. Fail-safe: never raises."""
     try:
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
@@ -114,7 +136,8 @@ async def mark_dead_letter(
             "doc_id": doc_id,
             "doc_type": doc_type,
             "is_placeholder": True,
-            DEAD_LETTER_KEY: True,
+            DEAD_LETTER_KEY: terminal,
+            ATTEMPTS_KEY: attempts,
             "etag": etag,
             "tiers_sig": tiers_sig,
             "reason": reason,
@@ -136,18 +159,145 @@ async def mark_dead_letter(
             points=[point],
             wait=True,
         )
-        logger.info(
-            "Dead-lettered %s_%s (reason=%s, etag=%s)",
-            doc_type,
-            doc_id,
-            reason,
-            etag,
-        )
     except Exception as e:
         logger.warning(
             "Failed to write dead-letter marker for %s_%s: %s", doc_type, doc_id, e
         )
         # Don't raise — dead-lettering is best-effort; a miss just retries.
+
+
+async def mark_dead_letter(
+    doc_id: str,
+    doc_type: str,
+    etag: str,
+    tiers_sig: str,
+    reason: str,
+    *,
+    file_path: str | None = None,
+) -> None:
+    """Upsert a durable dead-letter marker for a terminally-failed document.
+
+    Keyed by content (``etag``) + escalation config (``tiers_sig``); the scanner
+    skips re-queuing while both match. ``reason`` is the parse failure reason
+    (``timeout`` | ``oom`` | ``error``). Fail-safe: a Qdrant error is logged, not
+    raised — a missed mark just means the document is retried (the bounded prior
+    behaviour), never a crash.
+
+    Terminal on the first call: a hard parse failure at the deepest available
+    tier defeats a retry by construction. Repeatable *index* failures go through
+    :func:`record_index_failure` instead, which parks the document only after a
+    threshold. Overwrites any soft marker that path had left behind.
+    """
+    await _upsert_marker(
+        doc_id,
+        doc_type,
+        etag,
+        tiers_sig,
+        reason,
+        terminal=True,
+        attempts=1,
+        file_path=file_path,
+    )
+    logger.info(
+        "Dead-lettered %s_%s (reason=%s, etag=%s)",
+        doc_type,
+        doc_id,
+        reason,
+        etag,
+    )
+
+
+async def record_index_failure(
+    doc_id: str,
+    doc_type: str,
+    etag: str,
+    tiers_sig: str,
+    reason: str,
+    *,
+    file_path: str | None = None,
+) -> bool:
+    """Count one failed index attempt; dead-letter once the limit is reached.
+
+    The GH #1345 path. Unlike a parse failure, an embed/Qdrant/transport failure
+    is assumed transient at first — parking on the first one would drop every
+    in-flight document during a backend outage. So the count is kept on the
+    marker and the document is parked only at
+    ``VECTOR_SYNC_MAX_INDEX_FAILURES``; below that the marker stays soft and the
+    scanner keeps re-queuing, exactly as it did before this existed.
+
+    The count is *consecutive*: a successful index or a delete clears the marker
+    (``clear_dead_letter``), and a marker whose ``etag``/``tiers_sig`` no longer
+    match is treated as a fresh start — new content deserves its own budget
+    rather than inheriting the previous version's.
+
+    Returns True when this failure parked the document (so the caller can record
+    the dead-letter metric), False while it is still being retried. Fail-safe: a
+    Qdrant read error counts the attempt as the first, which at worst delays
+    parking — it never parks a document early.
+    """
+    settings = get_settings()
+    limit = settings.vector_sync_max_index_failures
+
+    previous = 0
+    try:
+        qdrant_client = await get_qdrant_client()
+        # Fetch by deterministic point ID rather than via ``_dead_letter_filter``:
+        # that filter matches terminal markers only, and a lookup by ID needs no
+        # payload index at all.
+        points = await qdrant_client.retrieve(
+            collection_name=settings.get_collection_name(),
+            ids=[_generate_dead_letter_id(doc_type, doc_id)],
+            with_payload=True,
+            with_vectors=False,
+        )
+        if points:
+            payload = dict(points[0].payload or {})
+            if payload.get("etag") == etag and payload.get("tiers_sig") == tiers_sig:
+                stored = payload.get(ATTEMPTS_KEY)
+                # A marker written before this field existed counts as one prior
+                # attempt rather than zero — it only ever recorded a failure.
+                previous = stored if isinstance(stored, int) else 1
+    except Exception as e:
+        logger.warning(
+            "Index-failure lookup failed for %s_%s (%s); counting as the first",
+            doc_type,
+            doc_id,
+            e,
+        )
+
+    attempts = previous + 1
+    terminal = attempts >= limit
+    await _upsert_marker(
+        doc_id,
+        doc_type,
+        etag,
+        tiers_sig,
+        reason,
+        terminal=terminal,
+        attempts=attempts,
+        file_path=file_path,
+    )
+    if terminal:
+        logger.warning(
+            "Dead-lettered %s_%s after %s consecutive index failures "
+            "(reason=%s, etag=%s); it will not be re-queued until its content or "
+            "the escalation-tier set changes",
+            doc_type,
+            doc_id,
+            attempts,
+            reason,
+            etag,
+        )
+    else:
+        logger.info(
+            "Index failure %s/%s for %s_%s (reason=%s); will retry",
+            attempts,
+            limit,
+            doc_type,
+            doc_id,
+            reason,
+        )
+    return terminal
 
 
 async def is_dead_lettered(
@@ -194,6 +344,12 @@ async def is_dead_lettered(
 async def clear_dead_letter(doc_id: str, doc_type: str) -> None:
     """Delete a document's dead-letter marker (on successful index / release).
 
+    Clears BOTH kinds — a terminal marker and a soft counting one. Deleting by
+    deterministic point ID rather than by ``_dead_letter_filter`` is what makes
+    that true (the filter matches ``dead_letter=True`` only); it is also cheaper,
+    and needs no payload index. This is what makes ``record_index_failure``'s
+    count consecutive: one success resets the budget.
+
     Idempotent and fail-safe: deleting a non-existent marker is a Qdrant no-op,
     and an error is logged rather than raised so it never breaks the indexing
     path that calls it.
@@ -203,7 +359,9 @@ async def clear_dead_letter(doc_id: str, doc_type: str) -> None:
         settings = get_settings()
         await qdrant_client.delete(
             collection_name=settings.get_collection_name(),
-            points_selector=_dead_letter_filter(doc_id, doc_type),
+            points_selector=models.PointIdsList(
+                points=[_generate_dead_letter_id(doc_type, doc_id)]
+            ),
         )
         logger.debug("Cleared dead-letter marker for %s_%s", doc_type, doc_id)
     except Exception as e:

--- a/nextcloud_mcp_server/vector/dead_letter.py
+++ b/nextcloud_mcp_server/vector/dead_letter.py
@@ -256,9 +256,13 @@ async def record_index_failure(
     failures for the same document can both read ``attempts=N`` and both write
     ``N+1``, undercounting by one — and that is reachable in normal operation,
     since a file shared by N users produces N tasks for the same ``doc_id``. The
-    consequence is the safe direction: parking is delayed by a round, never
-    triggered early. Qdrant offers no payload-level CAS to close it with, and
-    trading a lost round for that machinery is not worth it.
+    write is also last-write-wins on a deterministic point ID, so a straggling
+    task holding a stale pre-terminal count can overwrite an already-terminal
+    marker back to ``dead_letter=False`` shortly after it parked. Both land in
+    the same safe direction — parking is delayed by a round, never triggered
+    early — and the straggler's own next round re-parks it. Qdrant offers no
+    payload-level CAS to close either with, and trading a lost round for that
+    machinery is not worth it.
     """
     settings = get_settings()
     limit = settings.vector_sync_max_index_failures

--- a/nextcloud_mcp_server/vector/placeholder.py
+++ b/nextcloud_mcp_server/vector/placeholder.py
@@ -397,10 +397,14 @@ async def sweep_orphan_placeholders(
         for point in points:
             payload = point.payload or {}
             # Dead-letter markers (vector/dead_letter.py) reuse is_placeholder=True
-            # for the search exclusion but are DURABLE terminal-state records, not
+            # for the search exclusion but are DURABLE failure records, not
             # in-flight placeholders -- they carry no/foreign instance_id and must
-            # survive a Pod restart, so never sweep them as orphans.
-            if payload.get("dead_letter") is True:
+            # survive a Pod restart, so never sweep them as orphans. Keyed on the
+            # field's PRESENCE, not its value: a soft marker still counting index
+            # failures towards VECTOR_SYNC_MAX_INDEX_FAILURES carries
+            # dead_letter=False, and sweeping it would reset the count on every
+            # Pod restart and restore the GH #1345 infinite retry loop.
+            if payload.get("dead_letter") is not None:
                 # Tenant-wide and always kept (not Pod-scoped); counted under
                 # ``kept`` only because the sweep's tally has no separate bucket.
                 kept += 1

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -2305,17 +2305,6 @@ async def _index_document_inner(
             )
         )
 
-    # A successful (re-)index supersedes any prior terminal failure: clear a
-    # stale dead-letter marker (e.g. the file was fixed/replaced, or a new
-    # escalation tier finally parsed it) so it isn't left behind. Only files are
-    # ever dead-lettered, and only with a non-empty etag (is_dead_lettered
-    # early-returns without one), so skip the extra Qdrant round-trip otherwise.
-    # Cleared before the real-chunk upsert below: if that upsert then fails
-    # transiently, the document is re-queued and re-parses once on the next scan
-    # (an extra parse, never a silent drop) -- the safe ordering.
-    if doc_task.doc_type == "file" and doc_task.etag:
-        await clear_dead_letter(doc_task.doc_id, doc_task.doc_type)
-
     # Delete placeholder before writing real vectors
     # This prevents duplicates and cleans up the placeholder state
     try:
@@ -2360,6 +2349,27 @@ async def _index_document_inner(
                     batch_start // BATCH_SIZE + 1,
                     (len(points) + BATCH_SIZE - 1) // BATCH_SIZE,
                 )
+
+    # A successful (re-)index supersedes any prior failure record: clear the
+    # marker (e.g. the file was fixed/replaced, or a new escalation tier finally
+    # parsed it) so it isn't left behind. Only files are ever dead-lettered, and
+    # only with a non-empty etag (is_dead_lettered early-returns without one), so
+    # skip the extra Qdrant round-trip otherwise.
+    #
+    # Must run AFTER the upsert loop, not before it (GH #1345). The marker now
+    # also carries the consecutive-index-failure counter, and clear_dead_letter
+    # deletes by point ID -- so clearing first meant a persistently-failing
+    # upsert wiped its own count every round: `attempts` was rewritten to 1 each
+    # time, never reached VECTOR_SYNC_MAX_INDEX_FAILURES, and the document was
+    # re-queued forever. Exactly the case parking exists for.
+    #
+    # The old ordering existed so a stale TERMINAL marker could not block a
+    # re-queue if the upsert then failed. That is still safe here: on failure
+    # record_index_failure upserts the same point ID, overwriting any stale
+    # terminal marker with a soft one, so the document stays retryable either
+    # way.
+    if doc_task.doc_type == "file" and doc_task.etag:
+        await clear_dead_letter(doc_task.doc_id, doc_task.doc_type)
 
     logger.info(
         "Indexed %s_%s for %s (%s chunks)",

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -60,6 +60,7 @@ from nextcloud_mcp_server.vector.collection_metadata import build_embedding_iden
 from nextcloud_mcp_server.vector.dead_letter import (
     clear_dead_letter,
     mark_dead_letter,
+    record_index_failure,
 )
 from nextcloud_mcp_server.vector.document_chunker import (
     ChunkWithPosition,
@@ -766,6 +767,14 @@ async def process_document(
     5×3=15 provider calls (~90s wall-clock) before the document is dropped and
     re-picked on the next scan; the procrastinate path (max_retries=1) caps it at
     one outer attempt (~30s) and defers. Don't stack a third retry layer here.
+
+    Bounding the re-queue (GH #1345): being re-picked by the next scan is what
+    lets a transient outage recover, but on its own it never terminates — a
+    document that fails every round is re-downloaded and re-parsed forever. So
+    exhausting ``max_retries`` also records a consecutive-failure count against
+    the document's content version (``dead_letter.record_index_failure``), and the
+    document is dead-lettered once it reaches ``VECTOR_SYNC_MAX_INDEX_FAILURES``.
+    A successful index clears the count, so this bounds only *persistent* failure.
     """
     # EscalateError and BatchPending are control-flow signals that arise ONLY on
     # the per-tier external path (tier set). Bind them lazily here, and only when a
@@ -952,12 +961,38 @@ async def process_document(
                         # to mcp_qdrant_operations_total{error} would inflate that
                         # signal. The cause is captured by record_ingest_dropped
                         # instead, and the processing-error metric is recorded
-                        # once by the outer handler below (no double-count). The
-                        # document is NOT marked failed, so the next scan re-picks
-                        # it (re-queue via the scan loop, card 309).
+                        # once by the outer handler below (no double-count).
                         if reason == "qdrant":
                             record_qdrant_operation("upsert", "error")
                         record_ingest_dropped(reason)
+                        # The document is re-queued by the next scan (card 309) --
+                        # correct for a transient backend outage, but unbounded on
+                        # its own: a document that fails EVERY round loops forever,
+                        # re-downloading and re-parsing each time (GH #1345). Count
+                        # consecutive failures per content-version and park it once
+                        # the budget is spent. Clearing on success (see
+                        # _index_document) is what keeps the count consecutive, so
+                        # an outage that recovers costs no document. Files only:
+                        # the marker is content-addressed by etag, which other doc
+                        # types don't carry.
+                        if doc_task.doc_type == "file" and doc_task.etag:
+                            # Lazy import for the #877 invariant: the document
+                            # stack must stay off processor.py's module load path,
+                            # and this is a file-only, failure-only branch.
+                            from nextcloud_mcp_server.document_processors.escalation import (  # noqa: PLC0415
+                                escalation_tiers_signature,
+                            )
+
+                            parked = await record_index_failure(
+                                doc_task.doc_id,
+                                doc_task.doc_type,
+                                doc_task.etag,
+                                escalation_tiers_signature(get_settings()),
+                                reason,
+                                file_path=doc_task.file_path,
+                            )
+                            if parked:
+                                record_document_dead_lettered(reason)
                         raise
 
         except Exception as e:

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -972,9 +972,15 @@ async def process_document(
                         # consecutive failures per content-version and park it once
                         # the budget is spent. Clearing on success (see
                         # _index_document) is what keeps the count consecutive, so
-                        # an outage that recovers costs no document. Files only:
-                        # the marker is content-addressed by etag, which other doc
-                        # types don't carry.
+                        # an outage that recovers costs no document.
+                        #
+                        # Files only (card 1061): the marker is content-addressed
+                        # by etag, and DocumentTask.etag is None for every non-file
+                        # producer (scanner.py) -- without a version token a marker
+                        # could never be invalidated when the document changes. So a
+                        # note/calendar/deck_card that fails persistently is still
+                        # re-queued forever; widening this needs a per-doc_type
+                        # version token, tracked on that card.
                         if doc_task.doc_type == "file" and doc_task.etag:
                             # Lazy import for the #877 invariant: the document
                             # stack must stay off processor.py's module load path,

--- a/tests/unit/vector/test_dead_letter.py
+++ b/tests/unit/vector/test_dead_letter.py
@@ -266,6 +266,27 @@ class TestRecordIndexFailure:
         client.upsert.side_effect = RuntimeError("qdrant down")
         await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
 
+    async def test_a_qdrant_outage_cannot_park_anything(self, client) -> None:
+        """The counter lives in the store whose availability it is judging.
+
+        This is the load-bearing safety property for a Qdrant outage: the
+        marker read AND write both go to Qdrant, so while Qdrant is down the
+        count cannot advance and no document can be parked. Without it, a
+        >(limit x scan_interval) outage would park every in-flight document,
+        and they would stay parked until their etag changed — i.e. never, for a
+        static corpus.
+
+        Asserted across more rounds than the limit, since one swallowed failure
+        would pass by accident.
+        """
+        client.retrieve.side_effect = RuntimeError("qdrant down")
+        client.upsert.side_effect = RuntimeError("qdrant down")
+
+        limit = _Settings.vector_sync_max_index_failures
+        for _ in range(limit + 2):
+            parked = await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+            assert parked is False
+
     async def test_parked_marker_is_visible_to_is_dead_lettered(self, client) -> None:
         # End-to-end on the payload contract: what record_index_failure writes at
         # the limit is exactly what the scanner's lookup treats as parked.

--- a/tests/unit/vector/test_dead_letter.py
+++ b/tests/unit/vector/test_dead_letter.py
@@ -28,6 +28,8 @@ _COLLECTION = "test_collection"
 class _Settings:
     # The dense slot is always sized from the embedding provider (no keyword
     # branch anymore); the embedding service stub in the fixture returns dim=4.
+    vector_sync_max_index_failures = 3
+
     def get_collection_name(self) -> str:
         return _COLLECTION
 
@@ -46,6 +48,7 @@ def client(monkeypatch) -> AsyncMock:
     """
     qc = AsyncMock()
     qc.scroll.return_value = ([], None)
+    qc.retrieve.return_value = []
     monkeypatch.setattr(dl, "get_qdrant_client", AsyncMock(return_value=qc))
     monkeypatch.setattr(dl, "get_settings", lambda: _Settings())
     monkeypatch.setattr(
@@ -163,14 +166,110 @@ class TestIsDeadLettered:
 
 
 class TestClearDeadLetter:
-    async def test_deletes_by_marker_filter(self, client) -> None:
+    async def test_deletes_by_point_id(self, client) -> None:
+        # By ID, not by _dead_letter_filter: that filter matches dead_letter=True
+        # only, so a filter-based delete would leave a SOFT counting marker behind
+        # and the consecutive-failure count would never reset on success.
         await dl.clear_dead_letter("520189", "file")
         client.delete.assert_awaited_once()
-        flt = client.delete.await_args.kwargs["points_selector"]
-        conds = _must_conditions(flt)
-        assert conds[dl.DEAD_LETTER_KEY] is True
-        assert conds["doc_id"] == "520189"
+        selector = client.delete.await_args.kwargs["points_selector"]
+        assert selector.points == [dl._generate_dead_letter_id("file", "520189")]
 
     async def test_failure_is_swallowed(self, client) -> None:
         client.delete.side_effect = RuntimeError("qdrant down")
         await dl.clear_dead_letter("520189", "file")
+
+
+class TestRecordIndexFailure:
+    """GH #1345: bound the scanner's re-queue of a persistently failing document.
+
+    ``_Settings.vector_sync_max_index_failures`` is 3 in these tests.
+    """
+
+    def _marker(self, attempts, etag="e1", tiers_sig="sig1") -> SimpleNamespace:
+        payload = {
+            "doc_id": "520189",
+            dl.DEAD_LETTER_KEY: False,
+            "etag": etag,
+            "tiers_sig": tiers_sig,
+        }
+        if attempts is not None:
+            payload[dl.ATTEMPTS_KEY] = attempts
+        return _point(payload)
+
+    def _written(self, client) -> dict:
+        return client.upsert.await_args.kwargs["points"][0].payload
+
+    async def test_first_failure_writes_a_soft_marker(self, client) -> None:
+        parked = await dl.record_index_failure(
+            "520189", "file", "e1", "sig1", "timeout"
+        )
+        assert parked is False
+        payload = self._written(client)
+        assert payload[dl.ATTEMPTS_KEY] == 1
+        # Soft: is_dead_lettered filters on dead_letter=True, so the scanner keeps
+        # re-queuing — a transient outage must still recover on its own.
+        assert payload[dl.DEAD_LETTER_KEY] is False
+
+    async def test_counts_up_without_parking(self, client) -> None:
+        client.retrieve.return_value = [self._marker(1)]
+        parked = await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        assert parked is False
+        assert self._written(client)[dl.ATTEMPTS_KEY] == 2
+
+    async def test_parks_at_the_limit(self, client) -> None:
+        client.retrieve.return_value = [self._marker(2)]
+        parked = await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        assert parked is True
+        payload = self._written(client)
+        assert payload[dl.ATTEMPTS_KEY] == 3
+        assert payload[dl.DEAD_LETTER_KEY] is True
+
+    async def test_etag_change_restarts_the_budget(self, client) -> None:
+        client.retrieve.return_value = [self._marker(2, etag="old")]
+        # New content deserves its own budget rather than inheriting the previous
+        # version's — otherwise an edit one failure short of the limit is parked
+        # on its first attempt.
+        parked = await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        assert parked is False
+        assert self._written(client)[dl.ATTEMPTS_KEY] == 1
+
+    async def test_tiers_sig_change_restarts_the_budget(self, client) -> None:
+        client.retrieve.return_value = [self._marker(2, tiers_sig="ocr=0")]
+        parked = await dl.record_index_failure("520189", "file", "e1", "ocr=1", "x")
+        assert parked is False
+        assert self._written(client)[dl.ATTEMPTS_KEY] == 1
+
+    async def test_legacy_marker_without_attempts_counts_as_one(self, client) -> None:
+        # A marker written before ATTEMPTS_KEY existed still recorded a failure,
+        # so it counts as one prior attempt rather than zero.
+        client.retrieve.return_value = [self._marker(None)]
+        await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        assert self._written(client)[dl.ATTEMPTS_KEY] == 2
+
+    async def test_retrieve_error_counts_as_the_first(self, client) -> None:
+        client.retrieve.side_effect = RuntimeError("qdrant down")
+        # Fail-safe: at worst this delays parking; it must never park early.
+        parked = await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        assert parked is False
+        assert self._written(client)[dl.ATTEMPTS_KEY] == 1
+
+    async def test_retrieves_by_point_id(self, client) -> None:
+        await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        # By ID, so no payload index is needed and a SOFT marker is reachable
+        # (_dead_letter_filter matches dead_letter=True only).
+        assert client.retrieve.await_args.kwargs["ids"] == [
+            dl._generate_dead_letter_id("file", "520189")
+        ]
+
+    async def test_upsert_failure_is_swallowed(self, client) -> None:
+        client.upsert.side_effect = RuntimeError("qdrant down")
+        await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+
+    async def test_parked_marker_is_visible_to_is_dead_lettered(self, client) -> None:
+        # End-to-end on the payload contract: what record_index_failure writes at
+        # the limit is exactly what the scanner's lookup treats as parked.
+        client.retrieve.return_value = [self._marker(2)]
+        await dl.record_index_failure("520189", "file", "e1", "sig1", "x")
+        client.scroll.return_value = ([_point(self._written(client))], None)
+        assert await dl.is_dead_lettered("520189", "file", "e1", "sig1") is True

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -15,6 +15,7 @@ The sweep contract this file pins:
 * placeholder with **absent** ``instance_id`` → deleted
   (back-compat for placeholders written by pre-fix Pod versions)
 * placeholder with ``instance_id == _INSTANCE_ID`` → kept
+* dead-letter marker (``dead_letter`` present, True OR False) → kept
 * empty / no-results scroll → no-op (no spurious delete call)
 * multi-page scroll → all pages visited, deletes batched per page
 """
@@ -121,6 +122,38 @@ async def test_keeps_dead_letter_markers(monkeypatch):
     marker = SimpleNamespace(
         id="dl-1",
         payload={"is_placeholder": True, "dead_letter": True, "instance_id": "pod-old"},
+    )
+    client = _make_client([([marker], None)])
+
+    swept, kept = await sweep_orphan_placeholders(client, "nextcloud_content")
+
+    assert (swept, kept) == (0, 1)
+    client.delete.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_keeps_soft_dead_letter_markers(monkeypatch):
+    """A SOFT marker (``dead_letter=False``) must survive the sweep too.
+
+    GH #1345 added a consecutive-index-failure counter carried on the same
+    marker point, which stays ``dead_letter=False`` until the failure count
+    reaches the limit. The carve-out therefore keys off the field's PRESENCE,
+    not its value — sweeping a soft marker would reset the failure budget on
+    every Pod restart and restore the infinite retry loop the counter exists to
+    stop.
+
+    This is the case a future refactor is most likely to break, because
+    ``dead_letter is True`` reads more intuitively than ``is not None``.
+    """
+    monkeypatch.setattr(placeholder_module, "_INSTANCE_ID", "pod-new")
+    marker = SimpleNamespace(
+        id="dl-soft-1",
+        payload={
+            "is_placeholder": True,
+            "dead_letter": False,
+            "attempts": 2,
+            "instance_id": "pod-old",
+        },
     )
     client = _make_client([([marker], None)])
 

--- a/tests/unit/vector/test_processor_dead_letter.py
+++ b/tests/unit/vector/test_processor_dead_letter.py
@@ -519,3 +519,72 @@ async def test_buffered_fallback_cleans_up_its_temp_file(mocker):
     assert materialised, "the parse stub should have materialised the source"
     for path in materialised:
         assert not path.exists(), f"leaked temp file for the buffered path: {path}"
+
+
+class TestIndexFailureIsBounded:
+    """GH #1345: a document that fails INDEXING must not be re-queued forever.
+
+    The reported symptom was a 206-page PDF re-parsed 45 times in one morning:
+    the embedding provider timed out, ``process_document`` exhausted its retries
+    and re-raised without marking the document, and the scanner re-picked it
+    every cycle. Parsing succeeded every time — so the terminal-parse-failure
+    dead-letter above never applied.
+    """
+
+    def _patch(self, mocker, *, exc: BaseException):
+        mocker.patch.object(
+            processor, "get_settings", lambda: _settings(ocr_enabled=False)
+        )
+        mocker.patch.object(processor, "get_qdrant_client", AsyncMock())
+        mocker.patch.object(
+            processor, "allowed_doc_types", AsyncMock(return_value=None)
+        )
+        mocker.patch.object(processor, "_index_document", AsyncMock(side_effect=exc))
+        return SimpleNamespace(
+            record=mocker.patch.object(
+                processor, "record_index_failure", AsyncMock(return_value=False)
+            ),
+            dead_metric=mocker.patch.object(processor, "record_document_dead_lettered"),
+            dropped=mocker.patch.object(processor, "record_ingest_dropped"),
+        )
+
+    async def test_exhausted_retries_record_a_bounded_failure(self, mocker):
+        import httpx
+
+        spies = self._patch(mocker, exc=httpx.ReadTimeout(""))
+
+        with pytest.raises(httpx.ReadTimeout):
+            await processor.process_document(_file_task(), _nc_client(), max_retries=1)
+
+        spies.dropped.assert_called_once_with("timeout")
+        spies.record.assert_awaited_once()
+        args = spies.record.await_args.args
+        assert args[0] == "520189" and args[1] == "file"
+        assert args[2] == "etag-1"  # content-addressed, like the parse path
+        assert "ocr=0" in args[3]  # tiers_sig
+        assert args[4] == "timeout"  # drop reason
+        # Still below the limit -> not parked, so no dead-letter metric.
+        spies.dead_metric.assert_not_called()
+
+    async def test_metric_fires_when_the_failure_parks_the_document(self, mocker):
+        import httpx
+
+        spies = self._patch(mocker, exc=httpx.ConnectError(""))
+        spies.record.return_value = True  # this failure hit the limit
+
+        with pytest.raises(httpx.ConnectError):
+            await processor.process_document(_file_task(), _nc_client(), max_retries=1)
+
+        spies.dead_metric.assert_called_once_with("connection")
+
+    async def test_document_without_an_etag_is_not_counted(self, mocker):
+        import httpx
+
+        spies = self._patch(mocker, exc=httpx.ReadTimeout(""))
+        task = _file_task()
+        task.etag = ""  # nothing to content-address the marker with
+
+        with pytest.raises(httpx.ReadTimeout):
+            await processor.process_document(task, _nc_client(), max_retries=1)
+
+        spies.record.assert_not_awaited()


### PR DESCRIPTION
Fixes the retry loop reported in #1345. First of two PRs; the sibling fixes the failure that was being retried.

## Problem

A document whose **indexing** fails — as opposed to its **parsing** — is re-queued by the scanner forever.

`process_document` exhausts its in-process retries, re-raises, and deliberately leaves the document unmarked so the next scan re-picks it (card 309). That is what lets a transient backend outage recover, but on its own it never terminates. The reporter's 206-page PDF was re-downloaded, re-parsed (twice per round — it escalates) and re-embedded 45 times in one morning.

The only `mark_dead_letter` call site in the codebase was the terminal *parse* failure branch, so an embed / Qdrant / transport failure had no terminal state at all. The comment claiming a failed embedding endpoint "raises out of `generate_dense_embeddings` into `process_document`'s retry/**dead-letter** path" described a path that did not exist.

## Approach

Count consecutive index failures on the existing content-addressed marker and park the document once `VECTOR_SYNC_MAX_INDEX_FAILURES` (default 5) is reached.

- **`record_index_failure`** bumps an `attempts` field on the marker — keyed by `etag` + tiers signature exactly as before — and flips `dead_letter` to `True` at the limit. Below the limit the marker is *soft* (`dead_letter=False`), invisible to `is_dead_lettered`, so retries continue exactly as they do today. Parking on the first failure would drop every in-flight document during a backend outage, which is precisely what card 309 set out to avoid.
- **The count is consecutive, not cumulative.** `clear_dead_letter` — already called on a successful index and on delete — now deletes by point ID rather than by `_dead_letter_filter`, so it clears a soft marker too. An outage that recovers therefore costs no document.
- **The orphan-placeholder sweep** keys off the *presence* of the `dead_letter` field rather than its value. Sweeping a soft marker would reset the budget on every Pod restart and restore the loop.

A marker whose `etag`/`tiers_sig` no longer match is treated as a fresh start: new content deserves its own budget rather than inheriting the previous version's.

### Why no new payload index

Reading and clearing by deterministic point ID needs no index at all, and the two existing `dead_letter=True` filters — the scanner's `is_dead_lettered` lookup and the dead-lettered-documents gauge — keep matching only genuinely parked documents. So this adds a payload field, not an index migration.

## Test coverage

`tests/unit/vector/test_dead_letter.py` — counter increments, parking at the limit, etag change and tiers-sig change each restarting the budget, a legacy marker without the field counting as one prior attempt, `retrieve` failure counting as the first attempt (never parking early), clear-by-ID, and an end-to-end check that what is written at the limit is what `is_dead_lettered` treats as parked.

`tests/unit/vector/test_processor_dead_letter.py::TestIndexFailureIsBounded` — the exhausted-retry branch records the failure with the right content address and reason, the dead-letter metric fires only when the document is actually parked, and a document with no etag is not counted.

**API surface:** none. No MCP tool, HTTP route, or cross-service boundary changes, so no e2e/contract tier applies.

## Notes

`VECTOR_SYNC_MAX_INDEX_FAILURES` is documented in `docs/configuration.md`. Setting it to `1` restores immediate parking on the first exhausted-retry round.

Deck: [board 12 / card 1056](https://cloud.coutinho.io/index.php/apps/deck/board/12/card/1056)

---

_This PR was generated with the help of AI, and reviewed by a Human_


---

## Update: Qdrant-outage safety, and two tracked gaps

Audited this change against a Qdrant outage, since parking is only safe if a *global* fault can't trigger it.

**It's safe, structurally.** The counter lives in the very store whose availability it is judging — during a Qdrant outage both the marker read and the marker write fail, so the count cannot advance and nothing is parked. That was a happy consequence of the fail-safe error handling rather than a stated property, so it is now asserted by `test_a_qdrant_outage_cannot_park_anything` (run across more rounds than the limit, so a single swallowed failure can't pass by accident) and explained in `record_index_failure`'s docstring. A later refactor "fixing" those swallowed errors into a counting fallback would silently reintroduce an outage bug, and the test is there to catch that.

Two gaps found in the same audit, both tracked rather than left silent:

**1. The symmetry does not hold for the embedding backend** — [board 12 / card 1059](https://cloud.coutinho.io/index.php/apps/deck/board/12/card/1059). An Ollama/gateway outage leaves Qdrant healthy, so marker writes succeed, the count advances, and an outage longer than `limit x VECTOR_SYNC_SCAN_INTERVAL` (25 min on the defaults) parks every in-flight document — which then stay parked until their etag changes, i.e. never for a static corpus. That is the card-309 scenario this behaviour was meant to survive.

Documented in the code as a known asymmetry rather than papered over. The candidate fix is a TTL on index-failure markers (`failed_at` is already on the payload, so `is_dead_lettered` needs one comparison), which would make the parked state self-healing for *every* global-fault scenario. Deliberately not done here: it changes the durability semantics of the marker and deserves its own review rather than riding along on the bug fix.

**2. Qdrant runtime operations have no transient retry at all** — [board 12 / card 1060](https://cloud.coutinho.io/index.php/apps/deck/board/12/card/1060). Startup init is covered (`QDRANT_INIT_MAX_ATTEMPTS`, 30 attempts with jitter), but every runtime `upsert`/`scroll`/`count`/`delete`/`search` is a single-shot call — `AsyncQdrantClient` gets no retry config and qdrant-client's REST transport doesn't retry on its own. Same gap `OllamaProvider` had. Out of scope here because several of those call sites already sit inside a retry loop and the right fix is one layer per path, not a third nested one.
