### PR TITLE
refactor(client): put every OCS client on the shared header constant

### DIFF
--- a/nextcloud_mcp_server/api/apps.py
+++ b/nextcloud_mcp_server/api/apps.py
@@ -26,6 +26,7 @@ from nextcloud_mcp_server.api.management import (
     validate_token_and_get_user,
 )
 from nextcloud_mcp_server.auth.scope_authorization import ProvisioningRequiredError
+from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
 
 from ..http import nextcloud_httpx_client
 
@@ -72,7 +73,7 @@ async def get_installed_apps(request: Request) -> JSONResponse:
             response = await client.get(
                 "/ocs/v2.php/cloud/capabilities",
                 params={"format": "json"},
-                headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+                headers=dict(OCS_REQUEST_HEADERS),
             )
 
             if response.status_code != 200:

--- a/nextcloud_mcp_server/auth/storage.py
+++ b/nextcloud_mcp_server/auth/storage.py
@@ -50,6 +50,7 @@ from cryptography.fernet import Fernet
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 from sqlalchemy.pool import NullPool
 
+from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
 from nextcloud_mcp_server.config import (
     cfg,
     get_database_url,
@@ -2055,10 +2056,7 @@ class RefreshTokenStorage:
                 ) as client:
                     response = await client.get(
                         "/ocs/v2.php/cloud/user",
-                        headers={
-                            "OCS-APIRequest": "true",
-                            "Accept": "application/json",
-                        },
+                        headers=dict(OCS_REQUEST_HEADERS),
                     )
 
                 if response.status_code in (401, 403):

--- a/nextcloud_mcp_server/client/__init__.py
+++ b/nextcloud_mcp_server/client/__init__.py
@@ -23,6 +23,7 @@ from .groups import GroupsClient
 from .mail import MailClient
 from .news import NewsClient
 from .notes import NotesClient
+from .ocs import OCS_REQUEST_HEADERS
 from .sharing import SharingClient
 from .tables import TablesClient
 from .talk import TalkClient
@@ -222,7 +223,7 @@ class NextcloudClient:
     async def capabilities(self):
         response = await self._client.get(
             "/ocs/v2.php/cloud/capabilities",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=dict(OCS_REQUEST_HEADERS),
         )
         response.raise_for_status()
 
