### PR TITLE
fix(client): retry a lock-contended 423 with a jittered backoff

### DIFF
--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -75,9 +75,13 @@ def _lock_backoff(attempt: int) -> float:
     immediately, which is the opposite of what a contended lock needs.
     """
     ceiling = LOCK_BACKOFF_SECONDS * 2 ** (attempt - 1)
-    # Not a security decision -- this only decides how long to wait before
-    # retrying a file lock, and predictability costs nothing here.
-    return ceiling / 2 + random.uniform(0, ceiling / 2)  # NOSONAR(python:S2245)
+    # The marker below silences python:S2245 (pseudorandom generator). Not a
+    # security decision: this only chooses how long to wait before retrying a
+    # file lock, and predictability costs nothing here.
+    #
+    # Bare, not parenthesised -- a rule id in parentheses makes Sonar reject
+    # the comment as malformed (python:S7632) and suppress nothing.
+    return ceiling / 2 + random.uniform(0, ceiling / 2)  # NOSONAR
 
 
 def retry_on_429(func):

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -1,6 +1,7 @@
 """Base client for Nextcloud operations with shared authentication."""
 
 import logging
+import random
 import time
 import xml.etree.ElementTree as ET
 from abc import ABC
@@ -41,20 +42,42 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 5
 RATE_LIMIT_BACKOFF_SECONDS = 5
 
-#: Retries allowed for a lock-contended (423) call, and the first backoff.
+#: Retries allowed for a lock-contended (423) call, and the base backoff.
 #:
 #: 423 is a different failure from 429 and wants a different policy. Nextcloud
 #: raises ``OCP\Lock\LockedException`` when it cannot upgrade a shared lock to
-#: an exclusive one -- observed in CI as a note create failing on
-#: ``mkdir`` of its category folder with "2 shared locks" held by a concurrent
-#: reader. That contention clears in milliseconds, so the waits are short and
-#: doubling (0.5s, 1s, 2s: at most ~3.5s added) rather than 5s flat.
+#: an exclusive one. Observed in CI as a note create and a concurrent note
+#: LIST both calling ``mkdir`` on the same Notes folder: each holds a shared
+#: lock on the path and each wants to upgrade, so neither can.
+#:
+#: **The jitter is the load-bearing part, not the doubling.** With a fixed
+#: schedule both callers -- they are both this client, since the vector-sync
+#: scanner reads the same user's notes -- back off by the same amount and
+#: retry at the same instant, so they re-collide on every attempt. That is not
+#: a hypothesis: a CI run showed the two requests failing at four identical
+#: timestamps in a row before the budget ran out. Randomising the wait
+#: desynchronises them so one acquires the exclusive lock and the other
+#: follows.
 #:
 #: The budget is deliberately small and the original 423 is re-raised once it
 #: is spent: a lock held by a long upload or an open editing session is a real
 #: refusal, and this must never turn one into an unbounded wait.
 LOCK_MAX_RETRIES = 3
 LOCK_BACKOFF_SECONDS = 0.5
+
+
+def _lock_backoff(attempt: int) -> float:
+    """Jittered backoff for the *attempt*-th (1-based) lock retry.
+
+    Equal jitter: half the doubling schedule is fixed, half is random, so the
+    wait stays in ``[base * 2**(n-1) / 2, base * 2**(n-1)]``. Full jitter
+    (uniform from zero) would break lockstep too, but lets a retry fire almost
+    immediately, which is the opposite of what a contended lock needs.
+    """
+    ceiling = LOCK_BACKOFF_SECONDS * 2 ** (attempt - 1)
+    # Not a security decision -- this only decides how long to wait before
+    # retrying a file lock, and predictability costs nothing here.
+    return ceiling / 2 + random.uniform(0, ceiling / 2)  # NOSONAR(python:S2245)
 
 
 def retry_on_429(func):
@@ -67,9 +90,10 @@ def retry_on_429(func):
       ``RATE_LIMIT_BACKOFF_SECONDS`` and retries, up to ``MAX_RETRIES``
       attempts, then raises ``RuntimeError``.
     * **423 Locked** -- another request holds a lock on the path. Retries
-      ``LOCK_MAX_RETRIES`` times with a short doubling backoff, then re-raises
-      the original ``HTTPStatusError`` so a genuinely locked resource still
-      surfaces as 423 rather than as a retry-exhausted error.
+      ``LOCK_MAX_RETRIES`` times with a short *jittered* backoff (see
+      :func:`_lock_backoff`), then re-raises the original ``HTTPStatusError``
+      so a genuinely locked resource still surfaces as 423 rather than as a
+      retry-exhausted error.
 
     The two budgets are counted separately: a lock wait is not a rate-limit
     attempt, and spending one on the other would make either failure arrive
@@ -121,12 +145,12 @@ def retry_on_429(func):
                     lock_retries += 1
                     # A lock wait is not a rate-limit attempt.
                     retries -= 1
-                    # One expression, used by both the log line and the sleep:
-                    # computing it twice invites the two drifting apart, and a
-                    # log that misreports the wait is worse than no log.
-                    delay = LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1)
+                    # One value, used by both the log line and the sleep. It
+                    # is random, so recomputing it for the log would print a
+                    # wait that never happened.
+                    delay = _lock_backoff(lock_retries)
                     logger.warning(
-                        "423 Locked, retrying in %ss (attempt %s of %s): %s",
+                        "423 Locked, retrying in %.2fs (attempt %s of %s): %s",
                         delay,
                         lock_retries,
                         LOCK_MAX_RETRIES,

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -121,16 +121,20 @@ def retry_on_429(func):
                     lock_retries += 1
                     # A lock wait is not a rate-limit attempt.
                     retries -= 1
+                    # One expression, used by both the log line and the sleep:
+                    # computing it twice invites the two drifting apart, and a
+                    # log that misreports the wait is worse than no log.
+                    delay = LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1)
                     logger.warning(
                         "423 Locked, retrying in %ss (attempt %s of %s): %s",
-                        LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1),
+                        delay,
                         lock_retries,
                         LOCK_MAX_RETRIES,
                         e,
                     )
                     if len(args) > 0 and hasattr(args[0], "app_name"):
                         record_nextcloud_api_retry(app=args[0].app_name, reason="423")
-                    await anyio.sleep(LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1))
+                    await anyio.sleep(delay)
                 elif e.response.status_code == 404:
                     # 404 errors are often expected (e.g., checking if attachments exist)
                     # Log as debug instead of warning

--- a/nextcloud_mcp_server/client/base.py
+++ b/nextcloud_mcp_server/client/base.py
@@ -36,23 +36,56 @@ STREAMING_REQUEST_EXTENSION = "nextcloud_mcp_streaming"
 logger = logging.getLogger(__name__)
 
 
+#: Attempts allowed for a rate-limited (429) call, and the fixed wait between
+#: them. 429 means "slow down", so the wait is long and flat.
+MAX_RETRIES = 5
+RATE_LIMIT_BACKOFF_SECONDS = 5
+
+#: Retries allowed for a lock-contended (423) call, and the first backoff.
+#:
+#: 423 is a different failure from 429 and wants a different policy. Nextcloud
+#: raises ``OCP\Lock\LockedException`` when it cannot upgrade a shared lock to
+#: an exclusive one -- observed in CI as a note create failing on
+#: ``mkdir`` of its category folder with "2 shared locks" held by a concurrent
+#: reader. That contention clears in milliseconds, so the waits are short and
+#: doubling (0.5s, 1s, 2s: at most ~3.5s added) rather than 5s flat.
+#:
+#: The budget is deliberately small and the original 423 is re-raised once it
+#: is spent: a lock held by a long upload or an open editing session is a real
+#: refusal, and this must never turn one into an unbounded wait.
+LOCK_MAX_RETRIES = 3
+LOCK_BACKOFF_SECONDS = 0.5
+
+
 def retry_on_429(func):
-    """This decorator handles the 429 response from REST APIs
+    """Retry the two Nextcloud responses that mean "not now" rather than "no".
 
     The `func` is assumed to be a method that is similar to `httpx.Client.get`,
-    and returns an `httpx.Response` object. In the case of `Too Many Requests` HTTP
-    response, the function will wait for a couple of seconds and retry the request.
-    """
+    and returns an `httpx.Response` object.
 
