### PR TITLE
fix(calendar): stop rebuilding a VTODO from the partial update dict on error

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1286,7 +1286,6 @@ class CalendarClient:
             updated_ical = self._merge_ical_todo_properties(
                 todo.data,  # type: ignore[arg-type]
                 todo_data,
-                todo_uid,
             )
             logger.debug("Merged iCal data length: %s", len(updated_ical))
 
@@ -2509,122 +2508,118 @@ class CalendarClient:
             return None
 
     def _merge_ical_todo_properties(
-        self, raw_ical: str, todo_data: dict[str, Any], todo_uid: str
+        self, raw_ical: str, todo_data: dict[str, Any]
     ) -> str:
-        """Merge new todo data into existing raw iCal while preserving all properties."""
-        try:
-            logger.debug(
-                "Merging todo properties for %s: %s", todo_uid, list(todo_data.keys())
-            )
-            cal = Calendar.from_ical(raw_ical)
+        """Merge new todo data into existing raw iCal while preserving all properties.
 
-            for component in cal.walk():
-                if component.name == "VTODO":
-                    # Update only provided properties
-                    if "summary" in todo_data:
-                        component["SUMMARY"] = todo_data["summary"]
-                    if "description" in todo_data:
-                        component["DESCRIPTION"] = todo_data["description"]
-                    if "status" in todo_data:
-                        status_value = todo_data["status"].upper()
-                        component["STATUS"] = status_value
-                        logger.debug("Set STATUS to %s", status_value)
-                    if "priority" in todo_data:
-                        component["PRIORITY"] = todo_data["priority"]
-                    if "percent_complete" in todo_data:
-                        percent_value = todo_data["percent_complete"]
-                        component["PERCENT-COMPLETE"] = percent_value
-                        logger.debug("Set PERCENT-COMPLETE to %s", percent_value)
+        The todo's own ``UID`` is carried through from ``raw_ical`` like any other
+        preserved property, so no ``todo_uid`` argument is needed. (One used to be
+        required solely by the removed rebuild fallback.)
 
-                    # Due / start dates, paired the same way as
-                    # _create_ical_todo — except a side that isn't being
-                    # updated votes with the value type already stored.
-                    supplied = {
-                        prop: todo_data[prop]
-                        for prop in ("due", "dtstart")
-                        if todo_data.get(prop)
-                    }
-                    date_only = all(
-                        self._is_date_only(v) for v in supplied.values()
-                    ) and all(
-                        self._stored_is_all_day(component, prop.upper()) is not False
-                        for prop in ("due", "dtstart")
-                        if prop not in supplied
+        Raises on any merge failure rather than substituting a synthesised todo.
+        This previously caught every exception and fell back to
+        ``_create_ical_todo(todo_data, ...)``, which rebuilds the todo from the
+        *partial update dict* — destroying summary, due date, dtstart, completed
+        timestamp, categories, RRULE, alarms and every custom property the caller
+        did not happen to pass, while reporting success.
+        """
+        logger.debug("Merging todo properties: %s", list(todo_data.keys()))
+        cal = Calendar.from_ical(raw_ical)
+
+        for component in cal.walk():
+            if component.name == "VTODO":
+                # Update only provided properties
+                if "summary" in todo_data:
+                    component["SUMMARY"] = todo_data["summary"]
+                if "description" in todo_data:
+                    component["DESCRIPTION"] = todo_data["description"]
+                if "status" in todo_data:
+                    status_value = todo_data["status"].upper()
+                    component["STATUS"] = status_value
+                    logger.debug("Set STATUS to %s", status_value)
+                if "priority" in todo_data:
+                    component["PRIORITY"] = todo_data["priority"]
+                if "percent_complete" in todo_data:
+                    percent_value = todo_data["percent_complete"]
+                    component["PERCENT-COMPLETE"] = percent_value
+                    logger.debug("Set PERCENT-COMPLETE to %s", percent_value)
+
+                # Due / start dates, paired the same way as
+                # _create_ical_todo — except a side that isn't being
+                # updated votes with the value type already stored.
+                supplied = {
+                    prop: todo_data[prop]
+                    for prop in ("due", "dtstart")
+                    if todo_data.get(prop)
+                }
+                date_only = all(
+                    self._is_date_only(v) for v in supplied.values()
+                ) and all(
+                    self._stored_is_all_day(component, prop.upper()) is not False
+                    for prop in ("due", "dtstart")
+                    if prop not in supplied
+                )
+
+                # A partial update cannot flip one half of the pair on its
+                # own: writing the supplied side as a DATE-TIME while the
+                # side left out stays a stored DATE is exactly the mismatch
+                # §3.8.2.3 forbids, and there is no defensible time of day
+                # to invent for the property the caller didn't mention.
+                # _validate_all_day_flip rejects the same flip for VEVENT.
+                stranded = [
+                    prop
+                    for prop in ("due", "dtstart")
+                    if supplied
+                    and not date_only
+                    and prop not in supplied
+                    and self._stored_is_all_day(component, prop.upper())
+                ]
+                if stranded:
+                    raise ValueError(
+                        "changing a whole-day todo to a timed one requires "
+                        f"passing {' and '.join(sorted(supplied.keys() | set(stranded)))} "
+                        "together, so DUE and DTSTART cannot end up with "
+                        "mismatched value types"
                     )
 