@@ -239,7 +240,7 @@ class NextcloudClient:
         """
         response = await self._client.get(
             "/ocs/v2.php/core/navigation/apps",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=dict(OCS_REQUEST_HEADERS),
         )
         response.raise_for_status()
         data = response.json()

--- a/nextcloud_mcp_server/client/deck.py
+++ b/nextcloud_mcp_server/client/deck.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from httpx import HTTPStatusError, RequestError
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
 from nextcloud_mcp_server.models.deck import (
     DeckACL,
     DeckAttachment,
@@ -54,10 +55,24 @@ class DeckClient(BaseNextcloudClient):
 
     app_name = "deck"
 
+    # Own copy -- see the note in GroupsClient. Used by the /ocs/v2.php
+    # endpoints below (config, comments, sessions), NOT by the Deck REST API;
+    # see _get_deck_headers for why that one differs.
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
+
     def _get_deck_headers(
         self, additional_headers: Optional[Dict[str, str]] = None
     ) -> Dict[str, str]:
-        """Get standard headers required for Deck API calls."""
+        """Get standard headers required for Deck's own REST API.
+
+        Deliberately NOT ``_OCS_HEADERS``. These calls go to
+        ``/index.php/apps/deck/api/v1.0/...`` -- Deck's app REST API, not an
+        ``/ocs/v2.php`` route -- and they send ``Content-Type`` where the OCS
+        constant sends ``Accept``. That difference is left alone on purpose:
+        the endpoints work as-is, and swapping the header would be a
+        behaviour change riding along in a de-duplication pass. If it is ever
+        revisited, it is a change to Deck's REST calls only.
+        """
         headers = {"OCS-APIRequest": "true", "Content-Type": "application/json"}
         if additional_headers:
             headers.update(additional_headers)
@@ -748,7 +763,7 @@ class DeckClient(BaseNextcloudClient):
 
     # OCS API Endpoints (Config, Comments, Sessions)
     async def get_config(self) -> DeckConfig:
-        headers = {"OCS-APIRequest": "true", "Accept": "application/json"}
+        headers = self._OCS_HEADERS
         response = await self._make_request(
             "GET", "/ocs/v2.php/apps/deck/api/v1.0/config", headers=headers
         )
@@ -765,7 +780,7 @@ class DeckClient(BaseNextcloudClient):
             "POST",
             path,
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         return response.json()["ocs"]["data"]
 
@@ -777,7 +792,7 @@ class DeckClient(BaseNextcloudClient):
             "GET",
             f"/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments",
             params=params,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         return [DeckComment(**comment) for comment in response.json()["ocs"]["data"]]
 
@@ -791,7 +806,7 @@ class DeckClient(BaseNextcloudClient):
             "POST",
             f"/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments",
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         return DeckComment(**response.json()["ocs"]["data"])
 
@@ -803,7 +818,7 @@ class DeckClient(BaseNextcloudClient):
             "PUT",
             f"/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}",
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         return DeckComment(**response.json()["ocs"]["data"])
 
@@ -811,7 +826,7 @@ class DeckClient(BaseNextcloudClient):
         await self._make_request(
             "DELETE",
             f"/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
 
     async def create_session(self, board_id: int) -> DeckSession:
@@ -820,7 +835,7 @@ class DeckClient(BaseNextcloudClient):
             "PUT",
             "/ocs/v2.php/apps/deck/api/v1.0/session/create",
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         return DeckSession(**response.json()["ocs"]["data"])
 
@@ -830,7 +845,7 @@ class DeckClient(BaseNextcloudClient):
             "POST",
             "/ocs/v2.php/apps/deck/api/v1.0/session/sync",
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
 
     async def close_session(self, board_id: int, token: str) -> None:
@@ -839,5 +854,5 @@ class DeckClient(BaseNextcloudClient):
             "POST",
             "/ocs/v2.php/apps/deck/api/v1.0/session/close",
             json=json_data,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )

--- a/nextcloud_mcp_server/client/groups.py
+++ b/nextcloud_mcp_server/client/groups.py
@@ -16,6 +16,12 @@ class GroupsClient(BaseNextcloudClient):
 
     # Own copy: the module-level dict is shared by every OCS client, so passing
     # it straight through would make any future in-place edit a cross-client bug.
+    #
+    # It is still ONE object per class, not per instance or per call. Nothing
+    # mutates it today, and httpx does not touch the dict it is handed. But a
+    # future `additional_headers` parameter reaching for
+    # `self._OCS_HEADERS.update(...)` would leak into every instance and every
+    # later call -- build `{**self._OCS_HEADERS, ...}` instead.
     _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
 
     @retry_on_429

--- a/nextcloud_mcp_server/client/groups.py
+++ b/nextcloud_mcp_server/client/groups.py
@@ -4,6 +4,7 @@ import logging
 from typing import List
 
 from .base import BaseNextcloudClient, retry_on_429
+from .ocs import OCS_REQUEST_HEADERS
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,10 @@ class GroupsClient(BaseNextcloudClient):
     """Client for Nextcloud Groups API operations."""
 
     app_name = "groups"
+
+    # Own copy: the module-level dict is shared by every OCS client, so passing
+    # it straight through would make any future in-place edit a cross-client bug.
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
 
     @retry_on_429
     async def search_groups(
@@ -42,7 +47,7 @@ class GroupsClient(BaseNextcloudClient):
         response = await self._client.get(
             "/ocs/v2.php/cloud/groups",
             params=params,
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -64,7 +69,7 @@ class GroupsClient(BaseNextcloudClient):
         response = await self._client.post(
             "/ocs/v2.php/cloud/groups",
             data={"groupid": groupid},
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         logger.info("Created group: %s", groupid)
@@ -82,7 +87,7 @@ class GroupsClient(BaseNextcloudClient):
         """
         response = await self._client.delete(
             f"/ocs/v2.php/cloud/groups/{groupid}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         logger.info("Deleted group: %s", groupid)
@@ -100,7 +105,7 @@ class GroupsClient(BaseNextcloudClient):
         """
         response = await self._client.get(
             f"/ocs/v2.php/cloud/groups/{groupid}",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -121,7 +126,7 @@ class GroupsClient(BaseNextcloudClient):
         """
         response = await self._client.get(
             f"/ocs/v2.php/cloud/groups/{groupid}/subadmins",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         data = response.json()
@@ -147,7 +152,7 @@ class GroupsClient(BaseNextcloudClient):
         response = await self._client.put(
             f"/ocs/v2.php/cloud/groups/{groupid}",
             data={"key": "displayname", "value": displayname},
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         response.raise_for_status()
         logger.info("Updated group %s displayname to: %s", groupid, displayname)

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -53,8 +53,10 @@ from typing import Any, NamedTuple
 #:
 #: * ``webdav`` sends it on DAV verbs, which Sabre answers in XML, so this
 #:   constant's ``Accept`` would be a lie.
-#: * ``MailClient.get_attachment`` (and Deck's equivalent) downloads binary
-#:   attachment bytes, which are likewise not JSON.
+#: * ``MailClient.get_attachment`` downloads binary attachment bytes, which
+#:   are likewise not JSON. (Deck's attachment download sends no headers at
+#:   all, so it is not a third spelling of this pattern -- just another route
+#:   that has no use for the pairing.)
 #: * ``DeckClient._get_deck_headers`` serves Deck's own REST API rather than an
 #:   ``/ocs/v2.php`` route, and sends ``Content-Type`` rather than ``Accept``.
 OCS_REQUEST_HEADERS: Mapping[str, str] = MappingProxyType(

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -26,6 +26,8 @@ and each raises a different type that its callers already catch --
 three caller contracts at once.
 """
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, NamedTuple
 
 #: Headers Nextcloud's CSRF check requires on every OCS request. Omitting
@@ -34,9 +36,15 @@ from typing import Any, NamedTuple
 #:
 #: Used by every client that calls an ``/ocs/v2.php`` route: sharing,
 #: collectives, mail, deck, groups, tables, users, talk, and the two
-#: capability lookups on ``NextcloudClient`` itself. Each takes its own
-#: ``dict(...)`` copy, since an in-place edit of a module-level dict shared by
-#: nine clients would be a cross-client bug.
+#: capability lookups on ``NextcloudClient`` itself.
+#:
+#: Read-only on purpose. Nine clients share this one object, so an in-place
+#: edit here would be a cross-client bug; ``MappingProxyType`` makes that a
+#: ``TypeError`` at the point of the mistake rather than a comment asking
+#: nicely. Every consumer already takes a ``dict(...)`` or ``{**...}`` copy,
+#: which is now belt-and-braces rather than the only line of defence -- and if
+#: those copies are ever unified into one idiom, this is what makes dropping
+#: them safe.
 #:
 #: What this constant owns is the *pairing* -- ``OCS-APIRequest`` together with
 #: ``Accept: application/json`` -- and ``tests/unit/test_ocs_headers_are_shared``
@@ -49,10 +57,12 @@ from typing import Any, NamedTuple
 #:   attachment bytes, which are likewise not JSON.
 #: * ``DeckClient._get_deck_headers`` serves Deck's own REST API rather than an
 #:   ``/ocs/v2.php`` route, and sends ``Content-Type`` rather than ``Accept``.
-OCS_REQUEST_HEADERS: dict[str, str] = {
-    "OCS-APIRequest": "true",
-    "Accept": "application/json",
-}
+OCS_REQUEST_HEADERS: Mapping[str, str] = MappingProxyType(
+    {
+        "OCS-APIRequest": "true",
+        "Accept": "application/json",
+    }
+)
 
 #: Success codes: ``100`` from OCS v1, ``200`` from v2.
 OCS_SUCCESS_STATUS_CODES = frozenset({100, 200})

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -38,8 +38,6 @@ from typing import Any, NamedTuple
 #: ``dict(...)`` copy, since an in-place edit of a module-level dict shared by
 #: nine clients would be a cross-client bug.
 #:
-#: Two sets of headers stay separate on purpose:
-#:
 #: What this constant owns is the *pairing* -- ``OCS-APIRequest`` together with
 #: ``Accept: application/json`` -- and ``tests/unit/test_ocs_headers_are_shared``
 #: fails if any client outside this module spells that pairing itself. Header

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -59,6 +59,9 @@ from typing import Any, NamedTuple
 #:   that has no use for the pairing.)
 #: * ``DeckClient._get_deck_headers`` serves Deck's own REST API rather than an
 #:   ``/ocs/v2.php`` route, and sends ``Content-Type`` rather than ``Accept``.
+#: * ``api/passwords.py`` asks for JSON with the ``format=json`` query
+#:   parameter, which OCS honours in place of the header. Also correct -- do
+#:   not "fix" it by adding the pairing.
 OCS_REQUEST_HEADERS: Mapping[str, str] = MappingProxyType(
     {
         "OCS-APIRequest": "true",

--- a/nextcloud_mcp_server/client/ocs.py
+++ b/nextcloud_mcp_server/client/ocs.py
@@ -32,10 +32,25 @@ from typing import Any, NamedTuple
 #: ``OCS-APIRequest`` yields ``meta.statuscode: 997``, not a 4xx, which is why
 #: it is easy to misdiagnose.
 #:
-#: Used by the three clients this module serves (sharing, collectives, mail).
-#: The same literal still appears inline elsewhere -- deck, groups, tables,
-#: users, and the DAV calls in webdav that send it for unrelated reasons --
-#: which is a wider sweep than this module's scope.
+#: Used by every client that calls an ``/ocs/v2.php`` route: sharing,
+#: collectives, mail, deck, groups, tables, users, talk, and the two
+#: capability lookups on ``NextcloudClient`` itself. Each takes its own
+#: ``dict(...)`` copy, since an in-place edit of a module-level dict shared by
+#: nine clients would be a cross-client bug.
+#:
+#: Two sets of headers stay separate on purpose:
+#:
+#: What this constant owns is the *pairing* -- ``OCS-APIRequest`` together with
+#: ``Accept: application/json`` -- and ``tests/unit/test_ocs_headers_are_shared``
+#: fails if any client outside this module spells that pairing itself. Header
+#: dicts sending ``OCS-APIRequest`` alone are a different set and stay inline:
+#:
+#: * ``webdav`` sends it on DAV verbs, which Sabre answers in XML, so this
+#:   constant's ``Accept`` would be a lie.
+#: * ``MailClient.get_attachment`` (and Deck's equivalent) downloads binary
+#:   attachment bytes, which are likewise not JSON.
+#: * ``DeckClient._get_deck_headers`` serves Deck's own REST API rather than an
+#:   ``/ocs/v2.php`` route, and sends ``Content-Type`` rather than ``Accept``.
 OCS_REQUEST_HEADERS: dict[str, str] = {
     "OCS-APIRequest": "true",
     "Accept": "application/json",

--- a/nextcloud_mcp_server/client/tables.py
+++ b/nextcloud_mcp_server/client/tables.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseNextcloudClient
+from .ocs import OCS_REQUEST_HEADERS
 
 logger = logging.getLogger(__name__)
 
@@ -13,12 +14,15 @@ class TablesClient(BaseNextcloudClient):
 
     app_name = "tables"
 
+    # Own copy -- see the note in GroupsClient.
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
+
     async def list_tables(self) -> List[Dict[str, Any]]:
         """List all tables available to the user."""
         response = await self._make_request(
             "GET",
             "/ocs/v2.php/apps/tables/api/2/tables",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
         )
         result = response.json()
         return result["ocs"]["data"]
@@ -59,7 +63,7 @@ class TablesClient(BaseNextcloudClient):
         response = await self._make_request(
             "POST",
             f"/ocs/v2.php/apps/tables/api/2/tables/{table_id}/rows",
-            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+            headers=self._OCS_HEADERS,
             json={"data": api_data},
         )
         result = response.json()

--- a/nextcloud_mcp_server/client/talk.py
+++ b/nextcloud_mcp_server/client/talk.py
@@ -16,6 +16,7 @@ import re
 from typing import Any
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
 from nextcloud_mcp_server.models.talk import (
     TalkConversation,
     TalkMessage,
@@ -93,10 +94,7 @@ class TalkClient(BaseNextcloudClient):
         so setting it here would also leak it onto bodyless GETs and
         DELETEs.
         """
-        return {
-            "OCS-APIRequest": "true",
-            "Accept": "application/json",
-        }
+        return dict(OCS_REQUEST_HEADERS)
 
     # Conversations (rooms)
 

--- a/nextcloud_mcp_server/client/users.py
+++ b/nextcloud_mcp_server/client/users.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional
 
 from nextcloud_mcp_server.client.base import BaseNextcloudClient
+from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
 from nextcloud_mcp_server.models.users import UserDetails
 
 
@@ -13,7 +14,7 @@ class UsersClient(BaseNextcloudClient):
         self, additional_headers: Optional[Dict[str, str]] = None
     ) -> Dict[str, str]:
         """Get standard headers required for User API calls."""
-        headers = {"OCS-APIRequest": "true", "Accept": "application/json"}
+        headers = dict(OCS_REQUEST_HEADERS)
         if additional_headers:
             headers.update(additional_headers)
         return headers

--- a/nextcloud_mcp_server/client/webdav.py
+++ b/nextcloud_mcp_server/client/webdav.py
@@ -21,6 +21,17 @@ from .base import BaseNextcloudClient
 
 logger = logging.getLogger(__name__)
 
+# The ``{"OCS-APIRequest": "true"}`` headers throughout this module are
+# deliberately NOT ``ocs.OCS_REQUEST_HEADERS``. These are DAV requests
+# (PROPFIND / PUT / MKCOL / REPORT / MOVE / COPY), not OCS ones: they send the
+# header only to identify themselves as API traffic to Nextcloud's CSRF check,
+# and Sabre answers them in XML. The OCS constant also carries
+# ``Accept: application/json``, which would be a lie here. Most of these sites
+# additionally carry request-specific ``Depth`` / ``Content-Type`` values, so
+# there is nothing shared left to hoist -- keep writing them inline. The guard
+# in ``tests/unit/test_ocs_headers_are_shared`` only rejects the OCS+JSON
+# pairing, so these stay legal by construction rather than by exemption.
+
 
 class OversizeDownload(Exception):
     """A streamed download exceeded its byte budget and was aborted.

--- a/tests/unit/test_ocs_headers_are_shared.py
+++ b/tests/unit/test_ocs_headers_are_shared.py
@@ -1,0 +1,107 @@
+"""Guard: the OCS+JSON header pairing lives in one constant, not at each call.
+
+Omitting ``OCS-APIRequest: true`` does not produce a 4xx. Nextcloud answers
+``200`` with ``meta.statuscode: 997``, which reads as a server fault and sends
+whoever is debugging it hunting for one. ``client/ocs.py`` exists to make that
+failure legible; the literal being re-typed at every new call site is what
+keeps re-creating it.
+
+What is pinned here is the specific pairing the constant owns --
+``OCS-APIRequest`` *together with* ``Accept: application/json``, the shape every
+JSON-returning ``/ocs/v2.php`` call needs. Header dicts that send
+``OCS-APIRequest`` on its own are a different set with their own reasons (DAV
+verbs answered in XML, binary attachment downloads, Deck's own REST API) and
+are deliberately not folded in.
+
+The scan is over the AST rather than over lines, so a pairing split across two
+lines by the formatter still counts.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import nextcloud_mcp_server.client as client_pkg
+
+pytestmark = pytest.mark.unit
+
+#: The module that defines the constant is the one place allowed to spell it.
+DEFINING_MODULE = "ocs.py"
+
+#: The keys whose co-occurrence in one dict literal makes it a copy of
+#: ``OCS_REQUEST_HEADERS``.
+OWNED_PAIRING = {"OCS-APIRequest", "Accept"}
+
+
+def _client_sources() -> list[Path]:
+    return sorted(Path(client_pkg.__file__).parent.rglob("*.py"))
+
+
+def _copied_pairings(path: Path) -> list[int]:
+    """Line numbers of dict literals carrying the constant's whole pairing."""
+    tree = ast.parse(path.read_text())
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict)
+        and OWNED_PAIRING <= {k.value for k in node.keys if isinstance(k, ast.Constant)}
+    ]
+
+
+def test_scan_finds_the_client_package():
+    """Guard the guard: a bad glob would make the scan below vacuously pass."""
+    names = {p.name for p in _client_sources()}
+    assert {"ocs.py", "sharing.py", "deck.py", "webdav.py"} <= names
+
+
+def test_the_constant_is_still_the_pairing_being_guarded():
+    """Guard the guard: if OCS_REQUEST_HEADERS changes shape, so must this test.
+
+    Without it, renaming a key in ``ocs.py`` would leave every assertion below
+    scanning for a pairing that no longer exists — passing while the sprawl it
+    was written to catch quietly returns.
+    """
+    from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
+
+    assert set(OCS_REQUEST_HEADERS) == OWNED_PAIRING
+
+
+def test_no_client_retypes_the_ocs_header_pairing():
+    """Every JSON OCS call site must reach the header through the constant."""
+    offenders = [
+        f"{path.name}:{lineno}"
+        for path in _client_sources()
+        if path.name != DEFINING_MODULE
+        for lineno in _copied_pairings(path)
+    ]
+    assert not offenders, (
+        "these call sites re-type the OCS+JSON header pairing instead of using "
+        f"client.ocs.OCS_REQUEST_HEADERS: {offenders}"
+    )
+
+
+def test_every_ocs_client_imports_the_constant():
+    """The clients that call /ocs/v2.php must import the constant they need.
+
+    Checked separately from the literal scan because a client can pass that one
+    simply by sending no header at all -- which is the 997 this whole module
+    exists to prevent.
+    """
+    expected = {
+        "sharing.py",
+        "collectives.py",
+        "mail.py",
+        "deck.py",
+        "groups.py",
+        "tables.py",
+        "users.py",
+        "talk.py",
+        "__init__.py",
+    }
+    missing = {
+        path.name
+        for path in _client_sources()
+        if path.name in expected and "OCS_REQUEST_HEADERS" not in path.read_text()
+    }
+    assert not missing, f"OCS clients not using the shared header: {sorted(missing)}"

--- a/tests/unit/test_ocs_headers_are_shared.py
+++ b/tests/unit/test_ocs_headers_are_shared.py
@@ -105,3 +105,17 @@ def test_every_ocs_client_imports_the_constant():
         if path.name in expected and "OCS_REQUEST_HEADERS" not in path.read_text()
     }
     assert not missing, f"OCS clients not using the shared header: {sorted(missing)}"
+
+
+def test_the_constant_cannot_be_mutated():
+    """Nine clients share this one object; an in-place edit must not be possible.
+
+    The per-client ``dict(...)`` copies exist because of that sharing. Making
+    the source read-only turns the mistake those copies guard against into a
+    ``TypeError`` at the point it is made, rather than a cross-client bug
+    discovered later in whichever client happened to run next.
+    """
+    from nextcloud_mcp_server.client.ocs import OCS_REQUEST_HEADERS
+
+    with pytest.raises(TypeError):
+        OCS_REQUEST_HEADERS["Accept"] = "text/xml"  # ty: ignore[unsupported-operation]

--- a/tests/unit/test_ocs_headers_are_shared.py
+++ b/tests/unit/test_ocs_headers_are_shared.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-import nextcloud_mcp_server.client as client_pkg
+import nextcloud_mcp_server as root_pkg
 
 pytestmark = pytest.mark.unit
 
@@ -34,8 +34,16 @@ DEFINING_MODULE = "ocs.py"
 OWNED_PAIRING = {"OCS-APIRequest", "Accept"}
 
 
-def _client_sources() -> list[Path]:
-    return sorted(Path(client_pkg.__file__).parent.rglob("*.py"))
+def _package_sources() -> list[Path]:
+    """Every module in the distribution, not just ``client/``.
+
+    Scoping this to the client package is what let two call sites outside it
+    keep retyping the pairing -- ``api/apps.py`` and ``auth/storage.py`` both
+    build their own ``httpx.AsyncClient`` for an ``/ocs/v2.php`` route. A guard
+    that only watches the place the problem was already fixed is a guard that
+    reports success.
+    """
+    return sorted(Path(root_pkg.__file__).parent.rglob("*.py"))
 
 
 def _copied_pairings(path: Path) -> list[int]:
@@ -49,10 +57,15 @@ def _copied_pairings(path: Path) -> list[int]:
     ]
 
 
