### PR TITLE
perf(server): serialise tool results without indentation

### DIFF
--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -24,6 +24,7 @@ from nextcloud_mcp_server.capabilities import (
     enforce_capability,
     filter_by_capability,
 )
+from nextcloud_mcp_server.serialization import compact_tool_result
 
 #: ``summary``/``hint`` per status. 429 is rare -- ``retry_on_429`` in
 #: ``client/base.py`` absorbs it -- but ``_stream_request`` re-raises it once
@@ -188,8 +189,9 @@ def friendly_tool_error(exc: BaseException | None, tool_name: str) -> str | None
 
 
 class NextcloudFastMCP(FastMCP):
-    """FastMCP that rewrites raw HTTP failures into LLM-friendly messages and
-    hides tools this Nextcloud instance cannot serve.
+    """FastMCP that rewrites raw HTTP failures into LLM-friendly messages,
+    hides tools this Nextcloud instance cannot serve, and strips the SDK's
+    ``indent=2`` from tool results (GH #1395).
 
     Subclass rather than patch: ``FastMCP._setup_handlers`` binds
     ``self.call_tool``/``self.list_tools`` during ``__init__``, so a later
@@ -205,7 +207,7 @@ class NextcloudFastMCP(FastMCP):
     ) -> Sequence[ContentBlock] | dict[str, Any]:
         await enforce_capability(self, name)
         try:
-            return await super().call_tool(name, arguments)
+            return compact_tool_result(await super().call_tool(name, arguments))
         except ToolError as e:
             message = friendly_tool_error(e.__cause__, name)
             if message is None:

--- a/nextcloud_mcp_server/serialization.py
+++ b/nextcloud_mcp_server/serialization.py
@@ -18,11 +18,20 @@ from typing import Any
 
 from mcp.types import ContentBlock, TextContent
 
-#: ``json.dumps`` separators with no filler whitespace. The default
-#: ``(", ", ": ")`` spends two tokens per field on nothing; a tool building its
-#: own JSON string should pass these, since the compaction below cannot reach a
-#: single-line string a tool returned itself.
-COMPACT_SEPARATORS = (",", ":")
+
+def compact_json_dumps(data: Any) -> str:
+    """Serialise ``data`` as JSON with nothing spent on presentation.
+
+    Both settings matter and are easy to half-apply, which is why they live
+    together here rather than as arguments at each call site: the default
+    separators ``(", ", ": ")`` spend two tokens per field on filler, and the
+    default ``ensure_ascii=True`` re-escapes non-ASCII to ``\\uXXXX``, which
+    costs *more* than the whitespace this saves.
+
+    Use it for JSON a tool builds itself -- ``compact_tool_result`` cannot
+    reach a single-line string a tool already returned.
+    """
+    return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
 
 
 def compact_json_text(text: str) -> str:
@@ -30,8 +39,6 @@ def compact_json_text(text: str) -> str:
 
     Only text that opens the way ``indent=2`` output does is even parsed, so a
     tool returning prose or already-compact JSON is left untouched.
