### PR TITLE
feat(links): direct file links on semantic search results and file reads

### DIFF
--- a/docs/ADR-035-tool-response-deep-links.md
+++ b/docs/ADR-035-tool-response-deep-links.md
@@ -75,6 +75,28 @@ annotations stay truthful, the advertised `outputSchema` is unchanged, and the
 verbatim. (An earlier `_meta` design required returning `CallToolResult` and
 would have needed a carve-out there.)
 
+### 3. Two links where a result is both a passage and a file
+
+`SemanticSearchResult` keeps `url` pointing at the Astrolabe **chunk viewer**
+(the passage that matched) and adds `file_url` pointing at the **file itself**
+(`/index.php/f/{fileid}`), for `doc_type="file"` only. They answer different
+questions — "show me the quote in context" vs "open the document" — and
+overloading one field would have forced every caller to guess which it got.
+
+`file_url` costs nothing to build: for files the indexed `doc_id` **is** the
+Nextcloud fileid (`vector/scanner.py`), so no lookup is involved. It is `None`
+for every other `doc_type`, because no other indexed id is a fileid and feeding
+a note id to `/f/` opens an unrelated file.
+
+`ReadFileResponse` gains a plain `url` for the same reason — an agent that has
+just read a degraded parse should be able to offer the original. That one is
+**not** free: a WebDAV `GET` returns no `OC-FileId` header (only `PUT` does), so
+`nc_webdav_read_file` resolves the id with a Depth-0 PROPFIND
+(`WebDAVClient.get_fileid`), skipped entirely when no browser base URL is
+configured. It is stamped onto the response after the read rather than passed
+into all five `ReadFileResponse(...)` sites, so a site that is added later
+cannot silently return `None`.
+
 ## Consequences
 
 - Adding an app means one registry entry plus one `url` field. A unit test

--- a/nextcloud_mcp_server/links.py
+++ b/nextcloud_mcp_server/links.py
@@ -57,12 +57,26 @@ def _note_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
     return base + _NOTE_PATH.format(note_id=item.id)
 
 
-def _file_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
-    # file_id is optional — PROPFIND does not always return one — and Nextcloud's
-    # /f/ route needs it. Omit the link rather than emit one that 404s.
-    if item.file_id is None:
+def file_url(base: str | None, file_id: int | str | None) -> str | None:
+    """Link that opens a file in Nextcloud's Files UI, or None.
+
+    Public because two callers reach it outside the response walk: the semantic
+    search tool, whose file results carry the fileid as their ``doc_id``, and
+    ``nc_webdav_read_file``, which resolves one per read. Both would otherwise
+    re-spell ``_FILE_PATH``.
+
+    Returns None when there is no browser-reachable base URL, and when the id is
+    missing — PROPFIND does not always return one, and Nextcloud's /f/ route
+    needs it, so an id-less link would 404. Absent beats broken: a caller cannot
+    tell a dead link from a live one, whereas None is unambiguous.
+    """
+    if not base or file_id is None:
         return None
-    return base + _FILE_PATH.format(file_id=item.file_id)
+    return base + _FILE_PATH.format(file_id=file_id)
+
+
+def _file_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
+    return file_url(base, item.file_id)
 
 
 def _board_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:

--- a/nextcloud_mcp_server/models/semantic.py
+++ b/nextcloud_mcp_server/models/semantic.py
@@ -106,6 +106,18 @@ class SemanticSearchResult(BaseModel):
             "when this chunk carries no character offsets."
         ),
     )
+    file_url: str | None = Field(
+        default=None,
+        description=(
+            "Link that opens the underlying file itself in Nextcloud, for "
+            "results whose `doc_type` is `file`. Complements `url`, which "
+            "opens the matched passage in Astrolabe's chunk viewer: offer this "
+            "one when the user wants the document rather than the quotation. "
+            "None for every other doc_type (a note or deck card is not a file "
+            "— follow `url`), and when the server has no browser-reachable "
+            "Nextcloud base URL configured."
+        ),
+    )
     # Context expansion fields (optional, populated when include_context=True)
     has_context_expansion: bool = Field(
         default=False, description="Whether context expansion was performed"

--- a/nextcloud_mcp_server/models/webdav.py
+++ b/nextcloud_mcp_server/models/webdav.py
@@ -120,6 +120,17 @@ class ReadFileResponse(BaseResponse):
     )
     etag: Optional[str] = Field(None, description="ETag for versioning")
     last_modified: Optional[str] = Field(None, description="Last modification time")
