### PR TITLE
fix(ocr): a batch poll with no answer is pending, not a dropped document

### DIFF
--- a/nextcloud_mcp_server/providers/gateway_batch.py
+++ b/nextcloud_mcp_server/providers/gateway_batch.py
@@ -179,9 +179,10 @@ class GatewayBatchOcrClient:
         """Poll a batch job. Maps a terminal job's single-document result into
         :class:`BatchPollResult`. A ``404`` (the gateway has no record of this job —
         row purged/orphaned) raises :class:`OcrBatchJobNotFound` so the caller can
-        re-submit. A transport error or a 5xx yields a PENDING result (the job was
-        accepted; "no answer" is not "no job" — Deck #1192); any other non-2xx
-        propagates as a hard failure.
+        re-submit. A transport error, a 5xx, or a 429 yields a PENDING result (the
+        job was accepted; "no answer" is not "no job" — Deck #1192); any other
+        non-2xx propagates as a hard failure, as does a token-provider failure
+        (a different service — its errors must not read as job state).
 
         ``job_id`` is the gateway's namespaced id (``<provider>/<batch_job_id>``),
         so it embeds a ``/`` and the request path is multi-segment
@@ -189,6 +190,13 @@ class GatewayBatchOcrClient:
         path-capture parameter (``GET /v1/ocr/batch/{job_id:path}``) so the slash
         is captured whole — a plain single-segment ``{job_id}`` would 404 here.
         """
+        # Fetched OUTSIDE the try: the token provider talks to the OIDC token
+        # endpoint — a different service from the gateway — and raises the very same
+        # httpx types the except below remaps to PENDING. Left inside, an M2M issuer
+        # outage would read as "the gateway says the job is still running" and every
+        # in-flight document would poll forever behind a WARNING instead of surfacing
+        # the auth fault. Only the poll request itself is eligible for the remap.
+        headers = await self._headers()
         try:
             async with httpx.AsyncClient(
                 timeout=httpx.Timeout(
@@ -197,7 +205,7 @@ class GatewayBatchOcrClient:
                 )
             ) as client:
                 resp = await client.get(
-                    f"{self._base}/ocr/batch/{job_id}", headers=await self._headers()
+                    f"{self._base}/ocr/batch/{job_id}", headers=headers
                 )
                 if resp.status_code == 404:
                     # The gateway has no record of this job (a store-backed provider

--- a/nextcloud_mcp_server/providers/gateway_batch.py
+++ b/nextcloud_mcp_server/providers/gateway_batch.py
@@ -179,7 +179,9 @@ class GatewayBatchOcrClient:
         """Poll a batch job. Maps a terminal job's single-document result into
         :class:`BatchPollResult`. A ``404`` (the gateway has no record of this job —
         row purged/orphaned) raises :class:`OcrBatchJobNotFound` so the caller can
-        re-submit; any other non-2xx / transport error propagates as a hard failure.
+        re-submit. A transport error or a 5xx yields a PENDING result (the job was
+        accepted; "no answer" is not "no job" — Deck #1192); any other non-2xx
+        propagates as a hard failure.
 
         ``job_id`` is the gateway's namespaced id (``<provider>/<batch_job_id>``),
         so it embeds a ``/`` and the request path is multi-segment
@@ -187,22 +189,48 @@ class GatewayBatchOcrClient:
         path-capture parameter (``GET /v1/ocr/batch/{job_id:path}``) so the slash
         is captured whole — a plain single-segment ``{job_id}`` would 404 here.
         """
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(
-                _BATCH_REQUEST_TIMEOUT_SECONDS, connect=_BATCH_CONNECT_TIMEOUT_SECONDS
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    _BATCH_REQUEST_TIMEOUT_SECONDS,
+                    connect=_BATCH_CONNECT_TIMEOUT_SECONDS,
+                )
+            ) as client:
+                resp = await client.get(
+                    f"{self._base}/ocr/batch/{job_id}", headers=await self._headers()
+                )
+                if resp.status_code == 404:
+                    # The gateway has no record of this job (a store-backed provider
+                    # 404s an unknown id). Raise a typed error so the caller re-submits
+                    # instead of treating it as a generic failure and re-polling the
+                    # dead id forever.
+                    raise OcrBatchJobNotFound(job_id)
+                resp.raise_for_status()
+                body = resp.json()
+        except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+            # No usable answer (read/connect timeout, or a gateway 5xx — e.g. its
+            # upstream provider leg failing). Indistinguishable from "still working":
+            # the job WAS accepted, so the gateway owns its lifecycle (Deck #523) and
+            # PENDING is the only safe reading.
+            #
+            # Deck #1192: this used to propagate, where TieredEscalationStrategy
+            # counted it as a transient infra error against ``max_transient_attempts``
+            # and, once that was spent, TERMINALLY DROPPED a document the gateway may
+            # still have been OCRing — silent data loss (~200 docs / 10 min at peak).
+            # A non-404 4xx is a real client-side fault and still propagates.
+            if (
+                isinstance(exc, httpx.HTTPStatusError)
+                and exc.response.status_code < 500
+            ):
+                raise
+            logger.warning(
+                "batch OCR poll got no answer for job %s (%s: %s); treating as "
+                "pending and re-polling",
+                job_id,
+                type(exc).__name__,
+                exc,
             )
