### PR TITLE
fix(contacts): make photo payloads opt-in and add paging

### DIFF
--- a/nextcloud_mcp_server/models/contacts.py
+++ b/nextcloud_mcp_server/models/contacts.py
@@ -65,7 +65,20 @@ class Contact(BaseModel):
     addresses: List[ContactField] = Field(default_factory=list, description="Addresses")
     urls: List[ContactField] = Field(default_factory=list, description="URLs")
     note: Optional[str] = Field(None, description="Notes")
-    photo: Optional[str] = Field(None, description="Photo URL or base64 data")
+    photo: Optional[str] = Field(
+        None,
+        description=(
+            "Photo URL or base64 data. Omitted from list and search responses "
+            "unless include_photos is set -- see has_photo."
+        ),
+    )
+    has_photo: bool = Field(
+        False,
+        description=(
+            "Whether the contact has a photo, even when the data itself was "
+            "left out of this response."
+        ),
+    )
     birthday: Optional[str] = Field(None, description="Birthday (ISO date format)")
     categories: List[str] = Field(
         default_factory=list, description="Contact categories"

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -172,13 +172,29 @@ def _split_name_parts(raw_n: list | None) -> tuple[str | None, str | None]:
     return (family or None), (given or None)
 
 
-def _raw_contact_to_model(raw: dict) -> Contact:
+def _page(items: list, limit: int | None, offset: int) -> list:
+    """Slice one page out of a contact list.
+
+    Both bounds are defensive: a negative offset starts at the beginning, a
+    negative limit yields nothing rather than slicing from the end.
+    """
+    start = max(0, offset)
+    if limit is None:
+        return items[start:]
+    return items[start : start + max(0, limit)]
+
+
+def _raw_contact_to_model(raw: dict, *, include_photo: bool = False) -> Contact:
     """Convert a raw contact dict from the contacts client to a Contact model.
 
     Maps fullname, name parts, nickname, birthday, email, tel, address, org,
     title, note, url, categories, photo and X-* extension fields. Email/tel
     values may be plain strings, dicts with ``value``/``type`` keys, or lists of
     either – see :func:`_parse_vcard_fields`.
+
+    ``include_photo`` controls whether the inline PHOTO payload is carried
+    over. vCards commonly embed photos as base64, which dwarfs every other
+    field, so the default is to drop the bytes and keep ``has_photo``.
     """
     contact_info = raw.get("contact", {})
 
@@ -188,6 +204,7 @@ def _raw_contact_to_model(raw: dict) -> Contact:
     categories = _parse_categories(contact_info.get("categories"))
     custom_fields = _build_custom_fields(contact_info)
     family_name, given_name = _split_name_parts(contact_info.get("n"))
+    raw_photo = contact_info.get("photo")
 
     return Contact(
         uid=raw["vcard_id"],
@@ -199,7 +216,8 @@ def _raw_contact_to_model(raw: dict) -> Contact:
         organization=contact_info.get("org"),
         title=contact_info.get("title"),
         note=contact_info.get("note"),
-        photo=contact_info.get("photo"),
+        photo=raw_photo if include_photo else None,
+        has_photo=bool(raw_photo),
         birthday=contact_info["birthday"].isoformat()
         if isinstance(contact_info.get("birthday"), date)
         else contact_info.get("birthday"),
@@ -245,7 +263,12 @@ def configure_contacts_tools(mcp: FastMCP):
     @require_scopes("contacts.read")
     @instrument_tool
     async def nc_contacts_list_contacts(
-        ctx: Context, *, addressbook: str
+        ctx: Context,
+        *,
+        addressbook: str,
+        include_photos: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> ListContactsResponse:
         """List all contacts in the specified addressbook.
 
@@ -253,12 +276,26 @@ def configure_contacts_tools(mcp: FastMCP):
             addressbook: The URI slug of the addressbook (e.g. "contacts"),
                 not the display name. Use nc_contacts_list_addressbooks to
                 find available URI slugs.
+            include_photos: Include the inline base64 PHOTO payload. Off by
+                default: embedded photos dominate vCard size and can push the
+                response past what the transport delivers. ``has_photo`` still
+                says which contacts have one.
+            limit: Maximum number of contacts to return. None returns all.
+            offset: Number of contacts to skip, for paging through a large
+                addressbook together with ``limit``.
         """
         client = await get_client(ctx)
         contacts_data = await client.contacts.list_contacts(addressbook=addressbook)
-        contacts = [_raw_contact_to_model(c) for c in contacts_data]
+        total = len(contacts_data)
+
+        page = _page(contacts_data, limit, offset)
+        contacts = [
+            _raw_contact_to_model(c, include_photo=include_photos) for c in page
+        ]
+        # total_count reports the addressbook size, not the page size, so a
+        # caller can tell whether more contacts remain.
         return ListContactsResponse(
-            contacts=contacts, addressbook=addressbook, total_count=len(contacts)
+            contacts=contacts, addressbook=addressbook, total_count=total
         )
 
     @mcp.tool(
@@ -268,7 +305,11 @@ def configure_contacts_tools(mcp: FastMCP):
     @require_scopes("contacts.read")
     @instrument_tool
     async def nc_contacts_search_contacts(
-        ctx: Context, *, query: str, addressbook: str | None = None
+        ctx: Context,
+        *,
+        query: str,
+        addressbook: str | None = None,
+        include_photos: bool = False,
     ) -> ListContactsResponse:
         """Search contacts by free-text query across name, nickname, email, and phone.
 
@@ -284,6 +325,8 @@ def configure_contacts_tools(mcp: FastMCP):
                 An empty query returns no results — use list_contacts for that.
             addressbook: Optional URI slug of a specific addressbook to search.
                 When omitted, every addressbook for the user is searched.
+            include_photos: Include the inline base64 PHOTO payload. Off by
+                default -- see nc_contacts_list_contacts.
 
         Returns:
             ListContactsResponse with matching contacts. The ``addressbook``
@@ -312,7 +355,7 @@ def configure_contacts_tools(mcp: FastMCP):
         for ab_slug in address_books:
             raw_contacts = await client.contacts.list_contacts(addressbook=ab_slug)
             for raw in raw_contacts:
-                contact = _raw_contact_to_model(raw)
+                contact = _raw_contact_to_model(raw, include_photo=include_photos)
                 hay_parts: list[str] = []
                 if contact.fn:
                     hay_parts.append(contact.fn.lower())

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -184,7 +184,7 @@ def _page(items: list, limit: int | None, offset: int) -> list:
     return items[start : start + max(0, limit)]
 
 
-def _raw_contact_to_model(raw: dict, *, include_photo: bool = False) -> Contact:
+def _raw_contact_to_model(raw: dict, *, include_photo: bool = True) -> Contact:
     """Convert a raw contact dict from the contacts client to a Contact model.
 
     Maps fullname, name parts, nickname, birthday, email, tel, address, org,
@@ -193,8 +193,10 @@ def _raw_contact_to_model(raw: dict, *, include_photo: bool = False) -> Contact:
     either – see :func:`_parse_vcard_fields`.
 
     ``include_photo`` controls whether the inline PHOTO payload is carried
-    over. vCards commonly embed photos as base64, which dwarfs every other
-    field, so the default is to drop the bytes and keep ``has_photo``.
+    over. It defaults to True so single-contact mappings keep their previous
+    shape; only the list and search tools opt out, because vCards embed photos
+    as base64 and that dwarfs every other field when many contacts are
+    returned at once. ``has_photo`` is reported either way.
     """
     contact_info = raw.get("contact", {})
 
@@ -204,7 +206,9 @@ def _raw_contact_to_model(raw: dict, *, include_photo: bool = False) -> Contact:
     categories = _parse_categories(contact_info.get("categories"))
     custom_fields = _build_custom_fields(contact_info)
     family_name, given_name = _split_name_parts(contact_info.get("n"))
-    raw_photo = contact_info.get("photo")
+    # An empty PHOTO is no photo: normalising here keeps photo and has_photo
+    # consistent instead of reporting "" alongside has_photo=False.
+    raw_photo = contact_info.get("photo") or None
 
     return Contact(
         uid=raw["vcard_id"],

--- a/tests/server/test_contacts_mcp.py
+++ b/tests/server/test_contacts_mcp.py
@@ -265,3 +265,98 @@ async def test_mcp_contacts_surfaces_structured_fields_and_survives_bad_cards(
             await nc_client.contacts.delete_addressbook(name=addressbook_name)
         except Exception:
             pass
+
+
+async def test_mcp_contacts_photo_and_paging_parameters(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """The new list parameters survive the MCP schema and the transport.
+
+    Photos are the reason the tool exists in this shape: a base64 PHOTO per
+    contact dwarfs every other field, so it is opt-in and ``has_photo`` carries
+    the information instead.
+    """
+    addressbook_name = f"mcp-photo-{uuid.uuid4().hex[:8]}"
+    suffix = uuid.uuid4().hex[:8]
+    base = (
+        f"/remote.php/dav/addressbooks/users/"
+        f"{nc_client.contacts.username}/{addressbook_name}"
+    )
+    # A recognisable, deliberately chunky payload.
+    photo_b64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" * 20
+
+    await nc_client.contacts.create_addressbook(
+        name=addressbook_name, display_name=f"MCP Photo {suffix}"
+    )
+    try:
+        for index in range(3):
+            uid = f"photo-{suffix}-{index}"
+            vcard = (
+                "BEGIN:VCARD\r\n"
+                "VERSION:3.0\r\n"
+                f"UID:{uid}\r\n"
+                f"FN:Contact {index}\r\n"
+                f"PHOTO;ENCODING=b;TYPE=GIF:{photo_b64}\r\n"
+                "END:VCARD\r\n"
+            )
+            await nc_client.contacts._make_request(
+                "PUT",
+                f"{base}/{uid}.vcf",
+                content=vcard.encode("utf-8"),
+                headers={"Content-Type": "text/vcard; charset=utf-8"},
+            )
+
+        # Default: no photo bytes, but the flag says one exists.
+        default_result = await nc_mcp_client.call_tool(
+            "nc_contacts_list_contacts", {"addressbook": addressbook_name}
+        )
+        assert default_result.isError is False
+        default_payload = _extract_payload(default_result)
+        assert default_payload["total_count"] == 3
+        assert all(c["photo"] is None for c in default_payload["contacts"])
+        assert all(c["has_photo"] is True for c in default_payload["contacts"])
+
+        # Opt in and the bytes come back.
+        with_photos = await nc_mcp_client.call_tool(
+            "nc_contacts_list_contacts",
+            {"addressbook": addressbook_name, "include_photos": True},
+        )
+        assert with_photos.isError is False
+        assert all(c["photo"] for c in _extract_payload(with_photos)["contacts"])
+
+        # Paging: total_count stays the addressbook size, not the page size.
+        first = _extract_payload(
+            await nc_mcp_client.call_tool(
+                "nc_contacts_list_contacts",
+                {"addressbook": addressbook_name, "limit": 2},
+            )
+        )
+        assert len(first["contacts"]) == 2
+        assert first["total_count"] == 3
+
+        second = _extract_payload(
+            await nc_mcp_client.call_tool(
+                "nc_contacts_list_contacts",
+                {"addressbook": addressbook_name, "limit": 2, "offset": 2},
+            )
+        )
+        assert len(second["contacts"]) == 1
+        assert {c["uid"] for c in first["contacts"]}.isdisjoint(
+            c["uid"] for c in second["contacts"]
+        )
+
+        # Search takes the same opt-in.
+        found = _extract_payload(
+            await nc_mcp_client.call_tool(
+                "nc_contacts_search_contacts",
+                {"query": "Contact", "addressbook": addressbook_name},
+            )
+        )
+        assert found["total_count"] >= 1
+        assert all(c["photo"] is None for c in found["contacts"])
+        assert all(c["has_photo"] is True for c in found["contacts"])
+    finally:
+        try:
+            await nc_client.contacts.delete_addressbook(name=addressbook_name)
+        except Exception:
+            pass

--- a/tests/unit/server/test_contacts_paging.py
+++ b/tests/unit/server/test_contacts_paging.py
@@ -1,0 +1,38 @@
+"""Paging over a large addressbook.
+
+``total_count`` deliberately reports the addressbook size rather than the page
+size, so a caller can tell whether more contacts remain.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.server.contacts import _page
+
+pytestmark = pytest.mark.unit
+
+CONTACTS = list(range(10))
+
+
+class TestPaging:
+    def test_no_limit_returns_everything(self):
+        assert _page(CONTACTS, None, 0) == CONTACTS
+
+    def test_limit_truncates(self):
+        assert _page(CONTACTS, 3, 0) == [0, 1, 2]
+
+    def test_offset_skips(self):
+        assert _page(CONTACTS, 3, 3) == [3, 4, 5]
+
+    def test_pages_do_not_overlap(self):
+        first = _page(CONTACTS, 4, 0)
+        second = _page(CONTACTS, 4, 4)
+        assert set(first).isdisjoint(second)
+
+    def test_offset_past_the_end_is_empty(self):
+        assert _page(CONTACTS, 4, 99) == []
+
+    def test_negative_offset_is_clamped(self):
+        assert _page(CONTACTS, 2, -5) == [0, 1]
+
+    def test_negative_limit_yields_nothing(self):
+        assert _page(CONTACTS, -1, 0) == []

--- a/tests/unit/server/test_contacts_photo_payload.py
+++ b/tests/unit/server/test_contacts_photo_payload.py
@@ -1,0 +1,53 @@
+"""Contact listings must not be dominated by embedded photo bytes.
+
+vCards commonly carry PHOTO as base64. On a 186-contact addressbook that is
+~3 MB of vCard data, and the serialised response never reached the client --
+while the server logged the call as successful. Photos are therefore opt-in,
+with ``has_photo`` preserving the information that one exists.
+"""
+
+import pytest
+
+from nextcloud_mcp_server.server.contacts import _raw_contact_to_model
+
+pytestmark = pytest.mark.unit
+
+PHOTO = "data:image/jpeg;base64," + "A" * 4000
+
+
+def _raw(**contact_info) -> dict:
+    return {
+        "vcard_id": "abc",
+        "object_path": "/remote.php/dav/addressbooks/users/u/c/abc.vcf",
+        "getetag": '"etag"',
+        "contact": {"fullname": "Alice", **contact_info},
+    }
+
+
+class TestPhotoIsOptIn:
+    def test_photo_dropped_by_default(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO))
+        assert model.photo is None
+
+    def test_has_photo_still_reports_it(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO))
+        assert model.has_photo is True
+
+    def test_photo_returned_on_request(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO), include_photo=True)
+        assert model.photo == PHOTO
+        assert model.has_photo is True
+
+    def test_contact_without_photo(self):
+        model = _raw_contact_to_model(_raw())
+        assert model.photo is None
+        assert model.has_photo is False
+
+    def test_empty_photo_is_not_a_photo(self):
+        model = _raw_contact_to_model(_raw(photo=""), include_photo=True)
+        assert model.has_photo is False
+
+    def test_other_fields_are_unaffected(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO, org="ACME"))
+        assert model.fn == "Alice"
+        assert model.organization == "ACME"