-    MAX_RETRIES = 5
+    * **429 Too Many Requests** -- the server is rate limiting. Waits
+      ``RATE_LIMIT_BACKOFF_SECONDS`` and retries, up to ``MAX_RETRIES``
+      attempts, then raises ``RuntimeError``.
+    * **423 Locked** -- another request holds a lock on the path. Retries
+      ``LOCK_MAX_RETRIES`` times with a short doubling backoff, then re-raises
+      the original ``HTTPStatusError`` so a genuinely locked resource still
+      surfaces as 423 rather than as a retry-exhausted error.
+
+    The two budgets are counted separately: a lock wait is not a rate-limit
+    attempt, and spending one on the other would make either failure arrive
+    early.
+
+    (The name predates the 423 handling and is kept because every client
+    imports it.)
+    """
 
     @wraps(func)
     async def wrapper(*args, **kwargs):
         retries = 0
+        lock_retries = 0
 
-        while retries < MAX_RETRIES:
+        while True:
             try:
-                # Make GET API call
                 retries += 1
                 response = await func(*args, **kwargs)
                 break
@@ -68,7 +101,36 @@ def retry_on_429(func):
                     # Record retry metric (extract app name from args if available)
                     if len(args) > 0 and hasattr(args[0], "app_name"):
                         record_nextcloud_api_retry(app=args[0].app_name, reason="429")
-                    await anyio.sleep(5)
+                    await anyio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                    # Sleep first, then give up: preserves the original
+                    # accounting, where the last attempt also waited.
+                    if retries >= MAX_RETRIES:
+                        logger.warning("All API call retries failed")
+                        raise RuntimeError(
+                            f"Maximum number of retries ({MAX_RETRIES}) exceeded "
+                            "without success"
+                        ) from e
+                elif e.response.status_code == codes.LOCKED:
+                    if lock_retries >= LOCK_MAX_RETRIES:
+                        logger.warning(
+                            "423 Locked persisted after %s retries: %s",
+                            lock_retries,
+                            e,
+                        )
+                        raise
+                    lock_retries += 1
+                    # A lock wait is not a rate-limit attempt.
+                    retries -= 1
+                    logger.warning(
+                        "423 Locked, retrying in %ss (attempt %s of %s): %s",
+                        LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1),
+                        lock_retries,
+                        LOCK_MAX_RETRIES,
+                        e,
+                    )
+                    if len(args) > 0 and hasattr(args[0], "app_name"):
+                        record_nextcloud_api_retry(app=args[0].app_name, reason="423")
+                    await anyio.sleep(LOCK_BACKOFF_SECONDS * 2 ** (lock_retries - 1))
                 elif e.response.status_code == 404:
                     # 404 errors are often expected (e.g., checking if attachments exist)
                     # Log as debug instead of warning
@@ -95,13 +157,6 @@ def retry_on_429(func):
                     retries,
                 )
                 raise
-
-        # If for loop ends without break statement
-        else:
-            logger.warning("All API call retries failed")
-            raise RuntimeError(
-                f"Maximum number of retries ({MAX_RETRIES}) exceeded without success"
-            )
 
         return response
 

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1401,7 +1401,7 @@ def record_nextcloud_api_retry(app: str, reason: str) -> None:
 
     Args:
         app: Nextcloud app name
-        reason: Retry reason (429, timeout, connection_error)
+        reason: Retry reason (429, 423, timeout, connection_error)
     """
     nextcloud_api_retries_total.labels(app=app, reason=reason).inc()
 

