### PR TITLE
fix(vector): stop the ingest loop — prune stale chunks + deterministic placeholder resolution

### DIFF
--- a/nextcloud_mcp_server/providers/gateway_batch.py
+++ b/nextcloud_mcp_server/providers/gateway_batch.py
@@ -33,12 +33,20 @@ from .gateway import GatewayTokenProvider
 
 logger = logging.getLogger(__name__)
 
-# Connect timeout for the (cheap) submit/poll calls. These are control-plane-ish
-# requests — a submit returns immediately with a job id and a poll is a status
-# read — so they get a short, fixed timeout, NOT the document-OCR read timeout
-# (which sizes a synchronous transcription).
+# Connect timeout for the submit/poll calls. Neither waits on OCR itself, so
+# neither gets the document-OCR read timeout (which sizes a synchronous
+# transcription).
 _BATCH_CONNECT_TIMEOUT_SECONDS = 5.0
+# A poll IS control-plane-ish: a small status read that returns immediately.
 _BATCH_REQUEST_TIMEOUT_SECONDS = 30.0
+# A submit is NOT: it uploads the whole document, base64-inflated by 4/3, and the
+# gateway stages those bytes to object storage before it answers. 30s is a
+# multi-MB-PDF-sized cliff, and losing the race is worse than a slow call — the
+# gateway has already created the job, so a client-side timeout strands it: the
+# caller never learns the job_id, `insert_pending` never runs, and the retry
+# submits a SECOND job for the same document, paying for the OCR twice (Deck
+# #1084: 16 of 339 submissions in one 12h window). Size it for the upload.
+_BATCH_SUBMIT_TIMEOUT_SECONDS = 180.0
 
 # Gateway-normalised batch lifecycle (OcrBatchStatus on the gateway side).
 _PENDING = "pending"
