### PR TITLE
fix(config): don't warn when SEARCH_RERANK_URL points at the gateway

### DIFF
--- a/nextcloud_mcp_server/config.py
+++ b/nextcloud_mcp_server/config.py
@@ -1731,7 +1731,20 @@ class Settings:
         # rather than raise: the prefix set is the gateway's, not a closed
         # universe, and refusing to boot over a model name we cannot validate
         # would be worse than saying so.
-        if self.search_rerank_enabled and self.search_rerank_url:
+        #
+        # "Explicit URL" does NOT imply "not the gateway": pointing
+        # SEARCH_RERANK_URL at the gateway's own /v1/rerank is a legitimate
+        # configuration (it is how you pin the endpoint while still using the
+        # gateway), and the routing prefix is correct there. Only warn when the
+        # URL is somewhere OTHER than the configured gateway — otherwise the
+        # warning fires on a working setup and trains operators to ignore it.
+        _direct_rerank = bool(self.search_rerank_url) and not (
+            self.embedding_gateway_url
+            and self.search_rerank_url.startswith(
+                self.embedding_gateway_url.rstrip("/")
+            )
+        )
+        if self.search_rerank_enabled and _direct_rerank:
             _prefix, _, _bare = self.search_rerank_model.partition("/")
             if _prefix in GATEWAY_MODEL_NAMESPACES:
                 logger.warning(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -361,6 +361,26 @@ class TestGetSettings:
         os.environ,
         {
             "SEARCH_RERANK_ENABLED": "true",
+            "EMBEDDING_GATEWAY_URL": "https://gw.example",
+            "SEARCH_RERANK_URL": "https://gw.example/v1/rerank",
+        },
+        clear=True,
+    )
+    def test_rerank_url_pointing_at_the_gateway_is_quiet(self, caplog):
+        """Pinning SEARCH_RERANK_URL to the gateway's OWN /v1/rerank is a valid
+        configuration -- the routing prefix is correct there. Warning on it fires
+        on a working setup, which is how operators learn to ignore warnings."""
+        _reload_config()
+        with caplog.at_level(logging.WARNING, logger="nextcloud_mcp_server.config"):
+            settings = get_settings()
+
+        assert settings.search_rerank_model == "local/BAAI/bge-reranker-v2-m3"
+        assert "SEARCH_RERANK_MODEL" not in caplog.text
+
+    @patch.dict(
+        os.environ,
+        {
+            "SEARCH_RERANK_ENABLED": "true",
             "SEARCH_RERANK_URL": "http://infinity:7997/rerank",
             "SEARCH_RERANK_MODEL": "BAAI/bge-reranker-v2-m3",
         },


### PR DESCRIPTION
The mis-namespaced-model warning added in #1356 assumed "explicit `SEARCH_RERANK_URL`" implies "not the gateway". Pinning the URL to the gateway's own `/v1/rerank` is a legitimate configuration — it is how you fix the endpoint while still using the gateway — and the `local/` routing prefix is correct there.

So the warning fired on a **working** setup, which is how operators learn to ignore warnings.

## How it was found

Running the gateway-free rerank path end to end against a real login-flow stack. The server logged:

```
SEARCH_RERANK_MODEL='local/BAAI/bge-reranker-v2-m3' carries the embedding gateway's
'local/' routing prefix, but SEARCH_RERANK_URL points at a direct endpoint which has
no such routing. Use the bare model id (...) or reranking will silently degrade to
retrieval order.
```

…while reranking was working correctly, because `SEARCH_RERANK_URL` was the gateway's own `/v1/rerank`.

## The fix

Warn only when the URL is somewhere **other than** the configured gateway. Verified silent on the live deployment afterwards, with `rerank_available: true` and the endpoint still resolving to the explicit URL.

## Test coverage

Added `test_rerank_url_pointing_at_the_gateway_is_quiet` alongside the existing quiet-case test, so both sides of the boundary are pinned: a genuinely direct endpoint (`http://infinity:7997/rerank` + `local/…`) still warns; a gateway-pinned URL does not.

No API surface change, so no e2e/contract tier applies. 108 tests in `tests/unit/test_config.py` pass; `ruff`, `ruff format`, `ty` clean.

---

_This PR was generated with the help of AI, and reviewed by a Human_
