### PR TITLE
feat(talk): add conversation, participant and reaction tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1512,8 +1512,22 @@ from nextcloud_mcp_server.capabilities import require_capability
 async def deck_assign_dependent_card(ctx: Context, ...): ...
 ```
 
+Where the app publishes a feature flag, gate on that instead — it states what
+the tool needs, checked against what the instance says about itself rather than
+against a version floor someone has to look up and keep correct:
+
+```python
+@mcp.tool()
+@require_capability("spreed", feature="reactions")
+async def talk_react(ctx: Context, ...): ...
+```
+
 `app` is the OCS capability key (the app id for most apps — Talk's is `spreed`),
-and `min_version` is compared against the `version` the app advertises. Whole-app
+`min_version` is compared against the `version` the app advertises, and
+`feature` must appear in its advertised `features` list. Both may be given
+together, in which case both must hold. Each check is independently fail-open:
+an app that advertises no `version`, or no readable `features`, is not gated on
+that condition. Whole-app
 presence gates are applied automatically from `APP_CAPABILITY_KEY` in
 `nextcloud_mcp_server/server/__init__.py`; only add an app there after confirming
 it publishes a capability block, because a missing key is what closes the gate.

--- a/nextcloud_mcp_server/capabilities.py
+++ b/nextcloud_mcp_server/capabilities.py
@@ -168,7 +168,8 @@ def clear_cache() -> None:
 # Per-tool capability gates
 # ---------------------------------------------------------------------------
 
-#: Where the gate is stashed on a tool function: ``(app, min_version | None)``.
+#: Where the gate is stashed on a tool function:
+#: ``(app, min_version | None, feature | None)``.
 #: Mirrors ``_required_scopes`` in auth/scope_authorization.py — metadata on the
 #: function, read back at ``tools/list`` / ``tools/call`` time. ``functools.wraps``
 #: copies ``__dict__``, so this survives (and composes with) ``@require_scopes``
@@ -176,12 +177,20 @@ def clear_cache() -> None:
 _GATE_ATTR = "_required_capability"
 
 
-def require_capability(app: str, min_version: str | None = None) -> Callable:
+def require_capability(
+    app: str, min_version: str | None = None, feature: str | None = None
+) -> Callable:
     """Gate an MCP tool on what the upstream Nextcloud app advertises.
 
     ``app`` is the OCS capability key (the app id for most apps — note Talk's is
     ``spreed``). With ``min_version`` the app must also advertise a
-    ``version`` at least that high.
+    ``version`` at least that high. With ``feature`` it must list that string
+    in its advertised ``features``.
+
+    Prefer ``feature`` where the app publishes one: it states what the tool
+    actually needs, and it is checked against what the instance says about
+    itself rather than against a version floor someone has to look up and keep
+    correct.
 
     Only use this for apps that actually publish a capability block: absence of
     the key is what closes the gate, so gating an app that advertises nothing
@@ -199,14 +208,16 @@ def require_capability(app: str, min_version: str | None = None) -> Callable:
         Version(min_version)  # fail at import on a typo'd floor, not at runtime
 
     def decorator(func: Callable) -> Callable:
-        setattr(func, _GATE_ATTR, (app, min_version))
+        setattr(func, _GATE_ATTR, (app, min_version, feature))
         return func
 
     return decorator
 
 
-def get_required_capability(func: Callable) -> tuple[str, str | None] | None:
-    """The ``(app, min_version)`` gate declared on ``func``, if any."""
+def get_required_capability(
+    func: Callable,
+) -> tuple[str, str | None, str | None] | None:
+    """The ``(app, min_version, feature)`` gate declared on ``func``, if any."""
     return getattr(func, _GATE_ATTR, None)
 
 
@@ -217,7 +228,7 @@ def stamp_required_capability(func: Callable, app: str) -> None:
     carry a stricter version floor) always wins.
     """
     if get_required_capability(func) is None:
-        setattr(func, _GATE_ATTR, (app, None))
+        setattr(func, _GATE_ATTR, (app, None, None))
 
 
 async def unmet_capability(
@@ -225,6 +236,7 @@ async def unmet_capability(
     user_id: str,
     app: str,
     min_version: str | None,
+    feature: str | None = None,
 ) -> str | None:
     """Why this instance cannot serve a tool gated on ``app``, else ``None``.
 
@@ -243,6 +255,16 @@ async def unmet_capability(
             f"the Nextcloud '{app}' app is not installed, or is not enabled "
             "for this account"
         )
+    if feature is not None:
+        advertised_features = block.get("features")
+        if isinstance(advertised_features, list) and feature not in advertised_features:
+            return (
+                f"the Nextcloud '{app}' app here does not advertise the "
+                f"'{feature}' feature"
+            )
+        # A missing or non-list ``features`` key says nothing, so it does not
+        # gate -- same fail-open rule the version check follows.
+
     if min_version is None:
         return None
 
@@ -269,7 +291,7 @@ def _gating_disabled() -> bool:
     return cfg_bool("MCP_DISABLE_CAPABILITY_GATING")
 
 
-def _tool_gate(mcp: Any, name: str) -> tuple[str, str | None] | None:
+def _tool_gate(mcp: Any, name: str) -> tuple[str, str | None, str | None] | None:
     """The gate declared by the tool registered as ``name``, if any."""
     tool = mcp._tool_manager.get_tool(name)
     return get_required_capability(tool.fn) if tool is not None else None
@@ -301,8 +323,8 @@ async def filter_by_capability(mcp: Any, tools: list) -> list:
         client, user_id = await _gate_client(mcp)
         hidden = {
             tool.name
-            for tool, (app, min_version) in gated
-            if await unmet_capability(client, user_id, app, min_version)
+            for tool, (app, min_version, feature) in gated
+            if await unmet_capability(client, user_id, app, min_version, feature)
         }
     except Exception as exc:  # noqa: BLE001 — availability beats accuracy here
         logger.warning("Capability gating skipped (%s); listing every tool", exc)

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -37,6 +37,11 @@ TalkParticipantSource = Literal[
     "users", "groups", "emails", "circles", "federated_users"
 ]
 
+#: The room types spreed accepts: 1=one-to-one, 2=group, 3=public. A ``Literal``
+#: for the same reason as the source above -- an out-of-range value is rejected
+#: by the schema rather than reaching the server as a bare 400.
+TalkRoomType = Literal[1, 2, 3]
+
 _TALK_TOKEN_RE = re.compile(r"^[A-Za-z0-9]+$")
 
 
@@ -147,7 +152,7 @@ class TalkClient(BaseNextcloudClient):
     async def create_conversation(
         self,
         *,
-        room_type: int = 2,
+        room_type: TalkRoomType = 2,
         room_name: str,
         invite: str | None = None,
     ) -> TalkConversation:

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -143,16 +143,12 @@ class TalkClient(BaseNextcloudClient):
         room_name: str,
         invite: str | None = None,
     ) -> TalkConversation:
-        """Create a new conversation (used for tests/fixtures).
+        """Create a new conversation.
 
         Args:
             room_type: 1=one-to-one, 2=group, 3=public. Defaults to 2.
             room_name: Display name (required for group/public rooms).
             invite: Optional user/group ID to invite at creation time.
-
-        This client method is not exposed as an MCP tool in the initial
-        Talk integration; it exists so integration tests can spin up
-        scratch rooms.
         """
         body: dict[str, Any] = {"roomType": room_type, "roomName": room_name}
         if invite is not None:

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -13,13 +13,15 @@ application/json`` is sent.
 
 import logging
 import re
-from typing import Any, Literal
+from typing import Any
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
 from nextcloud_mcp_server.models.talk import (
     TalkConversation,
     TalkMessage,
     TalkParticipant,
+    TalkParticipantSource,
+    TalkRoomType,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,19 +31,6 @@ logger = logging.getLogger(__name__)
 # httpx does not normalise path traversal sequences, so a pathological token
 # like ``"../foo"`` would be sent verbatim. Validate up-front for clearer
 # errors and defence-in-depth.
-#: The actor sources spreed accepts when adding a participant. A ``Literal``
-#: rather than a bare ``str`` so an unsupported source is rejected by the schema
-#: -- and shows up as an enum in the MCP tool definition -- instead of reaching
-#: the server as a bare 400 that names no field.
-TalkParticipantSource = Literal[
-    "users", "groups", "emails", "circles", "federated_users"
-]
-
-#: The room types spreed accepts: 1=one-to-one, 2=group, 3=public. A ``Literal``
-#: for the same reason as the source above -- an out-of-range value is rejected
-#: by the schema rather than reaching the server as a bare 400.
-TalkRoomType = Literal[1, 2, 3]
-
 _TALK_TOKEN_RE = re.compile(r"^[A-Za-z0-9]+$")
 
 

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -13,7 +13,7 @@ application/json`` is sent.
 
 import logging
 import re
-from typing import Any
+from typing import Any, Literal
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
 from nextcloud_mcp_server.models.talk import (
@@ -29,6 +29,14 @@ logger = logging.getLogger(__name__)
 # httpx does not normalise path traversal sequences, so a pathological token
 # like ``"../foo"`` would be sent verbatim. Validate up-front for clearer
 # errors and defence-in-depth.
+#: The actor sources spreed accepts when adding a participant. A ``Literal``
+#: rather than a bare ``str`` so an unsupported source is rejected by the schema
+#: -- and shows up as an enum in the MCP tool definition -- instead of reaching
+#: the server as a bare 400 that names no field.
+TalkParticipantSource = Literal[
+    "users", "groups", "emails", "circles", "federated_users"
+]
+
 _TALK_TOKEN_RE = re.compile(r"^[A-Za-z0-9]+$")
 
 
@@ -317,7 +325,11 @@ class TalkClient(BaseNextcloudClient):
         return [TalkParticipant(**p) for p in data]
 
     async def add_participant(
-        self, token: str, participant: str, *, source: str = "users"
+        self,
+        token: str,
+        participant: str,
+        *,
+        source: TalkParticipantSource = "users",
     ) -> None:
         """Add a participant to a group or public conversation.
 
@@ -365,6 +377,8 @@ class TalkClient(BaseNextcloudClient):
         """
         _validate_token(token)
         _validate_message_id(message_id)
+        if reaction is not None:
+            _validate_reaction(reaction)
         params = {"reaction": reaction} if reaction is not None else None
         response = await self._make_request(
             "GET",

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -142,17 +142,26 @@ class TalkClient(BaseNextcloudClient):
         self,
         *,
         room_type: TalkRoomType = 2,
-        room_name: str,
+        room_name: str | None = None,
         invite: str | None = None,
     ) -> TalkConversation:
         """Create a new conversation.
 
         Args:
             room_type: 1=one-to-one, 2=group, 3=public. Defaults to 2.
-            room_name: Display name (required for group/public rooms).
-            invite: Optional user/group ID to invite at creation time.
+            room_name: Display name. Required by spreed for group and public
+                rooms; a one-to-one room is identified by its other
+                participant, and is created without one.
+            invite: User/group ID to invite at creation time. For a one-to-one
+                room this is the other participant, and is what defines the
+                room.
         """
-        body: dict[str, Any] = {"roomType": room_type, "roomName": room_name}
+        body: dict[str, Any] = {"roomType": room_type}
+        # Omitted rather than sent empty for a one-to-one room: spreed names
+        # those after the other participant, and a blank roomName is not the
+        # same request as no roomName.
+        if room_name is not None:
+            body["roomName"] = room_name
         if invite is not None:
             body["invite"] = invite
         response = await self._make_request(

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -37,6 +37,43 @@ def _validate_token(token: str) -> None:
         raise ValueError(f"Invalid Talk conversation token: {token!r}")
 
 
+def _validate_message_id(message_id: int) -> None:
+    """Reject message ids that cannot address a message.
+
+    ``bool`` is excluded explicitly: it is an ``int`` subclass, so ``True``
+    would otherwise sail through as message id 1.
+    """
+    if isinstance(message_id, bool) or not isinstance(message_id, int):
+        raise ValueError(f"Message ID must be an integer: {message_id!r}")
+    if message_id <= 0:
+        raise ValueError(f"Message ID must be positive: {message_id}")
+
+
+def _validate_reaction(reaction: str) -> None:
+    """Reject an empty reaction before it reaches the wire.
+
+    spreed rejects these too, but with a bare 400 that says nothing about which
+    field was at fault.
+    """
+    if not reaction or not reaction.strip():
+        raise ValueError("Reaction must not be empty or whitespace-only")
+
+
+def _reaction_map(data: Any) -> dict[str, list[dict[str, Any]]]:
+    """Normalise spreed's reactions payload to a map.
+
+    An empty reaction set comes back as ``{}`` on Talk 22, but PHP serialises
+    empty maps as ``[]`` elsewhere in this API, and ``null`` shows up on some
+    error paths. All three mean "no reactions".
+    """
+    if not data:
+        return {}
+    if not isinstance(data, dict):
+        logger.warning("Unexpected reactions payload of type %s", type(data).__name__)
+        return {}
+    return data
+
+
 class TalkClient(BaseNextcloudClient):
     """Client for Nextcloud Talk (spreed) app operations."""
 
@@ -44,6 +81,7 @@ class TalkClient(BaseNextcloudClient):
 
     _ROOM_BASE = "/ocs/v2.php/apps/spreed/api/v4/room"
     _CHAT_BASE = "/ocs/v2.php/apps/spreed/api/v1/chat"
+    _REACTION_BASE = "/ocs/v2.php/apps/spreed/api/v1/reaction"
 
     def _talk_headers(self) -> dict[str, str]:
         """Standard OCS+JSON headers for spreed API calls.
@@ -281,3 +319,102 @@ class TalkClient(BaseNextcloudClient):
         )
         data = response.json()["ocs"]["data"]
         return [TalkParticipant(**p) for p in data]
+
+    async def add_participant(
+        self, token: str, participant: str, *, source: str = "users"
+    ) -> None:
+        """Add a participant to a group or public conversation.
+
+        Returns nothing: spreed answers a successful add with an empty ``data``
+        payload (verified against Talk 22.0.17), so there is no participant
+        object to hand back.
+
+        Adding someone who is already in the room succeeds as a no-op, which is
+        why the tool in front of this is marked idempotent.
+
+        Args:
+            token: Conversation token.
+            participant: Identifier to add, interpreted per ``source``.
+            source: Actor source -- ``users`` (default), ``groups``, ``emails``,
+                ``circles``, or ``federated_users``.
+
+        Raises:
+            HTTPStatusError: 404 when the participant does not exist
+                (``data.error == "new-participant"``), 400 for a one-to-one
+                room, which cannot take additional participants
+                (``data.error == "room-type"``).
+        """
+        _validate_token(token)
+        await self._make_request(
+            "POST",
+            f"{self._ROOM_BASE}/{token}/participants",
+            json={"newParticipant": participant, "source": source},
+            headers=self._talk_headers(),
+        )
+
+    # Reactions
+
+    async def list_reactions(
+        self, token: str, message_id: int, *, reaction: str | None = None
+    ) -> dict[str, list[dict[str, Any]]]:
+        """List reactions on a chat message, keyed by emoji.
+
+        Args:
+            token: Conversation token.
+            message_id: ID of the message.
+            reaction: Optional single emoji to filter to.
+
+        Returns:
+            ``{emoji: [actor, ...]}``. Empty when nothing has been reacted.
+        """
+        _validate_token(token)
+        _validate_message_id(message_id)
+        params = {"reaction": reaction} if reaction is not None else None
+        response = await self._make_request(
+            "GET",
+            f"{self._REACTION_BASE}/{token}/{message_id}",
+            params=params,
+            headers=self._talk_headers(),
+        )
+        return _reaction_map(response.json()["ocs"]["data"])
+
+    async def add_reaction(
+        self, token: str, message_id: int, reaction: str
+    ) -> dict[str, list[dict[str, Any]]]:
+        """React to a chat message, returning the message's updated reactions.
+
+        spreed answers ``201`` for a new reaction and ``200`` when the actor had
+        already reacted with that emoji -- the end state is the same either way,
+        which is why the tool is marked idempotent.
+        """
+        _validate_token(token)
+        _validate_message_id(message_id)
+        _validate_reaction(reaction)
+        response = await self._make_request(
+            "POST",
+            f"{self._REACTION_BASE}/{token}/{message_id}",
+            json={"reaction": reaction},
+            headers=self._talk_headers(),
+        )
+        return _reaction_map(response.json()["ocs"]["data"])
+
+    async def remove_reaction(
+        self, token: str, message_id: int, reaction: str
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Remove the user's reaction, returning the updated reactions.
+
+        Raises:
+            HTTPStatusError: 404 if the user has no such reaction on the
+                message. The end state matches a successful removal, but spreed
+                reports it as an error rather than a no-op.
+        """
+        _validate_token(token)
+        _validate_message_id(message_id)
+        _validate_reaction(reaction)
+        response = await self._make_request(
+            "DELETE",
+            f"{self._REACTION_BASE}/{token}/{message_id}",
+            json={"reaction": reaction},
+            headers=self._talk_headers(),
+        )
+        return _reaction_map(response.json()["ocs"]["data"])

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -170,7 +170,13 @@ class TalkClient(BaseNextcloudClient):
         return TalkConversation(**response.json()["ocs"]["data"])
 
     async def delete_conversation(self, token: str) -> None:
-        """Delete a conversation. Used by integration test cleanup."""
+        """Delete a conversation. Used by integration test cleanup.
+
+        Does not apply to one-to-one rooms: spreed answers those with 400
+        (observed on Nextcloud 32/33/34). A participant *leaves* a one-to-one
+        conversation instead, after which it becomes a "former one-to-one"
+        room -- the type 5 the conversation model documents.
+        """
         _validate_token(token)
         await self._make_request(
             "DELETE", f"{self._ROOM_BASE}/{token}", headers=self._talk_headers()

--- a/nextcloud_mcp_server/models/talk.py
+++ b/nextcloud_mcp_server/models/talk.py
@@ -111,6 +111,15 @@ class TalkParticipant(BaseModel):
     statusMessage: str | None = None
 
 
+class TalkReactionActor(BaseModel):
+    """One actor's reaction to a chat message."""
+
+    actorType: str
+    actorId: str
+    actorDisplayName: str = ""
+    timestamp: int = 0
+
+
 # Response wrappers for MCP tools
 
 
@@ -169,3 +178,50 @@ class MarkAsReadResponse(StatusResponse):
         default=None,
         description="The message ID that was marked as the last-read marker",
     )
+
+
+class CreateConversationResponse(BaseResponse):
+    """Response model returned after creating a Talk conversation."""
+
+    conversation: TalkConversation = Field(description="The created conversation")
+
+
+class AddParticipantResponse(StatusResponse):
+    """Response model returned after adding a participant.
+
+    spreed answers a successful add with an empty ``data`` payload, so there is
+    no participant object to return -- the echo of what was added is all the
+    caller gets, and is what makes the result readable.
+    """
+
+    conversation_token: str = Field(description="Token of the conversation")
+    participant: str = Field(description="Identifier of the added participant")
+    source: str = Field(description="Actor source the participant was added from")
+
+
+class ReactionsResponse(BaseResponse):
+    """Reactions on a chat message, keyed by emoji.
+
+    spreed returns a map of emoji -> list of actors. An *empty* map arrives as
+    a JSON object (``{}``) on Talk 22, but PHP serialises empty maps as ``[]``
+    elsewhere in this API, so the validator below accepts either -- see the
+    PHP empty-array quirk in CLAUDE.md.
+    """
+
+    conversation_token: str = Field(description="Token of the conversation")
+    message_id: int = Field(description="ID of the message the reactions are on")
+    reactions: dict[str, list[TalkReactionActor]] = Field(
+        default_factory=dict,
+        description="Emoji -> the actors who reacted with it",
+    )
+    total: int = Field(
+        default=0, description="Number of distinct emoji on this message"
+    )
+
+    @field_validator("reactions", mode="before")
+    @classmethod
+    def _coerce_empty_list(cls, value: Any) -> Any:
+        """Treat PHP's empty-list-for-empty-map as an empty map."""
+        if isinstance(value, list) and not value:
+            return {}
+        return value

--- a/nextcloud_mcp_server/models/talk.py
+++ b/nextcloud_mcp_server/models/talk.py
@@ -1,10 +1,22 @@
 """Pydantic models for the Nextcloud Talk (spreed) integration."""
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .base import BaseResponse, StatusResponse
+
+#: The actor sources spreed accepts when adding a participant. A ``Literal``
+#: rather than a bare ``str`` so an unsupported source is rejected by the schema
+#: -- and appears as an enum in the MCP tool definition -- instead of reaching
+#: the server as a bare 400 that names no field.
+TalkParticipantSource = Literal[
+    "users", "groups", "emails", "circles", "federated_users"
+]
+
+#: The room types spreed accepts: 1=one-to-one, 2=group, 3=public. A ``Literal``
+#: for the same reason as the source above.
+TalkRoomType = Literal[1, 2, 3]
 
 # Domain models
 
@@ -196,7 +208,9 @@ class AddParticipantResponse(StatusResponse):
 
     conversation_token: str = Field(description="Token of the conversation")
     participant: str = Field(description="Identifier of the added participant")
-    source: str = Field(description="Actor source the participant was added from")
+    source: TalkParticipantSource = Field(
+        description="Actor source the participant was added from"
+    )
 
 
 class ReactionsResponse(BaseResponse):

--- a/nextcloud_mcp_server/models/talk.py
+++ b/nextcloud_mcp_server/models/talk.py
@@ -228,8 +228,12 @@ class ReactionsResponse(BaseResponse):
         default_factory=dict,
         description="Emoji -> the actors who reacted with it",
     )
-    total: int = Field(
-        default=0, description="Number of distinct emoji on this message"
+    distinct_emoji: int = Field(
+        default=0,
+        description=(
+            "Number of distinct emoji on this message -- not the total number "
+            "of reactions, which is the sum of the actor lists."
+        ),
     )
 
     @field_validator("reactions", mode="before")

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -4,16 +4,20 @@ import logging
 import uuid
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.talk import (
+    AddParticipantResponse,
+    CreateConversationResponse,
     GetConversationResponse,
     ListConversationsResponse,
     ListMessagesResponse,
     ListParticipantsResponse,
     MarkAsReadResponse,
+    ReactionsResponse,
     SendMessageResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
@@ -222,4 +226,180 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             message="Conversation marked as read",
             conversation_token=token,
             last_read_message=last_read_message,
+        )
+
+    @mcp.tool(
+        title="Create Talk Conversation",
+        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+    )
+    @require_scopes("talk.write")
+    @instrument_tool
+    async def talk_create_conversation(
+        ctx: Context,
+        room_name: str,
+        room_type: int = 2,
+        invite: str | None = None,
+    ) -> CreateConversationResponse:
+        """Create a new Talk conversation (room).
+
+        Args:
+            room_name: Display name for the room. Required for group and
+                public rooms.
+            room_type: 2 for a group room (default), 3 for a public room.
+                Type 1 is a one-to-one room, which is created by inviting a
+                single user rather than by naming a room.
+            invite: Optional user or group ID to add at creation time. For a
+                one-to-one room this is the other participant.
+        """
+        if not room_name or not room_name.strip():
+            raise ToolError("room_name must not be empty or whitespace-only")
+
+        client = await get_client(ctx)
+        conversation = await client.talk.create_conversation(
+            room_type=room_type,
+            room_name=room_name,
+            invite=invite,
+        )
+        return CreateConversationResponse(conversation=conversation)
+
+    @mcp.tool(
+        title="Add Talk Participant",
+        annotations=ToolAnnotations(
+            # Adding someone already in the room succeeds as a no-op (verified
+            # against Talk 22.0.17), so repeating the call leaves the same state.
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("talk.write")
+    @instrument_tool
+    async def talk_add_participant(
+        ctx: Context,
+        token: str,
+        participant: str,
+        source: str = "users",
+    ) -> AddParticipantResponse:
+        """Add a participant to a group or public Talk conversation.
+
+        A one-to-one conversation cannot take additional participants -- the
+        server rejects that with a room-type error.
+
+        Args:
+            token: Conversation token.
+            participant: Identifier to add, interpreted according to `source`.
+            source: Where the identifier comes from - "users" (default),
+                "groups", "emails", "circles", or "federated_users".
+        """
+        if not participant or not participant.strip():
+            raise ToolError("participant must not be empty or whitespace-only")
+
+        client = await get_client(ctx)
+        await client.talk.add_participant(token, participant, source=source)
+        return AddParticipantResponse(
+            conversation_token=token,
+            participant=participant,
+            source=source,
+        )
+
+    @mcp.tool(
+        title="List Talk Message Reactions",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
+    @require_scopes("talk.read")
+    @instrument_tool
+    async def talk_list_reactions(
+        ctx: Context,
+        token: str,
+        message_id: int,
+        reaction: str | None = None,
+    ) -> ReactionsResponse:
+        """List the reactions on a Talk chat message, grouped by emoji.
+
+        Args:
+            token: Conversation token.
+            message_id: ID of the message to read reactions from.
+            reaction: Optional single emoji to filter to.
+        """
+        client = await get_client(ctx)
+        reactions = await client.talk.list_reactions(
+            token, message_id, reaction=reaction
+        )
+        return ReactionsResponse(
+            conversation_token=token,
+            message_id=message_id,
+            reactions=reactions,
+            total=len(reactions),
+        )
+
+    @mcp.tool(
+        title="React to Talk Message",
+        annotations=ToolAnnotations(
+            # Reactions are a set: reacting twice with the same emoji leaves the
+            # same state (spreed answers 201 then 200).
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("talk.write")
+    @instrument_tool
+    async def talk_react(
+        ctx: Context,
+        token: str,
+        message_id: int,
+        reaction: str,
+    ) -> ReactionsResponse:
+        """React to a Talk chat message with an emoji.
+
+        Returns the message's reactions after the change, so the caller does
+        not need a follow-up read.
+
+        Args:
+            token: Conversation token.
+            message_id: ID of the message to react to.
+            reaction: The emoji to react with.
+        """
+        client = await get_client(ctx)
+        reactions = await client.talk.add_reaction(token, message_id, reaction)
+        return ReactionsResponse(
+            conversation_token=token,
+            message_id=message_id,
+            reactions=reactions,
+            total=len(reactions),
+        )
+
+    @mcp.tool(
+        title="Remove Talk Message Reaction",
+        annotations=ToolAnnotations(
+            destructiveHint=True,
+            # Same end state when repeated, though the server reports the second
+            # removal as a 404 rather than a no-op.
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    @require_scopes("talk.write")
+    @instrument_tool
+    async def talk_remove_reaction(
+        ctx: Context,
+        token: str,
+        message_id: int,
+        reaction: str,
+    ) -> ReactionsResponse:
+        """Remove the user's own reaction from a Talk chat message.
+
+        Removing a reaction the user has not made is reported by the server as
+        a not-found error rather than succeeding silently.
+
+        Args:
+            token: Conversation token.
+            message_id: ID of the message to remove the reaction from.
+            reaction: The emoji to remove.
+        """
+        client = await get_client(ctx)
+        reactions = await client.talk.remove_reaction(token, message_id, reaction)
+        return ReactionsResponse(
+            conversation_token=token,
+            message_id=message_id,
+            reactions=reactions,
+            total=len(reactions),
         )

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -239,23 +239,36 @@ def configure_talk_tools(mcp: FastMCP) -> None:
     @instrument_tool
     async def talk_create_conversation(
         ctx: Context,
-        room_name: str,
+        room_name: str | None = None,
         room_type: TalkRoomType = 2,
         invite: str | None = None,
     ) -> CreateConversationResponse:
         """Create a new Talk conversation (room).
 
         Args:
-            room_name: Display name for the room. Required for group and
-                public rooms.
-            room_type: 2 for a group room (default), 3 for a public room.
-                Type 1 is a one-to-one room, which is created by inviting a
-                single user rather than by naming a room.
-            invite: Optional user or group ID to add at creation time. For a
-                one-to-one room this is the other participant.
+            room_name: Display name for the room. Required for a group (2) or
+                public (3) room. Omit it for a one-to-one room, which spreed
+                names after the other participant.
+            room_type: 2 for a group room (default), 3 for a public room, 1 for
+                a one-to-one room.
+            invite: User or group ID to add at creation time. Required for a
+                one-to-one room, where it is the other participant and is what
+                defines the room. Optional otherwise.
         """
-        if not room_name or not room_name.strip():
-            raise ToolError("room_name must not be empty or whitespace-only")
+        if room_type == 1:
+            # A one-to-one room is defined by who is in it, not by a name --
+            # spreed accepts the create with no roomName at all. Without an
+            # invite there is no second participant, so there is no room.
+            if not invite or not invite.strip():
+                raise ToolError(
+                    "invite is required for a one-to-one room (room_type=1): "
+                    "the other participant is what identifies the room"
+                )
+        elif not room_name or not room_name.strip():
+            raise ToolError(
+                f"room_name is required for room_type={room_type} and must not "
+                "be empty or whitespace-only"
+            )
 
         client = await get_client(ctx)
         conversation = await client.talk.create_conversation(

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -346,7 +346,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             conversation_token=token,
             message_id=message_id,
             reactions=reactions,
-            total=len(reactions),
+            distinct_emoji=len(reactions),
         )
 
     @mcp.tool(
@@ -383,7 +383,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             conversation_token=token,
             message_id=message_id,
             reactions=reactions,
-            total=len(reactions),
+            distinct_emoji=len(reactions),
         )
 
     @mcp.tool(
@@ -421,5 +421,5 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             conversation_token=token,
             message_id=message_id,
             reactions=reactions,
-            total=len(reactions),
+            distinct_emoji=len(reactions),
         )

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -8,6 +8,8 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.capabilities import require_capability
+from nextcloud_mcp_server.client.talk import TalkParticipantSource
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.talk import (
     AddParticipantResponse,
@@ -277,7 +279,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         ctx: Context,
         token: str,
         participant: str,
-        source: str = "users",
+        source: TalkParticipantSource = "users",
     ) -> AddParticipantResponse:
         """Add a participant to a group or public Talk conversation.
 
@@ -306,6 +308,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         title="List Talk Message Reactions",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     )
+    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.read")
     @instrument_tool
     async def talk_list_reactions(
@@ -341,6 +344,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             openWorldHint=True,
         ),
     )
+    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.write")
     @instrument_tool
     async def talk_react(
@@ -378,6 +382,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             openWorldHint=True,
         ),
     )
+    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.write")
     @instrument_tool
     async def talk_remove_reaction(

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -9,7 +9,7 @@ from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import require_capability
-from nextcloud_mcp_server.client.talk import TalkParticipantSource
+from nextcloud_mcp_server.client.talk import TalkParticipantSource, TalkRoomType
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.talk import (
     AddParticipantResponse,
@@ -239,7 +239,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
     async def talk_create_conversation(
         ctx: Context,
         room_name: str,
-        room_type: int = 2,
+        room_type: TalkRoomType = 2,
         invite: str | None = None,
     ) -> CreateConversationResponse:
         """Create a new Talk conversation (room).
@@ -308,8 +308,8 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         title="List Talk Message Reactions",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     )
-    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.read")
+    @require_capability("spreed", feature="reactions")
     @instrument_tool
     async def talk_list_reactions(
         ctx: Context,
@@ -344,8 +344,8 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             openWorldHint=True,
         ),
     )
-    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.write")
+    @require_capability("spreed", feature="reactions")
     @instrument_tool
     async def talk_react(
         ctx: Context,
@@ -382,8 +382,8 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             openWorldHint=True,
         ),
     )
-    @require_capability("spreed", feature="reactions")
     @require_scopes("talk.write")
+    @require_capability("spreed", feature="reactions")
     @instrument_tool
     async def talk_remove_reaction(
         ctx: Context,

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -9,7 +9,6 @@ from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import require_capability
-from nextcloud_mcp_server.client.talk import TalkParticipantSource, TalkRoomType
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.talk import (
     AddParticipantResponse,
@@ -21,6 +20,8 @@ from nextcloud_mcp_server.models.talk import (
     MarkAsReadResponse,
     ReactionsResponse,
     SendMessageResponse,
+    TalkParticipantSource,
+    TalkRoomType,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -299,6 +299,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
             conversation_token=token,
             participant=participant,
             source=source,
+            message=f"Added {participant} ({source}) to the conversation",
         )
 
     @mcp.tool(

--- a/tests/client/talk/test_talk_api.py
+++ b/tests/client/talk/test_talk_api.py
@@ -463,3 +463,131 @@ async def test_talk_list_participants_with_include_status(mocker):
 
     params = mock_make_request.call_args[1]["params"]
     assert params["includeStatus"] == 1
+
+
+# Participants (write) and reactions
+
+
+@pytest.mark.parametrize("bad_id", [0, -1, "3", 3.5, True, None])
+async def test_reaction_rejects_invalid_message_id(mocker, bad_id):
+    """A message id that cannot address a message is refused before the wire.
+
+    ``True`` is in the list on purpose: ``bool`` is an ``int`` subclass, so
+    without an explicit check it would be accepted as message id 1.
+    """
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+    mock_request = mocker.patch.object(TalkClient, "_make_request")
+
+    with pytest.raises(ValueError, match="Message ID"):
+        await client.list_reactions("abc123", bad_id)
+
+    mock_request.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_reaction", ["", "   "])
+async def test_reaction_rejects_blank_emoji(mocker, bad_reaction):
+    """spreed rejects these too, but with a 400 that names no field."""
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+    mock_request = mocker.patch.object(TalkClient, "_make_request")
+
+    with pytest.raises(ValueError, match="Reaction must not be empty"):
+        await client.add_reaction("abc123", 1, bad_reaction)
+
+    mock_request.assert_not_called()
+
+
+async def test_add_reaction_posts_the_emoji(mocker):
+    """POST to the reaction endpoint with the emoji in the body."""
+    response = mocker.Mock()
+    response.json.return_value = {
+        "ocs": {
+            "meta": {"statuscode": 201},
+            "data": {"🎉": [{"actorType": "users", "actorId": "alice"}]},
+        }
+    }
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    reactions = await client.add_reaction("abc123", 42, "🎉")
+
+    assert reactions == {"🎉": [{"actorType": "users", "actorId": "alice"}]}
+    args, kwargs = mock_request.call_args
+    assert args[0] == "POST"
+    assert args[1] == "/ocs/v2.php/apps/spreed/api/v1/reaction/abc123/42"
+    assert kwargs["json"] == {"reaction": "🎉"}
+
+
+async def test_remove_reaction_sends_delete_with_body(mocker):
+    """spreed takes the emoji in the body of a DELETE, not the query string."""
+    response = mocker.Mock()
+    response.json.return_value = {"ocs": {"meta": {"statuscode": 200}, "data": {}}}
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    assert await client.remove_reaction("abc123", 42, "🎉") == {}
+
+    args, kwargs = mock_request.call_args
+    assert args[0] == "DELETE"
+    assert kwargs["json"] == {"reaction": "🎉"}
+
+
+@pytest.mark.parametrize("empty", [{}, [], None])
+async def test_reaction_map_normalises_empty_payloads(mocker, empty):
+    """ "No reactions" arrives in three shapes across spreed's responses.
+
+    Talk 22 returns ``{}`` for an unreacted message, but PHP serialises empty
+    maps as ``[]`` elsewhere in this API and ``null`` shows up on error paths.
+    All three have to mean the same thing to the caller.
+    """
+    response = mocker.Mock()
+    response.json.return_value = {"ocs": {"meta": {"statuscode": 200}, "data": empty}}
+    mocker.patch.object(TalkClient, "_make_request", return_value=response)
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    assert await client.list_reactions("abc123", 1) == {}
+
+
+async def test_list_reactions_filters_by_emoji(mocker):
+    """The optional filter is passed as a query parameter, not a body field."""
+    response = mocker.Mock()
+    response.json.return_value = {"ocs": {"meta": {"statuscode": 200}, "data": {}}}
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    await client.list_reactions("abc123", 7, reaction="👍")
+
+    assert mock_request.call_args.kwargs["params"] == {"reaction": "👍"}
+
+
+async def test_add_participant_posts_participant_and_source(mocker):
+    """The participant id and its source both reach the wire."""
+    response = mocker.Mock()
+    response.json.return_value = {"ocs": {"meta": {"statuscode": 200}, "data": []}}
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    await client.add_participant("abc123", "bob", source="groups")
+
+    args, kwargs = mock_request.call_args
+    assert args[0] == "POST"
+    assert args[1] == "/ocs/v2.php/apps/spreed/api/v4/room/abc123/participants"
+    assert kwargs["json"] == {"newParticipant": "bob", "source": "groups"}
+
+
+async def test_add_participant_rejects_path_traversal_token(mocker):
+    """Token validation guards the participants path too."""
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+    mock_request = mocker.patch.object(TalkClient, "_make_request")
+
+    with pytest.raises(ValueError, match="Invalid Talk conversation token"):
+        await client.add_participant("../../admin", "bob")
+
+    mock_request.assert_not_called()

--- a/tests/client/talk/test_talk_api.py
+++ b/tests/client/talk/test_talk_api.py
@@ -591,3 +591,63 @@ async def test_add_participant_rejects_path_traversal_token(mocker):
         await client.add_participant("../../admin", "bob")
 
     mock_request.assert_not_called()
+
+
+async def test_create_one_to_one_conversation_omits_room_name(mocker):
+    """A one-to-one room is created with no roomName at all.
+
+    spreed names those after the other participant (verified against Talk
+    22.0.17), so sending a blank name is a different request from sending
+    none -- the key is omitted rather than emptied.
+    """
+    response = mocker.Mock()
+    response.json.return_value = {
+        "ocs": {
+            "meta": {"statuscode": 200},
+            "data": {
+                "id": 7,
+                "token": "abc123",
+                "type": 1,
+                "name": "bob",
+                "displayName": "Bob",
+            },
+        }
+    }
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    await client.create_conversation(room_type=1, invite="bob")
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body == {"roomType": 1, "invite": "bob"}
+    assert "roomName" not in body
+
+
+async def test_create_group_conversation_sends_room_name(mocker):
+    """The group path is unchanged: the name is still sent."""
+    response = mocker.Mock()
+    response.json.return_value = {
+        "ocs": {
+            "meta": {"statuscode": 200},
+            "data": {
+                "id": 8,
+                "token": "def456",
+                "type": 2,
+                "name": "Team",
+                "displayName": "Team",
+            },
+        }
+    }
+    mock_request = mocker.patch.object(
+        TalkClient, "_make_request", return_value=response
+    )
+    client = TalkClient(mocker.AsyncMock(), "testuser")
+
+    await client.create_conversation(room_type=2, room_name="Team")
+
+    assert mock_request.call_args.kwargs["json"] == {
+        "roomType": 2,
+        "roomName": "Team",
+    }

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -348,7 +348,11 @@ async def test_talk_create_one_to_one_conversation_without_a_name(
     assert result.isError is False, result.content[0].text
 
     conversation = json.loads(result.content[0].text)["conversation"]
-    assert conversation["room_type"] == 1
+    # The wire key is "type", not the model's "room_type": that field carries
+    # alias="type" and responses serialise by alias. Asserting the room kind --
+    # rather than only that a token came back -- is what separates a real
+    # one-to-one room from a group room that happens to contain the invitee.
+    assert conversation["type"] == 1
 
     # The other user is really in it -- a one-to-one room that did not actually
     # pair the two would still have returned a token.

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -243,7 +243,7 @@ async def test_talk_reaction_round_trip(
     assert reacted.isError is False, reacted.content[0].text
     react_payload = json.loads(reacted.content[0].text)
     assert emoji in react_payload["reactions"]
-    assert react_payload["total"] == 1
+    assert react_payload["distinct_emoji"] == 1
     assert [a["actorId"] for a in react_payload["reactions"][emoji]] == ["admin"]
 
     # Reacting again with the same emoji leaves one reaction, not two -- this
@@ -386,3 +386,49 @@ async def test_talk_create_group_room_still_requires_a_name(
 
     assert result.isError is True
     assert "room_name is required" in result.content[0].text
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        ({"message_id": 0, "reaction": "\N{PARTY POPPER}"}, "message id"),
+        ({"message_id": 1, "reaction": "   "}, "reaction must not be empty"),
+        ({"message_id": 1, "reaction": "\N{PARTY POPPER}"}, None),
+    ],
+    ids=["bad-message-id", "blank-reaction", "control-valid-args"],
+)
+async def test_client_validation_surfaces_through_mcp(
+    nc_mcp_client: ClientSession,
+    temporary_conversation: dict,
+    arguments: dict,
+    expected: str | None,
+):
+    """Client-layer ValueErrors must reach the caller as a readable tool error.
+
+    The blank-name and blank-participant paths raise `ToolError` at the tool
+    layer and were already covered. These three validators raise plain
+    `ValueError` in the client instead, and nothing asserted what that looks
+    like after FastMCP has translated it -- a readable `isError` result or an
+    opaque internal failure. The control case is included so the assertion is
+    about the *rejections* rather than about every call failing.
+    """
+    token = temporary_conversation["token"]
+
+    if expected is None:
+        # Give the control case a message that really exists to react to.
+        send = await nc_mcp_client.call_tool(
+            "talk_send_message", {"token": token, "message": "seam control"}
+        )
+        arguments = {
+            **arguments,
+            "message_id": json.loads(send.content[0].text)["message"]["id"],
+        }
+
+    result = await nc_mcp_client.call_tool("talk_react", {"token": token, **arguments})
+
+    if expected is None:
+        assert result.isError is False, result.content[0].text
+        return
+
+    assert result.isError is True
+    assert expected in result.content[0].text.lower()

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import uuid
 
 import pytest
 from mcp import ClientSession
@@ -19,11 +20,16 @@ EXPECTED_TALK_TOOLS = {
     "talk_list_participants",
     "talk_send_message",
     "talk_mark_as_read",
+    "talk_create_conversation",
+    "talk_add_participant",
+    "talk_list_reactions",
+    "talk_react",
+    "talk_remove_reaction",
 }
 
 
 async def test_talk_mcp_connectivity(nc_mcp_client: ClientSession):
-    """All six Talk tools should be registered with the MCP server."""
+    """Every Talk tool should be registered with the MCP server."""
     tools = await nc_mcp_client.list_tools()
     tool_names = {tool.name for tool in tools.tools}
 
@@ -161,3 +167,122 @@ async def test_talk_send_message_validation_too_long(
     assert result.isError is True, (
         "Expected validation error for message longer than 32000 characters"
     )
+
+
+async def test_talk_create_conversation_and_add_participant(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """Create a room through MCP, then add a participant to it.
+
+    Both halves run together because the second needs a room the first
+    produced -- and creating one via the tool is the only way to know the tool
+    returns a usable token rather than merely reporting success.
+    """
+    room_name = f"MCP Created Room {uuid.uuid4().hex[:8]}"
+    token = None
+    try:
+        create_result = await nc_mcp_client.call_tool(
+            "talk_create_conversation", {"room_name": room_name}
+        )
+        assert create_result.isError is False, create_result.content[0].text
+
+        payload = json.loads(create_result.content[0].text)
+        assert payload["success"] is True
+        conversation = payload["conversation"]
+        token = conversation["token"]
+        assert conversation["name"] == room_name
+
+        # The room is real: fetching it back through a different tool works.
+        fetched = await nc_mcp_client.call_tool(
+            "talk_get_conversation", {"token": token}
+        )
+        assert fetched.isError is False
+        assert json.loads(fetched.content[0].text)["conversation"]["token"] == token
+
+        add_result = await nc_mcp_client.call_tool(
+            "talk_add_participant", {"token": token, "participant": "admin"}
+        )
+        assert add_result.isError is False, add_result.content[0].text
+        add_payload = json.loads(add_result.content[0].text)
+        assert add_payload["success"] is True
+        assert add_payload["participant"] == "admin"
+        assert add_payload["source"] == "users"
+    finally:
+        if token:
+            await nc_client.talk.delete_conversation(token)
+
+
+async def test_talk_reaction_round_trip(
+    nc_mcp_client: ClientSession, temporary_conversation: dict
+):
+    """React to a message, see it listed, remove it, see it gone.
+
+    The whole cycle in one test because each assertion is only meaningful
+    relative to the state the previous step left behind.
+    """
+    token = temporary_conversation["token"]
+    emoji = "\N{PARTY POPPER}"
+
+    send = await nc_mcp_client.call_tool(
+        "talk_send_message", {"token": token, "message": "react to me"}
+    )
+    message_id = json.loads(send.content[0].text)["message"]["id"]
+
+    # Nothing yet.
+    listed = await nc_mcp_client.call_tool(
+        "talk_list_reactions", {"token": token, "message_id": message_id}
+    )
+    assert listed.isError is False, listed.content[0].text
+    assert json.loads(listed.content[0].text)["reactions"] == {}
+
+    # React, and get the updated set back without a follow-up read.
+    reacted = await nc_mcp_client.call_tool(
+        "talk_react",
+        {"token": token, "message_id": message_id, "reaction": emoji},
+    )
+    assert reacted.isError is False, reacted.content[0].text
+    react_payload = json.loads(reacted.content[0].text)
+    assert emoji in react_payload["reactions"]
+    assert react_payload["total"] == 1
+    assert [a["actorId"] for a in react_payload["reactions"][emoji]] == ["admin"]
+
+    # Reacting again with the same emoji leaves one reaction, not two -- this
+    # is the claim talk_react's idempotentHint makes.
+    again = await nc_mcp_client.call_tool(
+        "talk_react",
+        {"token": token, "message_id": message_id, "reaction": emoji},
+    )
+    assert again.isError is False
+    assert len(json.loads(again.content[0].text)["reactions"][emoji]) == 1
+
+    removed = await nc_mcp_client.call_tool(
+        "talk_remove_reaction",
+        {"token": token, "message_id": message_id, "reaction": emoji},
+    )
+    assert removed.isError is False, removed.content[0].text
+    assert json.loads(removed.content[0].text)["reactions"] == {}
+
+
+async def test_talk_add_participant_rejects_blank_participant(
+    nc_mcp_client: ClientSession, temporary_conversation: dict
+):
+    """A blank participant is refused before the request is built."""
+    result = await nc_mcp_client.call_tool(
+        "talk_add_participant",
+        {"token": temporary_conversation["token"], "participant": "   "},
+    )
+
+    assert result.isError is True
+    assert "whitespace" in result.content[0].text.lower()
+
+
+async def test_talk_create_conversation_rejects_blank_name(
+    nc_mcp_client: ClientSession,
+):
+    """An unnamed group room is refused locally rather than at the server."""
+    result = await nc_mcp_client.call_tool(
+        "talk_create_conversation", {"room_name": "  "}
+    )
+
+    assert result.isError is True
+    assert "whitespace" in result.content[0].text.lower()

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -341,29 +341,30 @@ async def test_talk_create_one_to_one_conversation_without_a_name(
     """
     await nc_client.users.create_user(**test_user)
     other = test_user["userid"]
-    token = None
-    try:
-        result = await nc_mcp_client.call_tool(
-            "talk_create_conversation", {"room_type": 1, "invite": other}
-        )
-        assert result.isError is False, result.content[0].text
 
-        conversation = json.loads(result.content[0].text)["conversation"]
-        token = conversation["token"]
-        assert conversation["room_type"] == 1
+    result = await nc_mcp_client.call_tool(
+        "talk_create_conversation", {"room_type": 1, "invite": other}
+    )
+    assert result.isError is False, result.content[0].text
 
-        # The other user is really in it -- a one-to-one room that did not
-        # actually pair the two would still have returned a token.
-        participants = await nc_mcp_client.call_tool(
-            "talk_list_participants", {"token": token}
-        )
-        actor_ids = {
-            p["actorId"] for p in json.loads(participants.content[0].text)["results"]
-        }
-        assert other in actor_ids
-    finally:
-        if token:
-            await nc_client.talk.delete_conversation(token)
+    conversation = json.loads(result.content[0].text)["conversation"]
+    assert conversation["room_type"] == 1
+
+    # The other user is really in it -- a one-to-one room that did not actually
+    # pair the two would still have returned a token.
+    participants = await nc_mcp_client.call_tool(
+        "talk_list_participants", {"token": conversation["token"]}
+    )
+    actor_ids = {
+        p["actorId"] for p in json.loads(participants.content[0].text)["results"]
+    }
+    assert other in actor_ids
+
+    # No room cleanup here on purpose: spreed answers DELETE on a one-to-one
+    # room with 400 (reproduced on nc32/33/34). Those rooms are left, not
+    # deleted -- which is why the conversation model carries a "former
+    # one-to-one" type. The `test_user` fixture removes the other account,
+    # which is what actually undoes the pairing.
 
 
 async def test_talk_create_one_to_one_requires_an_invite(

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -328,3 +328,61 @@ async def test_talk_add_participant_is_idempotent(
     finally:
         if token:
             await nc_client.talk.delete_conversation(token)
+
+
+async def test_talk_create_one_to_one_conversation_without_a_name(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, test_user
+):
+    """A one-to-one room is created from the invitee alone, with no room_name.
+
+    The tool used to require `room_name` for every room type, forcing callers
+    to invent a name spreed ignores for one-to-one rooms. This is the path that
+    was documented as supported and never exercised.
+    """
+    await nc_client.users.create_user(**test_user)
+    other = test_user["userid"]
+    token = None
+    try:
+        result = await nc_mcp_client.call_tool(
+            "talk_create_conversation", {"room_type": 1, "invite": other}
+        )
+        assert result.isError is False, result.content[0].text
+
+        conversation = json.loads(result.content[0].text)["conversation"]
+        token = conversation["token"]
+        assert conversation["room_type"] == 1
+
+        # The other user is really in it -- a one-to-one room that did not
+        # actually pair the two would still have returned a token.
+        participants = await nc_mcp_client.call_tool(
+            "talk_list_participants", {"token": token}
+        )
+        actor_ids = {
+            p["actorId"] for p in json.loads(participants.content[0].text)["results"]
+        }
+        assert other in actor_ids
+    finally:
+        if token:
+            await nc_client.talk.delete_conversation(token)
+
+
+async def test_talk_create_one_to_one_requires_an_invite(
+    nc_mcp_client: ClientSession,
+):
+    """Without an invitee there is no second participant, so there is no room."""
+    result = await nc_mcp_client.call_tool("talk_create_conversation", {"room_type": 1})
+
+    assert result.isError is True
+    assert "invite is required" in result.content[0].text
+
+
+async def test_talk_create_group_room_still_requires_a_name(
+    nc_mcp_client: ClientSession,
+):
+    """Relaxing room_name for one-to-one must not relax it for group rooms."""
+    result = await nc_mcp_client.call_tool(
+        "talk_create_conversation", {"room_type": 2, "invite": "admin"}
+    )
+
+    assert result.isError is True
+    assert "room_name is required" in result.content[0].text

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -286,3 +286,45 @@ async def test_talk_create_conversation_rejects_blank_name(
 
     assert result.isError is True
     assert "whitespace" in result.content[0].text.lower()
+
+
+async def test_talk_add_participant_is_idempotent(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """Adding the same participant twice is a no-op, not an error or a duplicate.
+
+    This is the claim `talk_add_participant`'s `idempotentHint=True` makes, and
+    it was the one idempotency claim in this PR resting on a manual probe rather
+    than a test -- the reaction tools got a re-apply assertion and this did not.
+    """
+    room_name = f"MCP Idempotency Room {uuid.uuid4().hex[:8]}"
+    token = None
+    try:
+        created = await nc_mcp_client.call_tool(
+            "talk_create_conversation", {"room_name": room_name}
+        )
+        token = json.loads(created.content[0].text)["conversation"]["token"]
+
+        first = await nc_mcp_client.call_tool(
+            "talk_add_participant", {"token": token, "participant": "admin"}
+        )
+        assert first.isError is False, first.content[0].text
+
+        before = await nc_mcp_client.call_tool(
+            "talk_list_participants", {"token": token}
+        )
+        count_before = json.loads(before.content[0].text)["count"]
+
+        # Same call again: succeeds, and leaves the roster untouched.
+        second = await nc_mcp_client.call_tool(
+            "talk_add_participant", {"token": token, "participant": "admin"}
+        )
+        assert second.isError is False, second.content[0].text
+
+        after = await nc_mcp_client.call_tool(
+            "talk_list_participants", {"token": token}
+        )
+        assert json.loads(after.content[0].text)["count"] == count_before
+    finally:
+        if token:
+            await nc_client.talk.delete_conversation(token)

--- a/tests/unit/test_capability_gating.py
+++ b/tests/unit/test_capability_gating.py
@@ -399,3 +399,65 @@ async def test_feature_and_version_gates_compose():
 
     assert reason is not None
     assert "13.0.0" in reason
+
+
+# The Talk reaction tools' own gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["talk_list_reactions", "talk_react", "talk_remove_reaction"]
+)
+def test_reaction_tools_declare_the_spreed_reactions_gate(tool_name):
+    """The real tools carry the exact gate, not just a gate.
+
+    The machinery is tested above against synthetic functions, and the
+    integration suite proves these tools work on an instance that *does*
+    advertise `reactions` -- but nothing tied those two together, so "an old
+    Talk hides these three tools" was inferred across two files rather than
+    asserted. A typo in the app key or the flag would have passed both.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from nextcloud_mcp_server.server.talk import configure_talk_tools
+
+    mcp = FastMCP("test")
+    configure_talk_tools(mcp)
+
+    tool = mcp._tool_manager.get_tool(tool_name)
+
+    assert get_required_capability(tool.fn) == ("spreed", None, "reactions")
+
+
+def test_non_reaction_talk_tools_are_not_feature_gated():
+    """Only the reaction tools carry the flag.
+
+    Gating the read/send tools on `reactions` would hide working tools on an
+    older Talk -- the failure mode the fail-open contract exists to avoid.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    from nextcloud_mcp_server.server.talk import configure_talk_tools
+
+    mcp = FastMCP("test")
+    configure_talk_tools(mcp)
+
+    for tool_name in ("talk_list_conversations", "talk_send_message"):
+        gate = get_required_capability(mcp._tool_manager.get_tool(tool_name).fn)
+        # Either ungated here, or carrying only the module-wide presence gate.
+        assert gate is None or gate[2] is None, f"{tool_name} is feature-gated"
+
+
+async def test_both_conditions_failing_still_closes_the_gate():
+    """When feature and version both fail, the gate closes on the feature.
+
+    Precedence is worth pinning rather than leaving to reading order: a caller
+    that switched on the wording would otherwise break silently if the checks
+    were ever reordered.
+    """
+    client = _client(_payload(spreed={"version": "10.0.0", "features": ["chat-v2"]}))
+
+    reason = await unmet_capability(client, "alice", "spreed", "13.0.0", "reactions")
+
+    assert reason is not None
+    assert "reactions" in reason

--- a/tests/unit/test_capability_gating.py
+++ b/tests/unit/test_capability_gating.py
@@ -87,7 +87,7 @@ def test_require_capability_stamps_metadata():
     def tool():
         pass
 
-    assert get_required_capability(tool) == ("deck", "1.18.0")
+    assert get_required_capability(tool) == ("deck", "1.18.0", None)
 
 
 def test_require_capability_rejects_unparseable_floor():
@@ -110,7 +110,7 @@ def test_stamp_does_not_override_an_explicit_gate():
 
     stamp_required_capability(tool, "deck")
 
-    assert get_required_capability(tool) == ("deck", "1.18.0")
+    assert get_required_capability(tool) == ("deck", "1.18.0", None)
 
 
 def test_stamp_applies_presence_gate_when_undeclared():
@@ -119,7 +119,7 @@ def test_stamp_applies_presence_gate_when_undeclared():
 
     stamp_required_capability(tool, "spreed")
 
-    assert get_required_capability(tool) == ("spreed", None)
+    assert get_required_capability(tool) == ("spreed", None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -346,3 +346,56 @@ async def test_escape_hatch_reads_env_var_spellings(
     names = {tool.name for tool in await mcp.list_tools()}
 
     assert ("deck_assign_dependent_card" in names) is expected_disabled
+
+
+# Feature-flag gating
+# ---------------------------------------------------------------------------
+
+
+async def test_feature_gate_refuses_a_feature_the_app_does_not_advertise():
+    """A declared feature the app omits closes the gate.
+
+    Preferred over a version floor where the app publishes flags: it states
+    what the tool needs, checked against what the instance says about itself.
+    """
+    client = _client(
+        _payload(spreed={"version": "22.0.17", "features": ["chat-v2", "favorites"]})
+    )
+
+    reason = await unmet_capability(client, "alice", "spreed", None, "reactions")
+
+    assert reason is not None
+    assert "reactions" in reason
+
+
+async def test_feature_gate_allows_a_feature_the_app_advertises():
+    client = _client(
+        _payload(spreed={"version": "22.0.17", "features": ["chat-v2", "reactions"]})
+    )
+
+    assert await unmet_capability(client, "alice", "spreed", None, "reactions") is None
+
+
+@pytest.mark.parametrize("features", [None, "not-a-list", 42])
+async def test_feature_gate_fails_open_when_features_are_unreadable(features):
+    """An app saying nothing usable about its features must not be gated.
+
+    Same rule the version check follows: close the gate only on a positive
+    statement that the instance cannot serve the tool, never on a hunch.
+    """
+    block: dict = {"version": "22.0.17"}
+    if features is not None:
+        block["features"] = features
+    client = _client(_payload(spreed=block))
+
+    assert await unmet_capability(client, "alice", "spreed", None, "reactions") is None
+
+
+async def test_feature_and_version_gates_compose():
+    """Both conditions apply; failing either closes the gate."""
+    client = _client(_payload(spreed={"version": "10.0.0", "features": ["reactions"]}))
+
+    reason = await unmet_capability(client, "alice", "spreed", "13.0.0", "reactions")
+
+    assert reason is not None
+    assert "13.0.0" in reason


### PR DESCRIPTION
## Problem

Talk's MCP surface was read-mostly. Six tools could list rooms, read messages and post into an **existing** conversation — but an agent could not start one, or manage who was in it. Reactions had no support at all, in either layer.

`client/talk.py` already implemented `create_conversation` and `delete_conversation` with **no tool in front of them** — the capability existed and was unreachable.

## What's added

Five tools plus the client methods behind them:

| Tool | Notes |
|---|---|
| `talk_create_conversation` | wraps the existing, previously-unreachable client method |
| `talk_add_participant` | new client method; `users` / `groups` / `emails` / `circles` / `federated_users` |
| `talk_list_reactions` | new; optional single-emoji filter |
| `talk_react` | new |
| `talk_remove_reaction` | new |

## Three API shapes that changed the design

Every shape here was established by **probing Talk 22.0.17 directly**, not read off the docs. Three of them contradicted what I'd have assumed:

**Adding a participant returns no data.** Success is `200` with `data: []` — not a participant object. So `AddParticipantResponse` echoes what was added rather than pretending to return a parsed participant.

**Reacting returns `201` first time, `200` on a repeat**, with the same end state — reactions are a set. That makes `idempotentHint=True` correct, where ADR-017 would normally have a create be `False`.

**Removing a reaction twice returns `404`**, not a no-op. The *end state* matches a successful removal, which is what `idempotentHint` describes per ADR-017, so it stays `True` — but the discrepancy is documented, because callers will see it.

Empty reaction payloads are normalised from all three shapes spreed can send — `{}` (what Talk 22 actually returns), `[]` (the PHP empty-map-as-list quirk CLAUDE.md warns about *for this app specifically*), and `null` (error paths).

## Validation before the URL is built

Per the J1 pattern the existing Talk tools set:

- Tokens go through the existing allowlist regex — now covering the participants path too, with a path-traversal test.
- Message ids are rejected when non-positive or non-integer. `bool` is excluded **explicitly**: it is an `int` subclass, so `True` would otherwise sail through as message id 1.
- Blank emoji and room names are refused locally rather than as a bare server 400 that names no field.

## Test coverage

- **8 client unit tests** — validation rejections (asserting the request is never built), request shapes for each endpoint, and the three empty-payload forms.
- **4 integration tests** against a live instance, including a full react → list → re-react → remove cycle that asserts the idempotency the annotations claim, rather than taking it on faith.
- Existing Talk integration tests still pass (14 total), and `EXPECTED_TALK_TOOLS` is updated so a dropped registration fails loudly.

3562 unit tests, ruff/format/ty clean, secrets scan clean.

## On the CLAUDE.md e2e + contract gate

This **adds MCP tool surface**, so the gate applies and here is the explicit accounting it asks for:

- **e2e**: covered by the integration tests above.
- **contract**: does **not** apply. This consumes Nextcloud's own Talk API — it is not a call into `astrolabe-cloud-gateway`, and it is not part of the `/api/v1/*` surface that `astrolabe` consumes. No cross-service provider/consumer boundary is touched, so there is no pact to write.

Deck: board 12 card #1048.

---

_This PR was generated with the help of AI, and reviewed by a Human_
