### PR TITLE
refactor(sharing): route the OCS calls through _make_request

### DIFF
--- a/nextcloud_mcp_server/client/sharing.py
+++ b/nextcloud_mcp_server/client/sharing.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from nextcloud_mcp_server.models.sharing import ShareType
 
-from .base import BaseNextcloudClient, retry_on_429
+from .base import BaseNextcloudClient
 from .ocs import OCS_REQUEST_HEADERS, describe_ocs_failure, parse_ocs_envelope
 
 logger = logging.getLogger(__name__)
@@ -89,7 +89,17 @@ def _ocs_data(payload: Any) -> Any:
 
 
 class SharingClient(BaseNextcloudClient):
-    """Client for Nextcloud OCS Sharing API operations."""
+    """Client for Nextcloud OCS Sharing API operations.
+
+    Requests go through :meth:`BaseNextcloudClient._make_request`, matching
+    every other app client: that is what feeds the tracing spans and the
+    ``mcp_nextcloud_api_requests_total`` metric, and it raises for status on
+    the caller's behalf. It is also already decorated with ``@retry_on_429``,
+    which is why these methods no longer carry their own copy: a second,
+    outer copy is dead weight. It cannot extend the budget -- the inner loop
+    signals exhaustion with ``RuntimeError``, which ``retry_on_429`` does not
+    catch -- so it would only read as protection that is not there.
+    """
 
     app_name = "sharing"
 
@@ -98,7 +108,6 @@ class SharingClient(BaseNextcloudClient):
     # future in-place edit a cross-client bug.
     _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
 