-                    # A partial update cannot flip one half of the pair on its
-                    # own: writing the supplied side as a DATE-TIME while the
-                    # side left out stays a stored DATE is exactly the mismatch
-                    # §3.8.2.3 forbids, and there is no defensible time of day
-                    # to invent for the property the caller didn't mention.
-                    # _validate_all_day_flip rejects the same flip for VEVENT.
-                    stranded = [
-                        prop
-                        for prop in ("due", "dtstart")
-                        if supplied
-                        and not date_only
-                        and prop not in supplied
-                        and self._stored_is_all_day(component, prop.upper())
-                    ]
-                    if stranded:
-                        raise ValueError(
-                            "changing a whole-day todo to a timed one requires "
-                            f"passing {' and '.join(sorted(supplied.keys() | set(stranded)))} "
-                            "together, so DUE and DTSTART cannot end up with "
-                            "mismatched value types"
-                        )
+                for prop, value in supplied.items():
+                    parsed = self._parse_todo_date(value, date_only=date_only)
+                    component[prop.upper()] = vDDDTypes(parsed)
+                    logger.debug("Set %s to %s", prop.upper(), parsed)
 
-                    for prop, value in supplied.items():
-                        parsed = self._parse_todo_date(value, date_only=date_only)
-                        component[prop.upper()] = vDDDTypes(parsed)
-                        logger.debug("Set %s to %s", prop.upper(), parsed)
+                # Handle completed date
+                if "completed" in todo_data:
+                    completed_str = todo_data["completed"]
+                    if completed_str:
+                        completed_dt = self._ensure_timezone_aware(completed_str)
+                        component["COMPLETED"] = vDDDTypes(completed_dt)
+                        logger.debug("Set COMPLETED to %s", completed_dt)
 
-                    # Handle completed date
-                    if "completed" in todo_data:
-                        completed_str = todo_data["completed"]
-                        if completed_str:
-                            completed_dt = self._ensure_timezone_aware(completed_str)
-                            component["COMPLETED"] = vDDDTypes(completed_dt)
-                            logger.debug("Set COMPLETED to %s", completed_dt)
+                # Handle categories
+                if "categories" in todo_data:
+                    categories_str = todo_data["categories"]
+                    if categories_str:
+                        component["CATEGORIES"] = [
+                            c.strip() for c in categories_str.split(",")
+                        ]
+                        logger.debug("Set CATEGORIES to %s", categories_str)
 
-                    # Handle categories
-                    if "categories" in todo_data:
-                        categories_str = todo_data["categories"]
-                        if categories_str:
-                            component["CATEGORIES"] = [
-                                c.strip() for c in categories_str.split(",")
-                            ]
-                            logger.debug("Set CATEGORIES to %s", categories_str)
+                # Handle reminders (VALARM)
+                self._apply_reminders(
+                    component,
+                    todo_data,
+                    todo_data.get("summary") or str(component.get("summary", "")),
+                    _TODO_REMINDER_DESCRIPTION,
+                )
 