-def test_scan_finds_the_client_package():
-    """Guard the guard: a bad glob would make the scan below vacuously pass."""
-    names = {p.name for p in _client_sources()}
+def test_scan_reaches_beyond_the_client_package():
+    """Guard the guard: a bad glob would make the scan below vacuously pass.
+
+    Named modules from three different packages, so narrowing the scan back to
+    ``client/`` fails here rather than silently shrinking what is protected.
+    """
+    names = {p.name for p in _package_sources()}
     assert {"ocs.py", "sharing.py", "deck.py", "webdav.py"} <= names
+    assert {"apps.py", "storage.py"} <= names
 
 
 def test_the_constant_is_still_the_pairing_being_guarded():
@@ -68,10 +81,14 @@ def test_the_constant_is_still_the_pairing_being_guarded():
 
 
 def test_no_client_retypes_the_ocs_header_pairing():
-    """Every JSON OCS call site must reach the header through the constant."""
+    """Every JSON OCS call site must reach the header through the constant.
+
+    Not only the app clients: anything talking to ``/ocs/v2.php`` needs the
+    pairing, including modules that build a one-off ``httpx.AsyncClient``.
+    """
     offenders = [
         f"{path.name}:{lineno}"
-        for path in _client_sources()
+        for path in _package_sources()
         if path.name != DEFINING_MODULE
         for lineno in _copied_pairings(path)
     ]
