### PR TITLE
feat(calendar): make ETag concurrency reachable from the todo tools

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -171,6 +171,12 @@ re-read it, re-apply your change on the current copy, and retry. Omitting
 `etag` still guards the instant inside the call itself, but not the window
 since your read.
 
+One caveat on chaining: `etag` comes back empty if the server sent no `ETag`
+header on the write. Passing an empty value is the same as passing none, so a
+chain built on it degrades to unguarded silently rather than failing. If a
+write is worth guarding, check the returned `etag` is non-empty before
+chaining it, and re-read with `nc_calendar_list_todos` if it is not.
+
 On `nc_calendar_complete_todo` the `etag` is rarely wanted: marking a task done
 is usually the intended outcome whatever else changed. It is offered so that a
 caller who *does* want a guarded completion is not pushed back onto

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -138,6 +138,44 @@ await nc_calendar_complete_todo(
 Not idempotent: a second call without an explicit `completed` restamps the
 timestamp.
 
+## Guarding a todo update against a concurrent change
+
+`nc_calendar_update_todo` and `nc_calendar_complete_todo` both take an optional
+`etag`. Pass the one you read the todo with and the write is refused if
+anything changed in between, so a read-modify-write cycle cannot silently
+discard someone else's edit.
+
+```python
+todos = await nc_calendar_list_todos(calendar_name="Personal")
+todo = next(t for t in todos["results"] if t["uid"] == "abc-123")
+
+result = await nc_calendar_update_todo(
+    calendar_name="Personal",
+    todo_uid="abc-123",
+    summary="Revised title",
+    etag=todo["etag"],
+)
+
+# The write returns the next ETag, so a follow-up update stays guarded
+# without re-reading.
+await nc_calendar_update_todo(
+    calendar_name="Personal",
+    todo_uid="abc-123",
+    priority=1,
+    etag=result["etag"],
+)
+```
+
+If the todo moved on, the call fails with a message naming the recovery —
+re-read it, re-apply your change on the current copy, and retry. Omitting
+`etag` still guards the instant inside the call itself, but not the window
+since your read.
+
+On `nc_calendar_complete_todo` the `etag` is rarely wanted: marking a task done
+is usually the intended outcome whatever else changed. It is offered so that a
+caller who *does* want a guarded completion is not pushed back onto
+`nc_calendar_update_todo` and its three-property footgun.
+
 ## Recurring todos
 
 CalDAV does not expand VTODO recurrences: a `calendar-query` returns only the

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -147,7 +147,7 @@ discard someone else's edit.
 
 ```python
 todos = await nc_calendar_list_todos(calendar_name="Personal")
-todo = next(t for t in todos["results"] if t["uid"] == "abc-123")
+todo = next(t for t in todos["todos"] if t["uid"] == "abc-123")
 
 result = await nc_calendar_update_todo(
     calendar_name="Personal",

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -21,7 +21,7 @@ from icalendar import Todo as ICalTodo
 from lxml import etree  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 from ..config import get_nextcloud_ssl_verify
-from .dav_errors import dav_error_from_response
+from .dav_errors import DavPreconditionFailed, dav_error_from_response
 
 logger = logging.getLogger(__name__)
 
@@ -1301,6 +1301,15 @@ class CalendarClient:
                 "etag": new_etag,
                 "status_code": 200,
             }
+        except DavPreconditionFailed:
+            # Listed before the catch-all because it is not a failure of this
+            # call: it is the If-Match guard doing its job when another writer
+            # got there first. The tool layer already logs it at debug and
+            # translates it into an actionable error, so logging it as an error
+            # here would make every contended write look like a server fault --
+            # in exactly the concurrent-write scenario someone would be reading
+            # these logs to understand.
+            raise
         except Exception as e:
             logger.error("Error updating todo %s: %s", todo_uid, e)
             raise

--- a/nextcloud_mcp_server/models/__init__.py
+++ b/nextcloud_mcp_server/models/__init__.py
@@ -21,6 +21,7 @@ from .calendar import (
     ManageCalendarResponse,
     UpcomingEventsResponse,
     UpdateEventResponse,
+    UpdateTodoResponse,
 )
 
 # Contacts models
@@ -107,6 +108,7 @@ __all__ = [
     "CompleteTodoResponse",
     "CreateEventResponse",
     "UpdateEventResponse",
+    "UpdateTodoResponse",
     "DeleteEventResponse",
     "ListEventsResponse",
     "ListCalendarsResponse",

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -421,10 +421,24 @@ class CreateTodoResponse(BaseResponse):
 
 
 class UpdateTodoResponse(BaseResponse):
-    """Response model for todo updates."""
+    """Response model for todo updates.
 
-    todo: Todo = Field(description="The updated todo")
+    Carries identifiers and the post-write ETag rather than the updated
+    ``Todo``: the CalDAV write returns exactly this much, and rebuilding a full
+    todo would cost an extra read on every update. ``etag`` is the value to
+    pass back into the next update to keep a read-modify-write cycle guarded.
+    """
+
+    uid: str = Field(description="UID of the updated todo")
     calendar_name: str = Field(description="Name of the calendar the todo belongs to")
+    href: str = Field(default="", description="CalDAV href of the todo")
+    etag: str = Field(
+        default="",
+        description=(
+            "ETag after the write. Pass it as `etag` on the next update to "
+            "detect a concurrent change; empty if the server sent none."
+        ),
+    )
 
 
 class CompleteTodoResponse(BaseResponse):
@@ -440,6 +454,13 @@ class CompleteTodoResponse(BaseResponse):
     )
     completed: str = Field(description="ISO-8601 COMPLETED timestamp that was written")
     href: str = Field(default="", description="CalDAV href of the todo")
+    etag: str = Field(
+        default="",
+        description=(
+            "ETag after the write. Pass it as `etag` on the next update to "
+            "detect a concurrent change; empty if the server sent none."
+        ),
+    )
 
 
 class DeleteTodoResponse(StatusResponse):

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -1205,13 +1205,19 @@ def configure_calendar_tools(mcp: FastMCP):
     )
     @require_scopes("todo.write", "calendar.read")
     @instrument_tool
-    # NOSONAR(python:S107) -- 14 parameters, one over Sonar's limit. On an MCP
-    # tool the parameter list IS the published input schema: the rule's usual
-    # remedy, bundling them into one object, would nest every optional field a
-    # level deeper for every caller and every generated client. The sibling
-    # nc_calendar_update_event carries ~22 for the same reason and only escapes
-    # the rule by being older than the new-code period.
-    async def nc_calendar_update_todo(  # NOSONAR(python:S107)
+    # The suppression on the signature below silences python:S107 -- 14
+    # parameters, one over Sonar's limit. On an MCP tool the parameter list IS
+    # the published input schema: the rule's usual remedy, bundling them into
+    # one object, would nest every optional field a level deeper for every
+    # caller and every generated client. The sibling nc_calendar_update_event
+    # carries ~22 for the same reason and only escapes the rule by being older
+    # than the new-code period.
+    #
+    # Bare, because a parenthesised rule id is NOT a scoped filter -- Sonar
+    # rejects it as malformed (python:S7632) and then suppresses nothing, which
+    # is exactly what the first attempt at this did. Nothing else on the
+    # signature line trips a rule, so suppressing the whole line is safe.
+    async def nc_calendar_update_todo(  # NOSONAR
         calendar_name: str,
         todo_uid: str,
         ctx: Context,

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -3,9 +3,11 @@ import logging
 from typing import Any, Optional
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.calendar import (
     Calendar,
@@ -19,10 +21,28 @@ from nextcloud_mcp_server.models.calendar import (
     Reminder,
     Todo,
     UpcomingEventsResponse,
+    UpdateTodoResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
 
 logger = logging.getLogger(__name__)
+
+
+def _stale_etag_error(uid: str, e: DavPreconditionFailed) -> ToolError:
+    """Turn a 412 into something the caller can act on.
+
+    ``DavPreconditionFailed`` reaches an MCP client as an httpx status error
+    naming a CalDAV URL -- accurate, and useless for deciding what to do. The
+    only recovery is to re-read, re-apply and retry, so the message says that
+    and names the tool that actually returns a current ETag.
+    """
+    detail = e.dav_message or "it was modified after that ETag was read"
+    return ToolError(
+        f"Todo {uid} was not updated: {detail}. Another client changed it "
+        "since you read it. Re-read the todo with nc_calendar_list_todos to "
+        "get its current etag, re-apply your changes on top of that copy, and "
+        "retry."
+    )
 
 
 def _reminders_to_dicts(reminders: list[Reminder]) -> list[dict[str, Any]]:
@@ -1199,7 +1219,8 @@ def configure_calendar_tools(mcp: FastMCP):
         completed: Optional[str] = None,
         categories: Optional[str] = None,
         reminders: list[Reminder] | None = None,
-    ):
+        etag: str = "",
+    ) -> UpdateTodoResponse:
         """Update an existing todo/task.
 
         Args:
@@ -1219,9 +1240,17 @@ def configure_calendar_tools(mcp: FastMCP):
             categories: New categories (comma-separated)
             reminders: Replacement alarm list. Omit to keep the stored alarms,
                 or pass ``[]`` to clear them.
+            etag: The ETag you read this todo with (from nc_calendar_list_todos
+                or a previous update). The write is refused if the todo changed
+                since, so your read-modify-write cycle cannot silently discard
+                someone else's edit. Omitting it still guards the instant
+                inside this call, but not the window since your read.
 
         Returns:
-            Dict with todo update result
+            UpdateTodoResponse carrying the identifiers and the new ETag.
+
+        Raises:
+            ToolError: If the todo changed since ``etag`` was read.
         """
         client = await get_client(ctx)
 
@@ -1248,7 +1277,19 @@ def configure_calendar_tools(mcp: FastMCP):
         if reminders is not None:
             todo_data["reminders"] = _reminders_to_dicts(reminders)
 
-        return await client.calendar.update_todo(calendar_name, todo_uid, todo_data)
+        try:
+            result = await client.calendar.update_todo(
+                calendar_name, todo_uid, todo_data, etag
+            )
+        except DavPreconditionFailed as e:
+            raise _stale_etag_error(todo_uid, e) from e
+
+        return UpdateTodoResponse(
+            uid=todo_uid,
+            calendar_name=calendar_name,
+            href=result.get("href", ""),
+            etag=result.get("etag", ""),
+        )
 
     @mcp.tool(
         title="Complete Todo Task",
@@ -1266,6 +1307,7 @@ def configure_calendar_tools(mcp: FastMCP):
         todo_uid: str,
         ctx: Context,
         completed: Optional[str] = None,
+        etag: str = "",
     ) -> CompleteTodoResponse:
         """Mark a todo/task complete.
 
@@ -1279,13 +1321,28 @@ def configure_calendar_tools(mcp: FastMCP):
             todo_uid: UID of the todo to complete
             ctx: MCP context
             completed: Completion timestamp (ISO format). Defaults to now (UTC).
+            etag: The ETag you read this todo with. Optional, and usually
+                unnecessary — completing a task is normally the intended
+                outcome whatever else changed. It is offered anyway so that a
+                caller who *does* want a guarded completion is not pushed back
+                onto nc_calendar_update_todo and the three-property footgun
+                this tool exists to spare them.
 
         Returns:
             CompleteTodoResponse carrying the three values actually written.
+
+        Raises:
+            ToolError: If ``etag`` was given and the todo changed since.
         """
         client = await get_client(ctx)
         payload = _completion_payload(completed)
-        result = await client.calendar.update_todo(calendar_name, todo_uid, payload)
+        try:
+            result = await client.calendar.update_todo(
+                calendar_name, todo_uid, payload, etag
+            )
+        except DavPreconditionFailed as e:
+            raise _stale_etag_error(todo_uid, e) from e
+
         return CompleteTodoResponse(
             uid=todo_uid,
             calendar_name=calendar_name,
@@ -1293,6 +1350,7 @@ def configure_calendar_tools(mcp: FastMCP):
             percent_complete=payload["percent_complete"],
             completed=payload["completed"],
             href=result.get("href", ""),
+            etag=result.get("etag", ""),
         )
 
     @mcp.tool(

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -37,6 +37,11 @@ def _stale_etag_error(uid: str, e: DavPreconditionFailed) -> ToolError:
     and names the tool that actually returns a current ETag.
     """
     detail = e.dav_message or "it was modified after that ETag was read"
+    # debug, not warning: a caller losing a write race is the guard working,
+    # not a fault. It is logged at all because the refusal is otherwise
+    # invisible server-side -- and concurrent-write contention is exactly the
+    # kind of thing you end up reconstructing from logs after the fact.
+    logger.debug("Stale ETag on todo %s: %s", uid, detail)
     return ToolError(
         f"Todo {uid} was not updated: {detail}. Another client changed it "
         "since you read it. Re-read the todo with nc_calendar_list_todos to "
@@ -1213,12 +1218,18 @@ def configure_calendar_tools(mcp: FastMCP):
     # carries ~22 for the same reason and only escapes the rule by being older
     # than the new-code period.
     #
-    # Bare, because a parenthesised rule id is NOT a scoped filter -- Sonar
-    # rejects it as malformed (python:S7632) and then suppresses nothing, which
-    # is exactly what the first attempt at this did. Nothing else on the
-    # signature line trips a rule, so suppressing the whole line is safe.
-    async def nc_calendar_update_todo(  # NOSONAR
-        calendar_name: str,
+    # Two things had to be got right, both established by re-listing the PR's
+    # issues rather than by reasoning:
+    #
+    # 1. Bare, not parenthesised. A rule id in parentheses is not a scoped
+    #    filter -- Sonar rejects the whole comment as malformed (python:S7632)
+    #    and then suppresses nothing, which is what the first attempt did.
+    # 2. On the first PARAMETER line, not the `def` line. Sonar anchors S107 at
+    #    the start of the parameter list, so a marker on the signature line sits
+    #    one line above the issue and does nothing. Nothing else on that line
+    #    trips a rule, so suppressing it wholesale is safe.
+    async def nc_calendar_update_todo(
+        calendar_name: str,  # NOSONAR
         todo_uid: str,
         ctx: Context,
         summary: Optional[str] = None,

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -1205,7 +1205,13 @@ def configure_calendar_tools(mcp: FastMCP):
     )
     @require_scopes("todo.write", "calendar.read")
     @instrument_tool
-    async def nc_calendar_update_todo(
+    # NOSONAR(python:S107) -- 14 parameters, one over Sonar's limit. On an MCP
+    # tool the parameter list IS the published input schema: the rule's usual
+    # remedy, bundling them into one object, would nest every optional field a
+    # level deeper for every caller and every generated client. The sibling
+    # nc_calendar_update_event carries ~22 for the same reason and only escapes
+    # the rule by being older than the new-code period.
+    async def nc_calendar_update_todo(  # NOSONAR(python:S107)
         calendar_name: str,
         todo_uid: str,
         ctx: Context,

--- a/tests/server/test_calendar_todos_mcp.py
+++ b/tests/server/test_calendar_todos_mcp.py
@@ -646,9 +646,13 @@ async def test_stale_etag_refuses_the_write_end_to_end(
         listed = await nc_mcp_client.call_tool(
             "nc_calendar_list_todos", {"calendar_name": calendar_name}
         )
+        # ``todos``, not ``results``: ListTodosResponse names its list field
+        # after the resource. Several other list responses in this codebase do
+        # use ``results``, which is exactly why this is worth pinning in a
+        # comment rather than rediscovering.
         todo = next(
             t
-            for t in json.loads(listed.content[0].text)["results"]
+            for t in json.loads(listed.content[0].text)["todos"]
             if t["uid"] == todo_uid
         )
         first_etag = todo["etag"]

--- a/tests/server/test_calendar_todos_mcp.py
+++ b/tests/server/test_calendar_todos_mcp.py
@@ -615,3 +615,76 @@ async def test_mcp_complete_todo_accepts_explicit_timestamp(
         json.loads(complete_result.content[0].text)["completed"]
         == "2026-01-01T09:00:00+00:00"
     )
+
+
+async def test_stale_etag_refuses_the_write_end_to_end(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
+):
+    """A contended read-modify-write cycle must lose, not silently overwrite.
+
+    The unit tests pin the tool's plumbing against a mocked client; only this
+    exercises the part that is really in question -- that Nextcloud's own
+    If-Match evaluation refuses the second write. A mock can be made to raise
+    412 whether or not the header ever reaches Sabre.
+
+    The second update stands in for a concurrent client: it is a real write
+    that moves the ETag on, after which the first caller's copy is stale
+    exactly as it would be in a race.
+    """
+    calendar_name = temporary_calendar
+    todo_uid = None
+
+    try:
+        create_result = await nc_mcp_client.call_tool(
+            "nc_calendar_create_todo",
+            {"calendar_name": calendar_name, "summary": "ETag contention"},
+        )
+        assert create_result.isError is False
+        todo_uid = json.loads(create_result.content[0].text)["uid"]
+
+        # Read the ETag the way a caller would.
+        listed = await nc_mcp_client.call_tool(
+            "nc_calendar_list_todos", {"calendar_name": calendar_name}
+        )
+        todo = next(
+            t
+            for t in json.loads(listed.content[0].text)["results"]
+            if t["uid"] == todo_uid
+        )
+        first_etag = todo["etag"]
+        assert first_etag, "list_todos returned no ETag to guard with"
+
+        # Matching ETag: accepted, and hands back the next one.
+        accepted = await nc_mcp_client.call_tool(
+            "nc_calendar_update_todo",
+            {
+                "calendar_name": calendar_name,
+                "todo_uid": todo_uid,
+                "summary": "First writer wins",
+                "etag": first_etag,
+            },
+        )
+        assert accepted.isError is False, accepted.content[0].text
+        second_etag = json.loads(accepted.content[0].text)["etag"]
+        assert second_etag and second_etag != first_etag
+
+        # The original ETag is now stale: the write must be refused, readably.
+        refused = await nc_mcp_client.call_tool(
+            "nc_calendar_update_todo",
+            {
+                "calendar_name": calendar_name,
+                "todo_uid": todo_uid,
+                "summary": "Second writer must not clobber",
+                "etag": first_etag,
+            },
+        )
+        assert refused.isError is True
+        assert "nc_calendar_list_todos" in refused.content[0].text
+
+        # ...and the refusal really did leave the stored copy alone.
+        todos = await nc_client.calendar.list_todos(calendar_name)
+        stored = next(t for t in todos if t["uid"] == todo_uid)
+        assert stored["summary"] == "First writer wins"
+    finally:
+        if todo_uid:
+            await nc_client.calendar.delete_todo(calendar_name, todo_uid)

--- a/tests/unit/client/test_calendar_precondition_logging.py
+++ b/tests/unit/client/test_calendar_precondition_logging.py
@@ -1,0 +1,108 @@
+"""A lost ETag race must not be logged as a server error.
+
+``CalendarClient.update_todo`` wraps its body in ``except Exception`` and logs
+at ``error`` before re-raising. That fires for ``DavPreconditionFailed`` too --
+which is not a failure of the call, but the ``If-Match`` guard doing its job
+when another writer got there first.
+
+The tool layer deliberately logs that at ``debug`` ("a caller losing a write
+race is the guard working, not a fault"). An ``error`` one layer below
+contradicts it, and does so in exactly the concurrent-write scenario someone
+would be reading these logs to understand.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from httpx import Request, Response
+
+from nextcloud_mcp_server.client.calendar import CalendarClient
+from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
+
+pytestmark = pytest.mark.unit
+
+CALENDAR_LOGGER = "nextcloud_mcp_server.client.calendar"
+
+
+def _precondition_failed() -> DavPreconditionFailed:
+    request = Request("PUT", "https://nc.example.com/dav/todo-1.ics")
+    return DavPreconditionFailed(
+        "412 Precondition Failed",
+        request=request,
+        response=Response(412, request=request),
+        dav_message="If-Match did not match",
+    )
+
+
+@pytest.fixture
+def client(mocker):
+    """A CalendarClient with the CalDAV round-trip stubbed out.
+
+    Only the pieces ``update_todo`` touches on its way to the conditional PUT
+    are stubbed; the point is the except-ordering after that PUT fails, not the
+    DAV plumbing before it.
+    """
+    calendar_client = CalendarClient(
+        "https://nc.example.com", "testuser", password="pw"
+    )
+
+    todo = mocker.MagicMock()
+    todo.data = "BEGIN:VCALENDAR\nEND:VCALENDAR"
+    todo.url = "https://nc.example.com/dav/todo-1.ics"
+    todo.load.return_value = None
+
+    mocker.patch.object(
+        CalendarClient, "_ensure_calendar_home", mocker.AsyncMock(return_value=None)
+    )
+    mocker.patch.object(
+        CalendarClient, "_get_calendar", return_value=mocker.MagicMock()
+    )
+    mocker.patch.object(
+        CalendarClient, "_async_object_by_uid", mocker.AsyncMock(return_value=todo)
+    )
+    mocker.patch.object(
+        CalendarClient, "_merge_ical_todo_properties", return_value="ICAL"
+    )
+    return calendar_client
+
+
+async def test_stale_etag_is_not_logged_as_an_error(client, mocker, caplog):
+    """The 412 propagates, and leaves no ERROR record behind."""
+    mocker.patch.object(
+        CalendarClient,
+        "_conditional_put",
+        mocker.AsyncMock(side_effect=_precondition_failed()),
+    )
+    # Logger-scoped, so an unrelated module's ERROR cannot make this pass or
+    # fail by accident.
+    caplog.set_level(logging.ERROR, logger=CALENDAR_LOGGER)
+
+    with pytest.raises(DavPreconditionFailed):
+        await client.update_todo("Personal", "todo-1", {"summary": "x"}, '"stale"')
+
+    errors = [r for r in caplog.records if r.name == CALENDAR_LOGGER]
+    assert not errors, [r.getMessage() for r in errors]
+
+
+async def test_a_real_failure_is_still_logged_as_an_error(client, mocker, caplog):
+    """Guard the guard: the catch-all must still fire for everything else.
+
+    Without this, deleting the ``logger.error`` outright would pass the test
+    above -- and the error path this narrowing was careful to preserve would be
+    silently gone.
+    """
+    mocker.patch.object(
+        CalendarClient,
+        "_conditional_put",
+        mocker.AsyncMock(side_effect=RuntimeError("caldav exploded")),
+    )
+    caplog.set_level(logging.ERROR, logger=CALENDAR_LOGGER)
+
+    with pytest.raises(RuntimeError):
+        await client.update_todo("Personal", "todo-1", {"summary": "x"}, '"etag"')
+
+    errors = [r for r in caplog.records if r.name == CALENDAR_LOGGER]
+    assert len(errors) == 1
+    assert "todo-1" in errors[0].getMessage()

--- a/tests/unit/server/test_calendar_todo_etag.py
+++ b/tests/unit/server/test_calendar_todo_etag.py
@@ -1,0 +1,197 @@
+"""Unit tests for ETag concurrency on the todo tools.
+
+The CalDAV client layer has had real ``If-Match`` protection since #1335, but
+only ``nc_calendar_update_event`` exposed it. The todo tools called
+``update_todo`` with no ETag, so the write fell back to the one observed
+*during that call* -- which closes the millisecond inside the call and leaves
+the caller's actual read-modify-write cycle unguarded.
+
+Two things are pinned here: that the caller's ETag reaches the client
+unchanged, and that a stale one comes back as something the caller can act on.
+A bare ``DavPreconditionFailed`` reaches an MCP client as an httpx status error
+naming a CalDAV URL -- correct, and no help in deciding what to do next.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import Request, Response
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
+from nextcloud_mcp_server.server.calendar import configure_calendar_tools
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def calendar_tools():
+    mcp = FastMCP("test")
+    configure_calendar_tools(mcp)
+    return mcp._tool_manager
+
+
+@pytest.fixture
+def stub_client(mocker):
+    """A client recording what the tool layer forwards to ``update_todo``."""
+    client = mocker.MagicMock()
+    client.calendar.update_todo = mocker.AsyncMock(
+        return_value={"uid": "todo-1", "href": "/dav/todo-1.ics", "etag": '"new"'}
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.calendar.get_client",
+        mocker.AsyncMock(return_value=client),
+    )
+    # Pin the deployment mode: @require_scopes denies a context without a
+    # verified token only under login-flow, which would otherwise make this
+    # pass locally and fail in CI.
+    mocker.patch(
+        "nextcloud_mcp_server.auth.scope_authorization.get_settings",
+        return_value=mocker.MagicMock(enable_login_flow=False),
+    )
+    return client
+
+
+def _precondition_failed(dav_message: str | None = None) -> DavPreconditionFailed:
+    request = Request("PUT", "https://nc.example.com/dav/todo-1.ics")
+    return DavPreconditionFailed(
+        "412 Precondition Failed",
+        request=request,
+        response=Response(412, request=request),
+        dav_exception="Sabre\\DAV\\Exception\\PreconditionFailed",
+        dav_message=dav_message,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "extra_kwargs"),
+    [
+        ("nc_calendar_update_todo", {"summary": "new title"}),
+        ("nc_calendar_complete_todo", {}),
+    ],
+)
+async def test_caller_etag_reaches_the_client(
+    calendar_tools, stub_client, mocker, tool_name, extra_kwargs
+):
+    """Both write tools must forward the caller's ETag, not swallow it.
+
+    Parametrized rather than written once for update: ``complete_todo`` builds
+    its own payload and is the tool most likely to be given the ETag argument
+    and then quietly drop it.
+    """
+    await calendar_tools.get_tool(tool_name).fn(
+        calendar_name="Personal",
+        todo_uid="todo-1",
+        ctx=mocker.MagicMock(),
+        etag='"caller-read-this"',
+        **extra_kwargs,
+    )
+
+    # Positional, matching the client signature (…, todo_data, etag).
+    assert stub_client.calendar.update_todo.call_args.args[3] == '"caller-read-this"'
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["nc_calendar_update_todo", "nc_calendar_complete_todo"],
+)
+async def test_omitted_etag_forwards_empty_not_none(
+    calendar_tools, stub_client, mocker, tool_name
+):
+    """The no-ETag case must stay the client's documented ``""`` sentinel.
+
+    ``update_todo`` branches on ``if not etag`` to fall back to its own read.
+    ``None`` would take the same branch today, so this pins the contract rather
+    than a behaviour -- it is the kind of drift that only surfaces once someone
+    tightens that check.
+    """
+    await calendar_tools.get_tool(tool_name).fn(
+        calendar_name="Personal",
+        todo_uid="todo-1",
+        ctx=mocker.MagicMock(),
+    )
+
+    assert stub_client.calendar.update_todo.call_args.args[3] == ""
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["nc_calendar_update_todo", "nc_calendar_complete_todo"],
+)
+async def test_stale_etag_becomes_a_readable_tool_error(
+    calendar_tools, stub_client, mocker, tool_name
+):
+    """A 412 must name the recovery, not just the failure."""
+    stub_client.calendar.update_todo.side_effect = _precondition_failed(
+        "The ETag supplied in the If-Match header did not match"
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await calendar_tools.get_tool(tool_name).fn(
+            calendar_name="Personal",
+            todo_uid="todo-1",
+            ctx=mocker.MagicMock(),
+            etag='"stale"',
+        )
+
+    message = str(exc_info.value)
+    # The server's own wording survives...
+    assert "If-Match header did not match" in message
+    # ...and the caller is told how to recover, by a tool that exists.
+    assert "nc_calendar_list_todos" in message
+    assert "todo-1" in message
+
+
+async def test_stale_etag_without_a_server_message_still_explains_itself(
+    calendar_tools, stub_client, mocker
+):
+    """Sabre does not always send ``s:message``; the advice must not vanish."""
+    stub_client.calendar.update_todo.side_effect = _precondition_failed(None)
+
+    with pytest.raises(ToolError) as exc_info:
+        await calendar_tools.get_tool("nc_calendar_update_todo").fn(
+            calendar_name="Personal",
+            todo_uid="todo-1",
+            ctx=mocker.MagicMock(),
+            summary="new title",
+            etag='"stale"',
+        )
+
+    message = str(exc_info.value)
+    assert "modified after that ETag was read" in message
+    assert "nc_calendar_list_todos" in message
+
+
+async def test_update_returns_the_new_etag_for_chaining(
+    calendar_tools, stub_client, mocker
+):
+    """The post-write ETag has to come back, or the next update is unguarded."""
+    result = await calendar_tools.get_tool("nc_calendar_update_todo").fn(
+        calendar_name="Personal",
+        todo_uid="todo-1",
+        ctx=mocker.MagicMock(),
+        summary="new title",
+    )
+
+    # Called through .fn, so this is the model instance, not serialised JSON.
+    assert result.etag == '"new"'
+    assert result.uid == "todo-1"
+    assert result.calendar_name == "Personal"
+    assert result.href == "/dav/todo-1.ics"
+
+
+async def test_complete_returns_the_new_etag_alongside_what_it_wrote(
+    calendar_tools, stub_client, mocker
+):
+    result = await calendar_tools.get_tool("nc_calendar_complete_todo").fn(
+        calendar_name="Personal",
+        todo_uid="todo-1",
+        ctx=mocker.MagicMock(),
+    )
+
+    assert result.etag == '"new"'
+    # The three completion properties are still the point of this tool.
+    assert result.status == "COMPLETED"
+    assert result.percent_complete == 100
+    assert result.completed

--- a/tests/unit/server/test_calendar_todo_etag.py
+++ b/tests/unit/server/test_calendar_todo_etag.py
@@ -143,19 +143,31 @@ async def test_stale_etag_becomes_a_readable_tool_error(
     assert "todo-1" in message
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "extra_kwargs"),
+    [
+        ("nc_calendar_update_todo", {"summary": "new title"}),
+        ("nc_calendar_complete_todo", {}),
+    ],
+)
 async def test_stale_etag_without_a_server_message_still_explains_itself(
-    calendar_tools, stub_client, mocker
+    calendar_tools, stub_client, mocker, tool_name, extra_kwargs
 ):
-    """Sabre does not always send ``s:message``; the advice must not vanish."""
+    """Sabre does not always send ``s:message``; the advice must not vanish.
+
+    Parametrized to match its "with a message" sibling. The message-building
+    helper is shared, but each tool wires it up at its own call site -- so an
+    asymmetric pair here is how a per-tool gap survives unnoticed.
+    """
     stub_client.calendar.update_todo.side_effect = _precondition_failed(None)
 
     with pytest.raises(ToolError) as exc_info:
-        await calendar_tools.get_tool("nc_calendar_update_todo").fn(
+        await calendar_tools.get_tool(tool_name).fn(
             calendar_name="Personal",
             todo_uid="todo-1",
             ctx=mocker.MagicMock(),
-            summary="new title",
             etag='"stale"',
+            **extra_kwargs,
         )
 
     message = str(exc_info.value)


### PR DESCRIPTION
Closes Deck card 1052, the 🟢 follow-up the review bot raised on #1335.

## Problem

#1335 gave the CalDAV client layer real `If-Match` protection, but only
`nc_calendar_update_event` exposed it. `nc_calendar_update_todo` and
`nc_calendar_complete_todo` called `update_todo` with no ETag, so the write
fell back to the one observed *during that call* — which closes the millisecond
inside the call and leaves the caller's actual read-modify-write cycle
unguarded.

Not a regression: before #1335 neither had protection. An unfinished feature.

## The three decisions the card asked for

**1. `nc_calendar_update_todo` accepts and forwards `etag`.** Same shape as
`nc_calendar_update_event`.

**2. `nc_calendar_complete_todo` gets one too** — and this is a decision, not
symmetry. Completing a task is normally the intended outcome whatever else
changed, so the ETag is rarely wanted here. But without it, a caller who *does*
want a guarded completion is pushed back onto `nc_calendar_update_todo` and the
three-property footgun (`status` + `percent_complete` + `completed`) that
`complete_todo` exists to spare them. The docstring says exactly this.

**3. A stale ETag becomes a readable `ToolError`.** Raised bare,
`DavPreconditionFailed` reaches an MCP client as an httpx status error naming a
CalDAV URL — accurate, and no help in deciding what to do. The message keeps
Sabre's own `s:message` when there is one and points at
`nc_calendar_list_todos`, which I verified does return a current ETag rather
than assuming it.

## `UpdateTodoResponse`

It already existed, unused, shaped around a full `Todo` the update path never
has — filling it would mean an extra CalDAV read on every write. Rather than
add a second model beside a misleading dead one, it is reshaped to what the
write actually produces, so the post-write ETag comes back and the next update
can be guarded without re-reading.

This is the breaking part, and it carries a `BREAKING CHANGE:` footer: the
response gains the `BaseResponse` envelope plus `calendar_name` and drops
`status_code` (a failed update raises rather than reporting a status). Nothing
in this repo read that field, and the existing integration tests only assert
`isError is False`. `nc_calendar_complete_todo`'s new `etag` field is additive.

## Test coverage

Per CLAUDE.md this changes MCP tool surface, so both tiers are here:

- **Unit** (`tests/unit/server/test_calendar_todo_etag.py`) — forwarding on
  both tools, the `""`-not-`None` sentinel the client branches on, the error
  translation with and without a server `s:message`, and the returned ETag.
- **End-to-end** (`tests/server/test_calendar_todos_mcp.py`) — the whole cycle
  through MCP against a running Nextcloud: read the ETag, write with it, replay
  the stale one, and assert both the readable refusal *and* that the stored
  copy still holds the first writer's value. This exists because a mocked
  client can be made to raise 412 whether or not `If-Match` ever reaches Sabre;
  only the live run tests the part actually in question.

No cross-service boundary changes, so no new Pact interaction is needed.

---

_This PR was generated with the help of AI, and reviewed by a Human_