### PR TITLE
fix(ci): build the image from the checked-out tag, not the event commit

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -84,6 +84,13 @@ jobs:
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
+          # Without an explicit context, build-push-action builds from the
+          # implicit Git context, which resolves to the *event* commit
+          # (github.sha) and silently ignores the checkout above. Called from
+          # `Bump version`, that is the commit pushed to master -- the parent of
+          # the bump commit -- so every image shipped the right code carrying the
+          # previous release's version string.
+          context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
@@ -150,3 +157,17 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: Verify baked-in version matches the tag
+        env:
+          EXPECTED: ${{ needs.resolve-tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          actual=$(docker run --rm --entrypoint python \
+            "$IMAGE_NAME:$EXPECTED" \
+            -c "import importlib.metadata as m; print(m.version('nextcloud-mcp-server'))")
+          echo "expected=$EXPECTED actual=$actual"
+          [ "$actual" = "$EXPECTED" ] || {
+            echo "::error::Image reports $actual but the tag is $EXPECTED — /api/v1/status would lie about the running release"
+            exit 1
+          }


### PR DESCRIPTION
## Problem

Every published image reports the **previous** release's version. Reproducible on
both 0.176.3 and 0.176.5, so it is systematic:

```bash
docker run --rm --entrypoint python \
  ghcr.io/cbcoutinho/nextcloud-mcp-server:0.176.5 \
  -c "import importlib.metadata as m; print(m.version('nextcloud-mcp-server'))"
# -> 0.176.4
```

The *code* in each image is correct — only the version metadata lags, and that
is what `/api/v1/status` reports. It under-reports, which is the misleading
direction: an admin checking "do I have the fix?" concludes they do not.

## Root cause

`docker/build-push-action` was called with no `context:`. Its default is the
implicit **Git context**, which
[resolves to the event commit](https://github.com/docker/actions-toolkit/blob/main/src/buildx/build.ts)
(`github.sha`) and ignores the `actions/checkout` step above it entirely.

`docker-build-publish.yml` is invoked from `Bump version`, whose trigger is the
push to `master`. So `github.sha` is the commit that was pushed — the **parent**
of the `bump:` commit that commitizen then creates and tags. That parent has the
release's code and the previous version string:

| ref | code | `version` |
|---|---|---|
| `v0.176.5` (checked out, ignored) | JWKS fix | 0.176.5 |
| `de6c0d9` = `github.sha` (actually built) | JWKS fix | **0.176.4** |

which is exactly what the image reports.

`release.yml` (PyPI) was unaffected — it builds from its own checkout with `uv build`.

## Fix

- `context: .` — build the workspace the workflow already checked out at the tag.
- New `merge`-job step runs the just-published image and asserts
  `importlib.metadata.version` equals the tag, so a regression fails the release
  rather than shipping silently.

## Verification

Acceptance is only observable on a real release: this lands as a `fix:`, so the
bump publishes a new image and the new assertion step gates it. Confirm after
merge with the `docker run` command above against the new tag.

---

_This PR was generated with the help of AI, and reviewed by a Human_