+    url: str | None = Field(
+        default=None,
+        description=(
+            "Link that opens this file in Nextcloud. Offer it alongside the "
+            "content so the user can open the original -- particularly when "
+            "`parse_notes` says the extraction was degraded and what you have "
+            "is not the whole document. None when the server has no "
+            "browser-reachable Nextcloud base URL configured, or when the file "
+            "has no resolvable fileid."
+        ),
+    )
 
 
 class WriteFileResponse(StatusResponse):

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -18,6 +18,7 @@ from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import allowed_doc_types
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
+from nextcloud_mcp_server.links import file_url
 from nextcloud_mcp_server.models.semantic import (
     SemanticSearchResponse,
     SemanticSearchResult,
@@ -734,6 +735,17 @@ def configure_semantic_tools(mcp: FastMCP):
                             total_chunks=metadata.get("total_chunks"),
                             extra=link_extra,
                         ),
+                        # For doc_type="file" the doc_id IS the Nextcloud
+                        # fileid (vector/scanner.py indexes it as such), so the
+                        # /f/ link needs no extra lookup. Guarded on doc_type
+                        # because no other indexed type's id is a fileid — a
+                        # note id fed to /f/ would open an unrelated file or
+                        # 404.
+                        file_url=(
+                            file_url(browser_base, narrowed_id)
+                            if r.doc_type == "file"
+                            else None
+                        ),
                     )
                 )
 
@@ -819,6 +831,7 @@ def configure_semantic_tools(mcp: FastMCP):
                                     page_number=result.page_number,
                                     page_end=result.page_end,
                                     url=result.url,