--- a/nextcloud_mcp_server/retry.py
+++ b/nextcloud_mcp_server/retry.py
@@ -10,9 +10,22 @@ which caught exceptions are transient; everything else propagates immediately.
 exponential curve, which is what the startup probes want — without it, every
 replica in a deployment retries a briefly-unreachable dependency in lockstep.
 
+That failure mode is not hypothetical, and it is not confined to startup:
+``retry_on_429``'s lock branch was first written with a fixed schedule and CI
+caught two callers — a note write and the vector-sync scanner — retrying at
+four identical timestamps and re-colliding every time. If a new retry loop can
+ever have two instances of it running against the same resource, it wants
+jitter.
+
 Not every retry loop in this codebase belongs here, and the ones that stayed
 put did so for a reason:
 
+- ``BaseNextcloudClient.retry_on_429`` — the transport-level policy for
+  Nextcloud's two "not now" answers, 429 and 423. It keeps a separate budget
+  and backoff shape per status (flat 5s for rate limiting, short jittered
+  doubling for a file lock) and re-raises the original error for one and a
+  ``RuntimeError`` for the other. Two policies in one decorator is not what
+  ``should_retry`` models.
 - ``BaseNextcloudClient._stream_request`` — a partially-consumed stream cannot
   be replayed, and it meters every attempt on the API-call histogram.
 - ``CalendarClient._wait_for_calendar`` — a poll-until-a-condition-holds loop.

