### PR TITLE
feat(calendar): surface free/busy transparency for calendars and events

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -55,6 +55,18 @@ _TODO_REMINDER_DESCRIPTION = "Todo reminder"
 _VALARM_ACTIONS = frozenset({"DISPLAY", "EMAIL", "AUDIO"})
 
 
+def _calendar_is_transparent(response_elem: Any, ns: dict[str, str]) -> bool:
+    """Read CalDAV ``schedule-calendar-transp`` from a PROPFIND response.
+
+    Nextcloud exposes its per-calendar "never show me as busy" switch through
+    this property (RFC 4791 5.2.9). The value is an *element*, not text:
+    ``<c:schedule-calendar-transp><c:transparent/></c:schedule-calendar-transp>``.
+    A missing property means opaque, i.e. the calendar consumes time.
+    """
+    elem = response_elem.find(".//c:schedule-calendar-transp", ns)
+    return elem is not None and elem.find("./c:transparent", ns) is not None
+
+
 def _rrule_to_string(rrule: Any) -> str:
     """Render an icalendar ``vRecur`` as an RFC 5545 RRULE value.
 
@@ -510,6 +522,7 @@ class CalendarClient:
         <cs:calendar-color/>
         <ical:calendar-color/>
         <cs:source/>
+        <c:schedule-calendar-transp/>
     </d:prop>
 </d:propfind>"""
 
@@ -599,6 +612,8 @@ class CalendarClient:
                 elif source_elem.text and source_elem.text.strip():
                     source = source_elem.text.strip()
 
+            transparent = _calendar_is_transparent(response_elem, ns)
+
             result.append(
                 {
                     "name": calendar_name,
@@ -608,6 +623,7 @@ class CalendarClient:
                     "href": calendar_url,
                     "read_only": is_subscribed,
                     "source": source,
+                    "transparent": transparent,
                 }
             )
 
@@ -1836,6 +1852,11 @@ class CalendarClient:
             "description": str(component.get("description", "")),
             "location": str(component.get("location", "")),
             "status": str(component.get("status", "CONFIRMED")),
+            # TRANSP marks whether this event consumes time (RFC 5545
+            # 3.8.2.7). Nextcloud surfaces it as Busy/Free on the event.
+            # Without it a caller cannot tell that e.g. birthdays are
+            # explicitly non-blocking. Absent means OPAQUE.
+            "transp": str(component.get("transp", "OPAQUE")).upper(),
             "priority": int(component.get("priority", 5)),
             "privacy": str(component.get("class", "PUBLIC")),
             "url": str(component.get("url", "")),

--- a/nextcloud_mcp_server/models/calendar.py
+++ b/nextcloud_mcp_server/models/calendar.py
@@ -101,6 +101,15 @@ class Calendar(BaseModel):
         None,
         description="Source URL of an external/subscribed read-only calendar",
     )
+    transparent: bool = Field(
+        default=False,
+        description=(
+            "Whether the calendar is transparent for free/busy purposes "
+            "(CalDAV schedule-calendar-transp, RFC 4791 5.2.9). Nextcloud "
+            "surfaces this as 'never show me as busy'. Events in such a "
+            "calendar should be ignored when computing availability."
+        ),
+    )
 
 
 class CalendarEventSummary(BaseModel):
@@ -136,6 +145,14 @@ class CalendarEventSummary(BaseModel):
     location: Optional[str] = Field(None, description="Event location")
     description: Optional[str] = Field(None, description="Event description")
     categories: List[str] = Field(default_factory=list, description="Event categories")
+    transp: Optional[str] = Field(
+        None,
+        description=(
+            "Free/busy transparency of this event (RFC 5545 3.8.2.7 TRANSP): "
+            "'OPAQUE' consumes time, 'TRANSPARENT' does not. Nextcloud shows "
+            "this as 'Busy'/'Free' on the event."
+        ),
+    )
     status: Optional[str] = Field(
         None, description="Event status (CONFIRMED, TENTATIVE, CANCELLED)"
     )

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -103,6 +103,7 @@ def _event_dict_to_summary(event: dict) -> CalendarEventSummary:
         description=event.get("description") or None,
         categories=categories,
         status=event.get("status"),
+        transp=event.get("transp"),
         calendar_name=event.get("calendar_name"),
         calendar_display_name=event.get("calendar_display_name")
         or event.get("calendar_name"),