@@ -101,7 +118,7 @@ def test_every_ocs_client_imports_the_constant():
     }
     missing = {
         path.name
-        for path in _client_sources()
+        for path in _package_sources()
         if path.name in expected and "OCS_REQUEST_HEADERS" not in path.read_text()
     }
     assert not missing, f"OCS clients not using the shared header: {sorted(missing)}"

--- a/tests/unit/test_ocs_headers_are_shared.py
+++ b/tests/unit/test_ocs_headers_are_shared.py
@@ -27,11 +27,27 @@ import nextcloud_mcp_server as root_pkg
 pytestmark = pytest.mark.unit
 
 #: The module that defines the constant is the one place allowed to spell it.
-DEFINING_MODULE = "ocs.py"
+DEFINING_MODULE = "client/ocs.py"
 
 #: The keys whose co-occurrence in one dict literal makes it a copy of
 #: ``OCS_REQUEST_HEADERS``.
 OWNED_PAIRING = {"OCS-APIRequest", "Accept"}
+
+
+def _package_root() -> Path:
+    return Path(root_pkg.__file__).parent
+
+
+def _rel(path: Path) -> str:
+    """Package-relative POSIX path, e.g. ``client/sharing.py``.
+
+    Bare filenames are not identifiers here: the package holds a ``deck.py``, a
+    ``talk.py`` and a ``sharing.py`` under each of ``client/``, ``models/`` and
+    ``server/``, plus an ``__init__.py`` in every subpackage. Matching on
+    ``path.name`` silently conflated all of them the moment this scan grew
+    beyond ``client/``.
+    """
+    return path.relative_to(_package_root()).as_posix()
 
 
 def _package_sources() -> list[Path]:
@@ -43,7 +59,7 @@ def _package_sources() -> list[Path]:
     that only watches the place the problem was already fixed is a guard that
     reports success.
     """
-    return sorted(Path(root_pkg.__file__).parent.rglob("*.py"))
+    return sorted(_package_root().rglob("*.py"))
 
 
 def _copied_pairings(path: Path) -> list[int]:
@@ -63,9 +79,14 @@ def test_scan_reaches_beyond_the_client_package():
     Named modules from three different packages, so narrowing the scan back to
     ``client/`` fails here rather than silently shrinking what is protected.
     """
-    names = {p.name for p in _package_sources()}
-    assert {"ocs.py", "sharing.py", "deck.py", "webdav.py"} <= names
-    assert {"apps.py", "storage.py"} <= names
+    found = {_rel(p) for p in _package_sources()}
+    assert {
+        "client/ocs.py",
+        "client/sharing.py",
+        "client/deck.py",
+        "client/webdav.py",
+    } <= found
+    assert {"api/apps.py", "auth/storage.py"} <= found
 
 
 def test_the_constant_is_still_the_pairing_being_guarded():
@@ -87,9 +108,9 @@ def test_no_client_retypes_the_ocs_header_pairing():
     pairing, including modules that build a one-off ``httpx.AsyncClient``.
     """
     offenders = [
-        f"{path.name}:{lineno}"
+        f"{_rel(path)}:{lineno}"
         for path in _package_sources()
-        if path.name != DEFINING_MODULE
+        if _rel(path) != DEFINING_MODULE
         for lineno in _copied_pairings(path)
     ]
     assert not offenders, (
@@ -106,20 +127,25 @@ def test_every_ocs_client_imports_the_constant():
     exists to prevent.
     """
     expected = {
-        "sharing.py",
-        "collectives.py",
-        "mail.py",
-        "deck.py",
-        "groups.py",
-        "tables.py",
-        "users.py",
-        "talk.py",
-        "__init__.py",
+        "client/sharing.py",
+        "client/collectives.py",
+        "client/mail.py",
+        "client/deck.py",
+        "client/groups.py",
+        "client/tables.py",
+        "client/users.py",
+        "client/talk.py",
+        "client/__init__.py",
+        "api/apps.py",
+        "auth/storage.py",
     }