--- a/tests/unit/client/test_lock_retry.py
+++ b/tests/unit/client/test_lock_retry.py
@@ -73,12 +73,44 @@ async def test_lock_backoff_is_short_and_doubling(no_sleep):
     """423 waits sub-second and doubles, unlike 429's flat 5s.
 
     A lock upgrade clears in milliseconds; waiting 5s for it would turn a
-    recoverable blip into a visible stall on every contended write.
+    recoverable blip into a visible stall on every contended write. Asserted as
+    bounds rather than exact values because the wait is jittered -- see
+    ``test_lock_backoff_is_jittered`` for why that matters.
     """
     calls: list[int] = []
 
     assert await _failing_then([423, 423, 423], calls)() == "ok"
-    assert [c.args[0] for c in no_sleep.call_args_list] == [0.5, 1.0, 2.0]
+    waits = [c.args[0] for c in no_sleep.call_args_list]
+    assert len(waits) == 3
+    # Equal jitter: each wait sits in [ceiling/2, ceiling] for a doubling
+    # ceiling of 0.5, 1.0, 2.0.
+    for wait, ceiling in zip(waits, [0.5, 1.0, 2.0], strict=True):
+        assert ceiling / 2 <= wait <= ceiling
+    # Still monotonically backing off despite the randomness.
+    assert waits[0] < waits[2]
+
+
+def test_lock_backoff_is_jittered():
+    """Two callers must not retry in lockstep. This is the whole fix.
+
+    The 423 this policy exists for is a mutual shared->exclusive upgrade: a
+    note create and a concurrent note LIST both calling ``mkdir`` on the same
+    Notes folder, each holding a shared lock and each wanting to upgrade.
+    Both callers are this client (the vector-sync scanner reads the same
+    user's notes), so with a fixed schedule they back off by the same amount
+    and retry at the same instant.
+
+    That is exactly what CI showed: the two requests failed at four identical
+    timestamps in a row, the deterministic backoff turning a race into a
+    lockstep collision that could never resolve. Randomising the wait is what
+    lets one of them win.
+    """
+    from nextcloud_mcp_server.client.base import _lock_backoff
+
+    draws = {_lock_backoff(2) for _ in range(50)}
+
+    assert len(draws) > 1, "backoff is deterministic; two callers will re-collide"
+    assert all(0.5 <= d <= 1.0 for d in draws), draws
 
 
 async def test_a_persistent_lock_still_surfaces_as_423(no_sleep):