-    ``ensure_ascii=False`` matters: escaping non-ASCII back to ``\\uXXXX`` would
-    spend more tokens than the indentation this removes.
     """
     if not text.startswith(("{\n", "[\n")):
         return text
@@ -39,7 +46,7 @@ def compact_json_text(text: str) -> str:
         data = json.loads(text)
     except ValueError:
         return text
-    return json.dumps(data, separators=COMPACT_SEPARATORS, ensure_ascii=False)
+    return compact_json_dumps(data)
 
 
 def _compact_block(block: ContentBlock) -> ContentBlock:

--- a/nextcloud_mcp_server/serialization.py
+++ b/nextcloud_mcp_server/serialization.py
@@ -1,0 +1,59 @@
+"""Compact JSON in tool results (GH #1395).
+
+FastMCP serialises every non-string tool return with ``indent=2``
+(``mcp.server.fastmcp.utilities.func_metadata._convert_to_content``), and this
+SDK exposes no serializer hook to override it -- neither does the v2
+``mcpserver`` package, so migrating does not fix it either. The consumer is a
+language model with a bounded context window, and that indentation costs
+16-41% of every response while carrying no information.
+
+Re-serialising the *finished content blocks* keeps the fix on our side of the
+dependency boundary. Patching the SDK's private helper would silently stop
+applying if it were renamed; content blocks are protocol types that both SDK
+versions return, so this cannot fail quietly.
+"""
+
+import json
+from typing import Any
+
+from mcp.types import ContentBlock, TextContent
+
+
+def compact_json_text(text: str) -> str:
+    """Strip pretty-printing from ``text`` if it is an indented JSON document.
+
+    Only text that opens the way ``indent=2`` output does is even parsed, so a
+    tool returning prose or already-compact JSON is left untouched.
+    ``ensure_ascii=False`` matters: escaping non-ASCII back to ``\\uXXXX`` would
+    spend more tokens than the indentation this removes.
+    """
+    if not text.startswith(("{\n", "[\n")):
+        return text
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return text
+    return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+
+
+def _compact_block(block: ContentBlock) -> ContentBlock:
+    if not isinstance(block, TextContent):
+        return block
+    text = compact_json_text(block.text)
+    return block if text is block.text else block.model_copy(update={"text": text})
+
+
+def compact_tool_result(result: Any) -> Any:
+    """Compact the JSON in a ``FastMCP.call_tool`` result.
+
+    The SDK returns either a list of content blocks or, when the tool declares
+    an output schema, an ``(unstructured, structured)`` pair. Only the
+    unstructured half is rewritten -- the structured half is a dict the SDK
+    serialises itself, without indentation.
+    """
+    if isinstance(result, tuple) and len(result) == 2:
+        unstructured, structured = result
+        return compact_tool_result(unstructured), structured
+    if isinstance(result, list):
+        return [_compact_block(block) for block in result]
+    return result

--- a/nextcloud_mcp_server/serialization.py
+++ b/nextcloud_mcp_server/serialization.py
@@ -18,6 +18,12 @@ from typing import Any
 
 from mcp.types import ContentBlock, TextContent
 
+#: ``json.dumps`` separators with no filler whitespace. The default
+#: ``(", ", ": ")`` spends two tokens per field on nothing; a tool building its
+#: own JSON string should pass these, since the compaction below cannot reach a
+#: single-line string a tool returned itself.
+COMPACT_SEPARATORS = (",", ":")
+
 
 def compact_json_text(text: str) -> str:
     """Strip pretty-printing from ``text`` if it is an indented JSON document.
@@ -33,7 +39,7 @@ def compact_json_text(text: str) -> str:
         data = json.loads(text)
     except ValueError:
         return text
-    return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+    return json.dumps(data, separators=COMPACT_SEPARATORS, ensure_ascii=False)
 
 
 def _compact_block(block: ContentBlock) -> ContentBlock:

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -154,7 +154,7 @@ def configure_sharing_tools(mcp: FastMCP):
             # redirect, which is the failure this whole message path exists to
             # avoid.
             raise ToolError(str(e)) from e
-        return json.dumps(share_data, indent=2)
+        return json.dumps(share_data)
 
     @mcp.tool(
         title="Create Public Download Link",
@@ -240,9 +240,7 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         await client.sharing.delete_share(share_id)
-        return json.dumps(
-            {"success": True, "message": f"Share {share_id} deleted"}, indent=2
-        )
+        return json.dumps({"success": True, "message": f"Share {share_id} deleted"})
 
     @mcp.tool(
         title="Get Share Details",
@@ -264,7 +262,7 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         share_data = await client.sharing.get_share(share_id)
-        return json.dumps(share_data, indent=2)
+        return json.dumps(share_data)
 
     @mcp.tool(
         title="List Shares",
@@ -289,7 +287,7 @@ def configure_sharing_tools(mcp: FastMCP):
         shares = await client.sharing.list_shares(
             path=path, shared_with_me=shared_with_me
         )
-        return json.dumps(shares, indent=2)
+        return json.dumps(shares)
 
     @mcp.tool(
         title="Update Share",
@@ -320,4 +318,4 @@ def configure_sharing_tools(mcp: FastMCP):
         share_data = await client.sharing.update_share(
             share_id=share_id, permissions=permissions
         )
-        return json.dumps(share_data, indent=2)
+        return json.dumps(share_data)

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -13,6 +13,7 @@ from nextcloud_mcp_server.client.sharing import PublicLinkRecipientError
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models import PublicDownloadLinkResponse
 from nextcloud_mcp_server.observability.metrics import instrument_tool
+from nextcloud_mcp_server.serialization import COMPACT_SEPARATORS
 
 
 def _compute_link_expiry(expires_in_minutes: int, now: datetime) -> tuple[str, str]:
@@ -154,7 +155,7 @@ def configure_sharing_tools(mcp: FastMCP):
             # redirect, which is the failure this whole message path exists to
             # avoid.
             raise ToolError(str(e)) from e
-        return json.dumps(share_data)
+        return json.dumps(share_data, separators=COMPACT_SEPARATORS)
 
     @mcp.tool(
         title="Create Public Download Link",
@@ -240,7 +241,10 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         await client.sharing.delete_share(share_id)
-        return json.dumps({"success": True, "message": f"Share {share_id} deleted"})
+        return json.dumps(
+            {"success": True, "message": f"Share {share_id} deleted"},
+            separators=COMPACT_SEPARATORS,
+        )
 
     @mcp.tool(
         title="Get Share Details",
@@ -262,7 +266,7 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         share_data = await client.sharing.get_share(share_id)
-        return json.dumps(share_data)
+        return json.dumps(share_data, separators=COMPACT_SEPARATORS)
 
     @mcp.tool(
         title="List Shares",
@@ -287,7 +291,7 @@ def configure_sharing_tools(mcp: FastMCP):
         shares = await client.sharing.list_shares(
             path=path, shared_with_me=shared_with_me
         )
-        return json.dumps(shares)
+        return json.dumps(shares, separators=COMPACT_SEPARATORS)
 
     @mcp.tool(
         title="Update Share",
@@ -318,4 +322,4 @@ def configure_sharing_tools(mcp: FastMCP):
         share_data = await client.sharing.update_share(
             share_id=share_id, permissions=permissions
         )
-        return json.dumps(share_data)
+        return json.dumps(share_data, separators=COMPACT_SEPARATORS)

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -1,6 +1,5 @@
 """MCP tools for Nextcloud file/folder sharing operations."""
 
-import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -13,7 +12,7 @@ from nextcloud_mcp_server.client.sharing import PublicLinkRecipientError
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models import PublicDownloadLinkResponse
 from nextcloud_mcp_server.observability.metrics import instrument_tool
-from nextcloud_mcp_server.serialization import COMPACT_SEPARATORS
+from nextcloud_mcp_server.serialization import compact_json_dumps
 
 
 def _compute_link_expiry(expires_in_minutes: int, now: datetime) -> tuple[str, str]:
@@ -155,7 +154,7 @@ def configure_sharing_tools(mcp: FastMCP):
             # redirect, which is the failure this whole message path exists to
             # avoid.
             raise ToolError(str(e)) from e
-        return json.dumps(share_data, separators=COMPACT_SEPARATORS)
+        return compact_json_dumps(share_data)
 
     @mcp.tool(
         title="Create Public Download Link",
@@ -241,9 +240,8 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         await client.sharing.delete_share(share_id)
-        return json.dumps(
-            {"success": True, "message": f"Share {share_id} deleted"},
-            separators=COMPACT_SEPARATORS,
+        return compact_json_dumps(
+            {"success": True, "message": f"Share {share_id} deleted"}
         )
 
     @mcp.tool(
@@ -266,7 +264,7 @@ def configure_sharing_tools(mcp: FastMCP):
         """
         client = await get_client(ctx)
         share_data = await client.sharing.get_share(share_id)
-        return json.dumps(share_data, separators=COMPACT_SEPARATORS)
+        return compact_json_dumps(share_data)
 
     @mcp.tool(
         title="List Shares",
@@ -291,7 +289,7 @@ def configure_sharing_tools(mcp: FastMCP):
         shares = await client.sharing.list_shares(
             path=path, shared_with_me=shared_with_me
         )
-        return json.dumps(shares, separators=COMPACT_SEPARATORS)
+        return compact_json_dumps(shares)
 
     @mcp.tool(
         title="Update Share",
@@ -322,4 +320,4 @@ def configure_sharing_tools(mcp: FastMCP):
         share_data = await client.sharing.update_share(
             share_id=share_id, permissions=permissions
         )
-        return json.dumps(share_data, separators=COMPACT_SEPARATORS)
+        return compact_json_dumps(share_data)

--- a/tests/unit/test_compact_tool_results.py
+++ b/tests/unit/test_compact_tool_results.py
@@ -7,7 +7,11 @@ from mcp.types import ImageContent, TextContent
 
 from nextcloud_mcp_server.errors import NextcloudFastMCP
 from nextcloud_mcp_server.models.base import BaseResponse
-from nextcloud_mcp_server.serialization import compact_json_text, compact_tool_result
+from nextcloud_mcp_server.serialization import (
+    compact_json_dumps,
+    compact_json_text,
+    compact_tool_result,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -27,6 +31,16 @@ def test_indented_json_object_is_compacted():
 def test_non_ascii_survives_unescaped():
     # \uXXXX escaping would cost more tokens than the indentation removed.
     assert compact_json_text('{\n  "n": "Björn"\n}') == '{"n":"Björn"}'
+
+
+def test_compact_dumps_spends_nothing_on_presentation():
+    """The half-applied version of this cost a review round: separators without
+    ensure_ascii=False still pays the \\uXXXX tax on any non-ASCII field."""
+    text = compact_json_dumps({"owner": "Björn", "path": "/a b", "n": 1})
+
+    assert text == '{"owner":"Björn","path":"/a b","n":1}'
+    assert "\\u" not in text
+    assert ", " not in text
 
 
 def test_prose_and_compact_json_are_left_alone():

--- a/tests/unit/test_compact_tool_results.py
+++ b/tests/unit/test_compact_tool_results.py
@@ -54,9 +54,17 @@ def test_non_text_blocks_pass_through_untouched():
 
 
 def test_unrecognised_result_shapes_pass_through():
-    """A shape neither SDK returns today must survive an SDK change untouched."""
+    """A shape neither SDK returns today must survive an SDK change untouched.
+
+    A tuple that is not the ``(unstructured, structured)`` pair is the shape
+    most likely to appear if the SDK grows a third element, so it is worth
+    naming alongside the arbitrary object.
+    """
     sentinel = {"some": "future shape"}
     assert compact_tool_result(sentinel) is sentinel
+
+    triple = ([TextContent(type="text", text='{\n  "a": 1\n}')], {"a": 1}, "extra")
+    assert compact_tool_result(triple) is triple
 
 
 def test_structured_half_of_the_pair_is_preserved():

--- a/tests/unit/test_compact_tool_results.py
+++ b/tests/unit/test_compact_tool_results.py
@@ -39,6 +39,12 @@ def test_non_text_blocks_pass_through_untouched():
     assert compact_tool_result([image]) == [image]
 
 
+def test_unrecognised_result_shapes_pass_through():
+    """A shape neither SDK returns today must survive an SDK change untouched."""
+    sentinel = {"some": "future shape"}
+    assert compact_tool_result(sentinel) is sentinel
+
+
 def test_structured_half_of_the_pair_is_preserved():
     unstructured = [TextContent(type="text", text='{\n  "a": 1\n}')]
     structured = {"a": 1}

--- a/tests/unit/test_compact_tool_results.py
+++ b/tests/unit/test_compact_tool_results.py
@@ -1,0 +1,68 @@
+"""Unit tests for compact tool-result serialisation (GH #1395)."""
+
+import json
+
+import pytest
+from mcp.types import ImageContent, TextContent
+
+from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.models.base import BaseResponse
+from nextcloud_mcp_server.serialization import compact_json_text, compact_tool_result
+
+pytestmark = pytest.mark.unit
+
+
+def _text(result) -> str:
+    """The unstructured text of a call_tool result, whichever shape it has."""
+    blocks = result[0] if isinstance(result, tuple) else result
+    return blocks[0].text
+
+
+def test_indented_json_object_is_compacted():
+    assert (
+        compact_json_text('{\n  "a": 1,\n  "b": [\n    2\n  ]\n}') == '{"a":1,"b":[2]}'
+    )
+
+
+def test_non_ascii_survives_unescaped():
+    # \uXXXX escaping would cost more tokens than the indentation removed.
+    assert compact_json_text('{\n  "n": "Björn"\n}') == '{"n":"Björn"}'
+
+
+def test_prose_and_compact_json_are_left_alone():
+    for text in ("Share 5 deleted", '{"a": 1}', "[not json\n]", '{\n  "a": ,}'):
+        assert compact_json_text(text) is text
+
+
+def test_non_text_blocks_pass_through_untouched():
+    image = ImageContent(type="image", data="Zm9v", mimeType="image/png")
+    assert compact_tool_result([image]) == [image]
+
+
+def test_structured_half_of_the_pair_is_preserved():
+    unstructured = [TextContent(type="text", text='{\n  "a": 1\n}')]
+    structured = {"a": 1}
+
+    compacted, passed_through = compact_tool_result((unstructured, structured))
+
+    assert compacted[0].text == '{"a":1}'
+    assert passed_through is structured
+
+
+async def test_call_tool_returns_unindented_json():
+    """The end-to-end path: FastMCP's own indent=2 must not reach the client."""
+
+    class Item(BaseResponse):
+        name: str
+        tags: list[str]
+
+    mcp = NextcloudFastMCP("test")
+
+    @mcp.tool()
+    async def get_item() -> Item:
+        return Item(name="thing", tags=["a", "b"])
+
+    text = _text(await mcp.call_tool("get_item", {}))
+
+    assert "\n" not in text
+    assert json.loads(text)["tags"] == ["a", "b"]


### PR DESCRIPTION
Closes #1395.

FastMCP pretty-prints every non-string tool return with `indent=2`
(`mcp/server/fastmcp/utilities/func_metadata.py:_convert_to_content`). The consumer is
a language model with a bounded context window, so that whitespace costs 16–41% of
every response (measured by @IchbinkeinReh on real data: 186 contacts 34%, 337 tags
41%, trash listing 16%) and carries no information.

## Approach

SDK 1.29 has no `tool_serializer` hook — and the v2 `mcpserver` package still hardcodes
`indent=2`, so migrating would not fix it either. Raising it upstream is still worth
doing, but this lands the saving now.

Rather than patching the SDK's private `_convert_to_content` (which would silently stop
applying if it were renamed), `NextcloudFastMCP.call_tool` re-serialises the **finished
content blocks**. Those are protocol types both SDK versions return, so the fix cannot
fail quietly on an upgrade — and it sits in our own subclass, not in a dependency.

- `nextcloud_mcp_server/serialization.py` — only text that opens the way `indent=2`
  output does (`{\n` / `[\n`) is parsed at all; prose, already-compact JSON, and
  non-text blocks pass through untouched. `ensure_ascii=False`, because re-escaping
  non-ASCII to `\uXXXX` would cost more tokens than the indentation removed. The
  structured half of an `(unstructured, structured)` pair is left to the SDK.
- `server/sharing.py` — dropped the five local `indent=2` calls (issue item 1).

## Test coverage

`tests/unit/test_compact_tool_results.py`: the helper's edge cases plus an end-to-end
`NextcloudFastMCP.call_tool` assertion that no newline reaches the client. No API
surface is added or changed — same tools, same fields, same values, only the
whitespace between them — so no new e2e/contract coverage is required.

Deck: board 12, card #1182.

---

_This PR was generated with the help of AI, and reviewed by a Human_