-        ) as client:
-            resp = await client.get(
-                f"{self._base}/ocr/batch/{job_id}", headers=await self._headers()
-            )
-            if resp.status_code == 404:
-                # The gateway has no record of this job (a store-backed provider
-                # 404s an unknown id). Raise a typed error so the caller re-submits
-                # instead of treating it as a generic failure and re-polling the
-                # dead id forever.
-                raise OcrBatchJobNotFound(job_id)
-            resp.raise_for_status()
-            body = resp.json()
+            return BatchPollResult(status=_PENDING, pages=[])
         status = body.get("status")
         if status is None:
             # A well-formed gateway response always carries status. A 2xx without

--- a/nextcloud_mcp_server/providers/gateway_batch.py
+++ b/nextcloud_mcp_server/providers/gateway_batch.py
@@ -217,12 +217,24 @@ class GatewayBatchOcrClient:
             # counted it as a transient infra error against ``max_transient_attempts``
             # and, once that was spent, TERMINALLY DROPPED a document the gateway may
             # still have been OCRing — silent data loss (~200 docs / 10 min at peak).
-            # A non-404 4xx is a real client-side fault and still propagates.
+            #
+            # 429 joins the 5xx/transport set: "poll slower" is a statement about US,
+            # never about the job, so hard-failing it would reintroduce that exact
+            # drop for a gateway that rate-limits polls under load. Any OTHER 4xx is a
+            # real client-side fault and still propagates.
             if (
                 isinstance(exc, httpx.HTTPStatusError)
                 and exc.response.status_code < 500
+                and exc.response.status_code != httpx.codes.TOO_MANY_REQUESTS
             ):
                 raise
+            # A 429 (or any error response) may carry Retry-After; honour it so a
+            # rate-limited poll backs off as asked instead of at our own interval.
+            retry_after = (
+                _parse_retry_after(exc.response.headers.get("Retry-After"))
+                if isinstance(exc, httpx.HTTPStatusError)
+                else None
+            )
             logger.warning(
                 "batch OCR poll got no answer for job %s (%s: %s); treating as "
                 "pending and re-polling",
@@ -230,7 +242,7 @@ class GatewayBatchOcrClient:
                 type(exc).__name__,
                 exc,
             )
-            return BatchPollResult(status=_PENDING, pages=[])
+            return BatchPollResult(status=_PENDING, pages=[], retry_after=retry_after)
         status = body.get("status")
         if status is None:
             # A well-formed gateway response always carries status. A 2xx without

--- a/tests/unit/providers/test_gateway_batch.py
+++ b/tests/unit/providers/test_gateway_batch.py
@@ -295,3 +295,44 @@ async def test_submit_and_poll_use_separate_read_timeouts(monkeypatch):
     # The connect timeout stays short and shared -- neither call waits on OCR.
     assert submit_timeout.connect == poll_timeout.connect
     assert submit_timeout.connect == gbc._BATCH_CONNECT_TIMEOUT_SECONDS
+
+
+# --- Deck #1192: a poll that gets no answer must not terminalise the document ---
+
+
+async def test_poll_read_timeout_is_pending(monkeypatch):
+    """A ReadTimeout on the poll reads as PENDING, not as a hard failure.
+
+    Propagating it burned TieredEscalationStrategy's transient-attempt budget and
+    then DROPPED the document, while the gateway may still have been OCRing it.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("", request=request)
+
+    _patch_transport(monkeypatch, handler)
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/job-1")
+
+    assert result.is_pending
+    assert result.retry_after is None
+
+
+async def test_poll_5xx_is_pending(monkeypatch):
+    """A gateway 5xx (e.g. its upstream provider leg failing) is likewise "no
+    answer yet", not a terminal job state."""
+    _patch_transport(
+        monkeypatch, lambda r: httpx.Response(502, json={"detail": "poll failed"})
+    )
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/job-1")
+
+    assert result.is_pending
+
+
+async def test_poll_non_404_4xx_still_raises(monkeypatch):
+    """A client-side fault is a real error and must keep propagating; only 404
+    (unknown job) has its own typed signal."""
+    _patch_transport(monkeypatch, lambda r: httpx.Response(403, json={}))
+    client = gbc.GatewayBatchOcrClient("https://gw", "m")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.poll("mistral/job-1")