-    @retry_on_429
     async def create_share(
         self,
         path: str,
@@ -153,12 +162,12 @@ class SharingClient(BaseNextcloudClient):
         if share_with and share_with.strip():
             payload["shareWith"] = share_with.strip()
 
-        response = await self._client.post(
+        response = await self._make_request(
+            "POST",
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             headers=self._OCS_HEADERS,
             data=payload,
         )
-        response.raise_for_status()
         data = response.json()
 
         share_data = _ocs_data(data)
@@ -181,7 +190,6 @@ class SharingClient(BaseNextcloudClient):
         )
         return share_data
 
-    @retry_on_429
     async def create_public_link(
         self,
         path: str,
@@ -217,12 +225,12 @@ class SharingClient(BaseNextcloudClient):
         if expire_date is not None:
             data["expireDate"] = expire_date
 
-        response = await self._client.post(
+        response = await self._make_request(
+            "POST",
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             headers=self._OCS_HEADERS,
             data=data,
         )
-        response.raise_for_status()
         result = response.json()
 
         share_data = _ocs_data(result)
@@ -244,7 +252,6 @@ class SharingClient(BaseNextcloudClient):
         )
         return share_data
 
-    @retry_on_429
     async def delete_share(self, share_id: int) -> None:
         """Delete a share by its ID.
 
@@ -254,18 +261,17 @@ class SharingClient(BaseNextcloudClient):
         Raises:
             HTTPStatusError: If the request fails
         """
-        response = await self._client.delete(
+        response = await self._make_request(
+            "DELETE",
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
             headers=self._OCS_HEADERS,
         )
-        response.raise_for_status()
         data = response.json()
 
         _ocs_data(data)
 
         logger.info("Deleted share %s", share_id)
 
-    @retry_on_429
     async def get_share(self, share_id: int) -> dict[str, Any]:
         """Get information about a specific share.
 
@@ -278,11 +284,11 @@ class SharingClient(BaseNextcloudClient):
         Raises:
             HTTPStatusError: If the request fails
         """
-        response = await self._client.get(
+        response = await self._make_request(
+            "GET",
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
             headers=self._OCS_HEADERS,
         )
-        response.raise_for_status()
         data = response.json()
 
         share_data = _ocs_data(data)
@@ -291,7 +297,6 @@ class SharingClient(BaseNextcloudClient):
             return share_data[0]
         return share_data
 
-    @retry_on_429
     async def list_shares(
         self, path: str | None = None, shared_with_me: bool = False
     ) -> list[dict[str, Any]]:
@@ -313,12 +318,12 @@ class SharingClient(BaseNextcloudClient):
         if shared_with_me:
             params["shared_with_me"] = "true"
 
-        response = await self._client.get(
+        response = await self._make_request(
+            "GET",
             "/ocs/v2.php/apps/files_sharing/api/v1/shares",
             params=params,
             headers=self._OCS_HEADERS,
         )
-        response.raise_for_status()
         data = response.json()
 
         # Handle both single share and list of shares
@@ -327,7 +332,6 @@ class SharingClient(BaseNextcloudClient):
             return [shares_data]
         return shares_data if shares_data else []
 
-    @retry_on_429
     async def update_share(
         self, share_id: int, permissions: int | None = None
     ) -> dict[str, Any]:
@@ -347,12 +351,12 @@ class SharingClient(BaseNextcloudClient):
         if permissions is not None:
             data["permissions"] = permissions
 
-        response = await self._client.put(
+        response = await self._make_request(
+            "PUT",
             f"/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}",
             headers=self._OCS_HEADERS,
             data=data,
         )
-        response.raise_for_status()
         result = response.json()
 
         share_data = _ocs_data(result)

--- a/tests/client/test_sharing_client.py
+++ b/tests/client/test_sharing_client.py
@@ -10,7 +10,7 @@ These verify the payload shape sent to Nextcloud. Coverage includes:
 """
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, HTTPStatusError, Request
 
 from nextcloud_mcp_server.client.sharing import SharingClient
 
@@ -45,7 +45,9 @@ async def test_create_share_deck_type_payload(sharing_client, mocker):
     ShareAPIController routes shareType=12 to DeckShareProvider, which
     creates the deck-card share row binding the file to the card.
     """
-    sharing_client._client.post.return_value = _ok_share_response(mocker, share_id=99)
+    sharing_client._client.request.return_value = _ok_share_response(
+        mocker, share_id=99
+    )
 
     share = await sharing_client.create_share(
         path="/Notes/My Note.md",
@@ -55,9 +57,12 @@ async def test_create_share_deck_type_payload(sharing_client, mocker):
     )
 
     assert share["id"] == 99
-    sharing_client._client.post.assert_called_once()
-    call = sharing_client._client.post.call_args
-    assert call.args[0] == "/ocs/v2.php/apps/files_sharing/api/v1/shares"
+    sharing_client._client.request.assert_called_once()
+    call = sharing_client._client.request.call_args
+    assert call.args[:2] == (
+        "POST",
+        "/ocs/v2.php/apps/files_sharing/api/v1/shares",
+    )
     assert call.kwargs["data"] == {
         "path": "/Notes/My Note.md",
         "shareType": 12,
@@ -72,7 +77,7 @@ async def test_create_share_deck_type_payload(sharing_client, mocker):
 async def test_create_public_link_payload(sharing_client, mocker):
     """create_public_link must POST shareType=3 with no shareWith, and pass
     through expireDate when supplied. Public link data carries url + token."""
-    sharing_client._client.post.return_value = _ok_share_response(
+    sharing_client._client.request.return_value = _ok_share_response(
         mocker,
         share_id=7,
         url="https://nc.example.com/s/abc123",
@@ -91,9 +96,12 @@ async def test_create_public_link_payload(sharing_client, mocker):
     assert share["id"] == 7
     assert share["url"] == "https://nc.example.com/s/abc123"
     assert share["token"] == "abc123"
-    sharing_client._client.post.assert_called_once()
-    call = sharing_client._client.post.call_args
-    assert call.args[0] == "/ocs/v2.php/apps/files_sharing/api/v1/shares"
+    sharing_client._client.request.assert_called_once()
+    call = sharing_client._client.request.call_args
+    assert call.args[:2] == (
+        "POST",
+        "/ocs/v2.php/apps/files_sharing/api/v1/shares",
+    )
     assert call.kwargs["data"] == {
         "path": "/Receipts/receipt.jpg",
         "shareType": 3,
@@ -107,13 +115,13 @@ async def test_create_public_link_payload(sharing_client, mocker):
 
 async def test_create_public_link_omits_expire_date_when_none(sharing_client, mocker):
     """When no expiry is given, expireDate must be absent from the payload."""
-    sharing_client._client.post.return_value = _ok_share_response(
+    sharing_client._client.request.return_value = _ok_share_response(
         mocker, share_id=8, url="https://nc.example.com/s/noexpiry"
     )
 
     await sharing_client.create_public_link(path="/doc.pdf")
 
-    call = sharing_client._client.post.call_args
+    call = sharing_client._client.request.call_args
     assert "expireDate" not in call.kwargs["data"]
     assert call.kwargs["data"]["shareType"] == 3
 
@@ -125,7 +133,7 @@ async def test_create_public_link_raises_on_empty_data(sharing_client, mocker):
     response.json.return_value = {
         "ocs": {"meta": {"statuscode": 200, "message": "OK"}, "data": []}
     }
-    sharing_client._client.post.return_value = response
+    sharing_client._client.request.return_value = response
 
     with pytest.raises(RuntimeError, match="Public link creation failed"):
         await sharing_client.create_public_link(path="/missing.jpg")
@@ -144,7 +152,7 @@ async def test_create_public_link_raises_on_ocs_error(sharing_client, mocker):
             "data": [],
         }
     }
-    sharing_client._client.post.return_value = response
+    sharing_client._client.request.return_value = response
 
     with pytest.raises(RuntimeError, match="Wrong path"):
         await sharing_client.create_public_link(path="/nope.jpg")
@@ -163,7 +171,7 @@ async def test_create_share_raises_on_ocs_failure(sharing_client, mocker):
             "data": [],
         }
     }
-    sharing_client._client.post.return_value = response
+    sharing_client._client.request.return_value = response
 
     with pytest.raises(RuntimeError, match="Wrong path"):
         await sharing_client.create_share(
@@ -189,7 +197,7 @@ async def test_create_share_rejects_public_link_with_recipient(sharing_client):
         )
 
     # Refused before the wire: nothing was sent.
-    sharing_client._client.post.assert_not_called()
+    sharing_client._client.request.assert_not_called()
 
 
 @pytest.mark.parametrize("recipient", [None, "", "   "])
@@ -209,19 +217,21 @@ async def test_create_share_requires_recipient_for_user_share(
             share_type=0,
         )
 
-    sharing_client._client.post.assert_not_called()
+    sharing_client._client.request.assert_not_called()
 
 
 async def test_create_share_public_link_omits_share_with(sharing_client, mocker):
     """A recipient-less public link is allowed and sends no shareWith field."""
-    sharing_client._client.post.return_value = _ok_share_response(mocker, share_id=11)
+    sharing_client._client.request.return_value = _ok_share_response(
+        mocker, share_id=11
+    )
 
     await sharing_client.create_share(
         path="/Public/flyer.pdf",
         share_type=3,
     )
 
-    assert sharing_client._client.post.call_args.kwargs["data"] == {
+    assert sharing_client._client.request.call_args.kwargs["data"] == {
         "path": "/Public/flyer.pdf",
         "shareType": 3,
         "permissions": 1,
@@ -236,7 +246,9 @@ async def test_create_share_allows_unknown_share_type_with_recipient(
     Nextcloud may add share types we do not know about; refusing them here
     would break an otherwise-correct caller. Only the recipient rule applies.
     """
-    sharing_client._client.post.return_value = _ok_share_response(mocker, share_id=12)
+    sharing_client._client.request.return_value = _ok_share_response(
+        mocker, share_id=12
+    )
 
     await sharing_client.create_share(
         path="/Documents/report.md",
@@ -244,4 +256,53 @@ async def test_create_share_allows_unknown_share_type_with_recipient(
         share_type=99,
     )
 
-    assert sharing_client._client.post.call_args.kwargs["data"]["shareType"] == 99
+    assert sharing_client._client.request.call_args.kwargs["data"]["shareType"] == 99
+
+
+async def test_sharing_calls_are_metered_like_every_other_client(
+    sharing_client, mocker
+):
+    """A sharing call must reach the shared API-call metric.
+
+    Before this client routed through ``_make_request`` it issued
+    ``self._client.post(...)`` directly, so its six endpoints were the only app
+    calls in the codebase that produced no ``mcp_nextcloud_api_requests_total``
+    sample and no ``trace_nextcloud_api_call`` span -- invisible in exactly the
+    dashboards that exist to spot a failing Nextcloud.
+    """
+    record = mocker.patch("nextcloud_mcp_server.client.base.record_nextcloud_api_call")
+    sharing_client._client.request.return_value = _ok_share_response(mocker)
+
+    await sharing_client.list_shares()
+
+    record.assert_called_once()
+    assert record.call_args.kwargs["app"] == "sharing"
+    assert record.call_args.kwargs["method"] == "GET"
+
+
+async def test_rate_limit_retry_budget_survives_the_migration(sharing_client, mocker):
+    """A 429 must still cost 5 attempts, now that the retry lives one layer down.
+
+    These methods each carried their own ``@retry_on_429`` before routing
+    through ``_make_request``; the decorator on ``_make_request`` is now the
+    only one. That is a behaviour-preserving swap rather than a fix: nesting
+    the two could never have multiplied the budget, because the inner loop
+    reports exhaustion as ``RuntimeError`` and ``retry_on_429`` only catches
+    ``HTTPStatusError``. What this pins is that dropping the per-method copy
+    did not leave the calls with no retry at all. The mocked sleep keeps it
+    fast.
+    """
+    sleep = mocker.patch("nextcloud_mcp_server.client.base.anyio.sleep")
+
+    response = mocker.Mock()
+    response.status_code = 429
+    response.raise_for_status.side_effect = lambda: (_ for _ in ()).throw(
+        HTTPStatusError("429", request=Request("GET", "http://x"), response=response)
+    )
+    sharing_client._client.request.return_value = response
+
+    with pytest.raises(RuntimeError, match="Maximum number of retries"):
+        await sharing_client.list_shares()
+
+    assert sharing_client._client.request.call_count == 5
+    assert sleep.call_count == 5


### PR DESCRIPTION
Closes the follow-up filed as Deck card 1055, raised by the review bot on #1343.

## Problem

`SharingClient` issued its six requests via `self._client.post/get/put/delete`
directly — the only app client not going through
`BaseNextcloudClient._make_request`, which CLAUDE.md names as the contract.

The cost was **observability**, not correctness: none of the sharing endpoints
produced a `trace_nextcloud_api_call` span or an
`mcp_nextcloud_api_requests_total` sample, so they were absent from exactly the
dashboards that exist to spot a failing Nextcloud. `_resolve_url` was moot here
(all six paths are `/ocs/...`, which passes through unchanged).

## Change

All six call sites now go through `_make_request`. That also lets the explicit
`response.raise_for_status()` calls go — `_make_request` raises for status
itself — and makes the per-method `@retry_on_429` decorators redundant, since
`_make_request` already carries one.

## One correction to the card

The card assumed keeping both decorators would multiply the retry budget to 25
attempts. **It would not.** The inner loop reports exhaustion as `RuntimeError`
and `retry_on_429` only catches `HTTPStatusError`, so an outer copy can never
re-enter. I checked this rather than taking the premise, and the docstring now
records what is actually true. They are dropped as dead weight, not as a fix.

## Test coverage

Two tests added, both verified to fail against a reverted fix rather than
assumed to be load-bearing:

- `test_sharing_calls_are_metered_like_every_other_client` — the metric now
  fires with `app="sharing"`.
- `test_rate_limit_retry_budget_survives_the_migration` — pins the budget at 5
  attempts, i.e. that dropping the per-method decorator did not leave the calls
  with no retry at all. Confirmed failing (429 escapes immediately) when
  `_make_request` loses its own decorator.

The existing wire-format tests keep asserting the same URLs, payloads and
headers; only their mock target moves from `_client.post` to `_client.request`,
since that is what `_make_request` calls. No API surface changes, so the e2e +
contract gate does not apply — `tests/client/test_sharing_api.py` exercises
these methods against a live stack and is untouched.

---

_This PR was generated with the help of AI, and reviewed by a Human_