### PR TITLE
fix(auth): poll pending login flow before reporting stored scopes

### DIFF
--- a/docs/ADR-022-deployment-mode-consolidation.md
+++ b/docs/ADR-022-deployment-mode-consolidation.md
@@ -267,18 +267,20 @@ async def nc_auth_check_status(ctx: Context) -> ProvisionStatusResponse:
     """
     user_id = extract_user_from_mcp_token(ctx)
 
-    # Check for existing app password
-    existing = await storage.get_app_password_with_scopes(user_id)
-    if existing:
-        return ProvisionStatusResponse(
-            status="provisioned",
-            message="Access already provisioned.",
-            scopes=existing["scopes"],
-        )
-
-    # Get pending login flow session
+    # A pending login flow is polled BEFORE the stored app password is
+    # reported. nc_auth_update_scopes keeps the old password valid until the
+    # new one arrives (see "Re-auth Tool Implementation" below), so reporting
+    # it first would short-circuit every poll and the scope update could never
+    # complete (GH #1431).
     session = await storage.get_login_flow_session(user_id)
     if not session:
+        existing = await storage.get_app_password_with_scopes(user_id)
+        if existing:
+            return ProvisionStatusResponse(
+                status="provisioned",
+                message="Access already provisioned.",
+                scopes=existing["scopes"],
+            )
         return ProvisionStatusResponse(
             status="not_initiated",
             message="No provisioning in progress. Call nc_auth_provision_access first.",
@@ -459,6 +461,16 @@ Result:     [notes:read, calendar:read, calendar:write]
 ```
 
 **Note**: Scope reduction requires explicit revocation. Users cannot "downgrade" scopes without fully revoking and re-provisioning.
+
+**Implementation divergence — the old app password is *not* deleted up front.**
+The sketch below revokes the previous password before starting the new flow;
+the shipped `nc_auth_update_scopes` deliberately leaves it in place so the user
+keeps working while re-authenticating, and lets the upsert in
+`store_app_password_with_scopes()` replace it atomically when the flow
+completes. That makes the ordering inside `nc_auth_check_status` load-bearing:
+a pending flow session must be polled *before* the stored password is reported,
+or the update never lands. GH #1431 was exactly this — one half of the pair was
+changed and the other was not.
 
 #### Re-auth Tool Implementation
 

--- a/docs/ADR-022-deployment-mode-consolidation.md
+++ b/docs/ADR-022-deployment-mode-consolidation.md
@@ -434,43 +434,65 @@ After the user completes authentication in their browser:
 
 ### Re-Authentication for Scope Updates
 
-Users may need to update their authorized scopes after initial provisioning. The system supports **re-authentication** with scope merging.
+Users may need to update their authorized scopes after initial provisioning. The system supports **re-authentication** to widen or narrow the stored grant.
 
 #### Re-auth Scenarios
 
 | Scenario | Trigger | User Action Required |
 |----------|---------|----------------------|
 | **Initial provisioning** | User has no app password | Complete Login Flow v2 |
-| **Scope expansion** | Tool requires scope user hasn't authorized | Re-authenticate to add scopes |
-| **Scope reduction** | User wants to revoke specific scopes | Revoke and re-provision with fewer scopes |
+| **Scope expansion** | Tool requires a scope the stored grant does not carry | `nc_auth_update_scopes(add_scopes=[...])`, then complete Login Flow v2 |
+| **Scope reduction** | User wants to drop specific scopes | `nc_auth_update_scopes(remove_scopes=[...])`, then complete Login Flow v2 |
+| **Return to an unrestricted grant** | Stored allow-list has gone stale (see the 0.167.0 addendum) | Re-run `nc_auth_provision_access` |
 | **Token rotation** | Admin policy or user preference | Re-authenticate (new app password issued) |
 
-#### Scope Merging Behavior
+#### Scope Update Behavior
 
-When a user re-authenticates to add scopes:
+Both directions go through the same tool and the same Login Flow v2 re-run:
 
-1. **Existing scopes are preserved**: New scopes are merged with existing scopes
-2. **Old app password is revoked**: Nextcloud revokes the previous app password
-3. **New app password issued**: User authenticates via Login Flow v2
-4. **Merged scopes stored**: Both old and new scopes associated with new password
+1. **The new set is computed from the stored one**: `add_scopes` is unioned in,
+   `remove_scopes` subtracted. A NULL (unrestricted) grant is first materialised
+   as the full supported vocabulary, which is what makes narrowing possible at
+   all — and what makes that snapshot go stale later (0.167.0 addendum).
+2. **An unchanged set short-circuits**: the tool returns `unchanged` without
+   starting a flow. Adding to a NULL grant always lands here, because a NULL
+   grant already places no restriction; the denial in that case is on the OAuth
+   token, which this tool cannot widen.
+3. **New app password issued**: the user completes Login Flow v2.
+4. **New scopes stored**: `store_app_password_with_scopes()` upserts the new
+   password and the new list together, when `nc_auth_check_status` observes the
+   completed flow.
 
 ```
-Initial:    [notes:read]
-Request:    [calendar:read, calendar:write]
-Result:     [notes:read, calendar:read, calendar:write]
+Stored:     [notes.read]
+add_scopes: [calendar.read, calendar.write]
+Result:     [calendar.read, calendar.write, notes.read]
 ```
 
-**Note**: Scope reduction requires explicit revocation. Users cannot "downgrade" scopes without fully revoking and re-provisioning.
+**The previous app password stays valid until the new one lands.** Two
+corrections to what an earlier draft of this section claimed:
 
-**Implementation divergence — the old app password is *not* deleted up front.**
-The sketch below revokes the previous password before starting the new flow;
-the shipped `nc_auth_update_scopes` deliberately leaves it in place so the user
-keeps working while re-authenticating, and lets the upsert in
-`store_app_password_with_scopes()` replace it atomically when the flow
-completes. That makes the ordering inside `nc_auth_check_status` load-bearing:
-a pending flow session must be polled *before* the stored password is reported,
-or the update never lands. GH #1431 was exactly this — one half of the pair was
-changed and the other was not.
+- Nothing revokes the old password. Login Flow v2 *issues* a password; it does
+  not retire the previous one, and the server never calls Nextcloud's
+  app-password deletion API. The old credential remains usable in Nextcloud
+  until the user removes it under Settings → Security. Only the server's own
+  stored copy is replaced, by the upsert in step 4. The same is true of
+  *revocation*: `revoke_nextcloud_access` and
+  `DELETE /api/v1/users/{user_id}/app-password` both drop this server's stored
+  copy and nothing else — they end this server's access, not the credential's
+  validity. Retiring the credential itself is the user's action in Nextcloud,
+  which is what §"User Revocation" below refers to.
+- Scope reduction does **not** require revoking and re-provisioning.
+  `remove_scopes` has shipped; re-provisioning is the escape hatch for
+  returning to an *unrestricted* grant, not the mechanism for narrowing one.
+
+Keeping the old password alive is deliberate — the user keeps working while
+re-authenticating — but it makes the ordering inside `nc_auth_check_status`
+load-bearing: a pending flow session must be polled *before* the stored password
+is reported, or the update never lands. GH #1431 was exactly this. The sketch
+below still shows the original delete-then-create shape, where reporting the
+stored password first was harmless; treat the note above as authoritative where
+the two disagree.
 
 #### Re-auth Tool Implementation
 

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -243,18 +243,11 @@ def register_auth_tools(mcp: FastMCP) -> None:
 
         storage = await get_shared_storage()
 
-        # Check for existing app password
-        existing = await storage.get_app_password_with_scopes(user_id)
-        if existing:
-            return ProvisionStatusResponse(
-                status="provisioned",
-                message=f"Nextcloud access is provisioned for {existing.get('username') or user_id}.",
-                user_id=user_id,
-                scopes=existing["scopes"],
-                username=existing.get("username"),
-            )
-
-        # Check for pending login flow session
+        # A pending login flow is polled *before* the stored app password is
+        # reported. nc_auth_update_scopes deliberately leaves the old password
+        # in place while the new flow runs, so short-circuiting on it would
+        # report the old scopes forever and never store the re-provisioned
+        # grant — the scope update could never complete (GH #1431).
         try:
             session = await storage.get_login_flow_session(user_id)
         except Exception as e:
@@ -266,6 +259,15 @@ def register_auth_tools(mcp: FastMCP) -> None:
                 success=False,
             )
         if not session:
+            existing = await storage.get_app_password_with_scopes(user_id)
+            if existing:
+                return ProvisionStatusResponse(
+                    status="provisioned",
+                    message=f"Nextcloud access is provisioned for {existing.get('username') or user_id}.",
+                    user_id=user_id,
+                    scopes=existing["scopes"],
+                    username=existing.get("username"),
+                )
             return ProvisionStatusResponse(
                 status="not_initiated",
                 message=(
@@ -341,6 +343,21 @@ def register_auth_tools(mcp: FastMCP) -> None:
         if poll_result.status == "expired":
             # Clean up expired session
             await storage.delete_login_flow_session(user_id)
+            # An expired *scope update* leaves the previous grant intact — say
+            # so, rather than telling a provisioned user they have no access.
+            existing = await storage.get_app_password_with_scopes(user_id)
+            if existing:
+                return ProvisionStatusResponse(
+                    status="provisioned",
+                    message=(
+                        "Login flow expired; your previous access as "
+                        f"{existing.get('username') or user_id} is still valid. "
+                        "Call nc_auth_update_scopes again to retry the change."
+                    ),
+                    user_id=user_id,
+                    scopes=existing["scopes"],
+                    username=existing.get("username"),
+                )
             return ProvisionStatusResponse(
                 status="not_initiated",
                 message=(

--- a/tests/unit/test_auth_tools.py
+++ b/tests/unit/test_auth_tools.py
@@ -485,3 +485,128 @@ async def test_check_status_completion_wakes_user_manager(mocker):
     assert response.status == "provisioned"
     storage.store_app_password_with_scopes.assert_awaited_once()
     notify.assert_called_once()
+
+
+async def test_check_status_polls_pending_flow_while_still_provisioned(mocker):
+    """A scope update must complete even though the old app password is still stored.
+
+    nc_auth_update_scopes deliberately leaves the previous password in place
+    while the new Login Flow runs. Reporting that stored grant before polling
+    stranded the update forever: the user approved files.write, but every
+    nc_auth_check_status kept answering "provisioned, scopes=[files.read]"
+    and the new password was never stored (GH #1431).
+    """
+    check_status = _capture_registered_tools()["nc_auth_check_status"]
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(
+        return_value={
+            "scopes": ["files.read"],
+            "app_password": "old",
+            "username": "alice",
+        }
+    )
+    storage.get_login_flow_session = AsyncMock(
+        return_value={
+            "poll_endpoint": "https://nc/login/v2/poll",
+            "poll_token": "tok",
+            "requested_scopes": ["files.read", "files.write"],
+        }
+    )
+    storage.store_app_password_with_scopes = AsyncMock()
+    storage.delete_login_flow_session = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="https://nc", nextcloud_public_issuer_url=None
+        ),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_nextcloud_ssl_verify",
+        return_value=False,
+    )
+    mocker.patch("nextcloud_mcp_server.server.auth_tools.invalidate_scope_cache")
+
+    flow_client = AsyncMock()
+    flow_client.poll = AsyncMock(
+        return_value=LoginFlowPollResult(
+            status="completed",
+            login_name="alice",
+            app_password=secrets.token_urlsafe(24),
+        )
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.LoginFlowV2Client",
+        return_value=flow_client,
+    )
+    mocker.patch("nextcloud_mcp_server.app.notify_user_provisioned")
+
+    response = await check_status(MagicMock())
+
+    assert response.status == "provisioned"
+    assert response.scopes == ["files.read", "files.write"]
+    assert storage.store_app_password_with_scopes.await_args.kwargs["scopes"] == [
+        "files.read",
+        "files.write",
+    ]
+
+
+async def test_check_status_expired_flow_keeps_previous_grant(mocker):
+    """An expired scope-update flow must not report a provisioned user as unprovisioned."""
+    check_status = _capture_registered_tools()["nc_auth_check_status"]
+
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.extract_user_id_from_token",
+        AsyncMock(return_value="alice"),
+    )
+    storage = MagicMock()
+    storage.get_app_password_with_scopes = AsyncMock(
+        return_value={
+            "scopes": ["files.read"],
+            "app_password": "old",
+            "username": "alice",
+        }
+    )
+    storage.get_login_flow_session = AsyncMock(
+        return_value={
+            "poll_endpoint": "https://nc/login/v2/poll",
+            "poll_token": "tok",
+            "requested_scopes": ["files.read", "files.write"],
+        }
+    )
+    storage.delete_login_flow_session = AsyncMock()
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_shared_storage",
+        AsyncMock(return_value=storage),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_settings",
+        return_value=MagicMock(
+            nextcloud_host="https://nc", nextcloud_public_issuer_url=None
+        ),
+    )
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.get_nextcloud_ssl_verify",
+        return_value=False,
+    )
+
+    flow_client = AsyncMock()
+    flow_client.poll = AsyncMock(return_value=LoginFlowPollResult(status="expired"))
+    mocker.patch(
+        "nextcloud_mcp_server.server.auth_tools.LoginFlowV2Client",
+        return_value=flow_client,
+    )
+
+    response = await check_status(MagicMock())
+
+    assert response.status == "provisioned"
+    assert response.scopes == ["files.read"]
+    storage.delete_login_flow_session.assert_awaited_once()


### PR DESCRIPTION
## Problem

`nc_auth_update_scopes` starts a new Login Flow v2 and **deliberately leaves the
existing app password in place** until the new one arrives (so the user keeps
working while re-authenticating). But `nc_auth_check_status` checked for that
stored app password *first* and returned `provisioned` with the old scopes —
before ever polling the pending flow session.

Consequence: a scope update could never complete. The flow session was stored,
the user logged in and approved, and every subsequent `nc_auth_check_status`
short-circuited on the old row. The new app password + new scope list were
never written; the pending session sat there until it expired.

That is exactly GH #1431: user adds `files.write`, approves it in Nextcloud,
status keeps reporting `scopes: ["files.read"]`, and WebDAV writes stay denied
with `Missing scopes: files.write`. Re-authorising the OIDC client doesn't help,
because the stale value is the MCP server's own stored grant, not the token.

## Fix

- `nc_auth_check_status` polls a pending login-flow session **before** reporting
  the stored app password. The stored grant is only reported when no flow is in
  progress.
- An expired flow now reports the still-valid previous grant (`provisioned`,
  "call `nc_auth_update_scopes` again to retry") instead of telling a
  provisioned user they have no access.

## Test coverage

Two unit regression tests in `tests/unit/test_auth_tools.py`:

- `test_check_status_polls_pending_flow_while_still_provisioned` — old password
  stored *and* a pending flow requesting `files.read + files.write`: asserts the
  flow is polled, the new scope set is stored, and the response reports it. This
  fails on `master`.
- `test_check_status_expired_flow_keeps_previous_grant` — expired update flow
  keeps reporting the previous grant.

No API surface added or changed (behaviour of an existing tool corrected), so no
new contract/e2e tier is required; the existing login-flow integration tests
cover the flow end-to-end.

Deck: board 12, card #1197.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGQ9DYUn2tfpv4YDtr59Bx