--- a/tests/unit/providers/test_gateway_batch.py
+++ b/tests/unit/providers/test_gateway_batch.py
@@ -328,9 +328,22 @@ async def test_poll_5xx_is_pending(monkeypatch):
     assert result.is_pending
 
 
+async def test_poll_429_is_pending_and_honours_retry_after(monkeypatch):
+    """ "Poll slower" is a statement about us, never about the job. Hard-failing it
+    would reintroduce the drop for a gateway that rate-limits polls under load."""
+    _patch_transport(
+        monkeypatch,
+        lambda r: httpx.Response(429, json={}, headers={"Retry-After": "90"}),
+    )
+    result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/job-1")
+
+    assert result.is_pending
+    assert result.retry_after == 90
+
+
 async def test_poll_non_404_4xx_still_raises(monkeypatch):
-    """A client-side fault is a real error and must keep propagating; only 404
-    (unknown job) has its own typed signal."""
+    """A client-side fault is a real error and must keep propagating; 404 (unknown
+    job) and 429 (poll slower) have their own handling."""
     _patch_transport(monkeypatch, lambda r: httpx.Response(403, json={}))
     client = gbc.GatewayBatchOcrClient("https://gw", "m")
 

--- a/tests/unit/providers/test_gateway_batch.py
+++ b/tests/unit/providers/test_gateway_batch.py
@@ -225,13 +225,11 @@ async def test_poll_succeeded_no_results_is_failed(monkeypatch):
     assert result.is_failed
 
 
