### PR TITLE
fix(ci): point the pact CLI customManager at the script that holds the version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,12 +55,12 @@
     },
     {
       "customType": "regex",
-      "description": "Unified pact CLI installer URL pinned in the pact workflows",
+      "description": "Unified pact CLI version pinned in .github/scripts/install-pact-cli.sh (note: PACT_INSTALLER_SHA256 next to it must be bumped by hand)",
       "managerFilePatterns": [
-        "/^\\.github/workflows/.+\\.ya?ml$/"
+        "/^\\.github/scripts/install-pact-cli\\.sh$/"
       ],
       "matchStrings": [
-        "https://github\\.com/pact-foundation/pact-cli/releases/download/(?<currentValue>v[^/]+)/pact-installer\\.sh"
+        "PACT_CLI_VERSION=\"(?<currentValue>v[^\"]+)\""
       ],
       "depNameTemplate": "pact-foundation/pact-cli",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## What

`946933d1` moved the pact CLI install out of the workflows and into
`.github/scripts/install-pact-cli.sh` (to stop piping `curl` into `sh`), but
renovate's `customManager` for its version stayed pointed at the old location.
Both halves of it are stale:

1. **Scope** — no workflow contains that URL any more. The only occurrences under
   `.github/` are in the script: one in a header comment (as `<ver>`) and one live.
2. **Pattern** — in the script the URL is built from `${PACT_CLI_VERSION}`, so even
   scoped correctly the URL regex would capture the literal `${PACT_CLI_VERSION}`
   rather than a version.

Net effect: the pact CLI version has been silently unmanaged since that commit.

## Impact

Latent rather than harmful **so far** — the pinned `v0.10.7` is still the latest
upstream release (published 2026-07-13, checked today), so no update was actually
missed. But the next one would pass unnoticed, and a pinned installer that never
moves is one that never picks up a security fix.

## Fix

Point the manager at the script and match the version assignment:

```json
"managerFilePatterns": ["/^\\.github/scripts/install-pact-cli\\.sh$/"],
"matchStrings": ["PACT_CLI_VERSION=\"(?<currentValue>v[^\"]+)\""]
```

The description now also records renovate's blind spot here: it can bump the
version but **not** `PACT_INSTALLER_SHA256`, which has to be regenerated by hand
with the command in the script's header comment. Worth knowing before merging a
renovate bump for this dep — a version bump without the matching checksum fails
closed at `sha256sum --check --strict`, which is the right failure mode but an
opaque one if you don't know to expect it.

## How this was found

While closing the same finding class in `astrolabe`
(cbcoutinho/astrolabe#342 — SonarCloud security rating E → A). That repo had
copied this customManager and therefore inherited the same gap; it's fixed there
too.

## Test coverage

No API surface change — renovate config only, so the e2e + contract gate doesn't
apply. The regex was verified against the actual file (`PACT_CLI_VERSION="v0.10.7"`
at `.github/scripts/install-pact-cli.sh:18`) and the JSON re-parsed.

Deck: [board 11 / card 1081](https://cloud.coutinho.io/index.php/apps/deck/board/11/card/1081)

---

_This PR was generated with the help of AI, and reviewed by a Human_