+                                    file_url=result.file_url,
                                     # Context expansion fields
                                     has_context_expansion=True,
                                     marked_text=chunk_context.marked_text,

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -9,11 +9,12 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.client.webdav import like_predicate
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.context import get_client
-from nextcloud_mcp_server.links import with_links
+from nextcloud_mcp_server.links import file_url, with_links
 from nextcloud_mcp_server.models import (
     CopyResourceResponse,
     CreateFileCommentResponse,
@@ -56,6 +57,20 @@ _WEBDAV_CONFLICT_STATUSES = frozenset({404, 409, 412})
 #: content is absent. A constant rather than a setting: the useful bound is the
 #: client's context, not anything an operator knows better.
 RAW_CONTENT_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _stamp_url(response: ReadFileResponse, url: str | None) -> ReadFileResponse:
+    """Attach the Files-app link to a response, in place.
+
+    Stamped after the fact rather than passed into every ``ReadFileResponse(...)``
+    in this module: the read path builds one at five separate sites, and a
+    constructor argument that one of them forgets reverts silently to None (the
+    failure mode ``test_semantic_result_field_parity.py`` exists to catch in the
+    semantic tool). Every return goes through here instead, so a sixth site
+    added later is linked by construction rather than by remembering to.
+    """
+    response.url = url
+    return response
 
 
 async def _raw_response(
@@ -292,6 +307,9 @@ def configure_webdav_tools(mcp: FastMCP):
               ``if_match`` when writing this same path later, so a manual edit
               made elsewhere in the meantime (e.g. in the Nextcloud web UI) is
               detected as a conflict instead of silently overwritten.
+            - ``url``: a link that opens the file in Nextcloud. Offer it when
+              reporting on the file, and especially when ``parse_notes`` says
+              the extraction degraded.
         """
         client = await get_client(ctx)
 
@@ -299,6 +317,28 @@ def configure_webdav_tools(mcp: FastMCP):
         excluded = await get_excluded_file_paths(client.webdav)
         if is_path_excluded(path, excluded):
             raise ToolError(f"Access denied: {path!r} is tagged with an excluded tag")
+
+        # Nextcloud's /f/ route needs the fileid, and a WebDAV GET does not
+        # return one -- only a PUT sends OC-FileId -- so it costs a Depth-0
+        # PROPFIND. Negligible beside the download-and-parse that follows, and
+        # skipped entirely when no browser-reachable base URL is configured,
+        # since there would be nothing to build a link from. Resolved once here
+        # rather than at each of the five sites that build the response.
+        #
+        # Fail-open on purpose: the link is a convenience, the content is the
+        # tool's job. A PROPFIND that 403s, times out or returns unparseable XML
+        # must cost the caller its link, never its read -- so the lookup is
+        # caught broadly (get_fileid raises HTTPStatusError, RequestError or
+        # ParseError depending on how it goes wrong) and logged rather than
+        # propagated. The read that follows surfaces any real access problem
+        # with a far better error than this lookup could.
+        browser_base = astrolabe_browser_base()
+        url = None
+        if browser_base:
+            try:
+                url = file_url(browser_base, await client.webdav.get_fileid(path))
+            except Exception as e:
+                logger.debug("No file link for %r: fileid lookup failed: %s", path, e)
 
         # Imported lazily so server startup never loads the document-parsing
         # stack (document_processors -> pymupdf -> _isolation). That stack is an
@@ -377,17 +417,22 @@ def configure_webdav_tools(mcp: FastMCP):
                             f"instead."
                         )
                         logger.warning("Parsing document %r timed out: %s", path, e)
-                        return await _raw_response(source, path, "failed", [note])
+                        return _stamp_url(
+                            await _raw_response(source, path, "failed", [note]), url
+                        )
                     except Exception as e:
                         logger.warning("Failed to parse document %r: %s", path, e)
-                        return await _raw_response(
-                            source,
-                            path,
-                            "failed",
-                            [
-                                f"Parsing failed ({type(e).__name__}: {e}); the raw "
-                                f"file is returned instead."
-                            ],
+                        return _stamp_url(
+                            await _raw_response(
+                                source,
+                                path,
+                                "failed",
+                                [
+                                    f"Parsing failed ({type(e).__name__}: {e}); the "
+                                    f"raw file is returned instead."
+                                ],
+                            ),
+                            url,
                         )
 
                     summary = document_parser.summarize_parse(
@@ -398,34 +443,40 @@ def configure_webdav_tools(mcp: FastMCP):
                     if summary.status == "failed":
                         # An unsuccessful parse is never reported as content: hand
                         # back the raw file with the reason attached.
-                        return await _raw_response(
-                            source,
-                            path,
-                            "failed",
-                            summary.notes,
+                        return _stamp_url(
+                            await _raw_response(
+                                source,
+                                path,
+                                "failed",
+                                summary.notes,
+                                parse_tier=summary.tier,
+                                parse_processor=summary.processor,
+                                parsing_metadata=result.metadata,
+                            ),
+                            url,
+                        )
+                    return _stamp_url(
+                        ReadFileResponse(
+                            path=path,
+                            content=result.text,
+                            content_type=content_type,
+                            size=source.size,
+                            parsed=True,
+                            parse_status="parsed",
                             parse_tier=summary.tier,
                             parse_processor=summary.processor,
+                            content_format=summary.content_format,
+                            parse_notes=summary.notes,
                             parsing_metadata=result.metadata,
-                        )
-                    return ReadFileResponse(
-                        path=path,
-                        content=result.text,
-                        content_type=content_type,
-                        size=source.size,
-                        parsed=True,
-                        parse_status="parsed",
-                        parse_tier=summary.tier,
-                        parse_processor=summary.processor,
-                        content_format=summary.content_format,
-                        parse_notes=summary.notes,
-                        parsing_metadata=result.metadata,
-                        etag=etag,
+                            etag=etag,
+                        ),
+                        url,
                     )
 
                 status: ParseStatus = (
                     "skipped" if parse_document == "raw" else "not_applicable"
                 )
-                return await _raw_response(source, path, status, [])
+                return _stamp_url(await _raw_response(source, path, status, []), url)
         except OversizeDownload as e:
             # The transfer was aborted mid-flight, so there is no file left to
             # describe -- not even its content type. Say that plainly rather than

--- a/tests/integration/test_semantic_search_chunk_links.py
+++ b/tests/integration/test_semantic_search_chunk_links.py
@@ -10,10 +10,13 @@ row carries a link Astrolabe would open.
 
 import json
 import uuid
+from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
 import anyio
 import pytest
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
 from nextcloud_mcp_server.config import get_settings
 from tests.integration._search_helpers import document_is_searchable
@@ -134,6 +137,28 @@ async def test_context_expansion_preserves_the_chunk_link(nc_mcp_client, nc_clie
         await nc_client.notes.delete_note(note_id=note["id"])
 
 
+def _pdf_containing(term: str) -> bytes:
+    """A one-page born-digital PDF whose text layer contains ``term``.
+
+    Ordinary prose around the term on purpose: a page holding one short unspaced
+    token reads as a poor text layer to the tier-0 classifier and escalates off
+    the fast tier, which would make this a test of parse heuristics rather than
+    of the link.
+    """
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=letter)
+    pdf.drawString(72, 750, f"Quarterly report mentioning {term}")
+    pdf.drawString(
+        72,
+        730,
+        "This document exists so an integration test can index a real file and "
+        "check the links on its search results.",
+    )
+    pdf.drawString(72, 710, f"The term to search for is {term}.")
+    pdf.save()
+    return buffer.getvalue()
+
+
 async def _file_is_searchable(mcp_client, term: str, file_id: int) -> bool:
     """True once ``file_id`` is retrievable as a file result.
 
@@ -170,12 +195,13 @@ async def test_file_results_also_carry_a_link_to_the_file(nc_mcp_client, nc_clie
 
     unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
     test_dir = f"chunk_link_file_{uuid.uuid4().hex[:8]}"
-    path = f"{test_dir}/report.txt"
+    path = f"{test_dir}/report.pdf"
     await nc_client.webdav.create_directory(test_dir)
+    # A PDF, not a text file: tagged-file discovery filters on
+    # mime_type_filter="application/pdf" (vector/scanner.py), so a .txt is never
+    # discovered no matter how it is tagged — this test could only ever skip.
     await nc_client.webdav.write_file(
-        path,
-        f"This file exists to be found by the term {unique_term}.".encode(),
-        content_type="text/plain",
+        path, _pdf_containing(unique_term), content_type="application/pdf"
     )
     file_id = int((await nc_client.webdav.get_file_info(path))["id"])
     # File indexing is tag-gated; without the tag the scanner never sees it.

--- a/tests/integration/test_semantic_search_chunk_links.py
+++ b/tests/integration/test_semantic_search_chunk_links.py
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 import anyio
 import pytest
 
+from nextcloud_mcp_server.config import get_settings
 from tests.integration._search_helpers import document_is_searchable
 
 pytestmark = pytest.mark.integration
@@ -24,6 +25,12 @@ REQUIRED_PARAMS = {"doc_type", "doc_id", "chunk_start", "chunk_end"}
 
 INDEX_TIMEOUT_SECONDS = 180
 POLL_INTERVAL_SECONDS = 5
+
+# Files index more slowly than notes (tag-gated: the scanner has to see the tag
+# assignment on its next pass), and this budget must stay clear of the 180s
+# pytest-timeout — at 180 the poll loop is killed before it can reach its own
+# skip, turning "not indexed yet" into a hard failure.
+FILE_INDEX_TIMEOUT_SECONDS = 120
 
 
 async def test_search_results_carry_an_astrolabe_chunk_link(nc_mcp_client, nc_client):
@@ -67,6 +74,9 @@ async def test_search_results_carry_an_astrolabe_chunk_link(nc_mcp_client, nc_cl
             "nextcloud_browser_url from NEXTCLOUD_PUBLIC_ISSUER_URL, so an "
             "empty url means the builder was not reached"
         )
+
+        # A note is not a file: only the chunk viewer opens it.
+        assert result["file_url"] is None
 
         parsed = urlparse(url)
         assert parsed.scheme in ("http", "https")
@@ -122,3 +132,83 @@ async def test_context_expansion_preserves_the_chunk_link(nc_mcp_client, nc_clie
         assert ours[0]["url"], "context expansion dropped the chunk link"
     finally:
         await nc_client.notes.delete_note(note_id=note["id"])
+
+
+async def _file_is_searchable(mcp_client, term: str, file_id: int) -> bool:
+    """True once ``file_id`` is retrievable as a file result.
+
+    Local rather than ``document_is_searchable``, which requires doc_type
+    "note" when matching on an id.
+    """
+    try:
+        search = await mcp_client.call_tool(
+            "nc_semantic_search",
+            arguments={"query": term, "limit": 50, "doc_types": ["file"]},
+        )
+    except Exception:  # transient blip — keep polling
+        return False
+    if search.isError:
+        return False
+    try:
+        results = json.loads(search.content[0].text).get("results", [])
+    except (IndexError, ValueError):
+        return False
+    return any(str(r.get("id")) == str(file_id) for r in results)
+
+
+async def test_file_results_also_carry_a_link_to_the_file(nc_mcp_client, nc_client):
+    """A file result offers both links: the chunk viewer AND the file itself.
+
+    ``url`` opens the matched passage in Astrolabe; ``file_url`` opens the
+    document in Nextcloud. For doc_type="file" the doc_id IS the fileid, which
+    is what makes the second link free — and this is what checks that identity
+    still holds on a live index, rather than only in the indexer's source.
+    """
+    status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
+    if status.isError:
+        pytest.skip("Vector sync not enabled")
+
+    unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
+    test_dir = f"chunk_link_file_{uuid.uuid4().hex[:8]}"
+    path = f"{test_dir}/report.txt"
+    await nc_client.webdav.create_directory(test_dir)
+    await nc_client.webdav.write_file(
+        path,
+        f"This file exists to be found by the term {unique_term}.".encode(),
+        content_type="text/plain",
+    )
+    file_id = int((await nc_client.webdav.get_file_info(path))["id"])
+    # File indexing is tag-gated; without the tag the scanner never sees it.
+    tag = await nc_client.webdav.get_or_create_tag(
+        name=get_settings().vector_sync_tag,
+        user_visible=True,
+        user_assignable=True,
+    )
+    await nc_client.webdav.assign_tag_to_file(file_id, tag["id"])
+
+    try:
+        with anyio.move_on_after(FILE_INDEX_TIMEOUT_SECONDS) as scope:
+            while not await _file_is_searchable(nc_mcp_client, unique_term, file_id):
+                await anyio.sleep(POLL_INTERVAL_SECONDS)
+        if scope.cancelled_caught:
+            pytest.skip(
+                f"file {file_id} not indexed within {FILE_INDEX_TIMEOUT_SECONDS}s"
+            )
+
+        search = await nc_mcp_client.call_tool(
+            "nc_semantic_search",
+            {"query": unique_term, "limit": 50, "doc_types": ["file"]},
+        )
+        assert not search.isError, search
+        results = json.loads(search.content[0].text)["results"]
+
+        ours = [r for r in results if str(r["id"]) == str(file_id)]
+        assert ours, f"indexed file {file_id} missing from its own search"
+        result = ours[0]
+
+        assert result["file_url"], "file result carries no link to the file"
+        assert result["file_url"].endswith(f"/index.php/f/{file_id}")
+        # Both links, not one instead of the other.
+        assert result["url"], "the chunk link was lost"
+    finally:
+        await nc_client.webdav.delete_resource(test_dir)

--- a/tests/integration/test_webdav_document_read.py
+++ b/tests/integration/test_webdav_document_read.py
@@ -141,3 +141,39 @@ async def test_text_file_is_untouched_by_the_parse_argument(
     assert result["parse_status"] == "not_applicable"
     assert result["parsed"] is False
     assert result["parse_notes"] == []
+
+
+async def test_read_returns_a_link_that_opens_the_file(
+    nc_client: NextcloudClient, nc_mcp_client: ClientSession, text_layer_pdf: str
+):
+    """The response carries a Files link, so a caller can offer the original.
+
+    Pinned end-to-end because the fileid it needs is NOT in the read itself: a
+    WebDAV GET returns no ``OC-FileId`` (only a PUT does), so the tool resolves
+    it with a separate PROPFIND. A unit test on the URL builder cannot show that
+    lookup actually happens, or that it happens on the parsed path too.
+    """
+    result = await _read(nc_mcp_client, text_layer_pdf)
+
+    file_id = await nc_client.webdav.get_fileid(text_layer_pdf)
+    assert file_id, "fixture file has no fileid; the assertion below is vacuous"
+    assert result["url"], (
+        "no file link on the read; the mcp service resolves "
+        "nextcloud_browser_url from NEXTCLOUD_PUBLIC_ISSUER_URL, so an empty "
+        "url means the builder was not reached"
+    )
+    assert result["url"].endswith(f"/index.php/f/{file_id}")
+
+
+async def test_raw_read_is_linked_too(
+    nc_client: NextcloudClient, nc_mcp_client: ClientSession, text_layer_pdf: str
+):
+    """The raw path builds its response at a different site than the parsed one.
+
+    Five sites build a ``ReadFileResponse``; the link is stamped once, after the
+    fact, precisely so a second one cannot silently return None.
+    """
+    result = await _read(nc_mcp_client, text_layer_pdf, parse_document="raw")
+
+    file_id = await nc_client.webdav.get_fileid(text_layer_pdf)
+    assert result["url"].endswith(f"/index.php/f/{file_id}")

--- a/tests/unit/test_links.py
+++ b/tests/unit/test_links.py
@@ -11,7 +11,12 @@ from urllib.parse import urlparse
 
 import pytest
 
-from nextcloud_mcp_server.links import _URL_BUILDERS, attach_urls, with_links
+from nextcloud_mcp_server.links import (
+    _URL_BUILDERS,
+    attach_urls,
+    file_url,
+    with_links,
+)
 from nextcloud_mcp_server.models.deck import (
     BoardOverviewResponse,
     CardOperationResponse,
@@ -88,6 +93,21 @@ def test_file_without_a_fileid_gets_no_link():
     """PROPFIND does not always return one, and /f/ needs it."""
     info = FileInfo(name="a.txt", path="/a.txt", is_directory=False, file_id=None)
     assert _attach(info).url is None
+
+
+def test_file_url_builder_is_callable_outside_the_walk():
+    """Two callers reach it directly: the semantic search tool (whose file
+    results carry the fileid as their doc_id) and nc_webdav_read_file."""
+    assert file_url(BASE, 99) == f"{BASE}/index.php/f/99"
+    # doc_id arrives as a str on the search path.
+    assert file_url(BASE, "99") == f"{BASE}/index.php/f/99"
+
+
+@pytest.mark.parametrize(
+    "base, file_id", [(None, 99), ("", 99), (BASE, None)], ids=["none", "empty", "noid"]
+)
+def test_file_url_builder_omits_the_link_when_it_would_be_broken(base, file_id):
+    assert file_url(base, file_id) is None
 
 
 def test_stack_links_to_its_board():


### PR DESCRIPTION
## What

MCP clients could not offer "open this file in Nextcloud" from either of the two
tools most likely to be looking at one:

| Tool | Before | After |
|---|---|---|
| `nc_semantic_search` | `url` = Astrolabe **chunk viewer** (the matched passage) | unchanged, **plus** `file_url` = `/index.php/f/{fileid}` for `doc_type="file"` |
| `nc_webdav_read_file` | no link at all | `url` = `/index.php/f/{fileid}` |
| `nc_webdav_list_directory` / `search_files` / `find_by_*` / `list_favorites` | already linked via `@with_links` | unchanged |

`url` keeps its current meaning on search results, so "show me the quote in
context" and "open the document" stay separately answerable rather than one
field having to be guessed at.

## How

- `links.file_url(base, file_id)` — the existing `/f/` template, made callable
  outside the response walk. `_file_url` (the `@with_links` builder) now defers
  to it, so there is one spelling of the route.
- **Search side is free.** For `doc_type="file"` the indexed `doc_id` *is* the
  Nextcloud fileid (`vector/scanner.py`), so no lookup is involved. `None` for
  every other doc_type — no other indexed id is a fileid, and a note id fed to
  `/f/` would open an unrelated file.
- **Read side costs one Depth-0 PROPFIND.** A WebDAV `GET` returns no
  `OC-FileId` header — only a `PUT` does (verified against a live NC 32
  instance, not assumed) — so the tool resolves it via the existing
  `WebDAVClient.get_fileid`. Negligible beside the download-and-parse it
  accompanies, skipped entirely when no browser base URL is configured, and
  **fail-open**: a lookup that 403s or times out costs the caller its link,
  never its read.
- The link is stamped onto the read response after the fact rather than passed
  into all five `ReadFileResponse(...)` sites, so a sixth added later is linked
  by construction instead of by remembering to.

## Test coverage

- **Unit** — `tests/unit/test_links.py`: the shared builder, including every
  case that must yield `None` (no base URL, empty base, no id).
- **Integration (e2e tier)** — `tests/integration/test_webdav_document_read.py`:
  the parsed *and* raw read paths both return a link matching the file's real
  fileid. `tests/integration/test_semantic_search_chunk_links.py`: an indexed
  file carries both links; a note carries only the chunk link.
- **Contract (Pact)** — not applicable: no cross-service boundary changes.
  `/api/v1/search` builds its own result dicts and is untouched, so the
  astrolabe provider pact is unaffected. Both response schemas gain an optional
  field — additive and backwards compatible.
- One caveat worth flagging: the new semantic-search integration test polls for
  up to 120s for the tagged file to be indexed and **skips** rather than fails
  past that (file indexing is tag-gated and slower than notes). If it skips
  consistently in CI it is not earning its keep and should be reworked — the
  budget is deliberately under the 180s pytest-timeout so it can never turn
  "not indexed yet" into a hard failure.

Docs: ADR-035 gains a section on why a search result carries two links, and on
what the read-side lookup costs.

Deck: [board 12 #1080](https://cloud.coutinho.io/index.php/apps/deck/board/12/card/1080)

---

_This PR was generated with the help of AI, and reviewed by a Human_