--- a/tests/unit/server/test_contacts_photo_payload.py
+++ b/tests/unit/server/test_contacts_photo_payload.py
@@ -2,8 +2,11 @@
 
 vCards commonly carry PHOTO as base64. On a 186-contact addressbook that is
 ~3 MB of vCard data, and the serialised response never reached the client --
-while the server logged the call as successful. Photos are therefore opt-in,
-with ``has_photo`` preserving the information that one exists.
+while the server logged the call as successful.
+
+The mapper keeps including photos by default, so single-contact paths such as
+update_contact are unchanged; only the list and search tools opt out, and
+``has_photo`` preserves the information that one exists.
 """
 
 import pytest
@@ -24,27 +27,29 @@ def _raw(**contact_info) -> dict:
     }
 
 
-class TestPhotoIsOptIn:
-    def test_photo_dropped_by_default(self):
+class TestPhotoIsOptOut:
+    def test_included_by_default(self):
         model = _raw_contact_to_model(_raw(photo=PHOTO))
-        assert model.photo is None
-
-    def test_has_photo_still_reports_it(self):
-        model = _raw_contact_to_model(_raw(photo=PHOTO))
-        assert model.has_photo is True
-
-    def test_photo_returned_on_request(self):
-        model = _raw_contact_to_model(_raw(photo=PHOTO), include_photo=True)
         assert model.photo == PHOTO
         assert model.has_photo is True
 
+    def test_dropped_when_list_and_search_opt_out(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO), include_photo=False)
+        assert model.photo is None
+
+    def test_has_photo_survives_the_opt_out(self):
+        model = _raw_contact_to_model(_raw(photo=PHOTO), include_photo=False)
+        assert model.has_photo is True
+
     def test_contact_without_photo(self):
-        model = _raw_contact_to_model(_raw())
+        model = _raw_contact_to_model(_raw(), include_photo=False)
         assert model.photo is None
         assert model.has_photo is False
 
     def test_empty_photo_is_not_a_photo(self):
+        """An empty PHOTO must not report photo="" alongside has_photo=False."""
         model = _raw_contact_to_model(_raw(photo=""), include_photo=True)
+        assert model.photo is None
         assert model.has_photo is False
 
     def test_other_fields_are_unaffected(self):


### PR DESCRIPTION
`nc_contacts_list_contacts` and `nc_contacts_search_contacts` never deliver a response for my 186-contact addressbook. The client fails with

```
MCPError: SSE stream ended without a response
```

and fails again after an automatic reconnect. The server logs the same calls as **successful**:

```
INFO  ... tool call nc_contacts_list_contacts success in 1781ms
INFO  ... tool call nc_contacts_search_contacts success in 1265ms
```

So the response is produced but never arrives — and because the server considers the call a success, the failure is invisible in metrics. It looks healthy from the server side while the tool is completely unusable.

## Cause

vCards embed photos as base64, and `_raw_contact_to_model` passed `PHOTO` straight into the response model, where it dominates the payload.

Measured on this installation (`oc_cards`):

| Metric | Value |
|---|---|
| Contacts in addressbook | 186 |
| …with a `PHOTO` property | 86 |
| Total vCard bytes | 3047 kB |
| Mean per contact | 16.4 kB |
| Largest single contact | 136 kB |

For scale: after this change, requesting just **3** contacts with `include_photos=true` yields **125 kB** — roughly 42 kB per contact.

A small addressbook (`z-app-generated--contactsinteraction--recent`, a handful of entries) worked throughout, so this scales with payload size; it is not an auth, scope or permission problem. Every other tool family works.

#1152 already recognised this risk for `custom_fields` ("re-emitting a base64 image per contact would roughly double every `list_contacts` response") and excluded `PHOTO` there — but the top-level `photo` field still carried the full payload.

## Change

1. `include_photos: bool = False` on both tools. Photo bytes are omitted by default.
2. `has_photo: bool` on the `Contact` model, so callers still learn *that* a photo exists — only the bytes are dropped, not the information.
3. `limit` / `offset` on `nc_contacts_list_contacts`, with `total_count` still reporting the addressbook size rather than the page size.

Backward compatible: `include_photos=true` restores the previous payload.

Beyond size, omitting photos by default seems right for an MCP server specifically: the consumer is a language model, and multiple megabytes of base64 would exhaust the context window even if the transport delivered it.

## Result

```
before:  MCPError: SSE stream ended without a response
after:   194,782 chars, total_count 186, has_photo on 86, 38 birthdays present
```

Those figures match the database exactly (186 cards, 86 with `PHOTO`, 38 with `BDAY`).

## Testing

- `tests/unit/server/test_contacts_photo_payload.py` — photo opt-in, `has_photo`, empty-photo handling, other fields unaffected.
- `tests/unit/server/test_contacts_paging.py` — the `_page` helper, including offset past the end and defensive bounds.

The existing tool tests are integration tests needing a live instance, so the slicing was factored into `_page()` to make it unit-testable.

## Note

There is further easy headroom I left out of this PR to keep it focused: `resource_path` is ~20% of the remaining payload and is not needed for update or delete (both take `addressbook` + `uid`), field objects carry `components: null` / `preferred: false` per entry, and `title`/`note`/`photo` were null for all 186 contacts yet still serialised. Dropping empties and compacting field lists cut the response by a further 47% locally. Happy to open that separately if you think it is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomNRo5jTc6rDNNLYrRVRX
