### PR TITLE
ci: install oidc from the app store again

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -101,30 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      # submodules + the OIDC build are TEMPORARY: this job only needs them
-      # because docker-compose.yml mounts third_party/oidc while H2CK/oidc#696
-      # is unreleased. Drop both when that mount goes.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: 'true'
-
-      - name: Set up PHP 8.4
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-        with:
-          php-version: 8.4
-          coverage: none
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-
-      - name: Build OIDC app
-        run: |
-          cd third_party/oidc
-          composer install --no-dev --optimize-autoloader
-          npm ci --ignore-scripts
-          npm run build
 
       - name: Set up the uv environment
         uses: ./.github/actions/uv-env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,15 +200,17 @@ jobs:
         with:
           submodules: 'true'
 
-      # Unconditional (was: non-single-user only) because the OIDC app is built
-      # in every mode while the dev mount is in place -- see docker-compose.yml.
       - name: Set up PHP 8.4
+        if: matrix.mode != 'single-user'
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.4
           coverage: none
 
+      # OIDC app installed from app store (dev mount removed from docker-compose.yml)
+
       - name: Set up Node.js
+        if: matrix.mode != 'single-user'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -217,17 +219,6 @@ jobs:
         if: matrix.mode != 'single-user'
         run: |
           cd third_party/astrolabe
-          composer install --no-dev --optimize-autoloader
-          npm ci --ignore-scripts
-          npm run build
-
-      # TEMPORARY -- drop once H2CK/oidc#696 ships and the app-store install
-      # works on Nextcloud 32 again (see the mount comment in
-      # docker-compose.yml). A git checkout has no vendor/ or built js/, so the
-      # mounted app has to be built here.
-      - name: Build OIDC app
-        run: |
-          cd third_party/oidc
           composer install --no-dev --optimize-autoloader
           npm ci --ignore-scripts
           npm run build
@@ -398,30 +389,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linting]
     steps:
-      # submodules + the OIDC build are TEMPORARY: this job only needs them
-      # because docker-compose.yml mounts third_party/oidc while H2CK/oidc#696
-      # is unreleased. Drop both when that mount goes.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: 'true'
-
-      - name: Set up PHP 8.4
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-        with:
-          php-version: 8.4
-          coverage: none
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-
-      - name: Build OIDC app
-        run: |
-          cd third_party/oidc
-          composer install --no-dev --optimize-autoloader
-          npm ci --ignore-scripts
-          npm run build
 
       # docker-compose.yml requires TOKEN_ENCRYPTION_KEY; generate an ephemeral
       # one (the CI tokens.db is destroyed with the job). See the integration job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,14 +207,15 @@ jobs:
           php-version: 8.4
           coverage: none
 
-      # OIDC app installed from app store (dev mount removed from docker-compose.yml)
-
       - name: Set up Node.js
         if: matrix.mode != 'single-user'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
+      # Astrolabe is the only app built from its submodule here; oidc is
+      # installed from the app store by app-hooks/post-installation, so it
+      # needs no build step and no mount in docker-compose.yml.
       - name: Build Astrolabe app
         if: matrix.mode != 'single-user'
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,18 +37,7 @@ services:
       # The post-installation hook will register /opt/apps as an additional app directory
       #- ./third_party:/opt/apps:ro
       #- ./third_party/astrolabe:/opt/apps/astrolabe:ro
-      # TEMPORARY -- remove this mount (and re-comment it) once H2CK/oidc#696 is
-      # merged and released to the app store. oidc 2.1.0 cannot be enabled on
-      # Nextcloud 32 at all: its Version0022 migration adds `tex_enabled` as
-      # BOOLEAN NOT NULL, which NC32 rejects outright (NC33 softened that check
-      # in nextcloud/server#55156), so `occ app:enable oidc` aborts the app
-      # container's entrypoint and every nc32 lane dies before a test runs.
-      # See H2CK/oidc#695. Until the fix ships, the submodule is pinned to
-      # 2.1.0 + that one-line fix and mounted here instead of installing from
-      # the app store. Reverting means: re-comment this line, drop the
-      # "Build OIDC app" steps in .github/workflows/{test,pact}.yml, and drop
-      # `submodules` from the checkouts that only exist to feed this mount.
-      - ./third_party/oidc:/opt/apps/oidc:ro
+      #- ./third_party/oidc:/opt/apps/oidc:ro
     environment:
       - NEXTCLOUD_TRUSTED_DOMAINS=app
       - NEXTCLOUD_ADMIN_USER=admin


### PR DESCRIPTION
The Nextcloud 32 workaround from #1414 can go: [H2CK/oidc#696](https://github.com/H2CK/oidc/pull/696) merged upstream at 04:23 UTC and shipped in **2.1.1** at 05:59 UTC.

Verified before reverting rather than assuming, since merged upstream is not the same as installable:

- the `2.1.1` tag carries the fix (`'notnull' => false` in `Version0022Date20260825100100.php`);
- the app store's **Nextcloud 32** feed (`/api/v1/platform/32.0.0/apps.json`) lists `2.1.1` as the newest `oidc` release, so `occ app:install oidc` on an nc32 lane now resolves to the fixed version.

## What was reverted

Exactly the list `docker-compose.yml` carried for this purpose:

- the `third_party/oidc` mount — that file is now **byte-identical** to its pre-incident state (`git diff aa3764d4 -- docker-compose.yml` is empty);
- the `Build OIDC app` steps in `test.yml` and `pact.yml`;
- the `submodules: 'true'` added to the `docling-integration` and pact `provider` checkouts, which existed only to feed that mount;
- the PHP/Node setup that had to run in every integration mode, back to `if: matrix.mode != 'single-user'`.

## What deliberately stays

- **The `uv --no-build` work** (`.github/actions/uv-env`, `uv run --no-build --no-sync`, `--ignore-scripts`, `--frozen`). It came in the same PR but was never about oidc — it closes `githubactions:S8541`, and removing it would reopen the gate.
- **The submodule pointer moves to the `2.1.1` tag** rather than back to the March pin it had before. It is inert while unmounted, but anyone re-enabling the mount should get the released app, and a released tag keeps the pointer valid no matter what happens to the fork branch the fix was developed on. The fork's `master` and tags have been synced with upstream so that commit is permanent.

CI on this PR is the real test: the nc32 lanes now have to pass with the app-store install, which is the thing that was broken.

---

_This PR was generated with the help of AI, and reviewed by a Human_