--- a/tests/unit/client/test_calendar_transparency.py
+++ b/tests/unit/client/test_calendar_transparency.py
@@ -1,0 +1,110 @@
+"""Free/busy transparency must survive the trip from CalDAV to the model.
+
+Two independent switches decide whether something consumes time:
+
+* the calendar's ``schedule-calendar-transp`` (RFC 4791 5.2.9) -- Nextcloud
+  calls it "never show me as busy";
+* the event's ``TRANSP`` (RFC 5545 3.8.2.7) -- shown as Busy/Free per event.
+
+Neither was surfaced, so any consumer computing availability had to treat
+birthdays, subscribed holiday feeds and explicitly free events as busy.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.client.calendar import _calendar_is_transparent
+from nextcloud_mcp_server.models.calendar import Calendar, CalendarEventSummary
+
+pytestmark = pytest.mark.unit
+
+
+class TestCalendarModel:
+    def test_defaults_to_opaque(self):
+        cal = Calendar(name="work", display_name="Work")
+        assert cal.transparent is False
+
+    def test_transparent_round_trips(self):
+        cal = Calendar(name="kids", display_name="Kids", transparent=True)
+        assert cal.transparent is True
+
+
+class TestEventModel:
+    def test_transp_is_optional(self):
+        event = CalendarEventSummary(uid="1", summary="s", start="2026-09-07T09:00:00")
+        assert event.transp is None
+
+    @pytest.mark.parametrize("value", ["OPAQUE", "TRANSPARENT"])
+    def test_transp_round_trips(self, value):
+        event = CalendarEventSummary(
+            uid="1", summary="s", start="2026-09-07T09:00:00", transp=value
+        )
+        assert event.transp == value
+
+
+class TestPropfindParsing:
+    """The calendar property is an element, not text."""
+
+    NS = {"d": "DAV:", "c": "urn:ietf:params:xml:ns:caldav"}
+
+    @staticmethod
+    def _parse(fragment: str):
+        from lxml import etree
+
+        return etree.fromstring(fragment.encode("utf-8"))
+
+    def test_transparent_element_detected(self):
+        elem = self._parse(
+            '<d:prop xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+            "<c:schedule-calendar-transp><c:transparent/>"
+            "</c:schedule-calendar-transp></d:prop>"
+        )
+        assert _calendar_is_transparent(elem, self.NS) is True
+
+    def test_opaque_element_is_not_transparent(self):
+        elem = self._parse(
+            '<d:prop xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+            "<c:schedule-calendar-transp><c:opaque/>"
+            "</c:schedule-calendar-transp></d:prop>"
+        )
+        assert _calendar_is_transparent(elem, self.NS) is False
+
+    def test_missing_property_is_not_transparent(self):
+        elem = self._parse(
+            '<d:prop xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"/>'
+        )
+        assert _calendar_is_transparent(elem, self.NS) is False
+
+
+class TestEventTransp:
+    """TRANSP is read off the VEVENT, defaulting to OPAQUE when absent."""
+
+    @staticmethod
+    def _extract(ics: str) -> dict:
+        from icalendar import Calendar as ICalendar
+
+        from nextcloud_mcp_server.client.calendar import CalendarClient
+
+        cal = ICalendar.from_ical(ics)
+        vevent = next(c for c in cal.walk() if c.name == "VEVENT")
+        # The extractor only reads from the component; skip __init__ so the
+        # test does not need a live DAV client.
+        client = CalendarClient.__new__(CalendarClient)
+        return client._extract_vevent_data(vevent)
+
+    ICS = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//t//EN\r\n"
+        "BEGIN:VEVENT\r\nUID:1\r\nSUMMARY:s\r\n"
+        "DTSTART:20260907T090000Z\r\nDTEND:20260907T100000Z\r\n"
+        "{extra}END:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+
+    def test_absent_transp_defaults_to_opaque(self):
+        assert self._extract(self.ICS.format(extra=""))["transp"] == "OPAQUE"
+
+    def test_transparent_is_read(self):
+        data = self._extract(self.ICS.format(extra="TRANSP:TRANSPARENT\r\n"))
+        assert data["transp"] == "TRANSPARENT"
+
+    def test_opaque_is_read(self):
+        data = self._extract(self.ICS.format(extra="TRANSP:OPAQUE\r\n"))
+        assert data["transp"] == "OPAQUE"


### PR DESCRIPTION
Anything computing availability from this server currently has to treat every calendar entry as busy, because the two properties that say otherwise are not exposed.

## What is missing

| Level | Property | Nextcloud UI |
|---|---|---|
| Calendar | `schedule-calendar-transp` (RFC 4791 5.2.9) | "never show me as busy" |
| Event | `TRANSP` (RFC 5545 3.8.2.7) | Busy / Free on the event |

`nc_calendar_list_calendars` returned `color`, `ctag`, `description`, `display_name`, `enabled`, `href`, `name`, `read_only`, `source`, `timezone` — no transparency. `_extract_vevent_data` read `uid`, `title`, `description`, `location`, `status`, `priority`, `privacy`, `url`, `color` — no `TRANSP`.

## Why it matters in practice

On my instance (Nextcloud 33, 21 calendars, 1554 events):

- **6 of 21 calendars** are marked transparent — cross-checked against `oc_calendars.transparent`.
- **93 of 1554 events** carry `TRANSP:TRANSPARENT`, of which 60 are in the contact-birthday calendar and 25 in a subscribed school-holiday feed.

Note the interaction: that birthday calendar is *not* transparent at calendar level, but its events are. Reading only one of the two switches is not enough.

Concretely, one six-day entry in a transparent calendar made an entire week look fully booked, and a single all-day birthday erased a working day.

## Change

- `list_calendars` requests `<c:schedule-calendar-transp/>` and reports `Calendar.transparent`. The value is an element rather than text, so the check is factored into `_calendar_is_transparent()`.
- `_extract_vevent_data` reads `TRANSP`, defaulting to `OPAQUE` when absent, and `_event_dict_to_summary` passes it through to `CalendarEventSummary.transp`.

Both fields are additive and default to the previous behaviour (opaque), so nothing changes for existing consumers.

## Testing

`tests/unit/client/test_calendar_transparency.py` — 11 cases covering model defaults, the PROPFIND element form (transparent / opaque / property absent) and TRANSP extraction from a VEVENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomNRo5jTc6rDNNLYrRVRX
