### PR TITLE
perf(calendar): query calendars concurrently in cross-calendar search

### DIFF
--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -25,6 +25,12 @@ from .dav_errors import DavPreconditionFailed, dav_error_from_response
 
 logger = logging.getLogger(__name__)
 
+# How many calendars to query at once when searching across all of them.
+# Unbounded fan-out would open one connection per calendar; accounts with
+# dozens of calendars would hammer the Nextcloud instance for no gain, since
+# the win is already had after a handful run in parallel.
+CALENDAR_FANOUT = 8
+
 
 async def _maybe_await(result: Any) -> Any:
     """Await a result if it's a coroutine, otherwise return it directly.
@@ -1158,43 +1164,90 @@ class CalendarClient:
         logger.debug("Retrieved event %s", event_uid)
         return event_data, etag
 
+    async def _events_from_calendar(
+        self,
+        calendar: dict[str, Any],
+        start_datetime: dt.datetime | None,
+        end_datetime: dt.datetime | None,
+        filters: dict[str, Any] | None,
+        limiter: anyio.CapacityLimiter,
+        slots: list[list[dict[str, Any]]],
+        index: int,
+    ) -> None:
+        """One calendar's events, annotated, written into its own slot.
+
+        Failure is contained per calendar: a single unreachable or broken
+        calendar is logged and skipped, exactly as in the previous serial
+        loop, rather than cancelling the whole task group.
+        """
+        async with limiter:
+            try:
+                events = await self.get_calendar_events(
+                    calendar["name"], start_datetime, end_datetime
+                )
+            except Exception as e:
+                logger.warning(
+                    "Error getting events from calendar %s: %s", calendar["name"], e
+                )
+                return
+
+        # Apply filters if provided
+        if filters:
+            events = self._apply_event_filters(events, filters)
+
+        # Add calendar info to each event
+        for event in events:
+            event["calendar_name"] = calendar["name"]
+            event["calendar_display_name"] = calendar.get(
+                "display_name", calendar["name"]
+            )
+
+        slots[index] = events
+
     async def search_events_across_calendars(
         self,
         start_datetime: dt.datetime | None = None,
         end_datetime: dt.datetime | None = None,
         filters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        """Search events across all calendars with advanced filtering."""
+        """Search events across all calendars with advanced filtering.
+
+        The per-calendar REPORTs are fanned out via ``anyio.create_task_group``
+        instead of awaited one after another. The serial loop cost one full
+        round trip per calendar, so the runtime grew linearly with the number
+        of calendars while barely depending on how many events came back --
+        measured against a real account with 21 calendars, a one-day window
+        took 2.73 s and a 180-day window 2.93 s. The time was round trips, not
+        data.
+
+        Concurrency is bounded by ``CALENDAR_FANOUT``: an account with a
+        hundred calendars should not open a hundred simultaneous connections
+        to the Nextcloud instance.
+
+        Results are written into pre-allocated slots rather than appended, so
+        the returned order still follows the calendar order and does not
+        depend on which REPORT happens to finish first.
+        """
         await self._ensure_calendar_home()
         try:
             calendars = await self.list_calendars()
-            all_events = []
+            slots: list[list[dict[str, Any]]] = [[] for _ in calendars]
+            limiter = anyio.CapacityLimiter(CALENDAR_FANOUT)
 
-            for calendar in calendars:
-                try:
-                    events = await self.get_calendar_events(
-                        calendar["name"], start_datetime, end_datetime
+            async with anyio.create_task_group() as tg:
+                for index, calendar in enumerate(calendars):
+                    tg.start_soon(
+                        self._events_from_calendar,
+                        calendar,
+                        start_datetime,
+                        end_datetime,
+                        filters,
+                        limiter,
+                        slots,
+                        index,
                     )
 
-                    # Apply filters if provided
-                    if filters:
-                        events = self._apply_event_filters(events, filters)
-
-                    # Add calendar info to each event
-                    for event in events:
-                        event["calendar_name"] = calendar["name"]
-                        event["calendar_display_name"] = calendar.get(
-                            "display_name", calendar["name"]
-                        )
-
-                    all_events.extend(events)
-                except Exception as e:
-                    logger.warning(
-                        "Error getting events from calendar %s: %s", calendar["name"], e
-                    )
-                    continue
-
-            return all_events
+            return [event for events in slots for event in events]
 
         except Exception as e:
             logger.error("Error searching events across calendars: %s", e)
@@ -1340,34 +1393,59 @@ class CalendarClient:
             calendar_name, todo_uid, cdav.CompFilter("VTODO"), "todo"
         )
 
+    async def _todos_from_calendar(
+        self,
+        calendar: dict[str, Any],
+        filters: dict[str, Any] | None,
+        limiter: anyio.CapacityLimiter,
+        slots: list[list[dict[str, Any]]],
+        index: int,
+    ) -> None:
+        """One calendar's todos, annotated. Failure is contained per calendar."""
+        async with limiter:
+            try:
+                todos = await self.list_todos(calendar["name"], filters)
+            except Exception as e:
+                logger.warning(
+                    "Error getting todos from calendar %s: %s", calendar["name"], e
+                )
+                return
+
+        # Add calendar info to each todo
+        for todo in todos:
+            todo["calendar_name"] = calendar["name"]
+            todo["calendar_display_name"] = calendar.get(
+                "display_name", calendar["name"]
+            )
+
+        slots[index] = todos
+
     async def search_todos_across_calendars(
         self, filters: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
-        """Search todos across all calendars."""
+        """Search todos across all calendars.
+
+        Fanned out like :meth:`search_events_across_calendars` - same serial
+        round-trip problem, same bounded task group, same stable ordering.
+        """
         await self._ensure_calendar_home()
         try:
             calendars = await self.list_calendars()
-            all_todos = []
+            slots: list[list[dict[str, Any]]] = [[] for _ in calendars]
+            limiter = anyio.CapacityLimiter(CALENDAR_FANOUT)
 
-            for calendar in calendars:
-                try:
-                    todos = await self.list_todos(calendar["name"], filters)
-
-                    # Add calendar info to each todo
-                    for todo in todos:
-                        todo["calendar_name"] = calendar["name"]
-                        todo["calendar_display_name"] = calendar.get(
-                            "display_name", calendar["name"]
-                        )
-
-                    all_todos.extend(todos)
-                except Exception as e:
-                    logger.warning(
-                        "Error getting todos from calendar %s: %s", calendar["name"], e
+            async with anyio.create_task_group() as tg:
+                for index, calendar in enumerate(calendars):
+                    tg.start_soon(
+                        self._todos_from_calendar,
+                        calendar,
+                        filters,
+                        limiter,
+                        slots,
+                        index,
                     )
-                    continue
 
-            return all_todos
+            return [todo for todos in slots for todo in todos]
 
         except Exception as e:
             logger.error("Error searching todos across calendars: %s", e)

--- a/tests/unit/client/test_calendar_fanout.py
+++ b/tests/unit/client/test_calendar_fanout.py
@@ -1,0 +1,142 @@
+"""Unit tests for concurrent cross-calendar search.
+
+``search_events_across_calendars`` and ``search_todos_across_calendars`` used
+to ``await`` one calendar after another, so a REPORT round trip was paid per
+calendar and the wall clock grew linearly with how many calendars an account
+has -- almost independently of how many events came back.
+
+These pin the three properties that matter and are easy to lose when a serial
+loop becomes a task group: the calls really do overlap, one broken calendar
+does not take the rest down with it, and the result order still follows the
+calendar order rather than whichever REPORT happened to finish first.
+"""
+
+import anyio
+import pytest
+
+from nextcloud_mcp_server.client.calendar import CALENDAR_FANOUT, CalendarClient
+
+pytestmark = pytest.mark.unit
+
+CALENDARS = [{"name": f"cal{i}", "display_name": f"Cal {i}"} for i in range(6)]
+
+
+@pytest.fixture
+def client(mocker):
+    """CalendarClient with its DAV client and calendar home mocked out."""
+    mocker.patch("nextcloud_mcp_server.client.calendar.AsyncDAVClient")
+    client = CalendarClient("https://cloud.example.org", "alice", password="pw")
+    mocker.patch.object(client, "_ensure_calendar_home", return_value=None)
+    mocker.patch.object(client, "list_calendars", return_value=list(CALENDARS))
+    return client
+
+
+class _Tracker:
+    """Records how many calls are in flight at the same time."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+
+    async def run(self, name: str, *args, **kwargs):
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        # Yield so the other tasks get a chance to start before this returns;
+        # a serial loop would never let `active` climb above 1.
+        await anyio.sleep(0.01)
+        self.active -= 1
+        return [{"uid": f"{name}-1"}]
+
+
+async def test_events_are_fetched_concurrently(client, mocker):
+    tracker = _Tracker()
+    mocker.patch.object(client, "get_calendar_events", side_effect=tracker.run)
+
+    events = await client.search_events_across_calendars()
+
+    assert len(events) == len(CALENDARS)
+    assert tracker.peak > 1, "calendars were still queried one after another"
+    assert tracker.peak <= CALENDAR_FANOUT
+
+
+async def test_events_keep_calendar_order(client, mocker):
+    async def events_for(name, *args, **kwargs):
+        # Later calendars answer first, so appending in completion order
+        # would visibly scramble the result.
+        await anyio.sleep(0.05 / (int(name[-1]) + 1))
+        return [{"uid": f"{name}-1"}]
+
+    mocker.patch.object(client, "get_calendar_events", side_effect=events_for)
+
+    events = await client.search_events_across_calendars()
+
+    assert [e["calendar_name"] for e in events] == [c["name"] for c in CALENDARS]
+    assert events[0]["calendar_display_name"] == "Cal 0"
+
+
+async def test_one_broken_calendar_does_not_sink_the_rest(client, mocker):
+    async def events_for(name, *args, **kwargs):
+        if name == "cal2":
+            raise RuntimeError("calendar is on fire")
+        return [{"uid": f"{name}-1"}]
+
+    mocker.patch.object(client, "get_calendar_events", side_effect=events_for)
+
+    events = await client.search_events_across_calendars()
+
+    names = [e["calendar_name"] for e in events]
+    assert "cal2" not in names
+    assert len(names) == len(CALENDARS) - 1
+
+
+async def test_filters_are_applied_per_calendar(client, mocker):
+    mocker.patch.object(client, "get_calendar_events", side_effect=_one)
+    applied = mocker.patch.object(
+        client, "_apply_event_filters", side_effect=lambda events, f: events
+    )
+
+    await client.search_events_across_calendars(filters={"status": "CONFIRMED"})
+
+    assert applied.call_count == len(CALENDARS)
+
+
+async def test_fanout_is_bounded(client, mocker):
+    many = [{"name": f"cal{i}", "display_name": f"Cal {i}"} for i in range(40)]
+    mocker.patch.object(client, "list_calendars", return_value=many)
+    tracker = _Tracker()
+    mocker.patch.object(client, "get_calendar_events", side_effect=tracker.run)
+
+    await client.search_events_across_calendars()
+
+    # Both bounds matter: 1 would mean the loop went serial again, 40 would
+    # mean one open connection per calendar with no limiter in between.
+    assert 1 < tracker.peak <= CALENDAR_FANOUT
+
+
+async def test_todos_are_fetched_concurrently(client, mocker):
+    tracker = _Tracker()
+    mocker.patch.object(client, "list_todos", side_effect=tracker.run)
+
+    todos = await client.search_todos_across_calendars()
+
+    assert len(todos) == len(CALENDARS)
+    assert tracker.peak > 1, "calendars were still queried one after another"
+    assert [t["calendar_name"] for t in todos] == [c["name"] for c in CALENDARS]
+
+
+async def test_one_broken_calendar_does_not_sink_todos(client, mocker):
+    async def todos_for(name, *args, **kwargs):
+        if name == "cal4":
+            raise RuntimeError("todo list is on fire")
+        return [{"uid": f"{name}-1"}]
+
+    mocker.patch.object(client, "list_todos", side_effect=todos_for)
+
+    todos = await client.search_todos_across_calendars()
+
+    assert "cal4" not in [t["calendar_name"] for t in todos]
+    assert len(todos) == len(CALENDARS) - 1
+
+
+async def _one(name: str, *args, **kwargs):
+    return [{"uid": f"{name}-1"}]


### PR DESCRIPTION
## Problem

`search_events_across_calendars` and `search_todos_across_calendars` `await` one
calendar after another, so each calendar costs a full CalDAV round trip and the
wall clock grows linearly with how many calendars an account has.

Measured against a real account with **21 calendars**:

| window | before | after |
|---|---|---|
| 1 day | 2.73 s | **1.12 s** |
| 30 days | 2.97 s | **1.11 s** |
| 180 days | 2.93 s | **1.11 s** |

The interesting row is the last one: a 180× larger window returning 20 kB of
events cost only 0.2 s more than a single day. The time was **round trips, not
data** — which is why parallelising the requests is the fix rather than
trimming the payload.

For context on why this mattered enough to chase: the calendar lookup was the
single largest item in a voice assistant round trip built on this server,
larger than either model call, and it pushed the whole request past the
8-second budget Alexa allows a skill.

## Change

Both loops fan out via `anyio.create_task_group()`, matching the existing
concurrent call sites in `server/tag_exclusion.py` and `search/verification.py`,
bounded by `anyio.CapacityLimiter(CALENDAR_FANOUT)` (8). Unbounded fan-out
would open one connection per calendar; an account with a hundred calendars
should not hammer the instance for a win that is already had after a handful
run in parallel.

Two properties are easy to lose when a serial loop becomes a task group, and
are kept deliberately:

- **Per-calendar failure containment.** The exception is caught *inside* the
  child task. Letting it escape would cancel the whole group, so one broken
  calendar would take down the entire search instead of being logged and
  skipped as it was before.
- **Result order.** Results are written into pre-allocated slots rather than
  appended, so the output still follows calendar order instead of depending on
  which REPORT happens to finish first.

## Tests

`tests/unit/client/test_calendar_fanout.py`, 7 cases: calls really overlap,
fan-out stays within the limiter, order follows the calendar list even when
later calendars answer first, one broken calendar does not sink the rest
(events and todos), and filters are still applied per calendar.

I checked these bite: against a serial implementation of the same two methods
(with the constant left in place, so it is a behavioural comparison and not an
import error), the three concurrency assertions fail and the four
behaviour-preservation ones pass — which is the intended split.

Also verified against a live instance: fan-out and calendar-by-calendar
querying return the same 101 events over 30 days, in the same order. Existing
`tests/unit/client/` suite passes (412 tests), `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomNRo5jTc6rDNNLYrRVRX