@@ -146,7 +154,7 @@ class GatewayBatchOcrClient:
         }
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(
-                _BATCH_REQUEST_TIMEOUT_SECONDS, connect=_BATCH_CONNECT_TIMEOUT_SECONDS
+                _BATCH_SUBMIT_TIMEOUT_SECONDS, connect=_BATCH_CONNECT_TIMEOUT_SECONDS
             )
         ) as client:
             resp = await client.post(

--- a/nextcloud_mcp_server/vector/placeholder.py
+++ b/nextcloud_mcp_server/vector/placeholder.py
@@ -156,12 +156,36 @@ async def query_document_metadata(
     doc_type: str,
     user_id: str,
 ) -> dict | None:
-    """Query Qdrant for existing document entry (placeholder or real).
+    """Query Qdrant for this user's existing entry for a document.
 
-    Returns the payload of the first matching point, which could be:
-    - A placeholder (is_placeholder: True)
-    - A real indexed document (is_placeholder: False or missing)
-    - None if document not in Qdrant
+    Returns:
+    - the real indexed document's payload (``is_placeholder: False``), or
+    - the placeholder's payload (``is_placeholder: True``) when it represents
+      NEWER content than what is indexed (or nothing is indexed yet), or
+    - ``None`` when the document is not in Qdrant at all.
+
+    Placeholder and chunk points have different deterministic ids
+    (``…:placeholder`` vs ``…:chunk:<i>``), so they COEXIST — while a document is
+    being re-indexed, and afterwards if a scan wrote a placeholder that no
+    subsequent index cleared. This used to be one unfiltered
+    ``scroll(..., limit=1)``, which has no ordering: which of the two came back
+    was decided by point-id order, i.e. a per-document coin flip.
+
+    That was load-bearing. The scanner checks ``is_placeholder`` BEFORE it
+    compares ``index_mode``/``modified_at`` (``vector/scanner.py``), so a
+    fully-indexed, unchanged document whose leftover placeholder happened to sort
+    first was read as "still queued", went stale after
+    ``vector_sync_scan_interval * 5``, and was re-queued — every cycle, forever.
+    For OCR-tier documents that is a full re-OCR on the burst GPU each time.
+
+    Resolved explicitly instead of by luck, and NOT simply "prefer the real
+    point": while a genuinely newer version is in flight, the placeholder is the
+    authoritative state, and returning the stale indexed point instead would make
+    the scanner re-queue an already-queued document on every pass. So the
+    placeholder wins only when it is strictly newer; at equal or older
+    ``modified_at`` it is stale bookkeeping and the index answers. Leftovers are
+    cleared by the next successful index or dedup claim, so nothing is written
+    from this read path.
 
     Args:
         doc_id: Document ID
@@ -175,26 +199,43 @@ async def query_document_metadata(
         qdrant_client = await get_qdrant_client()
         settings = get_settings()
 
-        # Query for any entry matching doc_id, doc_type, user_id
-        scroll_result = await qdrant_client.scroll(
-            collection_name=settings.get_collection_name(),
-            scroll_filter=Filter(
-                must=[
-                    FieldCondition(key="user_id", match=MatchValue(value=user_id)),
-                    FieldCondition(key="doc_id", match=MatchValue(value=doc_id)),
-                    FieldCondition(key="doc_type", match=MatchValue(value=doc_type)),
-                ]
-            ),
-            limit=1,
-            with_payload=True,
-            with_vectors=False,
-        )
+        async def _first(is_placeholder: bool) -> dict | None:
+            points, _ = await qdrant_client.scroll(
+                collection_name=settings.get_collection_name(),
+                scroll_filter=Filter(
+                    must=[
+                        FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+                        FieldCondition(key="doc_id", match=MatchValue(value=doc_id)),
+                        FieldCondition(
+                            key="doc_type", match=MatchValue(value=doc_type)
+                        ),
+                        FieldCondition(
+                            key="is_placeholder",
+                            match=MatchValue(value=is_placeholder),
+                        ),
+                    ]
+                ),
+                limit=1,
+                with_payload=True,
+                with_vectors=False,
+            )
+            if not points:
+                return None
+            return dict(points[0].payload) if points[0].payload is not None else None
 
-        if scroll_result[0]:
-            point = scroll_result[0][0]
-            return dict(point.payload) if point.payload is not None else None
+        real = await _first(False)
+        placeholder = await _first(True)
 
-        return None
+        if placeholder is None:
+            return real
+        if real is None:
+            return placeholder
+        # Both exist: the placeholder only speaks for content newer than what is
+        # indexed. Equal modified_at means the index already covers the queued
+        # version -- the leftover-placeholder case that drove the re-queue loop.
+        if placeholder.get("modified_at", 0) > real.get("modified_at", 0):
+            return placeholder
+        return real
 
     except Exception as e:
         logger.warning(

--- a/nextcloud_mcp_server/vector/placeholder.py
+++ b/nextcloud_mcp_server/vector/placeholder.py
@@ -21,6 +21,7 @@ import logging
 import time
 import uuid
 
+import anyio
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.models import FieldCondition, Filter, MatchValue, PointStruct
 
@@ -223,8 +224,23 @@ async def query_document_metadata(
                 return None
             return dict(points[0].payload) if points[0].payload is not None else None
 
-        real = await _first(False)
-        placeholder = await _first(True)
+        # Concurrent, not sequential: the two lookups are independent, and this
+        # runs once per document per scan across every doc type — serializing
+        # them would double this check's wall-clock latency on a hot path for no
+        # reason. anyio task group per CLAUDE.md (never asyncio.gather). A
+        # failure in either child surfaces as an ExceptionGroup, which is an
+        # Exception, so the fail-open handler below still catches it.
+        found: dict[bool, dict | None] = {}
+
+        async def _load(is_placeholder: bool) -> None:
+            found[is_placeholder] = await _first(is_placeholder)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_load, False)
+            tg.start_soon(_load, True)
+
+        real = found[False]
+        placeholder = found[True]
 
         if placeholder is None:
             return real

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -378,7 +378,14 @@ async def prune_stale_chunks(
                 ]
             ),
         )
+        record_qdrant_operation("delete", "success")
     except Exception as e:  # noqa: BLE001 — never fail a successful index
+        # Metered, not just logged: swallowing the error is what keeps a
+        # successful index successful, but it also means sustained prune
+        # failures would otherwise show up only as scattered log lines — and a
+        # silent-but-wrong path is precisely what let the loop this function
+        # closes run undetected for months.
+        record_qdrant_operation("delete", "error")
         logger.warning(
             "Failed to prune stale chunks above %s for %s_%s: %s; next index retries",
             kept_chunks,

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -357,13 +357,27 @@ async def prune_stale_chunks(
     ``kept_chunks == 0`` is a no-op on purpose: a zero-point "success" (the
     silent short-embedding path) must never be allowed to wipe a good index.
 
-    Never raises. The caller runs inside ``process_document``'s retry loop, so
-    propagating a transient delete failure out of an ALREADY-SUCCESSFUL index
-    would re-download/re-parse/re-embed the document on every attempt and, once
-    the attempts are exhausted, dead-letter a file that is sitting correctly in
-    the index — the exact "re-processing forever" class this function exists to
-    close. Orphans are harmless until the next read happens to pick one, and the
-    next scan's prune clears them, so logging and moving on self-heals.
+    Never raises — deliberately UNLIKE its sibling
+    :func:`~nextcloud_mcp_server.vector.placeholder.delete_placeholder_point`,
+    which logs and re-raises (its caller does the swallowing). The difference is
+    the position in the write path: this runs AFTER the upsert, inside
+    ``process_document``'s retry loop, so propagating a transient delete failure
+    out of an ALREADY-SUCCESSFUL index would re-download/re-parse/re-embed the
+    document on every attempt and, once they are exhausted, dead-letter a file
+    that is sitting correctly in the index — the exact "re-processing forever"
+    class this function exists to close. Orphans are harmless until a read
+    happens to pick one, and the next scan's prune clears them, so logging and
+    moving on self-heals.
+
+    Known ordering hazard (pre-existing, self-healing): the filter scopes on
+    ``doc_id``/``doc_type``/``chunk_index`` with no etag or version check. If two
+    tasks for the same document are in flight on different content and the STALE
+    one lands last, it overwrites ``0..kept_chunks-1`` with old content and then
+    prunes above it, dropping chunks the fresher, larger write had produced. The
+    cross-worker dedup guard only covers the same-etag case, so the interleaving
+    predates this function — but pruning changes its failure mode from "harmless
+    stale orphan" to "silently drops fresher data", until the next scan
+    reconciles.
     """
     if kept_chunks <= 0:
         return

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -12,7 +12,13 @@ import anyio
 import httpx
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream
-from qdrant_client.models import PointStruct
+from qdrant_client.models import (
+    FieldCondition,
+    Filter,
+    MatchValue,
+    PointStruct,
+    Range,
+)
 
 if TYPE_CHECKING:
     # Type-only: the document stack is heavy (pymupdf/_isolation) and must stay
@@ -315,6 +321,54 @@ def resolve_page_end(chunk: ChunkWithPosition) -> int | None:
     citation range (single-page chunks report ``page_end == page_number``).
     """
     return chunk.page_end if chunk.page_end is not None else chunk.page_number
+
+
+async def prune_stale_chunks(
+    qdrant_client: Any,
+    *,
+    collection_name: str,
+    doc_id: str,
+    doc_type: str,
+    kept_chunks: int,
+) -> None:
+    """Drop chunk points left behind by a LONGER previous index of this document.
+
+    Chunk point IDs are ``uuid5("<doc_type>:<doc_id>:chunk:<i>")`` — deterministic
+    in the chunk INDEX but blind to the chunk COUNT — so re-indexing a document
+    that now yields fewer chunks overwrites ``0..kept_chunks-1`` in place and
+    strands every higher-index point from the previous run.
+
+    Stranded points keep the OLD payload (``etag``, ``index_mode``,
+    ``embedding_identity``), and both "is this already indexed?" reads take
+    whatever a single UNORDERED ``scroll(..., limit=1)`` hands back:
+    :func:`~nextcloud_mcp_server.vector.sharing_state.find_indexed_content`
+    (etag + embedding_identity) and
+    :func:`~nextcloud_mcp_server.vector.placeholder.query_document_metadata`
+    (index_mode). Handed an orphan, they report "not indexed" / "index mode
+    changed", the scanner re-queues the document, and the re-index strands the
+    same orphans again — an ingest loop that never converges. For OCR-tier
+    documents that re-burns the batch GPU on every scan cycle (Deck #1084, and
+    the unclosed tail of #509).
+
+    Called AFTER the upsert rather than clearing the document first, so the
+    document stays continuously searchable and ``acl_principals`` on the
+    surviving points is preserved.
+
+    ``kept_chunks == 0`` is a no-op on purpose: a zero-point "success" (the
+    silent short-embedding path) must never be allowed to wipe a good index.
+    """
+    if kept_chunks <= 0:
+        return
+    await qdrant_client.delete(
+        collection_name=collection_name,
+        points_selector=Filter(
+            must=[
+                FieldCondition(key="doc_id", match=MatchValue(value=doc_id)),
+                FieldCondition(key="doc_type", match=MatchValue(value=doc_type)),
+                FieldCondition(key="chunk_index", range=Range(gte=kept_chunks)),
+            ]
+        ),
+    )
 
 
 def should_use_page_aware(
@@ -2361,6 +2415,14 @@ async def _index_document_inner(
                     (len(points) + BATCH_SIZE - 1) // BATCH_SIZE,
                 )
 
+    await prune_stale_chunks(
+        qdrant_client,
+        collection_name=settings.get_collection_name(),
+        doc_id=doc_task.doc_id,
+        doc_type=doc_task.doc_type,
+        kept_chunks=len(points),
+    )
+
     # A successful (re-)index supersedes any prior failure record: clear the
     # marker (e.g. the file was fixed/replaced, or a new escalation tier finally
     # parsed it) so it isn't left behind. Only files are ever dead-lettered, and
@@ -2382,16 +2444,22 @@ async def _index_document_inner(
     if doc_task.doc_type == "file" and doc_task.etag:
         await clear_dead_letter(doc_task.doc_id, doc_task.doc_type)
 
+    # Report what was actually UPSERTED, not how many chunks were produced. The
+    # point loop zips ``chunks`` with ``sparse_embeddings`` and zip truncates
+    # silently, so a short/empty embedding batch used to report a clean success
+    # for a document that landed fewer points than it had chunks -- exactly the
+    # "silent zero-points bug" named at the top of this module. len(points) makes
+    # that visible in the log instead of only in the index.
     logger.info(
         "Indexed %s_%s for %s (%s chunks)",
         doc_task.doc_type,
         doc_task.doc_id,
         doc_task.user_id,
-        len(chunks),
+        len(points),
         extra={
             "doc_id": doc_task.doc_id,
             "doc_type": doc_task.doc_type,
-            "chunks": len(chunks),
+            "chunks": len(points),
             "status": "success",
         },
     )

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -356,19 +356,36 @@ async def prune_stale_chunks(
 
     ``kept_chunks == 0`` is a no-op on purpose: a zero-point "success" (the
     silent short-embedding path) must never be allowed to wipe a good index.
+
+    Never raises. The caller runs inside ``process_document``'s retry loop, so
+    propagating a transient delete failure out of an ALREADY-SUCCESSFUL index
+    would re-download/re-parse/re-embed the document on every attempt and, once
+    the attempts are exhausted, dead-letter a file that is sitting correctly in
+    the index — the exact "re-processing forever" class this function exists to
+    close. Orphans are harmless until the next read happens to pick one, and the
+    next scan's prune clears them, so logging and moving on self-heals.
     """
     if kept_chunks <= 0:
         return
-    await qdrant_client.delete(
-        collection_name=collection_name,
-        points_selector=Filter(
-            must=[
-                FieldCondition(key="doc_id", match=MatchValue(value=doc_id)),
-                FieldCondition(key="doc_type", match=MatchValue(value=doc_type)),
-                FieldCondition(key="chunk_index", range=Range(gte=kept_chunks)),
-            ]
-        ),
-    )
+    try:
+        await qdrant_client.delete(
+            collection_name=collection_name,
+            points_selector=Filter(
+                must=[
+                    FieldCondition(key="doc_id", match=MatchValue(value=doc_id)),
+                    FieldCondition(key="doc_type", match=MatchValue(value=doc_type)),
+                    FieldCondition(key="chunk_index", range=Range(gte=kept_chunks)),
+                ]
+            ),
+        )
+    except Exception as e:  # noqa: BLE001 — never fail a successful index
+        logger.warning(
+            "Failed to prune stale chunks above %s for %s_%s: %s; next index retries",
+            kept_chunks,
+            doc_type,
+            doc_id,
+            e,
+        )
 
 
 def should_use_page_aware(

--- a/tests/unit/providers/test_gateway_batch.py
+++ b/tests/unit/providers/test_gateway_batch.py
@@ -249,3 +249,49 @@ async def test_poll_raises_on_http_error(monkeypatch):
 )
 def test_parse_retry_after(raw, expected):
     assert gbc._parse_retry_after(raw) == expected
+
+
+def _capture_timeouts(monkeypatch, handler) -> list[httpx.Timeout]:
+    """Like ``_patch_transport`` but records the ``timeout`` each AsyncClient is
+    constructed with, so the submit/poll split can be asserted."""
+    timeouts: list[httpx.Timeout] = []
+    real = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        timeouts.append(kwargs["timeout"])
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    return timeouts
+
+
+async def test_submit_and_poll_use_separate_read_timeouts(monkeypatch):
+    """Submit must NOT share the poll's control-plane read timeout.
+
+    A poll is a small status read; a submit uploads the whole base64-inflated
+    document and the gateway stages it to object storage before answering. Losing
+    that race strands the job gateway-side: the caller never learns the job_id,
+    ``insert_pending`` never runs, and the retry submits a SECOND job for the same
+    document. Collapsing these two constants back together would silently restore
+    that duplicate-GPU-work bug, so pin them apart.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "surya/j", "status": "pending"})
+        return httpx.Response(202, json={"status": "pending"})
+
+    timeouts = _capture_timeouts(monkeypatch, handler)
+    client = gbc.GatewayBatchOcrClient("https://gw", "surya/surya-ocr-2")
+
+    await client.submit(b"%PDF-1.7", "application/pdf", custom_id="doc-1")
+    await client.poll("surya/j")
+
+    submit_timeout, poll_timeout = timeouts
+    assert submit_timeout.read == gbc._BATCH_SUBMIT_TIMEOUT_SECONDS
+    assert poll_timeout.read == gbc._BATCH_REQUEST_TIMEOUT_SECONDS
+    assert submit_timeout.read > poll_timeout.read
+    # The connect timeout stays short and shared -- neither call waits on OCR.
+    assert submit_timeout.connect == poll_timeout.connect
+    assert submit_timeout.connect == gbc._BATCH_CONNECT_TIMEOUT_SECONDS

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -250,3 +250,144 @@ async def test_write_placeholder_payload_includes_instance_id(monkeypatch):
     # Dense slot is always sized from the embedding provider (dim=4 here) — the
     # keyword/simple-dimension branch is gone (per-document index mode).
     assert len(upserted_point.vector["dense"]) == 4
+
+
+# --- query_document_metadata: placeholder vs real must not be a coin flip ---
+#
+# Placeholder and chunk points have different deterministic ids, so they coexist.
+# The lookup used to be one unfiltered scroll(limit=1) with no ordering, so which
+# one answered "is this indexed?" was decided by point-id order. The scanner tests
+# `is_placeholder` BEFORE `index_mode`/`modified_at`, so an indexed, unchanged
+# document whose leftover placeholder sorted first read as "still queued", went
+# stale, and was re-queued every cycle — a full re-OCR each time on the OCR tier.
+
+
+def _payload(*, is_placeholder: bool, modified_at: int) -> dict:
+    return {
+        "is_placeholder": is_placeholder,
+        "modified_at": modified_at,
+        "doc_id": "d-1",
+    }
+
+
+def _patch_lookup(monkeypatch, *, real: dict | None, placeholder: dict | None):
+    """Serve each scroll from its ``is_placeholder`` filter value, so the test
+    pins the resolution logic rather than any incidental call order."""
+    fake_qdrant = AsyncMock()
+
+    async def scroll(**kwargs):
+        wanted = next(
+            c.match.value
+            for c in kwargs["scroll_filter"].must
+            if c.key == "is_placeholder"
+        )
+        found = placeholder if wanted else real
+        return ([SimpleNamespace(id="p", payload=found)] if found else [], None)
+
+    fake_qdrant.scroll.side_effect = scroll
+
+    async def fake_get_qdrant_client():
+        return fake_qdrant
+
+    monkeypatch.setattr(placeholder_module, "get_qdrant_client", fake_get_qdrant_client)
+    monkeypatch.setattr(
+        placeholder_module,
+        "get_settings",
+        lambda: SimpleNamespace(get_collection_name=lambda: "c"),
+    )
+    return fake_qdrant
+
+
+@pytest.mark.unit
+async def test_leftover_placeholder_does_not_mask_the_index(monkeypatch):
+    """THE regression: same modified_at ⇒ the index answers, not the leftover.
+
+    A placeholder no newer than the indexed content is stale bookkeeping. If it
+    answered here the scanner would take its `is_placeholder` branch and re-queue
+    a document that is already correctly indexed — forever.
+    """
+    _patch_lookup(
+        monkeypatch,
+        real=_payload(is_placeholder=False, modified_at=1700),
+        placeholder=_payload(is_placeholder=True, modified_at=1700),
+    )
+
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+
+    assert got["is_placeholder"] is False
+
+
+@pytest.mark.unit
+async def test_in_flight_newer_version_still_wins(monkeypatch):
+    """A genuinely newer queued version must keep suppressing re-enqueues.
+
+    This is why the fix is not simply "always prefer the real point": while a
+    newer version is in flight, returning the stale indexed point would make the
+    scanner re-queue an already-queued document on every pass.
+    """
+    _patch_lookup(
+        monkeypatch,
+        real=_payload(is_placeholder=False, modified_at=1700),
+        placeholder=_payload(is_placeholder=True, modified_at=1800),
+    )
+
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+
+    assert got["is_placeholder"] is True
+
+
+@pytest.mark.unit
+async def test_placeholder_only_and_real_only_and_neither(monkeypatch):
+    """The three single-sided cases keep their pre-existing answers."""
+    _patch_lookup(
+        monkeypatch,
+        real=None,
+        placeholder=_payload(is_placeholder=True, modified_at=1700),
+    )
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+    assert got["is_placeholder"] is True  # queued, never indexed
+
+    _patch_lookup(
+        monkeypatch,
+        real=_payload(is_placeholder=False, modified_at=1700),
+        placeholder=None,
+    )
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+    assert got["is_placeholder"] is False  # indexed, nothing queued
+
+    _patch_lookup(monkeypatch, real=None, placeholder=None)
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+    assert got is None  # never seen
+
+
+@pytest.mark.unit
+async def test_lookup_failure_still_fails_open(monkeypatch):
+    """Unchanged contract: a Qdrant error reads as None ("never seen")."""
+    fake_qdrant = AsyncMock()
+    fake_qdrant.scroll.side_effect = RuntimeError("qdrant down")
+
+    async def fake_get_qdrant_client():
+        return fake_qdrant
+
+    monkeypatch.setattr(placeholder_module, "get_qdrant_client", fake_get_qdrant_client)
+    monkeypatch.setattr(
+        placeholder_module,
+        "get_settings",
+        lambda: SimpleNamespace(get_collection_name=lambda: "c"),
+    )
+
+    got = await placeholder_module.query_document_metadata(
+        doc_id="d-1", doc_type="file", user_id="alice"
+    )
+
+    assert got is None

--- a/tests/unit/vector/test_placeholder.py
+++ b/tests/unit/vector/test_placeholder.py
@@ -372,7 +372,13 @@ async def test_placeholder_only_and_real_only_and_neither(monkeypatch):
 
 @pytest.mark.unit
 async def test_lookup_failure_still_fails_open(monkeypatch):
-    """Unchanged contract: a Qdrant error reads as None ("never seen")."""
+    """Unchanged contract: a Qdrant error reads as None ("never seen").
+
+    Worth pinning now that the two scrolls run under an anyio task group: a child
+    failure surfaces as an ExceptionGroup, not the raw error. That is still an
+    Exception (3.11+), so the fail-open handler catches it — but silently, which
+    is exactly the kind of thing that stops being true after a refactor.
+    """
     fake_qdrant = AsyncMock()
     fake_qdrant.scroll.side_effect = RuntimeError("qdrant down")
 

--- a/tests/unit/vector/test_prune_stale_chunks.py
+++ b/tests/unit/vector/test_prune_stale_chunks.py
@@ -1,0 +1,97 @@
+"""Regression guard for the never-converging ingest loop (Deck #1084 / #509).
+
+Chunk point IDs are ``uuid5("<doc_type>:<doc_id>:chunk:<i>")`` — deterministic in
+the chunk INDEX but blind to the chunk COUNT. So a document re-indexed into fewer
+chunks than last time overwrites ``0..N-1`` and STRANDS every higher-index point,
+which keeps the previous run's ``etag`` / ``index_mode`` / ``embedding_identity``.
+
+Both "already indexed?" reads pick a single point via an unordered
+``scroll(..., limit=1)``, so either can be handed an orphan and conclude the
+document needs re-indexing — forever. In production that re-OCR'd the same 44
+PDFs on the burst GPU every scan cycle, indefinitely.
+
+``prune_stale_chunks`` closes it. These tests pin the two things that matter: the
+range is anchored at the NEW chunk count, and a zero-point index never nukes a
+good one.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from qdrant_client.models import Filter
+
+from nextcloud_mcp_server.vector.processor import prune_stale_chunks
+
+pytestmark = pytest.mark.unit
+
+
+def _client() -> SimpleNamespace:
+    return SimpleNamespace(delete=AsyncMock())
+
+
+def _conditions(selector: Filter) -> dict:
+    """Flatten the selector's must-conditions into {payload key: condition}."""
+    return {c.key: c for c in selector.must}
+
+
+async def test_prunes_chunks_above_the_new_count():
+    """A 3-chunk re-index must delete chunk_index >= 3, and nothing below it."""
+    client = _client()
+
+    await prune_stale_chunks(
+        client,
+        collection_name="tenant-x",
+        doc_id="1001",
+        doc_type="file",
+        kept_chunks=3,
+    )
+
+    client.delete.assert_awaited_once()
+    kwargs = client.delete.await_args.kwargs
+    assert kwargs["collection_name"] == "tenant-x"
+
+    by_key = _conditions(kwargs["points_selector"])
+    # Scoped to this document only — point IDs are user-agnostic, so a doc_id +
+    # doc_type filter is the whole document across every reader.
+    assert by_key["doc_id"].match.value == "1001"
+    assert by_key["doc_type"].match.value == "file"
+    # gte (not gt): chunk 3 is the first orphan when 3 chunks (0,1,2) were kept.
+    assert by_key["chunk_index"].range.gte == 3
+    assert by_key["chunk_index"].range.lt is None  # unbounded above
+
+
+async def test_zero_chunks_never_deletes():
+    """A zero-point 'success' must not wipe a previously good index.
+
+    The point loop zips chunks with sparse_embeddings and zip truncates silently,
+    so len(points) can legitimately reach 0 on a broken embedding batch. Pruning
+    from 0 would delete every chunk the document has.
+    """
+    client = _client()
+
+    await prune_stale_chunks(
+        client,
+        collection_name="tenant-x",
+        doc_id="1001",
+        doc_type="file",
+        kept_chunks=0,
+    )
+
+    client.delete.assert_not_awaited()
+
+
+async def test_single_chunk_document_still_prunes():
+    """The common OCR shape: a doc that used to chunk long and now yields one."""
+    client = _client()
+
+    await prune_stale_chunks(
+        client,
+        collection_name="tenant-x",
+        doc_id="1002",
+        doc_type="file",
+        kept_chunks=1,
+    )
+
+    by_key = _conditions(client.delete.await_args.kwargs["points_selector"])
+    assert by_key["chunk_index"].range.gte == 1

--- a/tests/unit/vector/test_prune_stale_chunks.py
+++ b/tests/unit/vector/test_prune_stale_chunks.py
@@ -81,6 +81,28 @@ async def test_zero_chunks_never_deletes():
     client.delete.assert_not_awaited()
 
 
+async def test_delete_failure_never_fails_the_index():
+    """A transient Qdrant blip must not propagate out of a successful index.
+
+    The caller sits inside process_document's retry loop, so raising here would
+    re-download/re-parse/re-embed on every attempt and, once they're exhausted,
+    dead-letter a file that is sitting correctly in the index — the very
+    "re-processing forever" class this function exists to close. Orphans are
+    harmless until a read happens to pick one, and the next prune clears them.
+    """
+    client = SimpleNamespace(delete=AsyncMock(side_effect=RuntimeError("qdrant down")))
+
+    await prune_stale_chunks(
+        client,
+        collection_name="tenant-x",
+        doc_id="1001",
+        doc_type="file",
+        kept_chunks=3,
+    )
+
+    client.delete.assert_awaited_once()
+
+
 async def test_single_chunk_document_still_prunes():
     """The common OCR shape: a doc that used to chunk long and now yields one."""
     client = _client()


### PR DESCRIPTION
## Problem

Chunk point IDs are `uuid5("<doc_type>:<doc_id>:chunk:<i>")` — deterministic in the chunk **index** but blind to the chunk **count**. Re-indexing a document into fewer chunks than last time overwrites `0..N-1` in place and strands every higher-index point from the previous run. Nothing anywhere prunes them (`vector/eviction.py` is per-user ACL release from the verify-on-read path, not stale-chunk cleanup).

Stranded points keep the **old** payload — `etag`, `index_mode`, `embedding_identity` — and both "is this already indexed?" reads pick a single point via an **unordered** `scroll(..., limit=1)`:

- `sharing_state.find_indexed_content` compares `embedding_identity` (and `etag`)
- `placeholder.query_document_metadata` feeds the scanner's `index_mode` comparison

Handed an orphan, they report "not indexed" / "index mode changed", the scanner re-queues the document, and the re-index strands the same orphans again. The loop never converges — and for OCR-tier documents it re-runs the batch GPU on **every scan cycle**.

## Evidence

Measured on a dev tenant, 12h window:

| signal | value |
|---|---|
| `POST /v1/ocr/batch` | 339 |
| `GET /v1/ocr/batch/…` → 202 (poll of an existing job) | 7,395 |
| `GET /v1/ocr/batch/…` → 200 (terminal) | 744 |
| `batch OCR job … not found on gateway (404)` | 0 |
| `File … index mode changed to hybrid; reindexing` | **630** |
| same, `… to keyword` | 0 |
| `Indexed file_*` per OCR worker pod generation | 44, 44, 44, 44, 45, 43, 42, 24 |
| fast/structured-tier re-indexes in 6h | **0** |

The same 44 PDFs are re-OCR'd and re-indexed end-to-end every ~45–50 min, forever. Note the submit:poll ratio — the batch `job_id` **is** persisted in `batch_ocr_jobs` and re-polled correctly across retries; this was never a retry-resubmit bug. And the fast/structured tiers converge fine, because those documents have no orphans.

This is the unclosed tail of the same never-converges bug whose keyword-mode half shipped in 0.128.2.

## Fix

`prune_stale_chunks()` deletes `chunk_index >= len(points)` **after** the upsert, so the document stays continuously searchable and `acl_principals` survives on the kept points. One call site — the single place every tier and every caller routes through — so it fixes the fast/structured paths too, not just the OCR symptom.

`kept_chunks == 0` is a deliberate no-op: the point loop zips `chunks` with `sparse_embeddings` and `zip` truncates silently, so a zero-point "success" must never wipe a good index.

No data repair needed: the first re-index after deploy prunes each tenant's existing orphans and the loop stops on the scan after that.

### Also in this PR

- **The success log reported `len(chunks)`, not `len(points)`** — so that same silent short-embedding path read as a clean success. Now reports what was actually upserted; this is what would have made the loop visible months ago.
- **`POST /v1/ocr/batch` shared the poll's 30s control-plane timeout.** Submit uploads the whole base64-inflated document and the gateway stages it to object storage before answering. Losing that race is worse than a slow call: the gateway has already created the job, so a client-side timeout *strands* it — the caller never learns the `job_id`, `insert_pending` never runs, and the retry submits a **second** job for the same document (16 of the 339 submissions above). Submit now gets its own 180s timeout; poll keeps 30s.

## Test coverage

`tests/unit/vector/test_prune_stale_chunks.py` — pins the two things that matter: the delete range is anchored at the **new** chunk count (`gte`, unbounded above, scoped to this doc), and a zero-point index never deletes.

No API surface changes (no MCP tool, no `/api/v1/*` route, no cross-service contract), so the e2e + contract gate is not triggered here. The pre-existing gap where the gateway batch `404` and `Retry-After` interactions are unpacted (board 11) is untouched by this PR.

## Verification after deploy

The convergence check that was never completed for the original bug: `ingest-ocr` drains to 0 and **stays** 0 across several scan intervals, `POST /v1/ocr/batch` goes flat, `index mode changed to hybrid` drops to 0, and the OCR worker stops being recreated every ~48 min.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5bnabgnQLLjuS4KJAztX1