-                    # Handle reminders (VALARM)
-                    self._apply_reminders(
-                        component,
-                        todo_data,
-                        todo_data.get("summary") or str(component.get("summary", "")),
-                        _TODO_REMINDER_DESCRIPTION,
-                    )
+                # Update timestamps
+                now = dt.datetime.now(dt.UTC)
+                component["LAST-MODIFIED"] = vDDDTypes(now)
+                component["DTSTAMP"] = vDDDTypes(now)
 
-                    # Update timestamps
-                    now = dt.datetime.now(dt.UTC)
-                    component["LAST-MODIFIED"] = vDDDTypes(now)
-                    component["DTSTAMP"] = vDDDTypes(now)
+                break
 
-                    break
-
-            return cal.to_ical().decode("utf-8")
-
-        except ValueError:
-            # A rejected update — a pairing conflict, or a date string that
-            # won't parse — is the caller's to fix. The fallback below rebuilds
-            # the todo from the *partial* update dict, so swallowing this would
-            # answer "invalid input" by silently dropping every stored property
-            # the caller didn't happen to pass, and reporting success.
-            # ``_merge_ical_properties`` dropped its identical fallback for
-            # VEVENT for exactly that reason.
-            raise
-        except Exception as e:
-            logger.error("Error merging iCal todo properties: %s", e)
-            return self._create_ical_todo(todo_data, todo_uid)
+        return cal.to_ical().decode("utf-8")
 
     # ============= Helper Methods - Filtering =============
 

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -1201,9 +1201,7 @@ def test_updating_only_the_due_date_inherits_the_stored_value_type():
         "uid-todo-update",
     )
 
-    merged = client._merge_ical_todo_properties(
-        stored, {"due": "2026-09-30"}, "uid-todo-update"
-    )
+    merged = client._merge_ical_todo_properties(stored, {"due": "2026-09-30"})
 
     parsed = client._parse_ical_todo(merged)
     assert parsed["due"] == "2026-09-30"
@@ -1224,9 +1222,7 @@ def test_making_only_one_half_of_a_whole_day_pair_timed_is_rejected():
     )
 
     with pytest.raises(ValueError, match="dtstart and due"):
-        client._merge_ical_todo_properties(
-            stored, {"dtstart": "2026-08-08T09:00:00Z"}, "uid-todo-half-flip"
-        )
+        client._merge_ical_todo_properties(stored, {"dtstart": "2026-08-08T09:00:00Z"})
 
 
 def test_making_a_whole_day_todo_timed_works_when_both_sides_are_given():
@@ -1238,9 +1234,7 @@ def test_making_a_whole_day_todo_timed_works_when_both_sides_are_given():
     )
 
     merged = client._merge_ical_todo_properties(
-        stored,
-        {"dtstart": "2026-08-08T09:00:00Z", "due": "2026-08-08T17:00:00Z"},
-        "uid-todo-full-flip",
+        stored, {"dtstart": "2026-08-08T09:00:00Z", "due": "2026-08-08T17:00:00Z"}
     )
 
     parsed = client._parse_ical_todo(merged)
@@ -1257,9 +1251,25 @@ def test_an_unparseable_date_does_not_silently_rebuild_the_todo():
     )
 
     with pytest.raises(ValueError):
-        client._merge_ical_todo_properties(
-            stored, {"due": "not-a-date"}, "uid-todo-bad-date"
-        )
+        client._merge_ical_todo_properties(stored, {"due": "not-a-date"})
+
+
+def test_a_non_value_error_does_not_silently_rebuild_the_todo():
+    """Only ValueError used to propagate; everything else rebuilt from the update dict.
+
+    A malformed reminder raises AttributeError, which the catch-all answered by
+    returning ``_create_ical_todo(todo_data, ...)`` — a todo carrying nothing but the
+    fields of this one failed call, with the stored summary, categories and due date
+    dropped and success reported.
+    """
+    client = _pure_client()
+    stored = client._create_ical_todo(
+        {"summary": "Keep me", "categories": "home", "due": "2026-08-08"},
+        "uid-todo-bad-reminder",
+    )
+
+    with pytest.raises(AttributeError):
+        client._merge_ical_todo_properties(stored, {"reminders": ["not-a-mapping"]})
 
 
 def test_unrelated_todo_update_survives_a_stored_mismatch():
