### PR TITLE
fix(ocr): re-submit a batch job whose provider no longer matches the model

### DIFF
--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -469,6 +469,27 @@ def _reset_poll_batch_client() -> None:
     _poll_batch_client_lock = None
 
 
+def _job_is_stale_for_model(job_id: str, model: str) -> bool:
+    """Whether a tracked batch job was submitted under a provider we no longer use.
+
+    ``batch_ocr_jobs`` is keyed on ``(user_id, doc_id, doc_type, etag)`` — the
+    document's *content* version. Nothing in that key covers the *configuration*
+    version, so re-pointing ``DOCUMENT_OCR_MODEL`` at another provider leaves
+    every in-flight row intact, and the next poll of unchanged content (same
+    etag) replays the OLD provider's job id forever. Deck #1192: a tenant moved
+    from ``mistral/*`` to ``surya/surya-ocr-2`` and its re-index kept polling
+    ``/v1/ocr/batch/mistral/<job>`` — an OCR leg that config said it had left.
+
+    Both ids are namespaced ``<provider>/<rest>`` (the submit pact pins the job id
+    to ``[^/]+/.+``), so the provider segment is the comparison. Fails OPEN — an
+    id without a prefix is not attributable to a provider, and a false "stale"
+    re-submits, and re-pays for, OCR on every single poll.
+    """
+    if "/" not in job_id or "/" not in model:
+        return False
+    return job_id.split("/", 1)[0] != model.split("/", 1)[0]
+
+
 async def poll_pending_batch_ocr(
     *, user_id: str, doc_id: str, etag: str, settings: Settings
 ) -> int | None:
@@ -494,6 +515,11 @@ async def poll_pending_batch_ocr(
     store = await BatchOcrJobStore.shared()
     job = await store.get(user_id=user_id, doc_id=doc_id, doc_type="file", etag=etag)
     if job is None:
+        return None
+    if _job_is_stale_for_model(job.job_id, settings.document_ocr_model):
+        # Submitted under a provider this instance no longer uses. Don't poll it:
+        # fall through so the normal path drops the row and re-submits under the
+        # configured model (which needs the file bytes anyway).
         return None
     client = await _get_poll_batch_client(settings)
     if client is None:
@@ -831,6 +857,24 @@ class OcrProcessor(DocumentProcessor):
         job = await store.get(
             user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
         )
+        if job is not None and _job_is_stale_for_model(
+            job.job_id, getattr(settings, self._model_setting)
+        ):
+            # The tracked job belongs to a provider we no longer use (Deck #1192).
+            # Polling it keeps talking to the old OCR leg for as long as the content
+            # is unchanged. Drop the row and fall into the submit branch below, which
+            # re-submits under the configured model.
+            logger.warning(
+                "batch OCR job %s was submitted under a different provider than the "
+                "configured model %s; re-submitting %s",
+                job.job_id,
+                getattr(settings, self._model_setting),
+                filename or doc_id,
+            )
+            await store.delete(
+                user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
+            )
+            job = None
         if job is None:
             # New submission. Drop any superseded-version rows for this doc first
             # (a re-edited file changes etag) — a no-op on the very first submit,

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -481,13 +481,14 @@ def _job_is_stale_for_model(job_id: str, model: str) -> bool:
     ``/v1/ocr/batch/mistral/<job>`` — an OCR leg that config said it had left.
 
     Both ids are namespaced ``<provider>/<rest>`` (the submit pact pins the job id
-    to ``[^/]+/.+``), so the provider segment is the comparison. Fails OPEN — an
-    id without a prefix is not attributable to a provider, and a false "stale"
+    to ``[^/]+/.+``), so the provider segment is the comparison, case-insensitively
+    (``Mistral`` and ``mistral`` are one provider, not a config change). Fails OPEN
+    — an id without a prefix is not attributable to a provider, and a false "stale"
     re-submits, and re-pays for, OCR on every single poll.
     """
     if "/" not in job_id or "/" not in model:
         return False
-    return job_id.split("/", 1)[0] != model.split("/", 1)[0]
+    return job_id.split("/", 1)[0].lower() != model.split("/", 1)[0].lower()
 
 
 async def poll_pending_batch_ocr(

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -41,10 +41,12 @@ from nextcloud_mcp_server.config import Settings, get_settings
 from .base import DocumentProcessor, ProcessingResult, ProcessorError
 
 if TYPE_CHECKING:
-    # Annotation-only import (the runtime import is lazy, inside
-    # build_gateway_batch_client, to avoid a document_processors -> providers
-    # cycle at load).
+    # Annotation-only imports (the runtime imports are lazy — inside
+    # build_gateway_batch_client, and inside the batch methods — to avoid a
+    # document_processors -> providers cycle and to keep the vector/DB stack off
+    # this module's load path).
     from ..providers.gateway_batch import GatewayBatchOcrClient
+    from ..vector.batch_ocr_store import BatchOcrJob, BatchOcrJobStore
 
 logger = logging.getLogger(__name__)
 
@@ -483,12 +485,15 @@ def _job_is_stale_for_model(job_id: str, model: str) -> bool:
     Both ids are namespaced ``<provider>/<rest>`` (the submit pact pins the job id
     to ``[^/]+/.+``), so the provider segment is the comparison, case-insensitively
     (``Mistral`` and ``mistral`` are one provider, not a config change). Fails OPEN
-    — an id without a prefix is not attributable to a provider, and a false "stale"
-    re-submits, and re-pays for, OCR on every single poll.
+    — an id carrying no usable provider segment (absent, or empty as in ``/rest``)
+    is not attributable to a provider, and a false "stale" re-submits, and re-pays
+    for, OCR on every single poll.
     """