+    present = {_rel(p) for p in _package_sources()}
+    assert expected <= present, f"expected modules are gone: {expected - present}"
     missing = {
-        path.name
+        rel
         for path in _package_sources()
-        if path.name in expected and "OCS_REQUEST_HEADERS" not in path.read_text()
+        if (rel := _rel(path)) in expected
+        and "OCS_REQUEST_HEADERS" not in path.read_text()
     }
     assert not missing, f"OCS clients not using the shared header: {sorted(missing)}"
 


### PR DESCRIPTION
Closes the follow-up filed as Deck card 1054, raised by the review bot on #1343.

## Problem

PR #1343 gave sharing, collectives and mail a single `OCS_REQUEST_HEADERS` in
`client/ocs.py`. The same literal was still typed out in `deck` (9 sites),
`groups` (6), `tables` (2), `users`, `talk` and the two capability lookups on
`NextcloudClient` itself. A new call site could still copy an un-shared literal
— and omitting `OCS-APIRequest` is what makes Nextcloud answer `997`, the
failure #1343 exists to make legible in the first place.

**Values are unchanged everywhere.** This only changes where they come from.

## What stays inline, and why

The card framed the remaining sites as "OCS clients to migrate" plus "the
webdav caveat". Working through them, the real line is narrower: the constant
owns a **pairing** — `OCS-APIRequest` *together with* `Accept: application/json`
— and three header sets are not that pairing:

- **`webdav`** sends `OCS-APIRequest` on DAV verbs (PROPFIND/PUT/MKCOL/REPORT),
  which Sabre answers in XML, so `Accept: application/json` would be a lie.
  Most of those sites also carry request-specific `Depth`/`Content-Type`,
  leaving nothing shared to hoist.
- **`MailClient.get_attachment`** downloads binary attachment bytes, likewise
  not JSON. *The card did not list this one — the guard test found it.*
- **`DeckClient._get_deck_headers`** serves Deck's own REST API
  (`/index.php/apps/deck/api/v1.0/...`), not an `/ocs/v2.php` route, and sends
  `Content-Type` where the constant sends `Accept`. The card asked whether that
  is deliberate. I can't establish intent, but it works as-is and changing it
  would be a behaviour change riding along in a de-duplication pass — so it's
  left alone and documented as a Deck-REST-only question if ever revisited.

Each of the three is recorded where the next person will be writing the code:
in `ocs.py`'s constant docstring, at the top of `webdav.py`, and on the Deck
helper itself.

## Test coverage

`tests/unit/test_ocs_headers_are_shared.py` walks the **AST** for dict literals
carrying both keys, rather than grepping lines — so a pairing the formatter
splits across two lines still counts, and the three sets above stay legal *by
construction* rather than by a maintained exemption list. It also pins the
constant's own shape, so renaming a key cannot leave the scan hunting for a
pairing that no longer exists, and asserts the nine OCS clients import it at
all (a client sending no header would otherwise pass the literal scan — which
is the exact 997 in question).

No API surface changes, so the e2e + contract gate does not apply.

---

_This PR was generated with the help of AI, and reviewed by a Human_