--- a/tests/unit/client/test_lock_retry.py
+++ b/tests/unit/client/test_lock_retry.py
@@ -1,0 +1,141 @@
+"""Unit tests for the 423 Locked retry policy in the shared transport.
+
+Diagnosed from the CI failure this exists to fix (Deck card 1066). A
+login-flow lane failed ``nc_notes_create_note`` with 423, and Nextcloud's own
+log named the cause exactly::
+
+    "/admin/files/Notes/LoginFlowTest" is locked, existing lock on file: 2 shared locks
+      View::changeLock('/admin/files/Notes/LoginFlowTest', 2)
+      View::basicOperation('mkdir', ...)
+      Folder::newFolder('/admin/files/Notes/LoginFlowTest')
+
+So the 423 was not the note file at all: it was the note's *category folder*,
+failing to upgrade a shared lock to an exclusive one while a concurrent reader
+held one. That is contention, not a refusal, and it clears in milliseconds --
+which is what makes a short bounded retry the right response rather than a
+blanket one.
+
+The two budgets are tested separately because the whole point is that they do
+not share: a lock wait must not spend a rate-limit attempt, or a 429 arriving
+after a lock race would give up early.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import HTTPStatusError, Request, Response
+
+from nextcloud_mcp_server.client.base import (
+    LOCK_MAX_RETRIES,
+    MAX_RETRIES,
+    retry_on_429,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def no_sleep(mocker):
+    """Keep the backoffs from actually elapsing."""
+    return mocker.patch("nextcloud_mcp_server.client.base.anyio.sleep")
+
+
+def _status_error(status: int) -> HTTPStatusError:
+    request = Request("POST", "https://nc.example.com/apps/notes/api/v1/notes")
+    return HTTPStatusError(
+        str(status), request=request, response=Response(status, request=request)
+    )
+
+
+def _failing_then(statuses: list[int], calls: list[int]):
+    """A callable raising each status in turn, then returning a sentinel."""
+
+    async def call():
+        calls.append(1)
+        index = len(calls) - 1
+        if index < len(statuses):
+            raise _status_error(statuses[index])
+        return "ok"
+
+    return retry_on_429(call)
+
+
+async def test_transient_lock_is_retried_and_succeeds(no_sleep):
+    """The observed failure: one contended attempt, then the lock clears."""
+    calls: list[int] = []
+
+    assert await _failing_then([423], calls)() == "ok"
+    assert len(calls) == 2
+    assert no_sleep.call_count == 1
+
+
+async def test_lock_backoff_is_short_and_doubling(no_sleep):
+    """423 waits sub-second and doubles, unlike 429's flat 5s.
+
+    A lock upgrade clears in milliseconds; waiting 5s for it would turn a
+    recoverable blip into a visible stall on every contended write.
+    """
+    calls: list[int] = []
+
+    assert await _failing_then([423, 423, 423], calls)() == "ok"
+    assert [c.args[0] for c in no_sleep.call_args_list] == [0.5, 1.0, 2.0]
+
+
+async def test_a_persistent_lock_still_surfaces_as_423(no_sleep):
+    """The budget must not convert a real refusal into an unbounded wait.
+
+    A file locked by a long upload or an open editing session is genuinely
+    unavailable. Once the retries are spent the caller gets the original 423 --
+    not a retry-exhausted RuntimeError, which would hide what happened.
+    """
+    calls: list[int] = []
+
+    with pytest.raises(HTTPStatusError) as exc_info:
+        await _failing_then([423] * 10, calls)()
+
+    assert exc_info.value.response.status_code == 423
+    assert len(calls) == LOCK_MAX_RETRIES + 1
+
+
+async def test_lock_retries_do_not_spend_the_rate_limit_budget(no_sleep):
+    """A 429 arriving after a lock race must still get its full budget.
+
+    This is the reason the two counters are separate. Sharing one would let a
+    contended write eat attempts a later 429 needs, so the rate-limit failure
+    would arrive early and for the wrong reason.
+    """
+    calls: list[int] = []
+    # Every lock retry, then rate limiting for the rest.
+    tool = _failing_then([423] * LOCK_MAX_RETRIES + [429] * 20, calls)
+
+    with pytest.raises(RuntimeError, match="Maximum number of retries"):
+        await tool()
+
+    assert len(calls) == LOCK_MAX_RETRIES + MAX_RETRIES
+
+
+async def test_rate_limit_budget_is_unchanged(no_sleep):
+    """The pre-existing 429 accounting must survive the restructure.
+
+    Five attempts, each followed by a wait, then RuntimeError -- the shape
+    every existing caller and test already depends on.
+    """
+    calls: list[int] = []
+
+    with pytest.raises(RuntimeError, match="Maximum number of retries"):
+        await _failing_then([429] * 20, calls)()
+
+    assert len(calls) == MAX_RETRIES
+    assert no_sleep.call_count == MAX_RETRIES
+
+
+@pytest.mark.parametrize("status", [400, 403, 404, 409, 500, 507])
+async def test_other_statuses_are_not_retried(no_sleep, status):
+    """Only "not now" is retried. Everything else is a decision, not a delay."""
+    calls: list[int] = []
+
+    with pytest.raises(HTTPStatusError):
+        await _failing_then([status] * 5, calls)()
+
+    assert len(calls) == 1
+    no_sleep.assert_not_called()


### PR DESCRIPTION
Relates to Deck card 1066. **Does not claim to close it** — see "What this does
not settle" below.

## Diagnosis (corrected once, from CI evidence both times)

The card asked to diagnose before adding a retry, since a blanket one would
hide a real ordering bug. Two artifacts, two different lock failures on the
same endpoint:

**First** (login-flow/nc32, the card's original failure) — the note's
*category* folder:

```
"/admin/files/Notes/LoginFlowTest" is locked, existing lock on file: 2 shared locks
  View::changeLock(...) ← shared→exclusive · basicOperation('mkdir') · Folder::newFolder(...)
```

**Second** (this PR's own lane, with a first-draft retry already in place) —
the Notes *root*, with both parties calling `mkdir` on it:

```
POST /notes  -> View->mkdir /admin/files/Notes   19:28:04, :08, :13, :19
GET  /notes  -> View->mkdir /admin/files/Notes   19:28:04, :08, :13, :19
```

A note create and a concurrent note LIST, each holding a shared lock on the
path and each wanting to upgrade. Neither can. This is a **mutual upgrade
deadlock**, not one request waiting out another's lock.

Both callers are this client: `mcp-login-flow` runs with
`ENABLE_SEMANTIC_SEARCH=true` and `VECTOR_SYNC_SCAN_INTERVAL=60`, so the
vector-sync scanner reads the same user's notes on a timer. That is why this
lane sees it and a plain single-user run mostly does not.

## The fix, and why jitter is the load-bearing part

Note the timestamps above: four attempts each, at the same second, four times
running. With a **fixed** backoff both callers wait the same amount and retry
together, re-colliding until the budget runs out — the deterministic schedule
turns a race that might resolve into a lockstep collision that cannot. That is
what the first draft of this PR did, and it is why it did not work.

`retry_on_429` now also retries 423, scoped to that condition rather than to
note creation, with:

- **Jittered backoff** (`_lock_backoff`). Equal jitter: half the doubling
  schedule fixed, half random, so retries desynchronise while a contended lock
  still gets a real pause. Full jitter would break lockstep too but can fire
  again almost immediately, which is the opposite of what a held lock needs.
- **Its own budget (3)**, counted separately from the rate-limit budget, so a
  lock wait never spends a 429 attempt.
- **The original 423 re-raised once spent** — not a retry-exhausted
  `RuntimeError`. A file held by a long upload or an open editing session is a
  real refusal, and this must never turn one into an unbounded wait.

The 429 accounting is deliberately unchanged (five attempts, each followed by a
wait, then `RuntimeError`) and is pinned by its own test so the restructure
cannot quietly alter it.

## What this does not settle

- **Whether the lane goes green.** The first version of this PR asserted that
  and was wrong. Card 1066 stays open until a lane result supports closing it.
- **A second fault on the same endpoint.** `single-user / nc34` failed with
  `NotPermittedException: Could not create path ".../Notes/TemporaryTesting/..."`
  → **500**, not 423 — same contention family, not covered by this retry, and a
  blanket 500 retry would be wrong. Recorded on the card.
- **`CalendarClient`** talks CalDAV through its own session and deliberately
  does not extend `BaseNextcloudClient`, so calendar writes get no 423 retry.
  Out of scope on purpose rather than by oversight.

No API surface changes, so the e2e + contract gate does not apply.

---

_This PR was generated with the help of AI, and reviewed by a Human_