-    if "/" not in job_id or "/" not in model:
+    job_provider = job_id.split("/", 1)[0].lower() if "/" in job_id else ""
+    model_provider = model.split("/", 1)[0].lower() if "/" in model else ""
+    if not job_provider or not model_provider:
         return False
-    return job_id.split("/", 1)[0].lower() != model.split("/", 1)[0].lower()
+    return job_provider != model_provider
 
 
 async def poll_pending_batch_ocr(
@@ -799,6 +804,42 @@ class OcrProcessor(DocumentProcessor):
                     self._batch_client_resolved = True
         return self._batch_client
 
+    async def _live_tracked_job(
+        self,
+        store: "BatchOcrJobStore",
+        *,
+        user_id: str,
+        doc_id: str,
+        doc_type: str,
+        etag: str,
+        settings: Settings,
+        label: str,
+    ) -> "BatchOcrJob | None":
+        """The in-flight batch job for this document+version, or ``None`` to submit.
+
+        ``None`` also covers a tracked job whose provider we no longer use (Deck
+        #1192): its row is dropped here so the caller's submit branch re-submits
+        under the configured model instead of polling the old OCR leg for as long
+        as the content is unchanged.
+        """
+        job = await store.get(
+            user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
+        )
+        if job is None:
+            return None
+        model = getattr(settings, self._model_setting)
+        if not _job_is_stale_for_model(job.job_id, model):
+            return job
+        logger.warning(
+            "batch OCR job %s was submitted under a different provider than the "
+            "configured model %s; re-submitting %s",
+            job.job_id,
+            model,
+            label,
+        )
+        await store.delete(user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag)
+        return None
+
     async def _process_batch(
         self,
         content: bytes,
@@ -855,27 +896,15 @@ class OcrProcessor(DocumentProcessor):
         mime = content_type.split(";")[0].strip().lower()
         poll_seconds = settings.document_ocr_batch_poll_seconds
 
-        job = await store.get(
-            user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
+        job = await self._live_tracked_job(
+            store,
+            user_id=user_id,
+            doc_id=doc_id,
+            doc_type=doc_type,
+            etag=etag,
+            settings=settings,
+            label=filename or doc_id,
         )
-        if job is not None and _job_is_stale_for_model(
-            job.job_id, getattr(settings, self._model_setting)
-        ):
-            # The tracked job belongs to a provider we no longer use (Deck #1192).
-            # Polling it keeps talking to the old OCR leg for as long as the content
-            # is unchanged. Drop the row and fall into the submit branch below, which
-            # re-submits under the configured model.
-            logger.warning(
-                "batch OCR job %s was submitted under a different provider than the "
-                "configured model %s; re-submitting %s",
-                job.job_id,
-                getattr(settings, self._model_setting),
-                filename or doc_id,
-            )
-            await store.delete(
-                user_id=user_id, doc_id=doc_id, doc_type=doc_type, etag=etag
-            )
-            job = None
         if job is None:
             # New submission. Drop any superseded-version rows for this doc first
             # (a re-edited file changes etag) — a no-op on the very first submit,

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -1117,6 +1117,10 @@ def test_job_is_stale_for_model_fails_open_without_a_prefix():
     and re-pays for, the OCR on every poll."""
     assert ocr._job_is_stale_for_model("bare-job-id", "surya/surya-ocr-2") is False
     assert ocr._job_is_stale_for_model("surya/j", "bare-model") is False
+    # An EMPTY provider segment is unattributable too, not "a provider that
+    # differs from every real one".
+    assert ocr._job_is_stale_for_model("/rest", "surya/surya-ocr-2") is False
+    assert ocr._job_is_stale_for_model("surya/j", "/surya-ocr-2") is False
 
 
 async def test_poll_pending_stale_provider_falls_through(monkeypatch):

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -1107,6 +1107,9 @@ def test_job_is_stale_for_model_compares_provider_segment():
     # Same provider, different model: not stale — the in-flight job is still
     # pollable and its output still usable.
     assert ocr._job_is_stale_for_model("mistral/j", "mistral/other") is False
+    # Case is not a config change — comparing case-sensitively would read a
+    # casing difference as a provider switch and re-pay for the OCR.
+    assert ocr._job_is_stale_for_model("Mistral/j", "mistral/other") is False
 
 
 def test_job_is_stale_for_model_fails_open_without_a_prefix():

--- a/tests/unit/test_ocr_processor.py
+++ b/tests/unit/test_ocr_processor.py
@@ -745,7 +745,7 @@ async def test_batch_poll_404_drops_row_and_resubmits(monkeypatch):
     # NOT re-poll the dead id forever (which flapped the burst GPU).
     from nextcloud_mcp_server.providers.gateway_batch import OcrBatchJobNotFound
 
-    preset = SimpleNamespace(job_id="surya/dead", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/dead", submitted_at=1000)
     client = _FakeBatchClient()
 
     async def _poll_404(job_id):
@@ -760,7 +760,7 @@ async def test_batch_poll_404_drops_row_and_resubmits(monkeypatch):
         b"%PDF", "application/pdf", options=dict(_IDENTITY)
     )
 
-    assert client.polled == ["surya/dead"]
+    assert client.polled == ["mistral/dead"]
     # tracking row dropped -> store.get is None next cycle -> fresh submit
     assert ("u1", "d1", "file", "v1") in store.deleted
     # returned the pending sentinel (re-poll → resubmit); did NOT resubmit inline
@@ -975,7 +975,7 @@ async def test_poll_pending_no_job_falls_through(monkeypatch):
 async def test_poll_pending_defers_without_download(monkeypatch):
     """A still-pending job within its deadline -> return the poll interval so the
     caller defers WITHOUT re-downloading the file (the win: polled by job_id only)."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
     got = await ocr.poll_pending_batch_ocr(
@@ -987,13 +987,13 @@ async def test_poll_pending_defers_without_download(monkeypatch):
         ),
     )
     assert got == 120
-    assert client.polled == ["surya/j"]  # polled by job_id; never submitted/fetched
+    assert client.polled == ["mistral/j"]  # polled by job_id; never submitted/fetched
 
 
 async def test_poll_pending_terminal_falls_through(monkeypatch):
     """A terminal (succeeded) job -> None so the caller re-polls + indexes via the
     pipeline (whose post-parse quality gate needs the real bytes)."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(
         poll=BatchPollResult(status="succeeded", pages=[(0, "hello", None)])
     )
@@ -1010,7 +1010,7 @@ async def test_poll_pending_terminal_falls_through(monkeypatch):
 async def test_poll_pending_polls_forever_no_deadline(monkeypatch):
     """Deck #523: past the old deadline still re-defers (a positive retry_in), never
     None — the gateway owns the lifecycle, so the worker polls forever."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(poll=BatchPollResult(status="pending", pages=[]))
     _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
     got = await ocr.poll_pending_batch_ocr(
@@ -1025,7 +1025,7 @@ async def test_poll_pending_polls_forever_no_deadline(monkeypatch):
 async def test_poll_pending_honours_retry_after(monkeypatch):
     """The gateway's Retry-After sets the poll cadence (anti-storm) when it's above
     the configured floor — passed through, not clamped (Deck #523)."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(
         poll=BatchPollResult(status="pending", pages=[], retry_after=200)
     )
@@ -1044,7 +1044,7 @@ async def test_poll_pending_honours_retry_after(monkeypatch):
 async def test_poll_pending_floors_retry_after(monkeypatch):
     """A Retry-After BELOW the poll interval is raised to the floor so a tiny value
     can't busy-loop the gateway (Deck #523)."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(
         poll=BatchPollResult(status="pending", pages=[], retry_after=5)
     )
@@ -1063,7 +1063,7 @@ async def test_poll_pending_floors_retry_after(monkeypatch):
 async def test_poll_pending_caps_retry_after(monkeypatch):
     """An absurd Retry-After (e.g. a malformed header with an extra zero) is capped
     so one document can't stall for an absurd duration — still no give-up (Deck #523)."""
-    preset = SimpleNamespace(job_id="surya/j", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
     client = _FakeBatchClient(
         poll=BatchPollResult(status="pending", pages=[], retry_after=999_999)
     )
@@ -1087,7 +1087,7 @@ async def test_poll_pending_job_gone_falls_through(monkeypatch):
         async def poll(self, job_id):
             raise OcrBatchJobNotFound(job_id)
 
-    preset = SimpleNamespace(job_id="surya/gone", submitted_at=1000)
+    preset = SimpleNamespace(job_id="mistral/gone", submitted_at=1000)
     _wire_batch(monkeypatch, client=_NotFoundClient(), store=_FakeStore(preset=preset))
     got = await ocr.poll_pending_batch_ocr(
         user_id="u1",
@@ -1096,3 +1096,71 @@ async def test_poll_pending_job_gone_falls_through(monkeypatch):
         settings=_settings(document_ocr_mode="batch"),
     )
     assert got is None
+
+
+# --- Deck #1192: a tracked job outliving a provider switch ---------------------
+
+
+def test_job_is_stale_for_model_compares_provider_segment():
+    assert ocr._job_is_stale_for_model("mistral/j", "surya/surya-ocr-2") is True
+    assert ocr._job_is_stale_for_model("surya/j", "surya/surya-ocr-2") is False
+    # Same provider, different model: not stale — the in-flight job is still
+    # pollable and its output still usable.
+    assert ocr._job_is_stale_for_model("mistral/j", "mistral/other") is False
+
+
+def test_job_is_stale_for_model_fails_open_without_a_prefix():
+    """An unattributable id must never read as stale: a false positive re-submits,
+    and re-pays for, the OCR on every poll."""
+    assert ocr._job_is_stale_for_model("bare-job-id", "surya/surya-ocr-2") is False
+    assert ocr._job_is_stale_for_model("surya/j", "bare-model") is False
+
+
+async def test_poll_pending_stale_provider_falls_through(monkeypatch):
+    """A job submitted under the OLD provider is not polled: fall through so the
+    normal path re-submits under the configured model."""
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
+    client = _FakeBatchClient()
+    _wire_batch(monkeypatch, client=client, store=_FakeStore(preset=preset))
+
+    got = await ocr.poll_pending_batch_ocr(
+        user_id="u1",
+        doc_id="d1",
+        etag="v1",
+        settings=_settings(
+            document_ocr_mode="batch", document_ocr_model="surya/surya-ocr-2"
+        ),
+    )
+
+    assert got is None
+    assert client.polled == []  # never talked to the old provider's job
+
+
+async def test_batch_stale_provider_drops_row_and_resubmits(monkeypatch):
+    """Deck #1192: batch_ocr_jobs is keyed on content (etag), not on config, so a
+    row survives a DOCUMENT_OCR_MODEL switch and keeps polling the old provider for
+    as long as the content is unchanged. The row must be dropped and re-submitted."""
+    preset = SimpleNamespace(job_id="mistral/j", submitted_at=1000)
+    client = _FakeBatchClient(submit_job="surya/fresh")
+    store = _FakeStore(preset=preset)
+    _wire_batch(
+        monkeypatch,
+        client=client,
+        store=store,
+        settings=_settings(
+            document_ocr_mode="batch",
+            document_ocr_provider="gateway",
+            embedding_gateway_url="https://gw",
+            document_ocr_model="surya/surya-ocr-2",
+        ),
+    )
+
+    r = await ocr.OcrProcessor().process(
+        b"%PDF", "application/pdf", options=dict(_IDENTITY)
+    )
+
+    assert client.polled == []  # the stale job is never polled
+    assert ("u1", "d1", "file", "v1") in store.deleted
+    assert len(client.submitted) == 1  # re-submitted under the configured model
+    assert store.rows[("u1", "d1", "file", "v1")].job_id == "surya/fresh"
+    assert r.metadata[ocr.OCR_BATCH_PENDING_KEY] is True


### PR DESCRIPTION
The routing half of Deck #1192 — **why a surya-configured tenant was talking to
Mistral at all**. #1425 stops the resulting timeout from destroying documents;
this stops the wrong provider from being contacted.

## Root cause

`batch_ocr_jobs` is keyed on `(user_id, doc_id, doc_type, etag)` — the
document's **content** version. Nothing in that key, and no column in the table,
covers the **configuration** version:

```
sa.Column("user_id"), sa.Column("doc_id"), sa.Column("doc_type"),
sa.Column("etag"),    sa.Column("job_id"), sa.Column("submitted_at")
```

So re-pointing `DOCUMENT_OCR_MODEL` from `mistral/*` to `surya/surya-ocr-2`
leaves every in-flight row intact, and the next poll of unchanged content (same
etag) replays the **old provider's** job id — `GET /v1/ocr/batch/mistral/<job>`.
Nothing ever clears it: `delete_stale_for_doc` only sweeps *other* etags of the
same document, and only from the fresh-submit branch that this stale hit is
precisely what prevents reaching.

That also resolves what looked like a contradiction on the card. A re-index of
unchanged files hits the *same* etag, so "consecutive `doc_id`s from the current
re-index" and "stale Mistral job ids" are not competing explanations — they are
the same rows. The tenant's `ocr_provider: gateway` / `ocr_model:
surya/surya-ocr-2` config was being honoured for *submits*; it just never
invalidated what was already in flight.

I previously wrote on the card that `mistral/` was "just a job-id prefix, not a
routing choice". The prefix part is right and the reassurance was wrong — a
persisted prefix **is** what selects the provider on every subsequent poll.

## Change

Both poll sites compare the stored job id's provider segment against the
configured model's:

- `_process_batch` — drops the row and falls into the existing submit branch, so
  the document is re-submitted under the current model.
- `poll_pending_batch_ocr` (fast path) — returns `None` and falls through to the
  above rather than polling the old provider, mirroring how it already handles a
  404.

Comparison **fails open** when either id lacks a `<provider>/` prefix: an
unattributable id must never read as stale, because a false positive re-submits
— and re-pays for — the OCR on every poll. Same-provider model changes
(`mistral/v1` → `mistral/v2`) are deliberately *not* stale: the in-flight job is
still pollable and its output still usable.

No migration: the provider is already carried in the `job_id` the table stores,
and the submit pact pins it to `[^/]+/.+`.

## Interaction with #1425

They fix the same incident from both ends and each covers the other's residual
risk:

- Without this, #1425 makes a stale-provider job poll a dead leg *forever*
  instead of dropping it — the residual risk I flagged on that PR.
- Without #1425, any transport blip on a legitimate poll still drops documents.

## Test coverage

Unit, `tests/unit/test_ocr_processor.py`: provider-segment comparison incl. the
same-provider and fail-open cases; the fast path refusing to poll a stale job;
and the full `_process_batch` path dropping the row and re-submitting under the
configured model.

Fixture note: several presets used `surya/*` job ids against the default
`mistral/*` model. That mismatch was arbitrary, and under this change it is
meaningful, so the fixtures are aligned with the configured model — each test
still exercises its original intent.

No API surface added or changed, so no new contract/e2e tier is required.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hcdhYzfD6ShefockFVwL2