-async def test_poll_raises_on_http_error(monkeypatch):
-    _patch_transport(
-        monkeypatch, lambda r: httpx.Response(503, json={"detail": "down"})
-    )
-    client = gbc.GatewayBatchOcrClient("https://gw", "m")
-    with pytest.raises(httpx.HTTPStatusError):
-        await client.poll("mistral/j")
+# Retired with Deck #1192: this asserted a 5xx poll RAISES. That contract is what
+# fed TieredEscalationStrategy's attempt budget and ultimately dropped documents,
+# so a 5xx now reads as PENDING — see test_poll_5xx_is_pending below, which covers
+# 503 alongside 502. A non-404/429 4xx still raises
+# (test_poll_non_404_4xx_still_raises).
 
 
 @pytest.mark.parametrize(
@@ -317,11 +315,13 @@ async def test_poll_read_timeout_is_pending(monkeypatch):
     assert result.retry_after is None
 
 
-async def test_poll_5xx_is_pending(monkeypatch):
+@pytest.mark.parametrize("status", [500, 502, 503])
+async def test_poll_5xx_is_pending(monkeypatch, status):
     """A gateway 5xx (e.g. its upstream provider leg failing) is likewise "no
-    answer yet", not a terminal job state."""
+    answer yet", not a terminal job state. This replaces the retired
+    test_poll_raises_on_http_error, which pinned the opposite for 503."""
     _patch_transport(
-        monkeypatch, lambda r: httpx.Response(502, json={"detail": "poll failed"})
+        monkeypatch, lambda r: httpx.Response(status, json={"detail": "poll failed"})
     )
     result = await gbc.GatewayBatchOcrClient("https://gw", "m").poll("mistral/job-1")
 

--- a/tests/unit/providers/test_gateway_batch.py
+++ b/tests/unit/providers/test_gateway_batch.py
@@ -341,6 +341,24 @@ async def test_poll_429_is_pending_and_honours_retry_after(monkeypatch):
     assert result.retry_after == 90
 
 
+async def test_poll_token_provider_failure_still_raises(monkeypatch):
+    """The token provider talks to the OIDC issuer, not the gateway, and raises the
+    same httpx types the PENDING remap catches. An M2M outage must surface as an auth
+    fault — not as "the gateway says the job is still running" on every document."""
+
+    class _BrokenTok:
+        async def get_token(self) -> str:
+            raise httpx.ConnectError("token endpoint unreachable")
+
+    _patch_transport(monkeypatch, lambda r: httpx.Response(200, json={}))
+    client = gbc.GatewayBatchOcrClient(
+        "https://gw", "m", token_provider=cast(Any, _BrokenTok())
+    )
+
+    with pytest.raises(httpx.ConnectError):
+        await client.poll("mistral/job-1")
+
+
 async def test_poll_non_404_4xx_still_raises(monkeypatch):
     """A client-side fault is a real error and must keep propagating; 404 (unknown
     job) and 429 (poll slower) have their own handling."""


### PR DESCRIPTION
Fixes the silent data loss on Deck #1192.

## Root cause

`GatewayBatchOcrClient.poll` (`providers/gateway_batch.py`) let a **read/connect
timeout or a gateway 5xx propagate as a hard error**. Both poll call sites —
`ocr.poll_pending_batch_ocr` (the fast path that skips the WebDAV re-download)
and `OcrProcessor._process_batch` — pass it up to
`TieredEscalationStrategy.get_retry_decision`, which classifies it via
`_is_transient_infra_error` → same-queue backoff until `max_transient_attempts`
is spent → `return None`. No retry, no dead-letter branch on that path: the
document is **terminally dropped** while the gateway may still have been OCRing
it. Nothing downstream reports the file as failed, so a tenant just sees a
smaller corpus.

That contradicts the batch contract (Deck #523, and the comment on the
`BatchPending` branch): once the gateway accepts a document it owns the OCR
lifecycle, and a pending job is never abandoned on a worker-side deadline. A
poll that gets **no answer** is indistinguishable from "still working" — it was
being treated as "job is gone".

## Change

`poll` now maps a transport error or a 5xx to a `PENDING` result and logs a
warning; the job re-polls on its normal cadence. Unchanged: `404` keeps its
typed `OcrBatchJobNotFound` signal (drop the row, re-submit), and any other
`4xx` — a genuine client-side fault — still propagates.

One choke point, so both call sites are fixed at once.

## Two premises on the card that turned out to be wrong

- **`ingest-ocr-upstream` is not a routing destination.** It is
  `LEGACY_INGEST_QUEUE_OCR_UPSTREAM` — a pre-#353 queue name that workers still
  *drain* so jobs parked by an older deploy aren't stranded (`tier_for_queue`
  maps it back to the single `ocr` tier). Nothing routes documents there; the
  tenant's `ocr_provider: gateway` config and the observed behaviour were never
  in conflict.
- **`mistral/` in the poll URL is not a routing choice either.** It is the
  provider prefix of the gateway-assigned namespaced job id
  (`<provider>/<batch_job_id>`), stored in `BatchOcrJobStore` at submit time and
  replayed on every poll.

So the "why is this tenant using the upstream leg" question dissolves — the
remaining question is why the gateway's mistral poll leg hangs / 502s with an
empty error string, which is gateway-side.

## Acceptance criteria

- [x] A document whose OCR provider fails is not silently dropped — it stays
      pending and keeps polling instead of being abandoned.
- [x] `max_retries: 1` reviewed — **working as designed, no change**. The
      in-process retry loop is deliberately disabled on the queue path
      (`bp.task(..., retry=TieredEscalationStrategy(...))`, "durable retry owned
      by the queue"); `max_retries=1` just means "don't retry in-process". The
      real budget is `max_transient_attempts`, which is what this bug was
      burning.
- [ ] The gateway's mistral poll error carries an actual message instead of `""`
      — **gateway-side** (`astrolabe-cloud-website`), not fixable here.
- [ ] Routing decision observable per document — **moot**, see above; there is
      no per-document upstream/in-cluster decision to observe.
- [ ] Either the Mistral leg works for this tenant, or routing stops selecting
      it — **gateway-side**.

## Residual risk

A gateway that 5xxs on one job *forever* now polls forever rather than dropping
it. That is the intended Deck #523 posture (the gateway is the lifecycle owner)
and it is loud — one WARNING per poll — but it is a log signal, not a metric. A
counter for "polls answered with an error" belongs with the observability work
on Deck #1191.

## Test coverage

Unit, in `tests/unit/providers/test_gateway_batch.py`: a `ReadTimeout` poll and
a `502` poll each read as pending; a `403` still raises. No API surface added or
changed, so no new contract/e2e tier is required — the existing batch-OCR
consumer pact (`tests/contract/test_gateway_batch_ocr_consumer.py`) still pins
the 2xx wire format, which this does not touch.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hcdhYzfD6ShefockFVwL2
