### PR TITLE
fix(test): assert the one-to-one pairing spreed actually records

### DIFF
--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -354,15 +354,19 @@ async def test_talk_create_one_to_one_conversation_without_a_name(
     # one-to-one room from a group room that happens to contain the invitee.
     assert conversation["type"] == 1
 
-    # The other user is really in it -- a one-to-one room that did not actually
-    # pair the two would still have returned a token.
-    participants = await nc_mcp_client.call_tool(
-        "talk_list_participants", {"token": conversation["token"]}
-    )
-    actor_ids = {
-        p["actorId"] for p in json.loads(participants.content[0].text)["results"]
-    }
-    assert other in actor_ids
+    # The room really pairs the two. Read from `name` rather than the
+    # participant list: on the create path spreed adds ONLY the actor --
+    # RoomService::createOneToOneConversation calls addUsers() with the actor
+    # alone, and the invitee is filled in later by ensureOneToOneRoomIsFilled,
+    # which runs from the chat / call / room-GET controllers. So a freshly
+    # created one-to-one room legitimately lists one participant.
+    #
+    # The pairing is in the room's stored name, which spreed sets to
+    # json_encode(sort([actor, target])) and RoomFormatter then renders, for a
+    # type-1 room, as whichever of the two is NOT the reader -- i.e. the
+    # invitee. That is written synchronously at creation, so it is the field
+    # that actually distinguishes a real pairing from a token.
+    assert conversation["name"] == other
 
     # No room cleanup here on purpose: spreed answers DELETE on a one-to-one
     # room with 400 (reproduced on nc32/33/34). Those rooms are left, not


### PR DESCRIPTION
Bottom of stack #1376. The four PRs above it fail `integration (single-user /
nc32|nc33|nc34)` on this test until it lands.

## What is failing

`test_talk_create_one_to_one_conversation_without_a_name`, added in #1349,
asserts the invitee appears in the new room's participant list:

```
E   AssertionError: assert 'testuser_88525ed9' in {'admin'}
```

Three-for-three across nc32/33/34 — not a flake. The assertion is wrong about
the API, not racing it.

## Why, from spreed's source rather than from the failure

`RoomService::createOneToOneConversation`, on the **create** path, adds the
actor and nobody else:

```php
$room = $this->manager->createRoom(Room::TYPE_ONE_TO_ONE, json_encode($users));

$this->participantService->addUsers($room, [
    [ 'actorId' => $actor->getUID(), 'participantType' => Participant::OWNER ],
], $actor);
```

The invitee is filled in later by `ensureOneToOneRoomIsFilled`, which runs from
the chat, call and room-GET controllers — not at creation. So a freshly created
one-to-one room legitimately lists exactly one participant. (It *is* called on
the room-**reuse** branch, which is plausibly why this looked like it worked at
some point.)

## What to assert instead

The pairing is recorded synchronously, just in a different field.
`createRoom()` stores the room name as `json_encode(sort([actor, target]))`,
and `RoomFormatter` renders `name`, for a type-1 room, as whichever of the two
is *not* the reader — i.e. the invitee:

```php
if ($room->getType() === Room::TYPE_ONE_TO_ONE) {
    $participants = json_decode($room->getName(), true);
    foreach ($participants as $participant) {
        if ($participant !== $attendee->getActorId()) {
            $roomData['name'] = (string)$participant;
```

So `conversation["name"] == other` is the check that actually distinguishes a
real pairing from a bare token, and it holds at creation time. The `type == 1`
assertion is unchanged.

My error in #1349: I verified the *creation* path against a live instance and
inferred the participant-list behaviour by analogy instead of checking it. The
assertion looked like the stronger one and was in fact testing something spreed
does not do until the room is next touched.

---

_This PR was generated with the help of AI, and reviewed by a Human_