@@ -1269,9 +1279,7 @@ def test_unrelated_todo_update_survives_a_stored_mismatch():
         {"summary": "Legacy", "due": "2026-08-08"}, "uid-todo-untouched"
     ).replace("DTSTAMP", "DTSTART;VALUE=DATE-TIME:20260801T090000Z\r\nDTSTAMP", 1)
 
-    merged = client._merge_ical_todo_properties(
-        stored, {"summary": "Renamed"}, "uid-todo-untouched"
-    )
+    merged = client._merge_ical_todo_properties(stored, {"summary": "Renamed"})
 
     parsed = client._parse_ical_todo(merged)
     assert parsed["summary"] == "Renamed"
@@ -1285,8 +1293,6 @@ def test_updating_a_timed_todo_with_a_bare_date_keeps_it_timed():
         {"summary": "Review PR", "dtstart": "2026-08-08T09:00:00Z"}, "uid-todo-timed-up"
     )
 
-    merged = client._merge_ical_todo_properties(
-        stored, {"due": "2026-08-09"}, "uid-todo-timed-up"
-    )
+    merged = client._merge_ical_todo_properties(stored, {"due": "2026-08-09"})
 
     assert client._parse_ical_todo(merged)["due"] == "2026-08-09T00:00:00+00:00"


### PR DESCRIPTION
Fixes #1252.

`_merge_ical_todo_properties` ended in a catch-all that returned
`_create_ical_todo(todo_data, todo_uid)`. On the update path `todo_data` holds only the
fields the caller passed, so any exception replaced the stored todo with one rebuilt from
that partial dict — dropping summary, due date, dtstart, the completed timestamp,
categories, RRULE, alarms and every custom property the caller did not re-send — and
reported success.

This is the same defect removed from the event merge in #544. `_merge_ical_properties`
raises instead and its docstring records why; the todo path never got the same treatment.
It was already half-fixed — `except ValueError: raise` was added with a comment pointing
at that precedent — but every other exception still fell through to the rebuild.

`todo_uid` goes with it, for the reason `event_uid` did: the parameter existed only to
feed the fallback, and the UID carries through from the stored iCal as a preserved
property.

### Reviewing

Most of the diff is the dedent from dropping the `try:`. **[`?w=1`](https://github.com/cbcoutinho/nextcloud-mcp-server/pull/1377/files?w=1) shows the real change: 35 lines.**

### Test

`test_a_non_value_error_does_not_silently_rebuild_the_todo` passes a malformed reminder,
which raises `AttributeError` — precisely what the catch-all swallowed. It fails on
`master` and passes with this change. No mocking; the input is real.

### On propagating instead of catching

One reviewer raised whether removing a catch-all risks unhandled exceptions reaching the
client. Worth stating what I checked: `nc_calendar_update_todo` catches only
`DavPreconditionFailed` and lets everything else propagate, and the event path has
behaved this way since #544. This change introduces no exception path that is not already
live for events. The alternative traded that for guaranteed silent data loss.

### Provenance

Written with AI assistance, then verified rather than trusted:

- The full unit suite runs clean — 56 passed, and the 13 collection errors are
  pre-existing on untouched `master` (missing optional test deps in my environment), not
  introduced here.
- `ruff check` reports one fewer error than `master`; `ruff format --check` is clean.
- The new test was confirmed to fail without the source change and pass with it.
- The patch was reviewed by three independent models plus a human before submission, and
  the one dissent is answered above.
- Running against my own Nextcloud instance, where this code path is in daily use.

Happy to split the whitespace-only dedent into its own commit if that reads better.
