### PR TITLE
feat(mcp): migrate to python-sdk v2 (protocol 2026-07-28)

### DIFF
--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -134,7 +134,7 @@ the review is purely negative.
 | Label | Meaning | Examples |
 |---|---|---|
 | 🔴 **blocking** | Must fix before push. Real bug, security issue, or violates an ADR/CLAUDE.md mandate. | Cache-hit bypass on auth gate; raw `List[Dict]` from MCP tool; missing `await` on async call; HMAC compare with strings instead of bytes. |
-| 🟡 **important** | Should fix. Not a bug today but a footgun that has caused review-rounds before. | Field description mismatches value; unbounded fan-out without semaphore; `int()` cast inside catch-all `except`; missing `openWorldHint=True`. |
+| 🟡 **important** | Should fix. Not a bug today but a footgun that has caused review-rounds before. | Field description mismatches value; unbounded fan-out without semaphore; `int()` cast inside catch-all `except`; missing `open_world_hint=True`. |
 | 🟢 **nit** | Polish. Not blocking, would be nice. | `Optional[X]` when surrounding file uses `X | None`; redundant regex anchors; missing test docstring; pluralization in error messages. |
 | 💡 **suggestion** | Alternative approach to consider. No fix expected. | "Could use `frozenset` here for O(1) lookup"; "Could centralise this rewrite in `_make_request`". |
 | 🎉 **praise** | Notable good pattern. Worth calling out for visibility. | Cache-hit AND cache-miss paths both enforce the gate; CI-guard test for registry exhaustiveness; explicit `*` keyword-only separator. |
@@ -184,7 +184,7 @@ PRs #733, #734, #735, #736, #737, #741, #745, #746, #747, #750.
 - **D1** — Public response models narrow, internal types may widen: if `SearchResult.id: int | str` for forward-compat, `SemanticSearchResult.id: int` and convert at the boundary with an explicit cast that fails loudly. (#750-r3)
 - **D2** — Field descriptions match the value: a field described as "unique documents" must hold a unique-document count, not a chunk count. Watch for `len(results)` assigned to a field whose docstring implies dedup. (#750-r1, #735)
 - **D3** — Symmetry between related fields: `verified_count` and `dropped_count` should count at the same granularity. (#750-r6)
-- **D4** — MCP tool annotations (ADR-017): tools that hit Nextcloud have `openWorldHint=True`. Read-only ops have `readOnlyHint=True`. Destructive ops have `destructiveHint=True` + `idempotentHint=True`. Create ops have `idempotentHint=False`. Update ops have `idempotentHint=False` (etag changes mean different inputs). (#741)
+- **D4** — MCP tool annotations (ADR-017): tools that hit Nextcloud have `open_world_hint=True`. Read-only ops have `read_only_hint=True`. Destructive ops have `destructive_hint=True` + `idempotent_hint=True`. Create ops have `idempotent_hint=False`. Update ops have `idempotent_hint=False` (etag changes mean different inputs). (#741)
 - **D5** — Keyword-only separators: use `*` in signatures with multiple optional params of the same/related types, e.g. `def __init__(self, *, password=None, token=None)` to prevent positional misuse. (#734)
 - **D6** — Defaults match documented constraints: if the docstring says "max 1000 characters", add `Field(max_length=1000)` — don't rely on the server returning 400. (#737)
 - **D7** — Create/update tools return `*Response` wrappers, not raw models: any new `@mcp.tool` returning a raw `BaseModel` (not `BaseResponse` subclass) is a finding. (#737, CLAUDE.md MCP Response Patterns)
@@ -229,7 +229,7 @@ PRs #733, #734, #735, #736, #737, #741, #745, #746, #747, #750.
 
 ### I. MCP response patterns (CLAUDE.md)
 
-- **I1** — No raw `List[Dict]` from MCP tools: tools return Pydantic models inheriting from `BaseResponse`. FastMCP mangles raw lists into dicts with numeric string keys. **🔴 blocking when violated.**
+- **I1** — No raw `List[Dict]` from MCP tools: tools return Pydantic models inheriting from `BaseResponse`. MCPServer mangles raw lists into dicts with numeric string keys. **🔴 blocking when violated.**
 - **I2** — Co-author trailer in commits: each AI-assisted commit ends with `Co-Authored-By: Claude ...`. Missing trailer on AI-touched commits is a 🟢 note.
 
 ### J. Security & input validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Use the authenticated **SonarQube CLI** (`sonar`, on `PATH` via
 
 ### Error Handling
 - **Use custom decorators**: `@retry_on_429` for rate limiting (see base_client.py)
-- **Standard exceptions**: `HTTPStatusError` from httpx, `McpError` for MCP-specific errors
+- **Standard exceptions**: `HTTPStatusError` from httpx, `MCPError` for MCP-specific errors
 - **Logging patterns**:
   - `logger.debug()` for expected 404s and normal operations
   - `logger.warning()` for retries and non-critical issues
@@ -109,7 +109,7 @@ Use the authenticated **SonarQube CLI** (`sonar`, on `PATH` via
 - **Pydantic responses**: All MCP tools return Pydantic models inheriting from `BaseResponse`
 - **Decorators**: `@require_scopes`, `@require_provisioning` for access control
 - **Context pattern**: `await get_client(ctx)` to access authenticated NextcloudClient (async!)
-- **FastMCP decorators**: `@mcp.tool()`, `@mcp.resource()`
+- **MCPServer decorators**: `@mcp.tool()`, `@mcp.resource()`
 - **Token acquisition**: `get_client()` resolves credentials per deployment mode (see Deployment Modes below)
 
 ### Version-dependent API surface: gate, don't try/except
@@ -125,7 +125,7 @@ from nextcloud_mcp_server.capabilities import require_capability
 async def deck_assign_dependent_card(ctx: Context, ...) -> DeckCardResponse: ...
 ```
 
-`NextcloudFastMCP` then hides the tool from `tools/list` and refuses
+`NextcloudMCPServer` then hides the tool from `tools/list` and refuses
 `tools/call` with the reason, per user, from the OCS capabilities the instance
 advertises (`capabilities.<app>.version`). Notes/Tables/Deck/Cookbook/Talk are
 additionally gated on the app being installed at all, via `APP_CAPABILITY_KEY`
@@ -153,8 +153,8 @@ from mcp.types import ToolAnnotations
 @mcp.tool(
     title="Human Readable Name",
     annotations=ToolAnnotations(
-        readOnlyHint=True,
-        openWorldHint=True,  # Nextcloud is external to MCP server
+        read_only_hint=True,
+        open_world_hint=True,  # Nextcloud is external to MCP server
     ),
 )
 
@@ -162,8 +162,8 @@ from mcp.types import ToolAnnotations
 @mcp.tool(
     title="Create Resource",
     annotations=ToolAnnotations(
-        idempotentHint=False,  # Creates new resources each time
-        openWorldHint=True,
+        idempotent_hint=False,  # Creates new resources each time
+        open_world_hint=True,
     ),
 )
 
@@ -171,8 +171,8 @@ from mcp.types import ToolAnnotations
 @mcp.tool(
     title="Update Resource",
     annotations=ToolAnnotations(
-        idempotentHint=False,  # ETag changes = different inputs
-        openWorldHint=True,
+        idempotent_hint=False,  # ETag changes = different inputs
+        open_world_hint=True,
     ),
 )
 
@@ -180,9 +180,9 @@ from mcp.types import ToolAnnotations
 @mcp.tool(
     title="Delete Resource",
     annotations=ToolAnnotations(
-        destructiveHint=True,   # Permanently deletes data
-        idempotentHint=True,    # Same end state if called repeatedly
-        openWorldHint=True,
+        destructive_hint=True,   # Permanently deletes data
+        idempotent_hint=True,    # Same end state if called repeatedly
+        open_world_hint=True,
     ),
 )
 
@@ -190,8 +190,8 @@ from mcp.types import ToolAnnotations
 @mcp.tool(
     title="Write File",
     annotations=ToolAnnotations(
-        idempotentHint=True,  # Same content = same end state
-        openWorldHint=True,
+        idempotent_hint=True,  # Same content = same end state
+        open_world_hint=True,
     ),
 )
 ```
@@ -199,7 +199,7 @@ from mcp.types import ToolAnnotations
 **Key Principles**:
 - **Idempotency**: Same inputs → same result. ETags change after updates, making them non-idempotent
 - **Destructive**: Operations that permanently delete/overwrite data
-- **Open World**: All Nextcloud tools access external service (openWorldHint=True)
+- **Open World**: All Nextcloud tools access external service (open_world_hint=True)
 - **Titles**: Use human-readable names, not snake_case function names
 
 **See**: `docs/ADR-017-mcp-tool-annotations.md` for detailed rationale and examples
@@ -407,7 +407,7 @@ Use `scripts/sqlitequery.py` for all SQLite queries:
 - `docs/ADR-004-progressive-consent.md` - Progressive consent implementation
 
 **Core Components**:
-- `nextcloud_mcp_server/app.py` - FastMCP server entry point
+- `nextcloud_mcp_server/app.py` - MCPServer entry point
 - `nextcloud_mcp_server/client/` - HTTP clients (Notes, Calendar, Contacts, Tables, WebDAV)
 - `nextcloud_mcp_server/server/` - MCP tool/resource definitions
 - `nextcloud_mcp_server/auth/` - OAuth/OIDC authentication
@@ -486,7 +486,7 @@ window (keep it, log on use, remove a version later), not a merge-order note.
 
 **Every MCP tool MUST return a Pydantic model that inherits from `BaseResponse`
 (`nextcloud_mcp_server/models/base.py`) — never a raw `dict`, `list`, or
-`List[Dict]`.** Raw `list`/`List[Dict]` returns are mangled by FastMCP into dicts
+`List[Dict]`.** Raw `list`/`List[Dict]` returns are mangled by MCPServer into dicts
 with numeric string keys; raw `dict` returns silently bypass the typed schema and
 the `success`/`timestamp` envelope every other tool provides, so clients can't rely
 on a consistent contract. This applies to **all** tools — list/search *and*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,40 @@ Use the authenticated **SonarQube CLI** (`sonar`, on `PATH` via
 - **MCPServer decorators**: `@mcp.tool()`, `@mcp.resource()`
 - **Token acquisition**: `get_client()` resolves credentials per deployment mode (see Deployment Modes below)
 
+#### Getting a `Context` where the SDK does not inject one
+
+**Declare `ctx: Context` as a parameter.** That is the only supported route in
+mcp 2.x, and it works for `@mcp.tool()` handlers and *template* resources
+(`@mcp.resource("nc://Notes/{note_id}")`).
+
+It does **not** work for two places, and both fail *silently* rather than
+raising, so reaching for the wrong thing here is expensive:
+
+- a **static** `@mcp.resource("nc://capabilities")` — the SDK refuses to
+  register one whose function declares a `Context` parameter;
+- `MCPServer.list_tools()`, which capability gating overrides and which takes no
+  context.
+
+For those, and only those, use
+`nextcloud_mcp_server.request_context.current_context(mcp)`. It reads a
+contextvar that `NextcloudMCPServer` publishes from a middleware for the
+duration of every inbound message.
+
+```python
+from nextcloud_mcp_server.request_context import current_context
+
+@mcp.resource("nc://capabilities")          # static: no ctx parameter allowed
+async def nc_get_capabilities():
+    client = await get_client(current_context(mcp))
+    return await client.capabilities()
+```
+
+`mcp.get_context()` and `mcp.server.lowlevel.server.request_ctx` were both
+**removed in mcp 2.x** — don't reach for either. `current_context()` raises
+`LookupError` outside a request served through the middleware (a direct
+`mcp.call_tool()` in a unit test), which is why the capability-gating callers
+fail open.
+
 ### Version-dependent API surface: gate, don't try/except
 
 When a tool wraps an endpoint that **does not exist on every supported version**

--- a/docs/ADR-017-mcp-tool-annotations.md
+++ b/docs/ADR-017-mcp-tool-annotations.md
@@ -33,10 +33,10 @@ from mcp.types import ToolAnnotations
 
 ToolAnnotations(
     title="Alternative Title",  # Decorator title takes precedence
-    readOnlyHint=True,         # Tool doesn't modify data
-    destructiveHint=True,       # Tool may delete/overwrite data
-    idempotentHint=True,        # Repeated calls with same args are safe
-    openWorldHint=True          # Interacts with external entities
+    read_only_hint=True,         # Tool doesn't modify data
+    destructive_hint=True,       # Tool may delete/overwrite data
+    idempotent_hint=True,        # Repeated calls with same args are safe
+    open_world_hint=True          # Interacts with external entities
 )
 ```
 
@@ -100,8 +100,8 @@ Add annotations based on corrected categorization:
 @mcp.tool(
     title="Search Notes",
     annotations=ToolAnnotations(
-        readOnlyHint=True,
-        openWorldHint=True  # Nextcloud is external to MCP server
+        read_only_hint=True,
+        open_world_hint=True  # Nextcloud is external to MCP server
     )
 )
 
@@ -109,9 +109,9 @@ Add annotations based on corrected categorization:
 @mcp.tool(
     title="Delete Note",
     annotations=ToolAnnotations(
-        destructiveHint=True,
-        idempotentHint=True,  # Deleting deleted item = same end state
-        openWorldHint=True
+        destructive_hint=True,
+        idempotent_hint=True,  # Deleting deleted item = same end state
+        open_world_hint=True
     )
 )
 
@@ -119,8 +119,8 @@ Add annotations based on corrected categorization:
 @mcp.tool(
     title="Create Note",
     annotations=ToolAnnotations(
-        idempotentHint=False,
-        openWorldHint=True
+        idempotent_hint=False,
+        open_world_hint=True
     )
 )
 
@@ -128,8 +128,8 @@ Add annotations based on corrected categorization:
 @mcp.tool(
     title="Update Note",
     annotations=ToolAnnotations(
-        idempotentHint=False,  # Etag required = different inputs each time
-        openWorldHint=True
+        idempotent_hint=False,  # Etag required = different inputs each time
+        open_world_hint=True
     )
 )
 
@@ -137,8 +137,8 @@ Add annotations based on corrected categorization:
 @mcp.tool(
     title="Append to Note",
     annotations=ToolAnnotations(
-        idempotentHint=False,
-        openWorldHint=True
+        idempotent_hint=False,
+        open_world_hint=True
     )
 )
 ```
@@ -152,7 +152,7 @@ Add Field() descriptions to parameters:
 ```python
 from pydantic import Field
 
-@mcp.tool(title="Create Note", annotations=ToolAnnotations(idempotentHint=False))
+@mcp.tool(title="Create Note", annotations=ToolAnnotations(idempotent_hint=False))
 async def nc_notes_create_note(
     title: str = Field(description="The title of the note"),
     content: str = Field(description="Markdown content of the note"),
@@ -168,7 +168,7 @@ async def nc_notes_create_note(
 
 ### Read-Only Tools (~40 tools)
 **Pattern**: List, search, get operations
-**Annotations**: `readOnlyHint=True`, `openWorldHint=True`
+**Annotations**: `read_only_hint=True`, `open_world_hint=True`
 
 Examples:
 - `nc_notes_search_notes` → "Search Notes"
@@ -180,7 +180,7 @@ Examples:
 
 ### Create Tools (~20 tools)
 **Pattern**: Create new resources
-**Annotations**: `idempotentHint=False`, `openWorldHint=True`
+**Annotations**: `idempotent_hint=False`, `open_world_hint=True`
 
 Examples:
 - `nc_notes_create_note` → "Create Note"
@@ -191,7 +191,7 @@ Examples:
 
 ### Update Tools (~25 tools)
 **Pattern**: Modify existing resources with etag
-**Annotations**: `idempotentHint=False` (etag changes), `openWorldHint=True`
+**Annotations**: `idempotent_hint=False` (etag changes), `open_world_hint=True`
 
 Examples:
 - `nc_notes_update_note` → "Update Note"
@@ -203,7 +203,7 @@ Examples:
 
 ### Append/Accumulate Tools (~5 tools)
 **Pattern**: Add content without replacing
-**Annotations**: `idempotentHint=False`, `openWorldHint=True`
+**Annotations**: `idempotent_hint=False`, `open_world_hint=True`
 
 Examples:
 - `nc_notes_append_content` → "Append to Note"
@@ -212,7 +212,7 @@ Examples:
 
 ### Delete Tools (~10 tools)
 **Pattern**: Remove resources
-**Annotations**: `destructiveHint=True`, `idempotentHint=True`, `openWorldHint=True`
+**Annotations**: `destructive_hint=True`, `idempotent_hint=True`, `open_world_hint=True`
 
 Examples:
 - `nc_notes_delete_note` → "Delete Note"
@@ -230,9 +230,9 @@ Examples:
 @mcp.tool(
     title="Grant Server Access to Nextcloud",
     annotations=ToolAnnotations(
-        readOnlyHint=False,
-        idempotentHint=False,  # Creates new OAuth session each time
-        openWorldHint=True
+        read_only_hint=False,
+        idempotent_hint=False,  # Creates new OAuth session each time
+        open_world_hint=True
     )
 )
 async def provision_nextcloud_access(ctx: Context):
@@ -243,8 +243,8 @@ async def provision_nextcloud_access(ctx: Context):
 @mcp.tool(
     title="Semantic Search",
     annotations=ToolAnnotations(
-        readOnlyHint=True,
-        openWorldHint=False  # Searches only indexed Nextcloud data
+        read_only_hint=True,
+        open_world_hint=False  # Searches only indexed Nextcloud data
     )
 )
 async def nc_semantic_search(query: str, ctx: Context):
@@ -310,7 +310,7 @@ Less frequently used:
 
 ### For MCP Clients
 - **Caching**: Cache results from read-only tools
-- **Safety prompts**: Warn before destructiveHint=true
+- **Safety prompts**: Warn before destructive_hint=true
 - **Retry logic**: Safely retry idempotent operations
 - **UI organization**: Group by behavior (reads vs writes vs deletes)
 - **Performance**: Optimize based on hints
@@ -355,9 +355,9 @@ from pydantic import Field
 @mcp.tool(
     title="Delete Note",
     annotations=ToolAnnotations(
-        destructiveHint=True,   # Deletes data permanently
-        idempotentHint=True,    # Same end state (note doesn't exist)
-        openWorldHint=True      # Nextcloud is external
+        destructive_hint=True,   # Deletes data permanently
+        idempotent_hint=True,    # Same end state (note doesn't exist)
+        open_world_hint=True      # Nextcloud is external
     )
 )
 @require_scopes("notes:write")
@@ -377,8 +377,8 @@ async def nc_notes_delete_note(
 @mcp.tool(
     title="Update Note",
     annotations=ToolAnnotations(
-        idempotentHint=False,   # NOT idempotent: etag changes each update
-        openWorldHint=True
+        idempotent_hint=False,   # NOT idempotent: etag changes each update
+        open_world_hint=True
     )
 )
 @require_scopes("notes:write")
@@ -418,8 +418,8 @@ async def nc_notes_update_note(
 @mcp.tool(
     title="Search Notes",
     annotations=ToolAnnotations(
-        readOnlyHint=True,    # Doesn't modify data
-        openWorldHint=True    # Queries Nextcloud
+        read_only_hint=True,    # Doesn't modify data
+        open_world_hint=True    # Queries Nextcloud
     )
 )
 @require_scopes("notes:read")
@@ -450,18 +450,18 @@ def test_notes_tools_have_annotations():
     # Check create tool
     create_tool = tools["nc_notes_create_note"]
     assert create_tool.title == "Create Note"
-    assert create_tool.annotations.idempotentHint is False
+    assert create_tool.annotations.idempotent_hint is False
 
     # Check delete tool
     delete_tool = tools["nc_notes_delete_note"]
     assert delete_tool.title == "Delete Note"
-    assert delete_tool.annotations.destructiveHint is True
-    assert delete_tool.annotations.idempotentHint is True
+    assert delete_tool.annotations.destructive_hint is True
+    assert delete_tool.annotations.idempotent_hint is True
 
     # Check read-only tool
     search_tool = tools["nc_notes_search_notes"]
     assert search_tool.title == "Search Notes"
-    assert search_tool.annotations.readOnlyHint is True
+    assert search_tool.annotations.read_only_hint is True
 ```
 
 ### Integration Tests
@@ -476,14 +476,14 @@ def test_notes_tools_have_annotations():
 ## Resolved Questions
 
 1. **WebDAV write_file idempotency** (Resolved: 2025-12-11)
-   - **Decision**: Mark as `idempotentHint=True`
+   - **Decision**: Mark as `idempotent_hint=True`
    - **Rationale**: Uses HTTP PUT without version control. Writing same content to same path repeatedly produces identical end state, which is the definition of idempotency in HTTP semantics.
 
-2. **Semantic search openWorldHint** (Resolved: 2025-12-11)
-   - **Decision**: Mark as `openWorldHint=True`
+2. **Semantic search open_world_hint** (Resolved: 2025-12-11)
+   - **Decision**: Mark as `open_world_hint=True`
    - **Rationale**: For consistency with other Nextcloud tools. While the data being searched is "indexed/internal", Nextcloud itself is external to the MCP server. The fact that data is indexed is an implementation detail, not a fundamental difference from other Nextcloud queries.
 
-3. **Read-only with side effects**: Should tools that log analytics still be readOnlyHint=true?
+3. **Read-only with side effects**: Should tools that log analytics still be read_only_hint=true?
    - **Decision**: Yes. Logging/analytics are non-visible side effects that don't change user-observable state. Read-only refers to data modifications that affect the user's content.
 
 ## Future Considerations
@@ -495,7 +495,7 @@ def test_notes_tools_have_annotations():
 
 - MCP Python SDK: `/home/chris/Software/python-sdk/`
 - ToolAnnotations spec: `src/mcp/types.py:1247`
-- FastMCP decorator: `src/mcp/server/fastmcp/server.py:444`
+- MCPServer decorator: `src/mcp/server/fastmcp/server.py:444`
 - Examples: `examples/fastmcp/parameter_descriptions.py`, `examples/fastmcp/icons_demo.py`
 
 ## Decision Timeline

--- a/docs/MCP-1.23-DNS-REBINDING-FIX.md
+++ b/docs/MCP-1.23-DNS-REBINDING-FIX.md
@@ -99,3 +99,16 @@ transport_security=TransportSecuritySettings(
 - Commit: `d3a1841` - "Auto-enable DNS rebinding protection for localhost servers"
 - Issue #373 (original report of k8s breakage)
 - PR #382 (MCP 1.23.x upgrade)
+
+## Update: mcp 2.x
+
+The mechanism is unchanged — the auto-enablement condition still fires on
+`host in ("127.0.0.1", "localhost", "::1")` with no explicit
+`transport_security` — but the parameter **moved off the `MCPServer`
+constructor onto the app factory**. `app.py` now passes it to
+`mcp.streamable_http_app(transport_security=...)`; passing it in the
+constructor raises `TypeError`.
+
+`streamable_http_app()` still defaults to `host="127.0.0.1"`, so a mounted app
+that omits `transport_security` has the protection **on** — the same k8s/Docker
+breakage this document describes. Keep passing it explicitly.

--- a/docs/testing-client-sessions-architecture.md
+++ b/docs/testing-client-sessions-architecture.md
@@ -31,7 +31,7 @@ async def create_mcp_client_session(
     """Uses native async context managers for clean LIFO cleanup."""
     headers = {"Authorization": f"Bearer {token}"} if token else None
 
-    async with streamablehttp_client(url, headers=headers) as (read_stream, write_stream, _):
+    async with streamable_http_client(url, headers=headers) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
             yield session
@@ -88,7 +88,7 @@ async def nc_mcp_client() -> AsyncGenerator[ClientSession, Any]:
 
     async def create_and_hold_session():
         """Runs in isolated task - creates session and keeps it alive."""
-        async with streamablehttp_client("http://localhost:8000/mcp") as (read_stream, write_stream, _):
+        async with streamable_http_client("http://localhost:8000/mcp") as (read_stream, write_stream, _):
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
                 session_holder["session"] = session
@@ -141,7 +141,7 @@ async def nc_mcp_client() -> AsyncGenerator[ClientSession, Any]:
 @pytest.fixture(scope="function")  # Changed from session
 async def nc_mcp_client() -> AsyncGenerator[ClientSession, Any]:
     """Function-scoped fixture with natural LIFO cleanup."""
-    async with streamablehttp_client("http://localhost:8000/mcp") as (read_stream, write_stream, _):
+    async with streamable_http_client("http://localhost:8000/mcp") as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
             yield session
@@ -150,11 +150,11 @@ async def nc_mcp_client() -> AsyncGenerator[ClientSession, Any]:
 @pytest.fixture(scope="function")
 async def multi_mcp_clients() -> AsyncGenerator[tuple[ClientSession, ClientSession], Any]:
     """Multiple clients with guaranteed LIFO cleanup through nesting."""
-    async with streamablehttp_client("http://localhost:8000/mcp") as (read1, write1, _):
+    async with streamable_http_client("http://localhost:8000/mcp") as (read1, write1, _):
         async with ClientSession(read1, write1) as session1:
             await session1.initialize()
 
-            async with streamablehttp_client("http://localhost:8001/mcp") as (read2, write2, _):
+            async with streamable_http_client("http://localhost:8001/mcp") as (read2, write2, _):
                 async with ClientSession(read2, write2) as session2:
                     await session2.initialize()
                     yield session1, session2
@@ -195,7 +195,7 @@ async def multi_mcp_clients() -> AsyncGenerator[tuple[ClientSession, ClientSessi
 # Fixtures work naturally with trio
 @pytest.fixture(scope="session")
 async def nc_mcp_client() -> AsyncGenerator[ClientSession, Any]:
-    async with streamablehttp_client("http://localhost:8000/mcp") as (read, write, _):
+    async with streamable_http_client("http://localhost:8000/mcp") as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
             yield session

--- a/nextcloud_mcp_server/api/visualization.py
+++ b/nextcloud_mcp_server/api/visualization.py
@@ -315,7 +315,7 @@ async def _search_with_acl(
             )
             # Verify-on-read (ADR-019): drop documents the caller can no longer
             # access (e.g. a revoked share). Eviction runs inline — this
-            # Starlette route has no FastMCP lifespan task group.
+            # Starlette route has no MCPServer lifespan task group.
             verify_start = anyio.current_time()
             results, dropped = await verify_search_results(nc_client, results)
             record_search_stage("http", "verify", anyio.current_time() - verify_start)

--- a/nextcloud_mcp_server/app.py
+++ b/nextcloud_mcp_server/app.py
@@ -18,7 +18,7 @@ import httpx
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.server.auth.settings import AuthSettings
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from pydantic import AnyHttpUrl
@@ -96,7 +96,7 @@ from nextcloud_mcp_server.config_validators import (
     validate_configuration,
 )
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
-from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.errors import NextcloudMCPServer
 from nextcloud_mcp_server.http import nextcloud_httpx_client
 from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 from nextcloud_mcp_server.observability import (
@@ -111,6 +111,7 @@ from nextcloud_mcp_server.observability.metrics import (
     set_dependency_health,
 )
 from nextcloud_mcp_server.observability.readiness import ReadinessCache
+from nextcloud_mcp_server.request_context import current_context
 from nextcloud_mcp_server.retry import retry_on_transient
 from nextcloud_mcp_server.server import (
     AVAILABLE_APPS,
@@ -373,7 +374,7 @@ class VectorSyncState:
     Module-level state for vector sync background tasks.
 
     This singleton bridges the Starlette server lifespan (where background tasks run)
-    and FastMCP session lifespans (where MCP tools need access to the streams).
+    and MCPServer session lifespans (where MCP tools need access to the streams).
     """
 
     document_send_stream: MemoryObjectSendStream | None = None
@@ -428,7 +429,7 @@ def _wire_vector_sync_state(
 
     Both lifespan paths (single-user and multi-user) previously duplicated these
     writes three times each: ``app.state``, the module singleton
-    ``_vector_sync_state`` (read by FastMCP session lifespans), and the mounted
+    ``_vector_sync_state`` (read by MCPServer session lifespans), and the mounted
     ``/app`` browser sub-app. ``document_send_stream``/``document_receive_stream``
     come from the transport — ``None`` in postgres mode (no in-process stream) —
     and ``task_producer`` is the transport's producer in both modes (Deck #183,
@@ -748,7 +749,7 @@ class AppContext:
     def eviction_task_group(self) -> TaskGroup | None:
         # Read dynamically from the module-level singleton instead of
         # snapshotting at lifespan-yield time. Snapshotting is order-sensitive:
-        # if the FastMCP server lifespan ever runs before the Starlette
+        # if the MCPServer server lifespan ever runs before the Starlette
         # lifespan assigns the task group, every session for the life of the
         # process would see ``None`` and fall back to inline eviction.
         return _vector_sync_state.eviction_task_group
@@ -931,9 +932,9 @@ async def load_oauth_client_credentials(
 
 
 @asynccontextmanager
-async def app_lifespan_basic(server: FastMCP) -> AsyncIterator[AppContext]:
+async def app_lifespan_basic(server: MCPServer) -> AsyncIterator[AppContext]:
     """
-    Manage application lifecycle for BasicAuth mode (FastMCP session lifespan).
+    Manage application lifecycle for BasicAuth mode (MCPServer session lifespan).
 
     For single-user mode: Creates a single Nextcloud client with basic authentication
     that is shared across all requests within a session.
@@ -941,7 +942,9 @@ async def app_lifespan_basic(server: FastMCP) -> AsyncIterator[AppContext]:
     For multi-user mode: No shared client - clients created per-request by BasicAuthMiddleware.
 
     Note: Background tasks (scanner, processor) are started at server level
-    in starlette_lifespan, not here. This lifespan runs per-session.
+    in starlette_lifespan, not here. mcp 2.x enters this lifespan once, when the
+    Streamable HTTP session manager starts, and shares the result across every
+    session and request (1.x entered it per session).
     """
     settings = get_settings()
     is_multi_user = settings.enable_multi_user_basic_auth
@@ -1079,7 +1082,7 @@ async def setup_oauth_config():
     - NEXTCLOUD_OIDC_CLIENT_ID / NEXTCLOUD_OIDC_CLIENT_SECRET: Static credentials (optional, uses DCR if not provided)
     - NEXTCLOUD_OIDC_SCOPES: Requested OAuth scopes
 
-    This is done synchronously before FastMCP initialization because FastMCP
+    This is done synchronously before MCPServer initialization because MCPServer
     requires token_verifier at construction time.
 
     Returns:
@@ -1472,6 +1475,31 @@ def _csv_setting(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
+#: Room for the JSON-RPC envelope around a maximum-size `nc_webdav_write_file`
+#: argument: method, id, path, content_type, and the quoting of the base64 blob.
+_REQUEST_ENVELOPE_SLACK = 1024 * 1024
+
+
+def _max_request_body_size() -> int:
+    """The Streamable HTTP POST body limit, derived from ``WEBDAV_WRITE_MAX_MB``.
+
+    mcp 2.x caps POST bodies at 4 MiB and answers 413 *before* parsing the JSON,
+    so the default would reject a `nc_webdav_write_file` call well below the
+    ``WEBDAV_WRITE_MAX_MB`` (50 MB) this server advertises -- with a transport
+    error instead of that tool's explanatory ``ToolError``. Sizing the transport
+    limit off the same setting keeps the one number operators tune in charge,
+    and keeps the size refusal where it can explain itself.
+
+    base64 inflates by 4/3, and the tool decodes the argument rather than
+    streaming it, so the wire form is what has to fit.
+    """
+    max_mb = get_settings().webdav_write_max_mb or 0.0
+    return max(
+        4 * 1024 * 1024,  # never below the SDK default
+        int(max_mb * 1024 * 1024 * 4 / 3) + _REQUEST_ENVELOPE_SLACK,
+    )
+
+
 def _build_transport_security() -> TransportSecuritySettings:
     """Assemble TransportSecuritySettings from configuration.
 
@@ -1728,7 +1756,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
         # Create lifespan function with captured OAuth context (closure)
         @asynccontextmanager
-        async def oauth_lifespan(server: FastMCP) -> AsyncIterator[OAuthAppContext]:
+        async def oauth_lifespan(server: MCPServer) -> AsyncIterator[OAuthAppContext]:
             """
             Lifespan context for OAuth mode - captures OAuth configuration from outer scope.
             """
@@ -1760,7 +1788,9 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             finally:
                 logger.info("Shutting down MCP server")
                 # NOTE: refresh_token_storage is deliberately NOT closed here.
-                # This lifespan is per MCP *session*, but the storage was built
+                # mcp 2.x enters this lifespan once, at session-manager startup,
+                # rather than per MCP session -- but the reasoning below is what
+                # keeps that safe either way, so it stays: the storage was built
                 # once at startup (setup_oauth_config) and is handed to the
                 # process-lifetime background tasks — user_manager_task and
                 # credential_cleanup_task both hold this very object
@@ -1783,26 +1813,24 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                         logger.warning("Error closing OAuth client: %s", e)
                 logger.info("MCP server shutdown complete")
 
-        mcp = NextcloudFastMCP(
+        mcp = NextcloudMCPServer(
             "Nextcloud MCP",
             lifespan=oauth_lifespan,
             token_verifier=token_verifier,
             auth=auth_settings,
-            transport_security=_build_transport_security(),
         )
     else:
         # BasicAuth modes (single-user or multi-user)
         logger.info("Configuring MCP server for %s mode", mode.value)
-        mcp = NextcloudFastMCP(
+        mcp = NextcloudMCPServer(
             "Nextcloud MCP",
             lifespan=app_lifespan_basic,
-            transport_security=_build_transport_security(),
         )
 
     @mcp.resource("nc://capabilities")
     async def nc_get_capabilities():
         """Get the Nextcloud Host capabilities"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_nextcloud_client(ctx)
         return await client.capabilities()
 
@@ -1899,12 +1927,19 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
     # Client-fleet observability: records the calling client's identity,
     # capabilities and negotiated protocol version, plus whether the SDK
-    # delivered each tool call as CallToolResult(isError=True) or as a JSON-RPC
+    # delivered each tool call as CallToolResult(is_error=True) or as a JSON-RPC
     # error. Deliberately outside the `if oauth_enabled` block above — unlike
     # the tool filter, this must work in every deployment mode.
     instrument_call_tool_outcomes(mcp)
 
-    mcp_app = mcp.streamable_http_app()
+    # mcp 2.x moved transport configuration off the MCPServer constructor onto
+    # the app factory. Passing transport_security explicitly also suppresses the
+    # SDK's host="127.0.0.1" auto-enable, which would break k8s/Docker service
+    # DNS names (docs/MCP-1.23-DNS-REBINDING-FIX.md).
+    mcp_app = mcp.streamable_http_app(
+        transport_security=_build_transport_security(),
+        max_request_body_size=_max_request_body_size(),
+    )
 
     async def _login_flow_cleanup_loop() -> None:
         """Periodically clean up expired Login Flow v2 sessions and proxy codes."""
@@ -2198,7 +2233,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             # get_app(transport=...) HTTP-transport parameter.
             ingest_transport = await build_transport(settings)
 
-            # Publish to app.state (ADR-007), the module singleton (FastMCP
+            # Publish to app.state (ADR-007), the module singleton (MCPServer
             # session lifespans), and the /app browser sub-app in one place.
             _wire_vector_sync_state(
                 app, ingest_transport, shutdown_event, scanner_wake_event
@@ -2413,7 +2448,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
                 # get_app(transport=...) HTTP-transport parameter.
                 ingest_transport = await build_transport(settings)
 
-                # Publish to app.state (ADR-007), the module singleton (FastMCP
+                # Publish to app.state (ADR-007), the module singleton (MCPServer
                 # session lifespans), and the /app browser sub-app in one place.
                 _wire_vector_sync_state(
                     app, ingest_transport, shutdown_event, scanner_wake_event
@@ -2936,7 +2971,7 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
 
     # Add user info routes (available in both BasicAuth and OAuth modes)
     # Create a separate Starlette app for browser routes that need session auth
-    # This prevents SessionAuthBackend from interfering with FastMCP's OAuth
+    # This prevents SessionAuthBackend from interfering with MCPServer's OAuth
     browser_routes = [
         Route("/", user_info_html, methods=["GET"]),  # /app → user info with all tabs
         Route(
@@ -2997,12 +3032,12 @@ def get_app(transport: str = "streamable-http", enabled_apps: list[str] | None =
             )
         )
 
-    # Mount FastMCP at root last (catch-all, handles OAuth via token_verifier)
+    # Mount MCPServer at root last (catch-all, handles OAuth via token_verifier)
     routes.append(Mount("/", app=mcp_app))
 
     app = Starlette(routes=routes, lifespan=starlette_lifespan)
     logger.info(
-        "Routes: /user/* with SessionAuth, /mcp with FastMCP OAuth Bearer tokens"
+        "Routes: /user/* with SessionAuth, /mcp with MCPServer OAuth Bearer tokens"
     )
 
     # Store supported scopes on app.state for AS metadata endpoint (ADR-023)

--- a/nextcloud_mcp_server/auth/context_helper.py
+++ b/nextcloud_mcp_server/auth/context_helper.py
@@ -6,7 +6,7 @@ ADR-005 compliant implementation for multi-audience token mode.
 import logging
 
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from ..client import NextcloudClient
 

--- a/nextcloud_mcp_server/auth/elicitation.py
+++ b/nextcloud_mcp_server/auth/elicitation.py
@@ -7,7 +7,8 @@ when the client supports it, or falling back to returning the URL in a message.
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
+from mcp.shared.exceptions import NoBackChannelError
 from pydantic import BaseModel, Field
 
 from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base
@@ -77,11 +78,11 @@ async def _run_elicit(
     ``mcp_elicitation_total`` metric.
 
     Every fallback here is deliberately silent to the caller — the point is to
-    degrade rather than fail — which is exactly why each one is counted. When
-    the MCP SDK moves to protocol 2026-07-28 the back-channel disappears and
-    elicitation starts landing in the generic ``reason="error"`` branch (or a
-    dedicated ``"no_back_channel"`` one, once that exception exists to catch);
-    without these counters that transition is invisible.
+    degrade rather than fail — which is exactly why each one is counted. On
+    protocol 2026-07-28 there is no back-channel and no server-initiated
+    request, so ``ctx.elicit()`` cannot run at all; that lands in
+    ``reason="no_back_channel"``. Watching that counter rise against
+    ``"accepted"`` is how the era transition becomes visible.
     """
     if not hasattr(ctx, "elicit"):
         logger.debug(
@@ -93,6 +94,17 @@ async def _run_elicit(
 
     try:
         result = await ctx.elicit(message=message, schema=schema)
+    except NoBackChannelError:
+        # 2026-07-28 has no server-initiated requests, so ctx.elicit() cannot
+        # reach the client at all (also true of a legacy session against a
+        # stateless_http / json_response server). The login URL still travels in
+        # the returned message, which is the whole point of this fallback.
+        logger.debug(
+            "No back-channel on this connection — message_only fallback (%s)",
+            prompt,
+        )
+        record_elicitation(prompt, "message_only", "no_back_channel")
+        return "message_only", None
     except NotImplementedError:
         logger.debug(
             "Elicitation not supported by client — message_only fallback (%s)",

--- a/nextcloud_mcp_server/auth/provisioning_decorator.py
+++ b/nextcloud_mcp_server/auth/provisioning_decorator.py
@@ -10,9 +10,8 @@ import logging
 from typing import Callable
 
 from mcp.server.auth.middleware.auth_context import get_access_token
-from mcp.server.fastmcp import Context
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData
+from mcp.server.mcpserver import Context
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.auth.storage import get_shared_storage
 
@@ -49,11 +48,9 @@ def require_provisioning(func: Callable) -> Callable:
             ctx = kwargs.get("ctx")
 
         if not ctx:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message="Context not found - cannot verify provisioning",
-                )
+            raise MCPError(
+                code=-1,
+                message="Context not found - cannot verify provisioning",
             )
 
         # Check if we're in BasicAuth mode - if so, skip provisioning check
@@ -73,11 +70,9 @@ def require_provisioning(func: Callable) -> Callable:
             logger.debug("Checking provisioning for user: %s", user_id)
 
         if not user_id:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message="Cannot determine user identity for provisioning check",
-                )
+            raise MCPError(
+                code=-1,
+                message="Cannot determine user identity for provisioning check",
             )
 
         # Check provisioning status — share the process-wide singleton
@@ -91,16 +86,14 @@ def require_provisioning(func: Callable) -> Callable:
             logger.info(
                 "User %s attempted to use Nextcloud tool without provisioning", user_id
             )
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=(
-                        "Nextcloud access not provisioned. "
-                        "Please run the 'provision_nextcloud_access' tool first to authorize "
-                        "the MCP server to access Nextcloud on your behalf. "
-                        "This is a one-time setup required for security."
-                    ),
-                )
+            raise MCPError(
+                code=-1,
+                message=(
+                    "Nextcloud access not provisioned. "
+                    "Please run the 'provision_nextcloud_access' tool first to authorize "
+                    "the MCP server to access Nextcloud on your behalf. "
+                    "This is a one-time setup required for security."
+                ),
             )
 
         logger.debug(

--- a/nextcloud_mcp_server/auth/scope_authorization.py
+++ b/nextcloud_mcp_server/auth/scope_authorization.py
@@ -7,8 +7,8 @@ from typing import Any, Callable
 
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.utilities.context_injection import find_context_parameter
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
 
 from nextcloud_mcp_server.auth.storage import get_shared_storage
 from nextcloud_mcp_server.config import get_settings
@@ -105,12 +105,12 @@ def require_scopes(*required_scopes: str):
         # Get function name for logging (works for any callable)
         func_name = getattr(func, "__name__", repr(func))
 
-        # Find which parameter receives the Context (FastMCP injects it by name)
+        # Find which parameter receives the Context (MCPServer injects it by name)
         context_param_name = find_context_parameter(func)
 
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Extract context from kwargs (where FastMCP injected it)
+            # Extract context from kwargs (where MCPServer injected it)
             ctx: Context | None = (
                 kwargs.get(context_param_name) if context_param_name else None
             )
@@ -402,7 +402,7 @@ def get_access_token_scopes(ctx: Context | None = None) -> set[str]:
     (``notes.read``) so they match tool ``@require_scopes`` decorators.
 
     Args:
-        ctx: FastMCP context object (unused, kept for compatibility)
+        ctx: MCPServer context object (unused, kept for compatibility)
 
     Returns:
         Set of scope strings, empty set if no token or no scopes
@@ -428,7 +428,7 @@ def check_scopes(ctx: Context, *required_scopes: str) -> tuple[bool, set[str]]:
     Utility function for manual scope checking without decorator.
 
     Args:
-        ctx: FastMCP context object
+        ctx: MCPServer context object
         *required_scopes: Variable number of required scope strings
 
     Returns:
@@ -559,16 +559,16 @@ def discover_all_scopes(mcp) -> list[str]:
     for available scopes based on the actual tool implementations.
 
     Args:
-        mcp: FastMCP instance with registered tools
+        mcp: MCPServer instance with registered tools
 
     Returns:
         Sorted list of unique scope strings, including base OIDC scopes
 
     Example:
         ```python
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        mcp = FastMCP("My Server")
+        mcp = MCPServer("My Server")
 
         @mcp.tool()
         @require_scopes("notes.read")
@@ -610,7 +610,7 @@ def discover_all_scopes(mcp) -> list[str]:
     try:
         tools = mcp._tool_manager.list_tools()
     except AttributeError:
-        logger.warning("FastMCP instance does not have _tool_manager attribute")
+        logger.warning("MCPServer instance does not have _tool_manager attribute")
         return sorted(all_scopes)
 
     # Extract scopes from each tool

--- a/nextcloud_mcp_server/auth/session_backend.py
+++ b/nextcloud_mcp_server/auth/session_backend.py
@@ -51,7 +51,7 @@ class SessionAuthBackend(AuthenticationBackend):
         """Authenticate the request based on session cookie or BasicAuth mode.
 
         This backend is only applied to browser routes (/user/*) via a separate
-        Starlette app mount. FastMCP routes use their own OAuth Bearer token
+        Starlette app mount. MCPServer routes use their own OAuth Bearer token
         authentication.
 
         Args:

--- a/nextcloud_mcp_server/auth/token_utils.py
+++ b/nextcloud_mcp_server/auth/token_utils.py
@@ -14,9 +14,8 @@ import jwt
 from jwt import PyJWKSet
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import Context
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData
+from mcp.server.mcpserver import Context
+from mcp.shared.exceptions import MCPError
 
 from ..http import nextcloud_httpx_client
 
@@ -256,7 +255,7 @@ async def extract_user_id_from_token(_ctx: Context) -> str:
 
     Args:
         _ctx: MCP context with access token. Intentionally unused — kept on
-            the public signature so call sites can pass the FastMCP Context
+            the public signature so call sites can pass the MCPServer Context
             they already hold without rewriting; identity is read from the
             verifier-populated AccessToken via get_access_token().
 
@@ -267,7 +266,7 @@ async def extract_user_id_from_token(_ctx: Context) -> str:
         caller's BasicAuth branch handles it).
 
     Raises:
-        McpError: An access token was present but had no ``sub`` claim
+        MCPError: An access token was present but had no ``sub`` claim
             (``access_token.resource`` empty). Failing closed prevents a
             malformed IdP token from silently bucketing every request
             under the ``"default_user"`` key in SQLite, which would risk
@@ -284,12 +283,10 @@ async def extract_user_id_from_token(_ctx: Context) -> str:
         logger.error(
             "Access token has no resource (sub) claim — verifier should have rejected it"
         )
-        raise McpError(
-            ErrorData(
-                # JSON-RPC 2.0 reserves -32000..-32099 for application errors.
-                code=-32001,
-                message="Cannot determine user identity from access token",
-            )
+        raise MCPError(
+            # JSON-RPC 2.0 reserves -32000..-32099 for application errors.
+            code=-32001,
+            message="Cannot determine user identity from access token",
         )
 
     return user_id

--- a/nextcloud_mcp_server/capabilities.py
+++ b/nextcloud_mcp_server/capabilities.py
@@ -32,11 +32,12 @@ from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from packaging.version import InvalidVersion, Version
 
 from nextcloud_mcp_server.config import cfg_bool
 from nextcloud_mcp_server.context import get_client
+from nextcloud_mcp_server.request_context import current_context
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +300,7 @@ def _tool_gate(mcp: Any, name: str) -> tuple[str, str | None, str | None] | None
 
 async def _gate_client(mcp: Any) -> tuple[_CapabilitiesClientProtocol, str]:
     """An authenticated client (+ user id) for the request being served."""
-    client = await get_client(mcp.get_context())
+    client = await get_client(current_context(mcp))
     return client, client.username
 
 

--- a/nextcloud_mcp_server/context.py
+++ b/nextcloud_mcp_server/context.py
@@ -1,10 +1,10 @@
 """Helper functions for accessing context in MCP tools."""
 
 import logging
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from httpx import BasicAuth
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from nextcloud_mcp_server.auth.context_helper import get_client_from_context
 from nextcloud_mcp_server.auth.scope_authorization import ProvisioningRequiredError
@@ -63,7 +63,7 @@ async def get_client(ctx: Context) -> NextcloudClient:
     if settings.enable_multi_user_basic_auth:
         return _get_client_from_basic_auth(ctx)
 
-    lifespan_ctx = ctx.request_context.lifespan_context
+    lifespan_ctx: Any = ctx.request_context.lifespan_context
 
     # Login Flow v2 multi-user mode: app password is REQUIRED for NC API access
     # OAuth token is only used for MCP session identity, not NC API calls

--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote
 from httpx import URL, HTTPStatusError, RequestError, Response, ResponseNotRead
 from mcp.server.context import CallNext, ServerRequestContext
 from mcp.server.mcpserver import Context, MCPServer
-from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError, UnexpectedToolError
 from mcp.shared.exceptions import MCPError
 from mcp.types import CallToolResult, InputRequiredResult
 from mcp.types import Tool as MCPTool
@@ -197,6 +197,20 @@ def friendly_tool_error(exc: BaseException | None, tool_name: str) -> str | None
     return None
 
 
+def _cause_message(exc: BaseException, tool_name: str) -> str:
+    """The message mcp 2.x withheld, or its own text if there is no cause.
+
+    Deliberately unfiltered: this restores the mcp 1.x contract that whatever a
+    tool raised reaches the model. The alternative -- the SDK's bare "Error
+    executing tool <name>" -- tells it nothing it can act on.
+    """
+    cause = exc.__cause__
+    if cause is None:
+        return str(exc)
+    text = str(cause).strip() or cause.__class__.__name__
+    return f"{tool_name} failed: {text}"
+
+
 class NextcloudMCPServer(MCPServer):
     """MCPServer that rewrites raw HTTP failures into LLM-friendly messages,
     hides tools this Nextcloud instance cannot serve, and strips the SDK's
@@ -242,11 +256,26 @@ class NextcloudMCPServer(MCPServer):
             return compact_tool_result(
                 await super().call_tool(name, arguments, context)
             )
-        except ToolError as e:
-            message = friendly_tool_error(e.__cause__, name)
-            if message is None:
-                raise
-            raise ToolError(message) from e.__cause__
+        except UnexpectedToolError as e:
+            # mcp 2.x replaces an unanticipated exception's message with a bare
+            # "Error executing tool <name>", withholding the original. 1.x
+            # shipped ``str(e)``, and a great deal of this server's behaviour
+            # rides on that: scope denials ("Missing required scopes:
+            # notes.write"), provisioning prompts, and every ``raise`` in a tool
+            # body that is not a ToolError. Withheld, the model is told the call
+            # failed and nothing about what to do next.
+            #
+            # So restore the message here rather than converting exception types
+            # one by one -- ``ScopeAuthorizationError`` and friends are raised
+            # from the auth layer and are also caught on HTTP routes, where
+            # ToolError would be the wrong type. This is the single place that
+            # sees every escaping exception.
+            raise ToolError(
+                friendly_tool_error(e.__cause__, name) or _cause_message(e, name)
+            ) from e.__cause__
+        except ToolError:
+            # Anticipated: the message is the tool author's and already good.
+            raise
         except MCPError as e:
             # mcp 2.x passes MCPError out of a tool as a top-level JSON-RPC
             # error; 1.x turned it into ``is_error=True`` content the model

--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -1,28 +1,37 @@
 """LLM-friendly rendering of tool failures (GH #1208).
 
-The MCP SDK funnels every tool exception through
-``ToolError(f"Error executing tool {name}: {e}")`` and returns that string
-verbatim as the error content, so an unhandled ``httpx`` error reaches the model
-as an internal URL plus an MDN link and no hint about what to do next. Rewriting
-that one string at the tool boundary fixes every tool at once -- see
-:class:`NextcloudFastMCP`.
+The MCP SDK funnels every unanticipated tool exception into a ``ToolError`` and
+returns its message as the error content. On mcp 1.x that message was
+``f"Error executing tool {name}: {e}"``, so an unhandled ``httpx`` error reached
+the model as an internal URL plus an MDN link and no hint about what to do next.
+mcp 2.x withholds the original entirely -- ``UnexpectedToolError`` says only
+``Error executing tool {name}`` -- which is less misleading and even less
+actionable.
+
+Either way the original is on ``__cause__``, so rewriting that one message at
+the tool boundary fixes every tool at once -- see :class:`NextcloudMCPServer`.
 """
 
 import json
 import re
-from collections.abc import Sequence
 from typing import Any
 from urllib.parse import unquote
 
 from httpx import URL, HTTPStatusError, RequestError, Response, ResponseNotRead
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ContentBlock
+from mcp.server.context import CallNext, ServerRequestContext
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.shared.exceptions import MCPError
+from mcp.types import CallToolResult, InputRequiredResult
 from mcp.types import Tool as MCPTool
 
 from nextcloud_mcp_server.capabilities import (
     enforce_capability,
     filter_by_capability,
+)
+from nextcloud_mcp_server.request_context import (
+    reset_request_context,
+    set_request_context,
 )
 from nextcloud_mcp_server.serialization import compact_tool_result
 
@@ -164,7 +173,7 @@ def friendly_tool_error(exc: BaseException | None, tool_name: str) -> str | None
     """Render ``exc`` for an LLM, or ``None`` if it is better left alone.
 
     ``None`` means "no improvement to offer" -- the caller re-raises unchanged,
-    so tools that already build a tailored ``McpError`` keep their own wording.
+    so tools that already build a tailored ``MCPError`` keep their own wording.
     """
     if isinstance(exc, HTTPStatusError):
         status = exc.response.status_code
@@ -188,28 +197,61 @@ def friendly_tool_error(exc: BaseException | None, tool_name: str) -> str | None
     return None
 
 
-class NextcloudFastMCP(FastMCP):
-    """FastMCP that rewrites raw HTTP failures into LLM-friendly messages,
+class NextcloudMCPServer(MCPServer):
+    """MCPServer that rewrites raw HTTP failures into LLM-friendly messages,
     hides tools this Nextcloud instance cannot serve, and strips the SDK's
     ``indent=2`` from tool results (GH #1395).
 
-    Subclass rather than patch: ``FastMCP._setup_handlers`` binds
+    Subclass rather than patch: ``MCPServer._setup_handlers`` binds
     ``self.call_tool``/``self.list_tools`` during ``__init__``, so a later
     reassignment is ignored.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.middleware.append(self._publish_request_context)
+
+    async def _publish_request_context(
+        self, ctx: ServerRequestContext, call_next: CallNext
+    ) -> Any:
+        """Republish ``ctx`` for the handlers mcp 2.x cannot inject it into.
+
+        ``list_tools()`` (capability gating) and static ``@mcp.resource()``
+        functions get no ``Context`` from the SDK and have no contextvar to read
+        since 2.x dropped ``request_ctx``; a middleware is where 2.x puts
+        per-message interception. See ``nextcloud_mcp_server.request_context``.
+        """
+        token = set_request_context(ctx)
+        try:
+            return await call_next(ctx)
+        finally:
+            reset_request_context(token)
 
     async def list_tools(self) -> list[MCPTool]:
         tools = await super().list_tools()
         return await filter_by_capability(self, tools)
 
     async def call_tool(
-        self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context[Any, Any] | None = None,
+    ) -> CallToolResult | InputRequiredResult:
         await enforce_capability(self, name)
         try:
-            return compact_tool_result(await super().call_tool(name, arguments))
+            return compact_tool_result(
+                await super().call_tool(name, arguments, context)
+            )
         except ToolError as e:
             message = friendly_tool_error(e.__cause__, name)
             if message is None:
                 raise
             raise ToolError(message) from e.__cause__
+        except MCPError as e:
+            # mcp 2.x passes MCPError out of a tool as a top-level JSON-RPC
+            # error; 1.x turned it into ``is_error=True`` content the model
+            # reads and reacts to. Every one of our raise sites is that second
+            # kind ("Note 5 not found", "Nextcloud access not provisioned"),
+            # which in 2.x is what ToolError means -- so map it back rather
+            # than silently change the wire contract for ~140 messages.
+            raise ToolError(e.message) from e

--- a/nextcloud_mcp_server/errors.py
+++ b/nextcloud_mcp_server/errors.py
@@ -252,6 +252,13 @@ class NextcloudMCPServer(MCPServer):
         context: Context[Any, Any] | None = None,
     ) -> CallToolResult | InputRequiredResult:
         await enforce_capability(self, name)
+        # The three clauses below are ordered by the SDK's hierarchy, and the
+        # order is load-bearing: ``UnexpectedToolError`` subclasses ``ToolError``
+        # (both under ``MCPServerError``), so the specific one must come first or
+        # every crash would take the "message is already good" path and ship the
+        # SDK's contentless text. ``MCPError`` is a separate tree entirely
+        # (``Exception`` directly), so it neither shadows nor is shadowed by the
+        # other two and its position is free.
         try:
             return compact_tool_result(
                 await super().call_tool(name, arguments, context)

--- a/nextcloud_mcp_server/links.py
+++ b/nextcloud_mcp_server/links.py
@@ -5,7 +5,7 @@ already built and fills in each linkable item's ``url`` field in place; nothing
 else about the tool changes, and it still returns the same ``BaseResponse`` model.
 
 The links live in the response body rather than in the result's ``_meta`` because
-``_meta`` is dropped by every MCP client today, whereas FastMCP serialises the
+``_meta`` is dropped by every MCP client today, whereas MCPServer serialises the
 model into both ``content`` and ``structuredContent``. See
 ``docs/ADR-035-tool-response-deep-links.md``.
 

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -21,10 +21,9 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from mcp import types
 from mcp.server.auth.middleware.auth_context import get_access_token
-from mcp.server.fastmcp import FastMCP
-from mcp.server.lowlevel.server import request_ctx
+from mcp.server.context import CallNext, ServerRequestContext
+from mcp.server.mcpserver import MCPServer
 from prometheus_client import (
     REGISTRY,
     Counter,
@@ -92,10 +91,19 @@ mcp_tool_errors_total = Counter(
 # Baseline for the mcp python-sdk 1.x -> 2.x (protocol 2026-07-28) upgrade,
 # whose two most consequential changes are silent: elicitation loses its
 # back-channel, and an MCPError raised in a tool stops becoming
-# CallToolResult(isError=True) and becomes a JSON-RPC error instead. Neither
+# CallToolResult(is_error=True) and becomes a JSON-RPC error instead. Neither
 # raises, neither shows up in existing metrics. These four record the fleet
 # composition and delivery semantics so the change is visible as a step in a
 # graph rather than a bug report.
+#
+# Post-upgrade, what each of the two now reads as:
+#   - elicitation: mcp_elicitation_total{outcome="message_only",
+#     reason="no_back_channel"} rising against reason="accepted" is 2026-era
+#     clients arriving. There is no back-channel to restore; the login URL
+#     travels in the returned message instead.
+#   - MCPError: NextcloudMCPServer.call_tool maps it back to ToolError, so
+#     mcp_tool_outcomes_total{outcome="protocol_error"} should stay at zero.
+#     A non-zero reading means something bypassed that boundary.
 
 mcp_client_sessions_total = Counter(
     "mcp_client_sessions_total",
@@ -118,7 +126,7 @@ mcp_elicitation_total = Counter(
 mcp_tool_outcomes_total = Counter(
     "mcp_tool_outcomes_total",
     "How the MCP SDK delivered each tool call: success | tool_error "
-    "(CallToolResult.isError, the model sees the message) | protocol_error "
+    "(CallToolResult.is_error, the model sees the message) | protocol_error "
     "(JSON-RPC error, the model does not). tool_name here is the tool's "
     "*registered* MCP name, while mcp_tool_calls_total uses the decorated "
     "function's __name__. Every tool function is named after the tool it "
@@ -1105,21 +1113,19 @@ def _minor_version(version: object) -> str:
     return ".".join(_client_label(version, 32).split(".")[:2])
 
 
-def record_client_session() -> None:
+def record_client_session(ctx: ServerRequestContext | None) -> None:
     """Record the calling MCP client's identity and capabilities, once per session.
 
-    Reads the SDK's per-request contextvar rather than taking a ``Context``, so
-    it works in every deployment mode (single-user, multi-user BasicAuth, Login
-    Flow v2, OAuth) and for every tool, including the auth/oauth tools that
-    carry no ``@instrument_tool``.
+    Takes the SDK's ``ServerRequestContext`` (v2 removed the ``request_ctx``
+    contextvar that v1 read instead), so it works in every deployment mode
+    (single-user, multi-user BasicAuth, Login Flow v2, OAuth) and for every
+    tool, including the auth/oauth tools that carry no ``@instrument_tool``.
 
     Never raises: instrumentation must not be able to fail a tool call.
     """
-    try:
-        ctx = request_ctx.get()
-    except LookupError:
+    if ctx is None:
         # Legitimate outside a request (startup, direct calls in tests), but this
-        # function is only wired into the CallToolRequest handler, where a missing
+        # function is only wired into the tools/call middleware, where a missing
         # request context means the wiring is wrong.
         _warn_once(
             "no_request_ctx",
@@ -1213,7 +1219,7 @@ def record_elicitation(prompt: str, outcome: str, reason: str = "none") -> None:
 
 
 # Redaction is by key *substring*, case-insensitively: the arguments reaching
-# the CallToolRequest handler are unvalidated client input (FastMCP registers it
+# the CallToolRequest handler are unvalidated client input (MCPServer registers it
 # with validate_input=False), so a caller can send "password" to a tool that
 # declares no such parameter, and a tool that does take one may call it
 # "access_token" or "clientSecret".
@@ -1229,7 +1235,7 @@ _SENSITIVE_ARG_SUBSTRINGS = (
 )
 
 # Arguments that say nothing about how the tool is being used: the injected
-# FastMCP Context and the concurrency etag every update tool carries.
+# MCPServer Context and the concurrency etag every update tool carries.
 _UNINTERESTING_ARGS = ("ctx", "etag")
 
 # Per value first, so one huge argument (a file body, a note) cannot fill the
@@ -1266,7 +1272,11 @@ def _sanitize_tool_args(arguments: Mapping[str, Any] | None) -> str | None:
 
 
 def _log_tool_call(
-    req: types.CallToolRequest, tool_name: str, outcome: str, started: float
+    requested_name: str,
+    arguments: Mapping[str, Any] | None,
+    tool_name: str,
+    outcome: str,
+    started: float,
 ) -> None:
     """Emit the one structured line per tool call that Loki queries.
 
@@ -1284,17 +1294,17 @@ def _log_tool_call(
         "duration_ms": int((time.perf_counter() - started) * 1000),
     }
 
-    if req.params.name != tool_name:
+    if requested_name != tool_name:
         # Kept out of the metric label to bound cardinality, kept here because a
         # client sending an unregistered name is exactly what you want to see.
-        fields["mcp_tool_requested"] = req.params.name[:100]
+        fields["mcp_tool_requested"] = requested_name[:100]
 
-    args = _sanitize_tool_args(req.params.arguments)
+    args = _sanitize_tool_args(arguments)
     if args:
         fields["mcp_tool_args"] = args
 
     # None in BasicAuth / single-user / stdio, where there is no OAuth identity.
-    # Deliberately not extract_user_id_from_token(): that raises McpError on a
+    # Deliberately not extract_user_id_from_token(): that raises MCPError on a
     # token without a sub claim, which would turn logging into a tool failure.
     token = get_access_token()
     if token:
@@ -1312,22 +1322,21 @@ def _log_tool_call(
     )
 
 
-def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
-    """Wrap the low-level CallToolRequest handler to record how the SDK replied.
+def instrument_call_tool_outcomes(mcp: MCPServer) -> None:
+    """Append a middleware that records how the SDK replied to ``tools/call``.
 
     The tool_error/protocol_error distinction is made *inside* the SDK, one
-    frame above ``FastMCP.call_tool``: the handler either returns
-    ``CallToolResult(isError=True)`` or lets an exception escape into
-    ``_handle_request``, which turns it into a JSON-RPC error. This is the only
-    place that can observe which happened.
+    frame above ``MCPServer.call_tool``: the handler either returns
+    ``CallToolResult(is_error=True)`` or lets an exception escape into the
+    dispatcher, which turns it into a JSON-RPC error. A middleware is the only
+    place that can observe which happened — mcp 2.x removed the
+    ``request_handlers`` dict this used to patch.
 
     Doing the same classification inside ``instrument_tool`` by inspecting the
     exception type would merely re-encode our current belief about the SDK, so
     the metric would read identically before and after the 2.x upgrade and
     detect nothing — which is the one thing this metric exists to do.
     """
-    server = mcp._mcp_server
-    original = server.request_handlers[types.CallToolRequest]
 
     def _tool_label(name: str) -> str:
         """Reduce a requested tool name to a registered one, or "unknown".
@@ -1349,29 +1358,34 @@ def instrument_call_tool_outcomes(mcp: FastMCP) -> None:
             logger.debug("Could not consult the tool registry", exc_info=True)
         return "unknown"
 
-    async def handler(req: types.CallToolRequest) -> types.ServerResult:
-        record_client_session()
-        tool_name = _tool_label(req.params.name)
+    async def middleware(ctx: ServerRequestContext, call_next: CallNext) -> Any:
+        if ctx.method != "tools/call":
+            return await call_next(ctx)
+
+        record_client_session(ctx)
+        params: Mapping[str, Any] = ctx.params or {}
+        requested = params.get("name")
+        requested = requested if isinstance(requested, str) else ""
+        arguments = params.get("arguments")
+        arguments = arguments if isinstance(arguments, Mapping) else None
+        tool_name = _tool_label(requested)
         started = time.perf_counter()
         try:
-            result = await original(req)
+            result = await call_next(ctx)
         except Exception:
             # Deliberately Exception, not BaseException: anyio cancellation is
             # not a protocol error and must not poison this signal.
             mcp_tool_outcomes_total.labels(
                 tool_name=tool_name, outcome="protocol_error"
             ).inc()
-            _log_tool_call(req, tool_name, "protocol_error", started)
+            _log_tool_call(requested, arguments, tool_name, "protocol_error", started)
             raise
-        # v1 wraps the result in the ServerResult RootModel; v2 returns the
-        # CallToolResult directly.
-        is_error = bool(getattr(getattr(result, "root", result), "isError", False))
-        outcome = "tool_error" if is_error else "success"
+        outcome = "tool_error" if getattr(result, "is_error", False) else "success"
         mcp_tool_outcomes_total.labels(tool_name=tool_name, outcome=outcome).inc()
-        _log_tool_call(req, tool_name, outcome, started)
+        _log_tool_call(requested, arguments, tool_name, outcome, started)
         return result
 
-    server.request_handlers[types.CallToolRequest] = handler
+    mcp.middleware.append(middleware)
 
 
 def record_nextcloud_api_call(

--- a/nextcloud_mcp_server/request_context.py
+++ b/nextcloud_mcp_server/request_context.py
@@ -1,0 +1,46 @@
+"""The per-request MCP ``Context``, for code the SDK cannot inject it into.
+
+mcp 2.x injects ``Context`` into tool functions and *template*-resource
+functions, and removed both the ``mcp.server.lowlevel.server.request_ctx``
+contextvar and ``MCPServer.get_context()``. That leaves three callers here with
+no route to a context at all:
+
+* ``MCPServer.list_tools()`` -- capability gating needs an authenticated client
+  to ask the instance what it can serve, and the override takes no context.
+* static ``@mcp.resource()`` functions (``nc://capabilities``,
+  ``notes://settings``, ``cookbook://version``) -- registering one with a ``ctx``
+  parameter is refused outright by the SDK.
+* ``capabilities.enforce_capability`` on the ``tools/call`` path.
+
+:class:`~nextcloud_mcp_server.errors.NextcloudMCPServer` republishes it here from
+a middleware, which is where mcp 2.x puts per-message interception. Handlers the
+SDK *does* inject into must keep taking ``ctx`` as a parameter -- this is the
+fallback for the ones it doesn't, not a general substitute.
+"""
+
+from contextvars import ContextVar, Token
+from typing import Any
+
+from mcp.server.context import ServerRequestContext
+from mcp.server.mcpserver import Context, MCPServer
+
+_request_ctx: ContextVar[ServerRequestContext] = ContextVar("nextcloud_request_ctx")
+
+
+def set_request_context(ctx: ServerRequestContext) -> Token[ServerRequestContext]:
+    """Publish ``ctx`` for the message being served. Returns a reset token."""
+    return _request_ctx.set(ctx)
+
+
+def reset_request_context(token: Token[ServerRequestContext]) -> None:
+    _request_ctx.reset(token)
+
+
+def current_context(mcp: MCPServer | None = None) -> Context[Any, Any]:
+    """The high-level ``Context`` for the MCP message currently being served.
+
+    Raises:
+        LookupError: outside a request served through the middleware -- notably
+            a direct ``mcp.call_tool()`` in a unit test, where callers fail open.
+    """
+    return Context(request_context=_request_ctx.get(), mcp_server=mcp)

--- a/nextcloud_mcp_server/search/algorithms.py
+++ b/nextcloud_mcp_server/search/algorithms.py
@@ -383,7 +383,7 @@ class SearchAlgorithm(ABC):
             List of SearchResult objects ranked by relevance
 
         Raises:
-            McpError: If search fails or configuration is invalid
+            MCPError: If search fails or configuration is invalid
         """
         pass
 

--- a/nextcloud_mcp_server/search/bm25_hybrid.py
+++ b/nextcloud_mcp_server/search/bm25_hybrid.py
@@ -376,7 +376,7 @@ class BM25HybridSearchAlgorithm(SearchAlgorithm):
             List of unverified SearchResult objects ranked by RRF fusion score
 
         Raises:
-            McpError: If vector sync is not enabled or search fails
+            MCPError: If vector sync is not enabled or search fails
         """
         if granularity not in VALID_GRANULARITIES:
             # Validated here rather than only at the tool boundary so every

--- a/nextcloud_mcp_server/search/semantic.py
+++ b/nextcloud_mcp_server/search/semantic.py
@@ -104,7 +104,7 @@ class SemanticSearchAlgorithm(SearchAlgorithm):
             List of unverified SearchResult objects ranked by similarity score
 
         Raises:
-            McpError: If vector sync is not enabled or search fails
+            MCPError: If vector sync is not enabled or search fails
         """
         if granularity != GRANULARITY_CHUNK:
             # Declared explicitly rather than swallowed by **kwargs, matching

--- a/nextcloud_mcp_server/search/verification.py
+++ b/nextcloud_mcp_server/search/verification.py
@@ -732,7 +732,7 @@ async def verify_search_results(
         eviction_task_group: Optional long-lived task group on which to
             spawn fire-and-forget eviction. Pass
             ``ctx.request_context.lifespan_context.eviction_task_group``
-            from FastMCP tools.
+            from MCPServer tools.
 
     Returns:
         Tuple of ``(kept_results, dropped_count)`` where ``kept_results`` is

--- a/nextcloud_mcp_server/serialization.py
+++ b/nextcloud_mcp_server/serialization.py
@@ -1,7 +1,7 @@
 """Compact JSON in tool results (GH #1395).
 
-FastMCP serialises every non-string tool return with ``indent=2``
-(``mcp.server.fastmcp.utilities.func_metadata._convert_to_content``), and this
+MCPServer serialises every non-string tool return with ``indent=2``
+(``mcp.server.mcpserver.utilities.func_metadata._convert_to_content``), and this
 SDK exposes no serializer hook to override it -- neither does the v2
 ``mcpserver`` package, so migrating does not fix it either. The consumer is a
 language model with a bounded context window, and that indentation costs
@@ -16,7 +16,7 @@ versions return, so this cannot fail quietly.
 import json
 from typing import Any
 
-from mcp.types import ContentBlock, TextContent
+from mcp.types import CallToolResult, ContentBlock, TextContent
 
 
 def compact_json_dumps(data: Any) -> str:
@@ -57,13 +57,17 @@ def _compact_block(block: ContentBlock) -> ContentBlock:
 
 
 def compact_tool_result(result: Any) -> Any:
-    """Compact the JSON in a ``FastMCP.call_tool`` result.
+    """Compact the JSON in a ``MCPServer.call_tool`` result.
 
-    The SDK returns either a list of content blocks or, when the tool declares
-    an output schema, an ``(unstructured, structured)`` pair. Only the
-    unstructured half is rewritten -- the structured half is a dict the SDK
-    serialises itself, without indentation.
+    mcp 2.x returns a ``CallToolResult``; only its ``content`` is rewritten --
+    ``structured_content`` is a dict the SDK serialises itself, without
+    indentation. The 1.x shapes (a bare block list, or an
+    ``(unstructured, structured)`` pair) are still handled because
+    ``ToolManager``-level callers and tests pass them directly.
     """
+    if isinstance(result, CallToolResult):
+        content = [_compact_block(block) for block in result.content]
+        return result.model_copy(update={"content": content})
     if isinstance(result, tuple) and len(result) == 2:
         unstructured, structured = result
         return compact_tool_result(unstructured), structured

--- a/nextcloud_mcp_server/server/__init__.py
+++ b/nextcloud_mcp_server/server/__init__.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.capabilities import stamp_required_capability
 
@@ -22,7 +22,7 @@ from .webdav import configure_webdav_tools
 # Used by app.py (HTTP), stdio.py (stdio), and cli.py (--enable-app choices).
 # Semantic search is excluded here because it is a cross-app feature gated
 # by VECTOR_SYNC_ENABLED, not an individual Nextcloud app.
-AVAILABLE_APPS: dict[str, Callable[[FastMCP], None]] = {
+AVAILABLE_APPS: dict[str, Callable[[MCPServer], None]] = {
     "notes": configure_notes_tools,
     "tables": configure_tables_tools,
     "webdav": configure_webdav_tools,
@@ -60,7 +60,7 @@ APP_CAPABILITY_KEY: dict[str, str] = {
 }
 
 
-def configure_app_tools(mcp: FastMCP, app_name: str) -> None:
+def configure_app_tools(mcp: MCPServer, app_name: str) -> None:
     """Register one app's tools, gated on the app being installed for the user.
 
     Used by both transports (app.py, stdio.py) so their tool sets cannot drift.

--- a/nextcloud_mcp_server/server/auth_tools.py
+++ b/nextcloud_mcp_server/server/auth_tools.py
@@ -9,7 +9,7 @@ tools during the migration period.
 
 import logging
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth.elicitation import present_login_url
@@ -32,7 +32,7 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 logger = logging.getLogger(__name__)
 
 
-def register_auth_tools(mcp: FastMCP) -> None:
+def register_auth_tools(mcp: MCPServer) -> None:
     """Register Login Flow v2 auth tools with the MCP server."""
 
     @mcp.tool(
@@ -44,8 +44,8 @@ def register_auth_tools(mcp: FastMCP) -> None:
             "You will be given a URL to open in your browser to log in."
         ),
         annotations=ToolAnnotations(
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")
@@ -218,9 +218,9 @@ def register_auth_tools(mcp: FastMCP) -> None:
             "Recommended polling interval: 5 seconds."
         ),
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            idempotentHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")
@@ -386,8 +386,8 @@ def register_auth_tools(mcp: FastMCP) -> None:
             "The current app password remains valid until the new one is obtained."
         ),
         annotations=ToolAnnotations(
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -2,8 +2,8 @@ import datetime as dt
 import logging
 from typing import Any, Optional
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -110,11 +110,11 @@ def _event_dict_to_summary(event: dict) -> CalendarEventSummary:
     )
 
 
-def configure_calendar_tools(mcp: FastMCP):
+def configure_calendar_tools(mcp: MCPServer):
     # Calendar tools
     @mcp.tool(
         title="List Calendars",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("calendar.read")
     @instrument_tool
@@ -128,7 +128,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Calendar Event",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("calendar.write")
     @instrument_tool
@@ -246,7 +246,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Calendar Events",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("calendar.read")
     @instrument_tool
@@ -289,7 +289,7 @@ def configure_calendar_tools(mcp: FastMCP):
         # to invent a throwaway value. It stays required otherwise — falling back
         # to a default calendar would silently search the wrong one.
         if not search_all_calendars and not calendar_name.strip():
-            raise ValueError(
+            raise ToolError(
                 "calendar_name is required when search_all_calendars is False"
             )
 
@@ -376,7 +376,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Calendar Event",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("calendar.read")
     @instrument_tool
@@ -392,7 +392,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Calendar Event",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("calendar.write")
     @instrument_tool
@@ -496,7 +496,7 @@ def configure_calendar_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Calendar Event",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("calendar.write")
@@ -525,7 +525,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Meeting",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("calendar.write")
     @instrument_tool
@@ -595,7 +595,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Upcoming Events",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("calendar.read")
     @instrument_tool
@@ -658,7 +658,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Find Availability",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("calendar.read")
     @instrument_tool
@@ -742,7 +742,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Bulk Calendar Operations",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("calendar.write")
     @instrument_tool
@@ -798,7 +798,7 @@ def configure_calendar_tools(mcp: FastMCP):
         client = await get_client(ctx)
 
         if operation not in ["update", "delete", "move"]:
-            raise ValueError("Operation must be 'update', 'delete', or 'move'")
+            raise ToolError("Operation must be 'update', 'delete', or 'move'")
 
         # Convert date strings to datetime objects
         start_datetime = None
@@ -922,7 +922,7 @@ def configure_calendar_tools(mcp: FastMCP):
                 update_data["reminder_minutes"] = new_reminder_minutes
 
             if not update_data:
-                raise ValueError("No update data provided for update operation")
+                raise ToolError("No update data provided for update operation")
 
             return await client.calendar.bulk_update_events(
                 filter_criteria, update_data
@@ -930,7 +930,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
         elif operation == "move":
             if not target_calendar:
-                raise ValueError("target_calendar is required for move operation")
+                raise ToolError("target_calendar is required for move operation")
 
             # Find matching events
             if calendar_name:
@@ -1030,7 +1030,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Manage Calendar",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("calendar.write")
     @instrument_tool
@@ -1064,7 +1064,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
         elif action == "create":
             if not calendar_name:
-                raise ValueError("calendar_name is required for create action")
+                raise ToolError("calendar_name is required for create action")
 
             return await client.calendar.create_calendar(
                 calendar_name=calendar_name,
@@ -1075,13 +1075,13 @@ def configure_calendar_tools(mcp: FastMCP):
 
         elif action == "delete":
             if not calendar_name:
-                raise ValueError("calendar_name is required for delete action")
+                raise ToolError("calendar_name is required for delete action")
 
             return await client.calendar.delete_calendar(calendar_name)
 
         elif action == "update":
             if not calendar_name:
-                raise ValueError("calendar_name is required for update action")
+                raise ToolError("calendar_name is required for update action")
 
             # Note: Calendar property updates require additional CalDAV PROPPATCH implementation
             # For now, return an informative message
@@ -1097,13 +1097,13 @@ def configure_calendar_tools(mcp: FastMCP):
             }
 
         else:
-            raise ValueError("Action must be 'create', 'delete', 'update', or 'list'")
+            raise ToolError("Action must be 'create', 'delete', 'update', or 'list'")
 
     # ============= Todo/Task Tools =============
 
     @mcp.tool(
         title="List Todo Tasks",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("todo.read", "calendar.read")
     @instrument_tool
@@ -1152,7 +1152,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Todo Task",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("todo.write", "calendar.read")
     @instrument_tool
@@ -1207,7 +1207,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Todo Task",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("todo.write", "calendar.read")
     @instrument_tool
@@ -1320,8 +1320,8 @@ def configure_calendar_tools(mcp: FastMCP):
         annotations=ToolAnnotations(
             # Not idempotent: a second call with completed=None restamps COMPLETED
             # with a fresh timestamp, so the same inputs produce a different card.
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("todo.write", "calendar.read")
@@ -1380,7 +1380,7 @@ def configure_calendar_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Todo Task",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("todo.write", "calendar.read")
@@ -1417,7 +1417,7 @@ def configure_calendar_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Search Todo Tasks",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("todo.read", "calendar.read")
     @instrument_tool

--- a/nextcloud_mcp_server/server/collectives.py
+++ b/nextcloud_mcp_server/server/collectives.py
@@ -4,9 +4,9 @@ import logging
 from typing import NoReturn
 
 from httpx import HTTPStatusError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.client.collectives import OCSError
@@ -37,24 +37,24 @@ def _raise_collectives_error(e: OCSError | HTTPStatusError) -> NoReturn:
     """Raise the client-facing form of a collectives failure.
 
     An OCS envelope carries a real server message, so it becomes an
-    ``McpError``. A transport-level ``HTTPStatusError`` is re-raised untouched:
-    ``NextcloudFastMCP`` renders it into an LLM-friendly message at the tool
+    ``MCPError``. A transport-level ``HTTPStatusError`` is re-raised untouched:
+    ``NextcloudMCPServer`` renders it into an LLM-friendly message at the tool
     boundary (GH #1208), and wrapping it in ``str(e)`` here would shadow that
     with httpx's internal-URL text.
     """
     if isinstance(e, OCSError):
-        raise McpError(ErrorData(code=-32603, message=e.message)) from e
+        raise MCPError(code=-32603, message=e.message) from e
     raise e
 
 
-def configure_collectives_tools(mcp: FastMCP):
+def configure_collectives_tools(mcp: MCPServer):
     """Configure Nextcloud Collectives tools for the MCP server."""
 
     # --- Read Tools ---
 
     @mcp.tool(
         title="List Collectives",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -72,7 +72,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Collective Pages",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -96,7 +96,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Collective Page",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -144,7 +144,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Search Collective Pages",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -172,7 +172,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Collective Tags",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -194,7 +194,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Trashed Collective Pages",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -218,7 +218,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Trashed Collectives",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.read")
     @instrument_tool
@@ -244,7 +244,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Collective",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -269,7 +269,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Set Collective Emoji",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -289,7 +289,7 @@ def configure_collectives_tools(mcp: FastMCP):
         try:
             raw = await client.collectives.update_collective(collective_id, emoji)
         except ValueError as e:
-            raise McpError(ErrorData(code=-32603, message=str(e))) from e
+            raise MCPError(code=-32603, message=str(e)) from e
         except (OCSError, HTTPStatusError) as e:
             _raise_collectives_error(e)
         collective = Collective(**raw)
@@ -301,7 +301,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Trash Collective",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -329,7 +329,7 @@ def configure_collectives_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Collective",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=False, openWorldHint=True
+            destructive_hint=True, idempotent_hint=False, open_world_hint=True
         ),
     )
     @require_scopes("collectives.write")
@@ -359,7 +359,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Restore Collective",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -385,7 +385,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Collective Page",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -418,7 +418,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Move Collective Page",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -459,7 +459,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Trash Collective Page",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -490,7 +490,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Restore Collective Page",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -518,7 +518,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Set Collective Page Emoji",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -550,7 +550,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Collective Tag",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -574,7 +574,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Assign Tag to Collective Page",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool
@@ -602,7 +602,7 @@ def configure_collectives_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Remove Tag from Collective Page",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("collectives.write")
     @instrument_tool

--- a/nextcloud_mcp_server/server/contacts.py
+++ b/nextcloud_mcp_server/server/contacts.py
@@ -3,8 +3,8 @@ from datetime import date
 from typing import Any
 
 from httpx import HTTPStatusError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -212,11 +212,11 @@ def _raw_contact_to_model(raw: dict) -> Contact:
     )
 
 
-def configure_contacts_tools(mcp: FastMCP):
+def configure_contacts_tools(mcp: MCPServer):
     # Contacts tools
     @mcp.tool(
         title="List Address Books",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("contacts.read")
     @instrument_tool
@@ -240,7 +240,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Contacts",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("contacts.read")
     @instrument_tool
@@ -263,7 +263,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Search Contacts",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("contacts.read")
     @instrument_tool
@@ -345,7 +345,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Address Book",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("contacts.write")
     @instrument_tool
@@ -366,7 +366,7 @@ def configure_contacts_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Address Book",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("contacts.write")
@@ -378,7 +378,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Contact",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("contacts.write")
     @instrument_tool
@@ -418,7 +418,7 @@ def configure_contacts_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Contact",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("contacts.write")
@@ -437,7 +437,7 @@ def configure_contacts_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Contact",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("contacts.write")
     @instrument_tool

--- a/nextcloud_mcp_server/server/cookbook.py
+++ b/nextcloud_mcp_server/server/cookbook.py
@@ -1,9 +1,9 @@
 import logging
 
 from httpx import HTTPStatusError, RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.context import get_client
@@ -25,15 +25,16 @@ from nextcloud_mcp_server.models.cookbook import (
     Version,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
+from nextcloud_mcp_server.request_context import current_context
 
 logger = logging.getLogger(__name__)
 
 
-def configure_cookbook_tools(mcp: FastMCP):
+def configure_cookbook_tools(mcp: MCPServer):
     @mcp.resource("cookbook://version")
     async def cookbook_get_version():
         """Get the Cookbook app and API version"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         version_data = await client.cookbook.get_version()
         return Version(**version_data)
@@ -41,7 +42,7 @@ def configure_cookbook_tools(mcp: FastMCP):
     @mcp.resource("cookbook://config")
     async def cookbook_get_config():
         """Get the Cookbook app configuration"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         config_data = await client.cookbook.get_config()
         return CookbookConfig(**config_data)
@@ -49,31 +50,25 @@ def configure_cookbook_tools(mcp: FastMCP):
     @mcp.resource("nc://Cookbook/{recipe_id}")
     async def nc_cookbook_get_recipe_resource(recipe_id: int):
         """Get a recipe by ID using resource URI"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         try:
             recipe_data = await client.cookbook.get_recipe(recipe_id)
             return Recipe(**recipe_data)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Recipe {recipe_id} not found")
-                )
+                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Access denied to recipe {recipe_id}")
-                )
+                raise MCPError(code=-1, message=f"Access denied to recipe {recipe_id}")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
                 )
 
     @mcp.tool(
         title="Import Recipe from URL",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("cookbook.write")
     @instrument_tool
@@ -96,45 +91,35 @@ def configure_cookbook_tools(mcp: FastMCP):
                 str(e)
                 or f"{type(e).__name__}: {getattr(e, '__cause__', 'unknown cause')}"
             )
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error importing recipe from {url}: {error_detail}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error importing recipe from {url}: {error_detail}",
             )
         except HTTPStatusError as e:
             if e.response.status_code == 400:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Invalid URL or missing 'url' field: {url}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Invalid URL or missing 'url' field: {url}",
                 )
             elif e.response.status_code == 409:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="A recipe with this name already exists. Import aborted.",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="A recipe with this name already exists. Import aborted.",
                 )
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to import recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to import recipes",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to import recipe from {url}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to import recipe from {url}: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="List Recipes",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -147,23 +132,19 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to list recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to list recipes",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to list recipes: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to list recipes: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Get Recipe",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -175,24 +156,18 @@ def configure_cookbook_tools(mcp: FastMCP):
             return Recipe(**recipe_data)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Recipe {recipe_id} not found")
-                )
+                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Access denied to recipe {recipe_id}")
-                )
+                raise MCPError(code=-1, message=f"Access denied to recipe {recipe_id}")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
                 )
 
     @mcp.tool(
         title="Create Recipe",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("cookbook.write")
     @instrument_tool
@@ -245,37 +220,29 @@ def configure_cookbook_tools(mcp: FastMCP):
             return CreateRecipeResponse(id=recipe_id)
         except HTTPStatusError as e:
             if e.response.status_code == 409:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"A recipe with name '{name}' already exists",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"A recipe with name '{name}' already exists",
                 )
             elif e.response.status_code == 422:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Recipe name is required and cannot be empty",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Recipe name is required and cannot be empty",
                 )
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to create recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to create recipes",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to create recipe: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to create recipe: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Update Recipe",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("cookbook.write")
     @instrument_tool
@@ -304,15 +271,11 @@ def configure_cookbook_tools(mcp: FastMCP):
             current_recipe = await client.cookbook.get_recipe(recipe_id)
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Recipe {recipe_id} not found")
-                )
+                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to fetch recipe {recipe_id}: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to fetch recipe {recipe_id}: {e.response.reason_phrase}",
                 )
 
         # Update only specified fields
@@ -345,31 +308,25 @@ def configure_cookbook_tools(mcp: FastMCP):
             return UpdateRecipeResponse(id=updated_id)
         except HTTPStatusError as e:
             if e.response.status_code == 422:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Recipe name is required and cannot be empty",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Recipe name is required and cannot be empty",
                 )
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied: insufficient permissions to update recipe {recipe_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied: insufficient permissions to update recipe {recipe_id}",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to update recipe {recipe_id}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to update recipe {recipe_id}: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Delete Recipe",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("cookbook.write")
@@ -389,27 +346,21 @@ def configure_cookbook_tools(mcp: FastMCP):
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Recipe {recipe_id} not found")
-                )
+                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied: insufficient permissions to delete recipe {recipe_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied: insufficient permissions to delete recipe {recipe_id}",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to delete recipe {recipe_id}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to delete recipe {recipe_id}: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Search Recipes",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -426,30 +377,24 @@ def configure_cookbook_tools(mcp: FastMCP):
             )
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to search recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to search recipes",
                 )
             elif e.response.status_code == 500:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Search failed: server error",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Search failed: server error",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Search failed: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Search failed: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="List Recipe Categories",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -464,23 +409,19 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ListCategoriesResponse(categories=categories)
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to list categories",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to list categories",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to list categories: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to list categories: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Get Recipes in Category",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -497,30 +438,24 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to access recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to access recipes",
                 )
             elif e.response.status_code == 500:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Could not find category '{category}'",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Could not find category '{category}'",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to get recipes in category: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to get recipes in category: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="List Recipe Keywords",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -533,23 +468,19 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ListKeywordsResponse(keywords=keywords)
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to list keywords",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to list keywords",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to list keywords: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to list keywords: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Get Recipes with Keywords",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("cookbook.read")
     @instrument_tool
@@ -564,30 +495,24 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to access recipes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to access recipes",
                 )
             elif e.response.status_code == 500:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Failed to get recipes with keywords: server error",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Failed to get recipes with keywords: server error",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to get recipes with keywords: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to get recipes with keywords: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Set Cookbook Configuration",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("cookbook.write")
     @instrument_tool
@@ -618,23 +543,19 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ReindexResponse(status_code=200, message=str(result))
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to set configuration",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to set configuration",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to set configuration: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to set configuration: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Reindex Recipes",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("cookbook.write")
     @instrument_tool
@@ -648,16 +569,12 @@ def configure_cookbook_tools(mcp: FastMCP):
             return ReindexResponse(status_code=200, message=message)
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to reindex",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to reindex",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to reindex: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to reindex: server error ({e.response.status_code})",
                 )

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -3,9 +3,10 @@ from typing import Final, Literal, cast
 
 import anyio
 from httpx import HTTPStatusError, RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.capabilities import require_capability
@@ -43,6 +44,7 @@ from nextcloud_mcp_server.models.deck import (
     StackOverview,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
+from nextcloud_mcp_server.request_context import current_context
 from nextcloud_mcp_server.utils.message_splitter import (
     COMMENT_MAX_LENGTH,
     is_blank_comment,
@@ -72,7 +74,7 @@ def _validate_positive_length(
     the parameter the caller actually passed.
     """
     if value is not None and value <= 0:
-        raise ValueError(f"{name} must be positive, got {value}")
+        raise ToolError(f"{name} must be positive, got {value}")
 
 
 # Nextcloud's core comment cap (see COMMENT_MAX_LENGTH). Deck adds no check of
@@ -101,7 +103,7 @@ def _validate_comment_message_not_blank(message: str) -> None:
     :func:`is_blank_comment` for why neither trim charlist alone is enough.
     """
     if is_blank_comment(message):
-        raise ValueError("Comment message must not be empty or whitespace-only")
+        raise ToolError("Comment message must not be empty or whitespace-only")
 
 
 def _validate_comment_message(message: str) -> None:
@@ -110,7 +112,7 @@ def _validate_comment_message(message: str) -> None:
 
     length = measured_length(message)
     if length > _COMMENT_MAX_LENGTH:
-        raise ValueError(_too_long_message(message, length))
+        raise ToolError(_too_long_message(message, length))
 
 
 def _min_parts_for(length: int) -> int:
@@ -234,7 +236,7 @@ def _comment_http_error(
     card_id: int,
     comment_id: int | None = None,
     message: str | None = None,
-) -> McpError:
+) -> MCPError:
     """Translate a Deck comment API failure into something an agent can act on.
 
     Args:
@@ -301,7 +303,7 @@ def _comment_http_error(
         )
 
     logger.warning("Deck comment error (%s while %s): %s", status, phrase, reason)
-    return McpError(ErrorData(code=-32603, message=reason))
+    return MCPError(code=-32603, message=reason)
 
 
 def _partial_split_error(
@@ -311,7 +313,7 @@ def _partial_split_error(
     posted: list[DeckComment],
     failed_part: int,
     total_parts: int,
-) -> McpError:
+) -> MCPError:
     """Report a split that died partway through.
 
     No rollback is attempted, deliberately. Deleting the parts already posted
@@ -361,7 +363,7 @@ def _partial_split_error(
         total_parts,
         posted_ids,
     )
-    return McpError(ErrorData(code=-32603, message=message))
+    return MCPError(code=-32603, message=message)
 
 
 async def _post_split_comment(
@@ -377,11 +379,11 @@ async def _post_split_comment(
     # Cheap bound first, so an enormous paste is rejected without running the
     # splitter over it.
     if _min_parts_for(length) > _MAX_SPLIT_PARTS:
-        raise ValueError(_too_long_to_split_message(length, None))
+        raise ToolError(_too_long_to_split_message(length, None))
 
     parts = split_message(message, max_length=_COMMENT_MAX_LENGTH)
     if len(parts) > _MAX_SPLIT_PARTS:
-        raise ValueError(_too_long_to_split_message(length, len(parts)))
+        raise ToolError(_too_long_to_split_message(length, len(parts)))
 
     posted: list[DeckComment] = []
     for index, part in enumerate(parts, 1):
@@ -685,59 +687,61 @@ async def _resolve_note_attach_path(client, note_id: int) -> str:
     )
 
 
-def configure_deck_tools(mcp: FastMCP):
+def configure_deck_tools(mcp: MCPServer):
     """Configure Nextcloud Deck tools and resources for the MCP server."""
 
     # Resources
     @mcp.resource("nc://Deck/boards")
     async def deck_boards_resource():
-        """List all Nextcloud Deck boards"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning("This message is deprecated, use the deck_get_board instead")
+        """List all Nextcloud Deck boards.
+
+        DEPRECATED: use the ``deck_get_boards`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         boards = await client.deck.get_boards()
         return [board.model_dump() for board in boards]
 
     @mcp.resource("nc://Deck/boards/{board_id}")
     async def deck_board_resource(board_id: int):
-        """Get details of a specific Nextcloud Deck board"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_board tool instead"
-        )
+        """Get details of a specific Nextcloud Deck board.
+
+        DEPRECATED: use the ``deck_get_board`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         board = await client.deck.get_board(board_id)
         return board.model_dump()
 
     @mcp.resource("nc://Deck/boards/{board_id}/stacks")
     async def deck_stacks_resource(board_id: int):
-        """List all stacks in a Nextcloud Deck board"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_stacks tool instead"
-        )
+        """List all stacks in a Nextcloud Deck board.
+
+        DEPRECATED: use the ``deck_get_stacks`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         stacks = await client.deck.get_stacks(board_id)
         return [stack.model_dump() for stack in stacks]
 
     @mcp.resource("nc://Deck/boards/{board_id}/stacks/{stack_id}")
     async def deck_stack_resource(board_id: int, stack_id: int):
-        """Get details of a specific Nextcloud Deck stack"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_stack tool instead"
-        )
+        """Get details of a specific Nextcloud Deck stack.
+
+        DEPRECATED: use the ``deck_get_stack`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         stack = await client.deck.get_stack(board_id, stack_id)
         return stack.model_dump()
 
     @mcp.resource("nc://Deck/boards/{board_id}/stacks/{stack_id}/cards")
     async def deck_cards_resource(board_id: int, stack_id: int):
-        """List all cards in a Nextcloud Deck stack"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_cards tool instead"
-        )
+        """List all cards in a Nextcloud Deck stack.
+
+        DEPRECATED: use the ``deck_get_cards`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         stack = await client.deck.get_stack(board_id, stack_id)
         if stack.cards:
@@ -746,33 +750,33 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.resource("nc://Deck/boards/{board_id}/stacks/{stack_id}/cards/{card_id}")
     async def deck_card_resource(board_id: int, stack_id: int, card_id: int):
-        """Get details of a specific Nextcloud Deck card"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_card tool instead"
-        )
+        """Get details of a specific Nextcloud Deck card.
+
+        DEPRECATED: use the ``deck_get_card`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         card = await client.deck.get_card(board_id, stack_id, card_id)
         return card.model_dump()
 
     @mcp.resource("nc://Deck/boards/{board_id}/labels")
     async def deck_labels_resource(board_id: int):
-        """List all labels in a Nextcloud Deck board"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_labels tool instead"
-        )
+        """List all labels in a Nextcloud Deck board.
+
+        DEPRECATED: use the ``deck_get_labels`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         board = await client.deck.get_board(board_id)
         return [label.model_dump() for label in (board.labels or [])]
 
     @mcp.resource("nc://Deck/boards/{board_id}/labels/{label_id}")
     async def deck_label_resource(board_id: int, label_id: int):
-        """Get details of a specific Nextcloud Deck label"""
-        ctx: Context = mcp.get_context()
-        await ctx.warning(
-            "This resource is deprecated, use the deck_get_label tool instead"
-        )
+        """Get details of a specific Nextcloud Deck label.
+
+        DEPRECATED: use the ``deck_get_label`` tool instead.
+        """
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         label = await client.deck.get_label(board_id, label_id)
         return label.model_dump()
@@ -781,7 +785,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Boards",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -794,7 +798,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Deck Board",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -829,7 +833,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Stacks",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -920,7 +924,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Deck Stack",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -1008,7 +1012,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Archived Deck Stacks",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -1074,7 +1078,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Cards",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -1153,7 +1157,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Deck Board Overview",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -1251,7 +1255,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Deck Card",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @with_links
@@ -1266,7 +1270,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Labels",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @instrument_tool
@@ -1279,7 +1283,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Deck Label",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @instrument_tool
@@ -1293,7 +1297,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Deck Board",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -1314,7 +1318,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Deck Stack",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -1334,7 +1338,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Deck Stack",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -1365,7 +1369,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Deck Stack",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -1391,7 +1395,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Card Tools
     @mcp.tool(
         title="Create Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1429,7 +1433,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1488,7 +1492,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Deck Card",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -1519,7 +1523,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Archive Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1546,7 +1550,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Unarchive Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1573,7 +1577,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Reorder Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1614,7 +1618,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Move Deck Card to Another Board",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1677,7 +1681,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Label Tools
     @mcp.tool(
         title="Create Deck Label",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -1697,7 +1701,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Deck Label",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -1728,7 +1732,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Deck Label",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -1754,7 +1758,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Card-Label Assignment Tools
     @mcp.tool(
         title="Assign Label to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1782,7 +1786,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Remove Label from Deck Card",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1811,7 +1815,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Card-User Assignment Tools
     @mcp.tool(
         title="Assign User to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @with_links
@@ -1840,7 +1844,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Unassign User from Deck Card",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -1870,7 +1874,7 @@ def configure_deck_tools(mcp: FastMCP):
     # Card Dependency Tools
     @mcp.tool(
         title="Add Dependent Card to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @require_capability("deck", min_version="1.18.0")
@@ -1911,7 +1915,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Remove Dependent Card from Deck Card",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -1952,7 +1956,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Card Comments",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @instrument_tool
@@ -1990,11 +1994,9 @@ def configure_deck_tools(mcp: FastMCP):
         except HTTPStatusError as e:
             raise _comment_http_error(e, operation="list", card_id=card_id) from e
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-32603,
-                    message=(f"Network error listing comments on card {card_id}: {e}"),
-                )
+            raise MCPError(
+                code=-32603,
+                message=(f"Network error listing comments on card {card_id}: {e}"),
             ) from e
         shaped = _shape_comments(
             comments,
@@ -2006,7 +2008,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Deck Card Comment",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -2073,13 +2075,11 @@ def configure_deck_tools(mcp: FastMCP):
             except HTTPStatusError as e:
                 raise _comment_http_error(e, operation="create", card_id=card_id) from e
             except RequestError as e:
-                raise McpError(
-                    ErrorData(
-                        code=-32603,
-                        message=(
-                            f"Network error creating a comment on card {card_id}: {e}"
-                        ),
-                    )
+                raise MCPError(
+                    code=-32603,
+                    message=(
+                        f"Network error creating a comment on card {card_id}: {e}"
+                    ),
                 ) from e
             return CardCommentResponse(comment=comment)
 
@@ -2088,7 +2088,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Deck Card Comment",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write")
     @instrument_tool
@@ -2124,21 +2124,19 @@ def configure_deck_tools(mcp: FastMCP):
                 message=message,
             ) from e
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-32603,
-                    message=(
-                        f"Network error updating comment {comment_id} on card "
-                        f"{card_id}: {e}"
-                    ),
-                )
+            raise MCPError(
+                code=-32603,
+                message=(
+                    f"Network error updating comment {comment_id} on card "
+                    f"{card_id}: {e}"
+                ),
             ) from e
         return CardCommentResponse(comment=comment)
 
     @mcp.tool(
         title="Delete Deck Card Comment",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")
@@ -2162,14 +2160,12 @@ def configure_deck_tools(mcp: FastMCP):
                 e, operation="delete", card_id=card_id, comment_id=comment_id
             ) from e
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-32603,
-                    message=(
-                        f"Network error deleting comment {comment_id} on card "
-                        f"{card_id}: {e}"
-                    ),
-                )
+            raise MCPError(
+                code=-32603,
+                message=(
+                    f"Network error deleting comment {comment_id} on card "
+                    f"{card_id}: {e}"
+                ),
             ) from e
         return CardCommentOperationResponse(
             success=True,
@@ -2180,7 +2176,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Attach File to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write", "files.read")
     @instrument_tool
@@ -2206,7 +2202,7 @@ def configure_deck_tools(mcp: FastMCP):
                 with "/", e.g. "/Documents/spec.pdf" or "/Notes/My Note.md")
         """
         if not path.startswith("/"):
-            raise ValueError(
+            raise ToolError(
                 f"path must start with '/', got: {path!r} "
                 "(paths are relative to the user's Files root)"
             )
@@ -2225,7 +2221,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Attach Note to Deck Card",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("deck.write", "files.read", "notes.read")
     @instrument_tool
@@ -2265,7 +2261,7 @@ def configure_deck_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Deck Card Attachments",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("deck.read")
     @instrument_tool
@@ -2290,7 +2286,7 @@ def configure_deck_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Deck Card Attachment",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("deck.write")

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -7,9 +7,9 @@ from contextlib import contextmanager
 from typing import Annotated
 
 from httpx import HTTPStatusError, RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def _mail_errors(action: str) -> Iterator[None]:
-    """Map client transport errors onto ``McpError`` with a consistent message.
+    """Map client transport errors onto ``MCPError`` with a consistent message.
 
     Args:
         action: Present-participle description used in the message, e.g.
@@ -47,14 +47,10 @@ def _mail_errors(action: str) -> Iterator[None]:
     try:
         yield
     except RequestError as e:
-        raise McpError(
-            ErrorData(code=-1, message=f"Network error {action}: {str(e)}")
-        ) from e
+        raise MCPError(code=-1, message=f"Network error {action}: {str(e)}") from e
     except HTTPStatusError as e:
-        raise McpError(
-            ErrorData(
-                code=-1, message=f"Failed {action}: HTTP {e.response.status_code}"
-            )
+        raise MCPError(
+            code=-1, message=f"Failed {action}: HTTP {e.response.status_code}"
         ) from e
 
 
@@ -89,12 +85,12 @@ def _cap_attachment_content(content: str | None) -> str | None:
     return content
 
 
-def configure_mail_tools(mcp: FastMCP):
+def configure_mail_tools(mcp: MCPServer):
     """Configure Mail app MCP tools (read, send, flags, tags, move, delete)."""
 
     @mcp.tool(
         title="List Mail Accounts",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -106,20 +102,16 @@ def configure_mail_tools(mcp: FastMCP):
             accounts = [MailAccount(**a) for a in accounts_data]
             return ListAccountsResponse(results=accounts, total_count=len(accounts))
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing accounts: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error listing accounts: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list accounts: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list accounts: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="List Mail Mailboxes",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -141,20 +133,18 @@ def configure_mail_tools(mcp: FastMCP):
             mailboxes = [MailMailbox(**m) for m in mailboxes_data]
             return ListMailboxesResponse(results=mailboxes, total_count=len(mailboxes))
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing mailboxes: {str(e)}")
+            raise MCPError(
+                code=-1, message=f"Network error listing mailboxes: {str(e)}"
             )
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list mailboxes: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list mailboxes: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="List Mail Messages",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -218,20 +208,16 @@ def configure_mail_tools(mcp: FastMCP):
                 has_more=len(messages) == effective_limit,
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing messages: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error listing messages: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list messages: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list messages: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get Mail Message",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -255,36 +241,27 @@ def configure_mail_tools(mcp: FastMCP):
             # MailMessage(**{}) raise an uncaught ValidationError; treat it as
             # not-found instead.
             if not message_data:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Message {message_id} not found")
-                )
+                raise MCPError(code=-1, message=f"Message {message_id} not found")
             message = MailMessage(**message_data)
             return GetMessageResponse(message=message)
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error getting message {message_id}: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error getting message {message_id}: {str(e)}",
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Message {message_id} not found")
-                )
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get message {message_id}: "
-                    f"{e.response.status_code}",
-                )
+                raise MCPError(code=-1, message=f"Message {message_id} not found")
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get message {message_id}: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Send Mail Message",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Stages a new outbox entry each call (ADR-017)
-            openWorldHint=True,
+            idempotent_hint=False,  # Stages a new outbox entry each call (ADR-017)
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.send")
@@ -341,25 +318,19 @@ def configure_mail_tools(mcp: FastMCP):
                 success=True, message="Message sent successfully"
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error sending message: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error sending message: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to send message: {e.response.status_code} "
-                    f"{e.response.text[:500]}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to send message: {e.response.status_code} "
+                f"{e.response.text[:500]}",
             )
         except json.JSONDecodeError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
 
     @mcp.tool(
         title="Get Mail Attachment",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -388,24 +359,20 @@ def configure_mail_tools(mcp: FastMCP):
                 content=_cap_attachment_content(data.get("content")),
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error getting attachment: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error getting attachment: {str(e)}"
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message="Attachment not found"))
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get attachment: {e.response.status_code}",
-                )
+                raise MCPError(code=-1, message="Attachment not found")
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get attachment: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get Mail Message Source",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("mail.read")
     @instrument_tool
@@ -434,8 +401,8 @@ def configure_mail_tools(mcp: FastMCP):
         title="Set Mail Message Flags",
         annotations=ToolAnnotations(
             # Same inputs -> same end state (a flag set twice stays set).
-            idempotentHint=True,
-            openWorldHint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")
@@ -478,12 +445,10 @@ def configure_mail_tools(mcp: FastMCP):
             if value is not None
         }
         if not flags:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message="No flags given; pass at least one of seen, flagged, "
-                    "answered, junk",
-                )
+            raise MCPError(
+                code=-1,
+                message="No flags given; pass at least one of seen, flagged, "
+                "answered, junk",
             )
 
         client = await get_client(ctx)
@@ -500,8 +465,8 @@ def configure_mail_tools(mcp: FastMCP):
         annotations=ToolAnnotations(
             # Create-or-get: the Mail app returns the existing tag for a name
             # that already resolves to the same IMAP label.
-            idempotentHint=True,
-            openWorldHint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")
@@ -536,8 +501,8 @@ def configure_mail_tools(mcp: FastMCP):
     @mcp.tool(
         title="Tag Mail Message",
         annotations=ToolAnnotations(
-            idempotentHint=True,  # Re-tagging a tagged message is a no-op
-            openWorldHint=True,
+            idempotent_hint=True,  # Re-tagging a tagged message is a no-op
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")
@@ -568,8 +533,8 @@ def configure_mail_tools(mcp: FastMCP):
     @mcp.tool(
         title="Untag Mail Message",
         annotations=ToolAnnotations(
-            idempotentHint=True,  # Removing an absent tag leaves the same state
-            openWorldHint=True,
+            idempotent_hint=True,  # Removing an absent tag leaves the same state
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")
@@ -603,8 +568,8 @@ def configure_mail_tools(mcp: FastMCP):
             # with the same message_id is rejected (the Mail app answers 403)
             # rather than being a harmless no-op. Verified against a live Mail
             # app -- see test_move_message_between_mailboxes.
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")
@@ -637,13 +602,13 @@ def configure_mail_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Mail Message",
         annotations=ToolAnnotations(
-            destructiveHint=True,  # Removes the message from its mailbox
+            destructive_hint=True,  # Removes the message from its mailbox
             # NOT idempotent, unlike most deletes. Trashing is a move, so it
             # invalidates the id: a retry is rejected (403) instead of being a
             # no-op, and if the message was already in trash the first call
             # expunges it permanently. Verified against a live Mail app.
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("mail.write")

--- a/nextcloud_mcp_server/server/news.py
+++ b/nextcloud_mcp_server/server/news.py
@@ -3,9 +3,9 @@
 import logging
 
 from httpx import HTTPStatusError, RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.client.news import NewsItemType
@@ -27,12 +27,12 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 logger = logging.getLogger(__name__)
 
 
-def configure_news_tools(mcp: FastMCP):
+def configure_news_tools(mcp: MCPServer):
     """Configure News app MCP tools."""
 
     @mcp.tool(
         title="List News Folders",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -44,20 +44,16 @@ def configure_news_tools(mcp: FastMCP):
             folders = [NewsFolder(**f) for f in folders_data]
             return ListFoldersResponse(results=folders, total_count=len(folders))
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing folders: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error listing folders: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list folders: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list folders: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="List News Feeds",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -77,20 +73,16 @@ def configure_news_tools(mcp: FastMCP):
                 total_count=len(feeds),
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing feeds: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error listing feeds: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list feeds: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list feeds: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="List News Items",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -151,20 +143,16 @@ def configure_news_tools(mcp: FastMCP):
                 oldest_id=oldest_id,
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error listing items: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error listing items: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to list items: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list items: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get News Item",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -183,26 +171,22 @@ def configure_news_tools(mcp: FastMCP):
             item = NewsItem(**item_data)
             return GetItemResponse(item=item)
         except ValueError as e:
-            raise McpError(ErrorData(code=-1, message=str(e)))
+            raise MCPError(code=-1, message=str(e))
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error getting item {item_id}: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error getting item {item_id}: {str(e)}"
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Item {item_id} not found"))
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get item {item_id}: {e.response.status_code}",
-                )
+                raise MCPError(code=-1, message=f"Item {item_id} not found")
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get item {item_id}: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get Starred News Items",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -240,22 +224,18 @@ def configure_news_tools(mcp: FastMCP):
                 oldest_id=oldest_id,
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error getting starred items: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error getting starred items: {str(e)}"
             )
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get starred items: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get starred items: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get Unread News Items",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -293,22 +273,18 @@ def configure_news_tools(mcp: FastMCP):
                 oldest_id=oldest_id,
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error getting unread items: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error getting unread items: {str(e)}"
             )
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get unread items: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get unread items: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get News Feed Health",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -337,25 +313,21 @@ def configure_news_tools(mcp: FastMCP):
                         error_count=feed.update_error_count,
                         last_error=feed.last_update_error,
                     )
-            raise McpError(ErrorData(code=-1, message=f"Feed {feed_id} not found"))
+            raise MCPError(code=-1, message=f"Feed {feed_id} not found")
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error getting feed health: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error getting feed health: {str(e)}",
             )
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get feed health: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get feed health: {e.response.status_code}",
             )
 
     @mcp.tool(
         title="Get News App Status",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("news.read")
     @instrument_tool
@@ -372,13 +344,9 @@ def configure_news_tools(mcp: FastMCP):
                 warnings=status_data.get("warnings", {}),
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error getting status: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error getting status: {str(e)}")
         except HTTPStatusError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to get status: {e.response.status_code}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get status: {e.response.status_code}",
             )

--- a/nextcloud_mcp_server/server/notes.py
+++ b/nextcloud_mcp_server/server/notes.py
@@ -1,9 +1,9 @@
 import logging
 
 from httpx import HTTPStatusError, RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, ToolAnnotations
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.context import get_client
@@ -19,17 +19,18 @@ from nextcloud_mcp_server.models.notes import (
     UpdateNoteResponse,
 )
 from nextcloud_mcp_server.observability.metrics import instrument_tool
+from nextcloud_mcp_server.request_context import current_context
 
 logger = logging.getLogger(__name__)
 
 
-def configure_notes_tools(mcp: FastMCP):
+def configure_notes_tools(mcp: MCPServer):
     @mcp.resource("notes://settings")
     async def notes_get_settings():
         """Get the Notes App settings"""
-        ctx: Context = (
-            mcp.get_context()
-        )  # https://github.com/modelcontextprotocol/python-sdk/issues/244
+        # Static resources get no Context from the SDK:
+        # https://github.com/modelcontextprotocol/python-sdk/issues/244
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         settings_data = await client.notes.get_settings()
         return NotesSettings(**settings_data)
@@ -37,7 +38,7 @@ def configure_notes_tools(mcp: FastMCP):
     @mcp.resource("nc://Notes/{note_id}/attachments/{attachment_filename}")
     async def nc_notes_get_attachment_resource(note_id: int, attachment_filename: str):
         """Get a specific attachment from a note"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         # Assuming a method get_note_attachment exists in the client
         # This method should return the raw content and determine the mime type
@@ -59,38 +60,32 @@ def configure_notes_tools(mcp: FastMCP):
     async def nc_get_note_resource(note_id: int):
         """Get user note using note id"""
 
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_client(ctx)
         try:
             note_data = await client.notes.get_note(note_id)
             return Note(**note_data)
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error retrieving note {note_id}: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error retrieving note {note_id}: {str(e)}",
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Note {note_id} not found"))
+                raise MCPError(code=-1, message=f"Note {note_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Access denied to note {note_id}")
-                )
+                raise MCPError(code=-1, message=f"Access denied to note {note_id}")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
                 )
 
     @mcp.tool(
         title="Create Note",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Multiple calls create multiple notes
-            openWorldHint=True,
+            idempotent_hint=False,  # Multiple calls create multiple notes
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.write")
@@ -112,39 +107,31 @@ def configure_notes_tools(mcp: FastMCP):
                 id=note.id, title=note.title, category=note.category, etag=note.etag
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error creating note: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error creating note: {str(e)}")
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to create notes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to create notes",
                 )
             elif e.response.status_code == 413:
-                raise McpError(ErrorData(code=-1, message="Note content too large"))
+                raise MCPError(code=-1, message="Note content too large")
             elif e.response.status_code == 409:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"A note with title '{title}' already exists in this category",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"A note with title '{title}' already exists in this category",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to create note: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to create note: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Update Note",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Requires etag which changes = not idempotent
-            openWorldHint=True,
+            idempotent_hint=False,  # Requires etag which changes = not idempotent
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.write")
@@ -179,45 +166,35 @@ def configure_notes_tools(mcp: FastMCP):
                 id=note.id, title=note.title, category=note.category, etag=note.etag
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error updating note {note_id}: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error updating note {note_id}: {str(e)}"
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Note {note_id} not found"))
+                raise MCPError(code=-1, message=f"Note {note_id} not found")
             elif e.response.status_code == 412:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
                 )
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied: insufficient permissions to update note {note_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied: insufficient permissions to update note {note_id}",
                 )
             elif e.response.status_code == 413:
-                raise McpError(
-                    ErrorData(code=-1, message="Updated note content is too large")
-                )
+                raise MCPError(code=-1, message="Updated note content is too large")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Append to Note",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Each call adds content = not idempotent
-            openWorldHint=True,
+            idempotent_hint=False,  # Each call adds content = not idempotent
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.write")
@@ -240,42 +217,34 @@ def configure_notes_tools(mcp: FastMCP):
                 id=note.id, title=note.title, category=note.category, etag=note.etag
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error appending to note {note_id}: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error appending to note {note_id}: {str(e)}",
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Note {note_id} not found"))
+                raise MCPError(code=-1, message=f"Note {note_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied: insufficient permissions to modify note {note_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied: insufficient permissions to modify note {note_id}",
                 )
             elif e.response.status_code == 413:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Content to append would make the note too large",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Content to append would make the note too large",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Search Notes",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Search doesn't modify data
-            openWorldHint=True,
+            read_only_hint=True,  # Search doesn't modify data
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.read")
@@ -302,34 +271,26 @@ def configure_notes_tools(mcp: FastMCP):
                 results=results, query=query, total_found=len(results)
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error searching notes: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error searching notes: {str(e)}")
         except HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Access denied: insufficient permissions to search notes",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Access denied: insufficient permissions to search notes",
                 )
             elif e.response.status_code == 400:
-                raise McpError(
-                    ErrorData(code=-1, message="Invalid search query format")
-                )
+                raise MCPError(code=-1, message="Invalid search query format")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Search failed: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Search failed: server error ({e.response.status_code})",
                 )
 
     @mcp.tool(
         title="Get Note",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Read operation only
-            openWorldHint=True,
+            read_only_hint=True,  # Read operation only
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.read")
@@ -342,31 +303,25 @@ def configure_notes_tools(mcp: FastMCP):
             note_data = await client.notes.get_note(note_id)
             return Note(**note_data)
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error getting note {note_id}: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error getting note {note_id}: {str(e)}"
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Note {note_id} not found"))
+                raise MCPError(code=-1, message=f"Note {note_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(code=-1, message=f"Access denied to note {note_id}")
-                )
+                raise MCPError(code=-1, message=f"Access denied to note {note_id}")
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
                 )
 
     @mcp.tool(
         title="Get Note Attachment",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Read operation only
-            openWorldHint=True,
+            read_only_hint=True,  # Read operation only
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.read")
@@ -386,41 +341,33 @@ def configure_notes_tools(mcp: FastMCP):
                 "data": content,
             }
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Attachment {attachment_filename} not found for note {note_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Attachment {attachment_filename} not found for note {note_id}",
                 )
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied to attachment {attachment_filename} for note {note_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied to attachment {attachment_filename} for note {note_id}",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
                 )
 
     @mcp.tool(
         title="Delete Note",
         annotations=ToolAnnotations(
-            destructiveHint=True,  # Permanently deletes data
-            idempotentHint=True,  # Deleting deleted note = same end state
-            openWorldHint=True,
+            destructive_hint=True,  # Permanently deletes data
+            idempotent_hint=True,  # Deleting deleted note = same end state
+            open_world_hint=True,
         ),
     )
     @require_scopes("notes.write")
@@ -437,25 +384,19 @@ def configure_notes_tools(mcp: FastMCP):
                 deleted_id=note_id,
             )
         except RequestError as e:
-            raise McpError(
-                ErrorData(
-                    code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
-                )
+            raise MCPError(
+                code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
             )
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise McpError(ErrorData(code=-1, message=f"Note {note_id} not found"))
+                raise MCPError(code=-1, message=f"Note {note_id} not found")
             elif e.response.status_code == 403:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Access denied: insufficient permissions to delete note {note_id}",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Access denied: insufficient permissions to delete note {note_id}",
                 )
             else:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
                 )

--- a/nextcloud_mcp_server/server/oauth_tools.py
+++ b/nextcloud_mcp_server/server/oauth_tools.py
@@ -8,9 +8,10 @@ Nextcloud access using the Flow 2 (Resource Provisioning) OAuth flow.
 import logging
 import secrets
 from datetime import datetime, timezone
+from typing import Any
 from urllib.parse import urlencode
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
@@ -458,7 +459,7 @@ async def _check_logged_in(ctx: Context, user_id: str) -> str:
         server_client_id = cfg("MCP_SERVER_CLIENT_ID")
         if not server_client_id:
             # Try to get from lifespan context (DCR)
-            lifespan_ctx = ctx.request_context.lifespan_context
+            lifespan_ctx: Any = ctx.request_context.lifespan_context
             if hasattr(lifespan_ctx, "server_client_id"):
                 server_client_id = lifespan_ctx.server_client_id
 
@@ -609,8 +610,8 @@ def register_oauth_tools(mcp):
             "You'll need to complete an OAuth authorization in your browser."
         ),
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Creates new OAuth session each time
-            openWorldHint=True,
+            idempotent_hint=False,  # Creates new OAuth session each time
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")
@@ -624,9 +625,9 @@ def register_oauth_tools(mcp):
         title="Revoke Server Access to Nextcloud",
         description="Revoke offline access to Nextcloud resources.",
         annotations=ToolAnnotations(
-            destructiveHint=True,  # Removes stored access tokens
-            idempotentHint=True,  # Revoking revoked access = same end state
-            openWorldHint=True,
+            destructive_hint=True,  # Removes stored access tokens
+            idempotent_hint=True,  # Revoking revoked access = same end state
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")
@@ -640,8 +641,8 @@ def register_oauth_tools(mcp):
         title="Check Provisioning Status",
         description="Check whether Nextcloud access is provisioned.",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Only checks status, doesn't modify
-            openWorldHint=True,
+            read_only_hint=True,  # Only checks status, doesn't modify
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")
@@ -658,8 +659,8 @@ def register_oauth_tools(mcp):
             "If not logged in, this tool will prompt you to complete the login flow."
         ),
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Checking status doesn't modify state
-            openWorldHint=True,
+            read_only_hint=True,  # Checking status doesn't modify state
+            open_world_hint=True,
         ),
     )
     @require_scopes("openid")

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -927,10 +927,12 @@ def configure_semantic_tools(mcp: MCPServer):
             raise MCPError(code=-1, message=f"Network error during search: {str(e)}")
         except Exception as e:
             # Genuinely-unexpected bucket (after the ValueError / RequestError
-            # cases above). We convert it to a client-facing MCPError, which
-            # MCPServer returns as a structured protocol error without logging a
-            # server-side traceback — so, like the sampling catch-all below, keep
-            # the stack here (logger.exception) for triage.
+            # cases above). We convert it to an MCPError so the reason survives:
+            # NextcloudMCPServer.call_tool maps that back to ToolError, which the
+            # SDK delivers as is_error=True content the model can read. Raised
+            # bare, mcp 2.x would replace the message with "Error executing tool
+            # <name>". Neither path logs a server-side traceback, so — like the
+            # sampling catch-all below — keep the stack here for triage.
             logger.exception("Search error: %s", e)
             raise MCPError(code=-1, message=f"Search failed: {str(e)}")
         finally:

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -1,14 +1,13 @@
 """Semantic search MCP tools using vector database."""
 
 import logging
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 import anyio
 from httpx import RequestError
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.exceptions import McpError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
 from mcp.types import (
-    ErrorData,
     ToolAnnotations,
 )
 from pydantic import Field
@@ -84,21 +83,21 @@ def _consent_narrowed_doc_types(
     return [dt for dt in doc_types if dt in allowed]
 
 
-def configure_semantic_tools(mcp: FastMCP):
+def configure_semantic_tools(mcp: MCPServer):
     """Configure semantic search tools for MCP server."""
 
     @mcp.tool(
         title="Semantic Search",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Search doesn't modify data
-            openWorldHint=True,  # Queries external Nextcloud service
+            read_only_hint=True,  # Search doesn't modify data
+            open_world_hint=True,  # Queries external Nextcloud service
         ),
     )
     @require_scopes("semantic.read")
     @instrument_tool
     async def nc_semantic_search(  # NOSONAR(S107)
         # S107 (too many parameters) is suppressed deliberately: for an MCP tool
-        # the parameter list IS the wire schema that FastMCP publishes to
+        # the parameter list IS the wire schema that MCPServer publishes to
         # clients. Grouping these into a settings object to satisfy the rule
         # would change the tool's advertised interface and break every caller,
         # so the smell is inherent to the surface rather than to this function.
@@ -322,16 +321,14 @@ def configure_semantic_tools(mcp: FastMCP):
 
         # Check that vector sync is enabled — search queries the Qdrant index.
         if not settings.vector_sync_enabled:
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message="Cross-app search requires VECTOR_SYNC_ENABLED=true",
-                )
+            raise MCPError(
+                code=-1,
+                message="Cross-app search requires VECTOR_SYNC_ENABLED=true",
             )
 
         # Normalize the RFC 3339 / Unix-seconds date bounds to int Unix seconds
         # for the numeric ``modified_at`` Range filter (ADR-027). A bad format
-        # surfaces as a clean McpError rather than a 500.
+        # surfaces as a clean MCPError rather than a 500.
         try:
             modified_after_ts = parse_modified_timestamp(
                 modified_after, param_name="modified_after"
@@ -340,27 +337,25 @@ def configure_semantic_tools(mcp: FastMCP):
                 modified_before, param_name="modified_before"
             )
         except ValueError as exc:
-            raise McpError(ErrorData(code=-1, message=str(exc))) from exc
+            raise MCPError(code=-1, message=str(exc)) from exc
 
         # Cross-field invariant: a per-parameter pydantic ``Field`` constraint
-        # (validated by FastMCP from the signature) bounds each date on its own
+        # (validated by MCPServer from the signature) bounds each date on its own
         # but cannot express the relationship between them. Guard it here so an
-        # inverted range surfaces a clean McpError rather than silently
+        # inverted range surfaces a clean MCPError rather than silently
         # returning zero results (ADR-027).
         if (
             modified_after_ts is not None
             and modified_before_ts is not None
             and modified_after_ts > modified_before_ts
         ):
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=(
-                        "modified_after must be <= modified_before "
-                        f"(got modified_after={modified_after!r}, "
-                        f"modified_before={modified_before!r})"
-                    ),
-                )
+            raise MCPError(
+                code=-1,
+                message=(
+                    "modified_after must be <= modified_before "
+                    f"(got modified_after={modified_after!r}, "
+                    f"modified_before={modified_before!r})"
+                ),
             )
 
         # Capability gate. Rejecting is deliberate: silently returning
@@ -370,16 +365,14 @@ def configure_semantic_tools(mcp: FastMCP):
         # probe. (A reranker that is configured but momentarily unavailable is
         # a different case — that degrades, and the response says so.)
         if rerank and not rerank_available(settings):
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=(
-                        "Reranking is not configured on this server. Set "
-                        "SEARCH_RERANK_ENABLED=true (requires "
-                        "EMBEDDING_GATEWAY_URL), or omit rerank to use "
-                        "retrieval ordering."
-                    ),
-                )
+            raise MCPError(
+                code=-1,
+                message=(
+                    "Reranking is not configured on this server. Set "
+                    "SEARCH_RERANK_ENABLED=true (requires "
+                    "EMBEDDING_GATEWAY_URL), or omit rerank to use "
+                    "retrieval ordering."
+                ),
             )
 
         # Merge the legacy single path_prefix and the path_prefixes list into one
@@ -455,7 +448,7 @@ def configure_semantic_tools(mcp: FastMCP):
                 )
 
         # Search-metric state, recorded in the ``finally`` below so every exit —
-        # success, McpError, or an unexpected raise — lands exactly one
+        # success, MCPError, or an unexpected raise — lands exactly one
         # ``astrolabe_search_requests_total`` sample. Defaults describe the
         # failure case; the success path overwrites them.
         metric_status = "error"
@@ -614,9 +607,8 @@ def configure_semantic_tools(mcp: FastMCP):
             # AttributeError surfaces during the first search rather than
             # silently degrading to inline eviction for the life of the
             # process.
-            eviction_task_group = (
-                ctx.request_context.lifespan_context.eviction_task_group
-            )
+            lifespan_ctx: Any = ctx.request_context.lifespan_context
+            eviction_task_group = lifespan_ctx.eviction_task_group
             verification_start = anyio.current_time()
             verified_results, dropped_count = await verify_search_results(
                 client,
@@ -926,27 +918,21 @@ def configure_semantic_tools(mcp: FastMCP):
         except ValueError as e:
             error_msg = str(e)
             if "No embedding provider configured" in error_msg:
-                raise McpError(
-                    ErrorData(
-                        code=-1,
-                        message="Embedding service not configured. Set OLLAMA_BASE_URL environment variable.",
-                    )
+                raise MCPError(
+                    code=-1,
+                    message="Embedding service not configured. Set OLLAMA_BASE_URL environment variable.",
                 )
-            raise McpError(
-                ErrorData(code=-1, message=f"Configuration error: {error_msg}")
-            )
+            raise MCPError(code=-1, message=f"Configuration error: {error_msg}")
         except RequestError as e:
-            raise McpError(
-                ErrorData(code=-1, message=f"Network error during search: {str(e)}")
-            )
+            raise MCPError(code=-1, message=f"Network error during search: {str(e)}")
         except Exception as e:
             # Genuinely-unexpected bucket (after the ValueError / RequestError
-            # cases above). We convert it to a client-facing McpError, which
-            # FastMCP returns as a structured protocol error without logging a
+            # cases above). We convert it to a client-facing MCPError, which
+            # MCPServer returns as a structured protocol error without logging a
             # server-side traceback — so, like the sampling catch-all below, keep
             # the stack here (logger.exception) for triage.
             logger.exception("Search error: %s", e)
-            raise McpError(ErrorData(code=-1, message=f"Search failed: {str(e)}"))
+            raise MCPError(code=-1, message=f"Search failed: {str(e)}")
         finally:
             # One sample per search, on every exit path. Paired with the
             # identical call in api/visualization.py so the MCP and HTTP
@@ -964,8 +950,8 @@ def configure_semantic_tools(mcp: FastMCP):
     @mcp.tool(
         title="Check Indexing Status",
         annotations=ToolAnnotations(
-            readOnlyHint=True,  # Only checks status
-            openWorldHint=True,
+            read_only_hint=True,  # Only checks status
+            open_world_hint=True,
         ),
     )
     @require_scopes("semantic.read")
@@ -1009,7 +995,7 @@ def configure_semantic_tools(mcp: FastMCP):
                 get_ingest_pending,
             )
 
-            lifespan_ctx = ctx.request_context.lifespan_context
+            lifespan_ctx: Any = ctx.request_context.lifespan_context
             pending = await get_ingest_pending(
                 task_producer=lifespan_ctx.task_producer,
                 document_receive_stream=lifespan_ctx.document_receive_stream,
@@ -1062,9 +1048,7 @@ def configure_semantic_tools(mcp: FastMCP):
 
         except Exception as e:
             logger.error("Error getting vector sync status: %s", e)
-            raise McpError(
-                ErrorData(
-                    code=-1,
-                    message=f"Failed to retrieve vector sync status: {str(e)}",
-                )
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve vector sync status: {str(e)}",
             )

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -32,7 +32,7 @@ def _compute_link_expiry(expires_in_minutes: int, now: datetime) -> tuple[str, s
         A tuple of ``(expireDate as YYYY-MM-DD, expires_at as RFC3339 'Z')``.
 
     Raises:
-        ValueError: If ``expires_in_minutes`` is not positive — this tool only
+        ToolError: If ``expires_in_minutes`` is not positive — this tool only
             creates short-lived links, never a permanent (non-expiring) one.
     """
     if expires_in_minutes <= 0:
@@ -57,13 +57,16 @@ def _build_link_response(
         expires_at: Advisory RFC3339 expiry computed by ``_compute_link_expiry``.
 
     Raises:
-        RuntimeError: If the payload carries no ``url``. OCS always returns one
+        ToolError: If the payload carries no ``url``. OCS always returns one
             for ``shareType=3``; its absence means the response shape changed,
             and a hard error beats handing the caller unusable empty URLs.
+            ``ToolError`` rather than a bare exception because mcp 2.x replaces
+            an unanticipated exception's message with "Error executing tool
+            <name>" -- the model would be told the call failed but not why.
     """
     url = share_data.get("url", "")
     if not url:
-        raise RuntimeError(
+        raise ToolError(
             f"Public link share {share_data.get('id')} for {path} returned no "
             "url — unexpected OCS response shape"
         )
@@ -205,7 +208,8 @@ def configure_sharing_tools(mcp: MCPServer):
             advisory expiry.
 
         Raises:
-            ValueError: If ``expires_in_minutes`` is not positive.
+            ToolError: If ``expires_in_minutes`` is not positive, or if the OCS
+                response carries no share url.
         """
         expire_date, expires_at = _compute_link_expiry(
             expires_in_minutes, datetime.now(timezone.utc)

--- a/nextcloud_mcp_server/server/sharing.py
+++ b/nextcloud_mcp_server/server/sharing.py
@@ -3,8 +3,8 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -36,7 +36,7 @@ def _compute_link_expiry(expires_in_minutes: int, now: datetime) -> tuple[str, s
             creates short-lived links, never a permanent (non-expiring) one.
     """
     if expires_in_minutes <= 0:
-        raise ValueError("expires_in_minutes must be a positive number of minutes")
+        raise ToolError("expires_in_minutes must be a positive number of minutes")
     target = now + timedelta(minutes=expires_in_minutes)
     expire_date = (target.date() + timedelta(days=1)).isoformat()
     # Match BaseResponse.serialize_timestamp: only collapse a *trailing* UTC
@@ -79,16 +79,16 @@ def _build_link_response(
     )
 
 
-def configure_sharing_tools(mcp: FastMCP):
+def configure_sharing_tools(mcp: MCPServer):
     """Configure sharing-related MCP tools.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer server instance
     """
 
     @mcp.tool(
         title="Create Share",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("sharing.write")
     @instrument_tool
@@ -158,7 +158,7 @@ def configure_sharing_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Create Public Download Link",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("sharing.write")
     @instrument_tool
@@ -222,7 +222,7 @@ def configure_sharing_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Share",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("sharing.write")
@@ -246,7 +246,7 @@ def configure_sharing_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Share Details",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("sharing.write")
     @instrument_tool
@@ -268,7 +268,7 @@ def configure_sharing_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="List Shares",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("sharing.write")
     @instrument_tool
@@ -293,7 +293,7 @@ def configure_sharing_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Share",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("sharing.write")
     @instrument_tool

--- a/nextcloud_mcp_server/server/tables.py
+++ b/nextcloud_mcp_server/server/tables.py
@@ -1,6 +1,6 @@
 import logging
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -11,11 +11,11 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 logger = logging.getLogger(__name__)
 
 
-def configure_tables_tools(mcp: FastMCP):
+def configure_tables_tools(mcp: MCPServer):
     # Tables tools
     @mcp.tool(
         title="List Tables",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("tables.read")
     @instrument_tool
@@ -28,7 +28,7 @@ def configure_tables_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Get Table Schema",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("tables.read")
     @instrument_tool
@@ -39,7 +39,7 @@ def configure_tables_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Read Table Rows",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("tables.read")
     @instrument_tool
@@ -55,7 +55,7 @@ def configure_tables_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Insert Table Row",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("tables.write")
     @instrument_tool
@@ -69,7 +69,7 @@ def configure_tables_tools(mcp: FastMCP):
 
     @mcp.tool(
         title="Update Table Row",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("tables.write")
     @instrument_tool
@@ -84,7 +84,7 @@ def configure_tables_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete Table Row",
         annotations=ToolAnnotations(
-            destructiveHint=True, idempotentHint=True, openWorldHint=True
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
     )
     @require_scopes("tables.write")

--- a/nextcloud_mcp_server/server/talk.py
+++ b/nextcloud_mcp_server/server/talk.py
@@ -3,8 +3,8 @@
 import logging
 import uuid
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.auth import require_scopes
@@ -37,21 +37,21 @@ def _validate_message_text(message: str) -> None:
     # Reject both empty strings and whitespace-only strings — spreed
     # would happily post the latter as a visually-blank message.
     if not message or not message.strip():
-        raise ValueError("Message text must not be empty or whitespace-only")
+        raise ToolError("Message text must not be empty or whitespace-only")
     if len(message) > _MESSAGE_MAX_LENGTH:
-        raise ValueError(
+        raise ToolError(
             f"Message too long: {len(message)} characters (max {_MESSAGE_MAX_LENGTH})"
         )
 
 
-def configure_talk_tools(mcp: FastMCP) -> None:
+def configure_talk_tools(mcp: MCPServer) -> None:
     """Configure Nextcloud Talk (spreed) MCP tools."""
 
     # Read tools
 
     @mcp.tool(
         title="List Talk Conversations",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.read")
     @instrument_tool
@@ -77,7 +77,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="Get Talk Conversation",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.read")
     @instrument_tool
@@ -95,7 +95,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="Get Talk Messages",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.read")
     @instrument_tool
@@ -141,7 +141,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="List Talk Conversation Participants",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.read")
     @instrument_tool
@@ -168,7 +168,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="Send Talk Message",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("talk.write")
     @instrument_tool
@@ -205,7 +205,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="Mark Talk Conversation as Read",
-        annotations=ToolAnnotations(idempotentHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.write")
     @instrument_tool
@@ -233,7 +233,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="Create Talk Conversation",
-        annotations=ToolAnnotations(idempotentHint=False, openWorldHint=True),
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
     )
     @require_scopes("talk.write")
     @instrument_tool
@@ -283,8 +283,8 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(
             # Adding someone already in the room succeeds as a no-op (verified
             # against Talk 22.0.17), so repeating the call leaves the same state.
-            idempotentHint=True,
-            openWorldHint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("talk.write")
@@ -320,7 +320,7 @@ def configure_talk_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         title="List Talk Message Reactions",
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
     )
     @require_scopes("talk.read")
     @require_capability("spreed", feature="reactions")
@@ -354,8 +354,8 @@ def configure_talk_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(
             # Reactions are a set: reacting twice with the same emoji leaves the
             # same state (spreed answers 201 then 200).
-            idempotentHint=True,
-            openWorldHint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("talk.write")
@@ -389,11 +389,11 @@ def configure_talk_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         title="Remove Talk Message Reaction",
         annotations=ToolAnnotations(
-            destructiveHint=True,
+            destructive_hint=True,
             # Same end state when repeated, though the server reports the second
             # removal as a 404 rather than a no-op.
-            idempotentHint=True,
-            openWorldHint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("talk.write")

--- a/nextcloud_mcp_server/server/webdav.py
+++ b/nextcloud_mcp_server/server/webdav.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Literal
 
 import anyio
 from anyio.to_thread import run_sync
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base
@@ -192,13 +192,13 @@ async def _resolve_commented_file(client: "NextcloudClient", path: str) -> int:
         ) from None
 
 
-def configure_webdav_tools(mcp: FastMCP):
+def configure_webdav_tools(mcp: MCPServer):
     # WebDAV file system tools
     @mcp.tool(
         title="List Files and Directories",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -257,8 +257,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Read File",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -494,8 +494,8 @@ def configure_webdav_tools(mcp: FastMCP):
             # succeeds once then returns 412 ("already exists") on repeat, and
             # an if_match overwrite is invalidated by its own success (the etag
             # changes) -- mirroring nc_notes_update_note's etag-guarded update.
-            idempotentHint=False,
-            openWorldHint=True,
+            idempotent_hint=False,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -597,8 +597,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Create Directory",
         annotations=ToolAnnotations(
-            idempotentHint=True,  # Creating existing dir returns 405 = same end state
-            openWorldHint=True,
+            idempotent_hint=True,  # Creating existing dir returns 405 = same end state
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -630,9 +630,9 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Delete File or Directory",
         annotations=ToolAnnotations(
-            destructiveHint=True,  # Permanently deletes data
-            idempotentHint=True,  # Deleting deleted resource = same end state
-            openWorldHint=True,
+            destructive_hint=True,  # Permanently deletes data
+            idempotent_hint=True,  # Deleting deleted resource = same end state
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -661,8 +661,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Move or Rename File",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Moving changes source and dest
-            openWorldHint=True,
+            idempotent_hint=False,  # Moving changes source and dest
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -732,8 +732,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Copy File or Directory",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Creates new resource each time
-            openWorldHint=True,
+            idempotent_hint=False,  # Creates new resource each time
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -803,8 +803,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Search Files",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -922,8 +922,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Find Files by Name",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -966,8 +966,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Find Files by Type",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -1010,8 +1010,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="List Favorite Files",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -1051,8 +1051,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="List File Comments",
         annotations=ToolAnnotations(
-            readOnlyHint=True,
-            openWorldHint=True,
+            read_only_hint=True,
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.read")
@@ -1078,9 +1078,9 @@ def configure_webdav_tools(mcp: FastMCP):
             ListFileCommentsResponse with the comments, newest first.
         """
         if limit <= 0:
-            raise ValueError(f"limit must be positive, got {limit}")
+            raise ToolError(f"limit must be positive, got {limit}")
         if offset < 0:
-            raise ValueError(f"offset must not be negative, got {offset}")
+            raise ToolError(f"offset must not be negative, got {offset}")
 
         client = await get_client(ctx)
         file_id = await _resolve_commented_file(client, path)
@@ -1100,8 +1100,8 @@ def configure_webdav_tools(mcp: FastMCP):
     @mcp.tool(
         title="Comment on File",
         annotations=ToolAnnotations(
-            idempotentHint=False,  # Each call adds another comment
-            openWorldHint=True,
+            idempotent_hint=False,  # Each call adds another comment
+            open_world_hint=True,
         ),
     )
     @require_scopes("files.write")
@@ -1131,10 +1131,10 @@ def configure_webdav_tools(mcp: FastMCP):
             CreateFileCommentResponse with the new comment's ID.
         """
         if is_blank_comment(message):
-            raise ValueError("Comment message must not be empty or whitespace-only")
+            raise ToolError("Comment message must not be empty or whitespace-only")
         length = measured_length(message)
         if length > COMMENT_MAX_LENGTH:
-            raise ValueError(
+            raise ToolError(
                 f"Comment message is {length} characters; Nextcloud's limit is "
                 f"{COMMENT_MAX_LENGTH} (measured after trimming whitespace, "
                 f"counting Unicode code points). It is "

--- a/nextcloud_mcp_server/stdio.py
+++ b/nextcloud_mcp_server/stdio.py
@@ -1,6 +1,6 @@
 """Lightweight stdio transport for the Nextcloud MCP server.
 
-Provides a minimal FastMCP instance suitable for ``mcp.run(transport="stdio")``.
+Provides a minimal MCPServer instance suitable for ``mcp.run(transport="stdio")``.
 Only single-user BasicAuth mode is supported.  Background sync, semantic search,
 OAuth, and the observability *plumbing* — the Prometheus HTTP endpoint and the
 OTel tracing setup — are deliberately excluded; the per-tool-call logging and
@@ -14,15 +14,16 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.client import NextcloudClient
 from nextcloud_mcp_server.config import get_settings
 from nextcloud_mcp_server.config_validators import AuthMode, validate_configuration
 from nextcloud_mcp_server.context import BasicAuthLifespanContext
 from nextcloud_mcp_server.context import get_client as get_nextcloud_client
-from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.errors import NextcloudMCPServer
 from nextcloud_mcp_server.observability.metrics import instrument_call_tool_outcomes
+from nextcloud_mcp_server.request_context import current_context
 from nextcloud_mcp_server.server import AVAILABLE_APPS, configure_app_tools
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class StdioContext(BasicAuthLifespanContext):
 
 
 @asynccontextmanager
-async def stdio_lifespan(server: FastMCP) -> AsyncIterator[StdioContext]:
+async def stdio_lifespan(server: MCPServer) -> AsyncIterator[StdioContext]:
     """Create and tear down a single :class:`NextcloudClient`."""
     logger.info("Starting MCP server in stdio mode (single-user BasicAuth)")
     client = NextcloudClient.from_env()
@@ -52,8 +53,8 @@ async def stdio_lifespan(server: FastMCP) -> AsyncIterator[StdioContext]:
         logger.info("stdio session shut down")
 
 
-def get_stdio_mcp(enabled_apps: list[str] | None = None) -> FastMCP:
-    """Return a :class:`FastMCP` instance configured for stdio transport.
+def get_stdio_mcp(enabled_apps: list[str] | None = None) -> MCPServer:
+    """Return a :class:`MCPServer` instance configured for stdio transport.
 
     Parameters
     ----------
@@ -81,16 +82,17 @@ def get_stdio_mcp(enabled_apps: list[str] | None = None) -> FastMCP:
             f"and NEXTCLOUD_PASSWORD."
         )
 
-    mcp = NextcloudFastMCP("Nextcloud MCP", lifespan=stdio_lifespan)
+    mcp = NextcloudMCPServer("Nextcloud MCP", lifespan=stdio_lifespan)
 
     # --- capabilities resource (mirrors app.py) ---
-    # NOTE: mcp.get_context() is required here because FastMCP's
-    # FunctionResource (non-template resources) does not support
-    # context parameter injection — only template resources do.
+    # NOTE: current_context() is required here because MCPServer's
+    # FunctionResource (non-template resources) does not support context
+    # parameter injection — only template resources do — and mcp 2.x removed
+    # get_context(). See nextcloud_mcp_server.request_context.
     @mcp.resource("nc://capabilities")
     async def nc_get_capabilities():
         """Get the Nextcloud Host capabilities"""
-        ctx: Context = mcp.get_context()
+        ctx = current_context(mcp)
         client = await get_nextcloud_client(ctx)
         return await client.capabilities()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.11"
 keywords = ["nextcloud", "mcp", "model-context-protocol", "llm", "ai", "claude", "webdav", "caldav", "carddav"]
 dependencies = [
-    "mcp[cli] (>=1.29,<1.30)",
+    "mcp[cli] (>=2.1,<3)",
     "httpx (>=0.28.1,<0.29.0)",
     # Imported directly at runtime. Each was previously reachable only because
     # some other dependency happened to pull it in — the accident that broke
@@ -152,6 +152,10 @@ module-root = ""
 [dependency-groups]
 dev = [
     "commitizen>=4.8.2",
+    # Imported directly by tests/conftest.py and tests/load/ to build the
+    # httpx2.AsyncClient that mcp 2.x's streamable_http_client takes; mcp pulls
+    # it in anyway, but the import here is ours.
+    "httpx2>=2.5.0",
     "deptry>=0.20.0",
     "ipython>=9.2.0",
     "playwright>=1.49.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,12 @@ from urllib.parse import parse_qs, quote, urlparse
 
 import anyio
 import httpx
+import httpx2
 import pytest
 from httpx import HTTPStatusError
 from mcp import ClientSession
-from mcp.client.session import RequestContext
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.context import ClientRequestContext
+from mcp.client.streamable_http import streamable_http_client
 from mcp.types import ElicitRequestParams, ElicitResult, ErrorData
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
@@ -176,9 +177,9 @@ async def create_mcp_client_session(
         token: Optional OAuth access token for Bearer authentication
         client_name: Client name for logging (e.g., "OAuth MCP (Playwright)")
         elicitation_callback: Optional callback for handling elicitation requests.
-            Should match signature: async def callback(context: RequestContext, params: ElicitRequestParams) -> ElicitResult | ErrorData
+            Should match signature: async def callback(context: ClientRequestContext, params: ElicitRequestParams) -> ElicitResult | ErrorData
         sampling_callback: Optional callback for handling sampling (LLM generation) requests.
-            Should match signature: async def callback(context: RequestContext, params: CreateMessageRequestParams) -> CreateMessageResult | ErrorData
+            Should match signature: async def callback(context: ClientRequestContext, params: CreateMessageRequestParams) -> CreateMessageResult | ErrorData
         headers: Optional custom headers (e.g., for BasicAuth). If both headers and token are provided,
             custom headers take precedence.
 
@@ -198,21 +199,28 @@ async def create_mcp_client_session(
         headers = {"Authorization": f"Bearer {token}"} if token else None
 
     # Use native async with - Python ensures LIFO cleanup
-    # Cleanup order will be: ClientSession.__aexit__ -> streamablehttp_client.__aexit__
-    async with streamablehttp_client(url, headers=headers) as (
-        read_stream,
-        write_stream,
-        _,
-    ):
-        async with ClientSession(
+    # Cleanup order will be: ClientSession.__aexit__ -> http_client.__aexit__
+    http_client = httpx2.AsyncClient(
+        headers=headers,
+        # mcp 1.x's streamablehttp_client defaulted to these; a bare
+        # httpx2.AsyncClient falls back to a flat 5s, too short for the GET stream.
+        timeout=httpx2.Timeout(30, read=300),
+        follow_redirects=True,
+    )
+    async with http_client:
+        async with streamable_http_client(url, http_client=http_client) as (
             read_stream,
             write_stream,
-            elicitation_callback=elicitation_callback,
-            sampling_callback=sampling_callback,
-        ) as session:
-            await session.initialize()
-            logger.info("%s client session initialized successfully", client_name)
-            yield session
+        ):
+            async with ClientSession(
+                read_stream,
+                write_stream,
+                elicitation_callback=elicitation_callback,
+                sampling_callback=sampling_callback,
+            ) as session:
+                await session.initialize()
+                logger.info("%s client session initialized successfully", client_name)
+                yield session
 
     # Cleanup happens automatically in LIFO order - no exception suppression needed
     logger.debug("%s client session cleaned up successfully", client_name)
@@ -373,7 +381,7 @@ async def nc_mcp_oauth_client_with_elicitation(
     elicitation_triggered = {"count": 0}
 
     async def elicitation_callback(
-        context: RequestContext[ClientSession, Any],
+        context: ClientRequestContext,
         params: ElicitRequestParams,
     ) -> ElicitResult | ErrorData:
         """Handle elicitation by completing OAuth flow with Playwright."""

--- a/tests/integration/_search_helpers.py
+++ b/tests/integration/_search_helpers.py
@@ -31,7 +31,7 @@ async def document_is_searchable(
     except Exception as e:  # transient transport/availability blip — keep polling
         logger.debug("Semantic search poll failed: %s", e)
         return False
-    if search.isError:
+    if search.is_error:
         logger.debug("Semantic search poll error: %s", search)
         return False
 

--- a/tests/integration/client/test_document_processing_progress.py
+++ b/tests/integration/client/test_document_processing_progress.py
@@ -100,10 +100,10 @@ class TestDocumentProcessingProgress:
                 "nc_webdav_read_file", arguments={"path": test_path}
             )
 
-            # Note: FastMCP progress notifications are sent automatically by ctx.report_progress
+            # Note: MCPServer progress notifications are sent automatically by ctx.report_progress
             # We can't easily capture them in this test without mocking the MCP transport layer
             # The important thing is that the code path is exercised without errors
-            assert result.isError is False
+            assert result.is_error is False
 
         finally:
             # Cleanup

--- a/tests/integration/test_astrolabe_chunk_context.py
+++ b/tests/integration/test_astrolabe_chunk_context.py
@@ -142,7 +142,7 @@ async def test_chunk_context_endpoint_uses_app_password(
             client_name="Alice Chunk Context Test",
         ) as mcp_client:
             initial_sync = await mcp_client.call_tool("nc_get_vector_sync_status", {})
-            if initial_sync.isError:
+            if initial_sync.is_error:
                 pytest.skip("Vector sync not enabled on mcp-multi-user-basic")
             initial_count = json.loads(initial_sync.content[0].text).get(
                 "indexed_count", 0
@@ -165,7 +165,7 @@ async def test_chunk_context_endpoint_uses_app_password(
                     "category": "Test",
                 },
             )
-            assert not note_response.isError, f"Create note failed: {note_response}"
+            assert not note_response.is_error, f"Create note failed: {note_response}"
             note_id = json.loads(note_response.content[0].text).get("id")
             assert note_id is not None
 

--- a/tests/integration/test_astrolabe_plotly_visualization.py
+++ b/tests/integration/test_astrolabe_plotly_visualization.py
@@ -84,7 +84,7 @@ async def wait_for_vector_sync(
 
     while waited < timeout_seconds:
         sync_status = await mcp_client.call_tool("nc_get_vector_sync_status", {})
-        if sync_status.isError:
+        if sync_status.is_error:
             logger.warning("Vector sync status error: %s", sync_status)
             return False, None
 
@@ -193,7 +193,7 @@ async def test_astrolabe_plotly_visualization_with_basic_auth(
                 "nc_get_vector_sync_status", {}
             )
 
-            if initial_sync.isError:
+            if initial_sync.is_error:
                 pytest.skip("Vector sync not enabled on mcp-multi-user-basic")
 
             initial_data = json.loads(initial_sync.content[0].text)
@@ -222,7 +222,7 @@ The visualization should show this document as a point in PCA-reduced space.
                 },
             )
 
-            if note_response.isError:
+            if note_response.is_error:
                 pytest.fail(f"Failed to create test note: {note_response}")
 
             note_data = json.loads(note_response.content[0].text)
@@ -396,7 +396,7 @@ The visualization should show this document as a point in PCA-reduced space.
                     delete_response = await alice_mcp_client.call_tool(
                         "nc_notes_delete_note", {"note_id": note_id}
                     )
-                    if not delete_response.isError:
+                    if not delete_response.is_error:
                         logger.info("✓ Cleaned up test note %s", note_id)
                         note_id = None  # Mark as cleaned
                     else:
@@ -418,7 +418,7 @@ The visualization should show this document as a point in PCA-reduced space.
                     delete_response = await cleanup_client.call_tool(
                         "nc_notes_delete_note", {"note_id": note_id}
                     )
-                    if not delete_response.isError:
+                    if not delete_response.is_error:
                         logger.info("✓ Cleaned up test note %s (finally)", note_id)
                     else:
                         logger.warning(

--- a/tests/integration/test_deck_dependent_card.py
+++ b/tests/integration/test_deck_dependent_card.py
@@ -121,17 +121,17 @@ async def test_assign_and_remove_dependent_card_via_mcp(
             "deck_get_card",
             {"board_id": board_id, "stack_id": stack_id, "card_id": card_id},
         )
-        assert result.isError is False, f"get_card failed: {result.content}"
+        assert result.is_error is False, f"get_card failed: {result.content}"
         return json.loads(result.content[0].text).get("dependentCards") or []
 
     # Assign via MCP
     assign_result = await nc_mcp_client.call_tool("deck_assign_dependent_card", args)
-    assert assign_result.isError is False, f"assign failed: {assign_result.content}"
+    assert assign_result.is_error is False, f"assign failed: {assign_result.content}"
     assert json.loads(assign_result.content[0].text)["success"] is True
     assert await get_dependent_cards() == [dependency.id]
 
     # Remove via MCP
     remove_result = await nc_mcp_client.call_tool("deck_remove_dependent_card", args)
-    assert remove_result.isError is False, f"remove failed: {remove_result.content}"
+    assert remove_result.is_error is False, f"remove failed: {remove_result.content}"
     assert json.loads(remove_result.content[0].text)["success"] is True
     assert await get_dependent_cards() == []

--- a/tests/integration/test_deck_vector_search.py
+++ b/tests/integration/test_deck_vector_search.py
@@ -20,7 +20,7 @@ async def test_deck_card_semantic_search(nc_mcp_client, nc_client, mocker):
     """
     # Skip if vector sync is not enabled
     settings_response = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
-    if settings_response.isError:
+    if settings_response.is_error:
         pytest.skip("Vector sync not enabled")
 
     # Create a test board
@@ -82,8 +82,8 @@ async def test_deck_card_semantic_search(nc_mcp_client, nc_client, mocker):
             )
 
             # If vector sync is working, we should find the card
-            if not search_result.isError:
-                data = search_result.structuredContent
+            if not search_result.is_error:
+                data = search_result.structured_content
                 results = data.get("results", [])
 
                 # Check if our card is in the results
@@ -119,7 +119,7 @@ async def test_deck_card_appears_in_cross_app_search(nc_mcp_client, nc_client):
     """
     # Skip if vector sync is not enabled
     settings_response = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
-    if settings_response.isError:
+    if settings_response.is_error:
         pytest.skip("Vector sync not enabled")
 
     # Create a test board with a distinctive card
@@ -151,8 +151,8 @@ async def test_deck_card_appears_in_cross_app_search(nc_mcp_client, nc_client):
                 },
             )
 
-            if not search_result.isError:
-                data = search_result.structuredContent
+            if not search_result.is_error:
+                data = search_result.structured_content
                 results = data.get("results", [])
 
                 # Check if deck_card appears in cross-app results

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -513,18 +513,18 @@ async def test_delete_message_removes_it_from_the_inbox(
     assert message_id not in [m["databaseId"] for m in remaining]
 
     # Trashing is a move, so it invalidates the id the same way: a retry is
-    # rejected rather than being a no-op. This is what idempotentHint=False on
+    # rejected rather than being a no-op. This is what idempotent_hint=False on
     # nc_mail_delete_message records.
     retry = await nc_mcp_client.call_tool(
         "nc_mail_delete_message", {"message_id": message_id}
     )
-    assert retry.isError, "expected the stale message id to be rejected on retry"
+    assert retry.is_error, "expected the stale message id to be rejected on retry"
 
 
 async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_account):
     """Move a message out of INBOX and confirm it lands in the destination.
 
-    Also pins the move's *non*-idempotency, which is what ``idempotentHint=False``
+    Also pins the move's *non*-idempotency, which is what ``idempotent_hint=False``
     on the tool records: the move invalidates the source id (the message is
     re-cached in the destination under a new one), so repeating the call with
     the same id fails instead of being a harmless no-op. An agent that reads the
@@ -587,4 +587,4 @@ async def test_move_message_between_mailboxes(nc_mcp_client, provisioned_mail_ac
         "nc_mail_move_message",
         {"message_id": message_id, "destination_mailbox_id": destination["databaseId"]},
     )
-    assert retry.isError, "expected the stale message id to be rejected on retry"
+    assert retry.is_error, "expected the stale message id to be rejected on retry"

--- a/tests/integration/test_mail_greenmail.py
+++ b/tests/integration/test_mail_greenmail.py
@@ -43,7 +43,7 @@ def _tool_payload(result) -> dict:
     content block; ``isError`` results raise so the test fails loudly with the
     server-side error (which, for a CSRF rejection, is the evidence we want).
     """
-    if getattr(result, "isError", False):
+    if getattr(result, "is_error", False):
         text = result.content[0].text if result.content else "<no content>"
         raise AssertionError(f"MCP tool returned an error: {text}")
     return json.loads(result.content[0].text)

--- a/tests/integration/test_multi_user_basic_auth.py
+++ b/tests/integration/test_multi_user_basic_auth.py
@@ -20,7 +20,7 @@ async def test_basic_auth_pass_through_notes_search(nc_mcp_basic_auth_client):
 
     # Verify tool executed successfully with pass-through auth
     assert response is not None
-    assert not response.isError, f"Tool returned error: {response.content}"
+    assert not response.is_error, f"Tool returned error: {response.content}"
     # Response should have content with results
     assert len(response.content) > 0
     data = json.loads(response.content[0].text)
@@ -42,7 +42,7 @@ async def test_basic_auth_pass_through_notes_create(nc_mcp_basic_auth_client):
     )
 
     assert response is not None
-    assert not response.isError, f"Tool returned error: {response.content}"
+    assert not response.is_error, f"Tool returned error: {response.content}"
     # Parse response and verify note was created
     data = json.loads(response.content[0].text)
     assert data.get("success") is True or "note_id" in data
@@ -61,7 +61,7 @@ async def test_basic_auth_pass_through_get_note(nc_mcp_basic_auth_client):
             "category": "Test",
         },
     )
-    assert not create_response.isError
+    assert not create_response.is_error
     create_data = json.loads(create_response.content[0].text)
     note_id = create_data.get("id")
 
@@ -71,7 +71,7 @@ async def test_basic_auth_pass_through_get_note(nc_mcp_basic_auth_client):
     )
 
     assert response is not None
-    assert not response.isError, f"Tool returned error: {response.content}"
+    assert not response.is_error, f"Tool returned error: {response.content}"
     data = json.loads(response.content[0].text)
     # Nextcloud may append a number to duplicate titles
     assert data.get("title", "").startswith("BasicAuth Get Test")

--- a/tests/integration/test_semantic_search_chunk_links.py
+++ b/tests/integration/test_semantic_search_chunk_links.py
@@ -39,7 +39,7 @@ FILE_INDEX_TIMEOUT_SECONDS = 120
 async def test_search_results_carry_an_astrolabe_chunk_link(nc_mcp_client, nc_client):
     """A freshly indexed note comes back with a link that opens its chunk."""
     status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
-    if status.isError:
+    if status.is_error:
         pytest.skip("Vector sync not enabled")
 
     # A nonsense term the seed corpus cannot contain, so the match is ours.
@@ -64,7 +64,7 @@ async def test_search_results_carry_an_astrolabe_chunk_link(nc_mcp_client, nc_cl
         search = await nc_mcp_client.call_tool(
             "nc_semantic_search", {"query": unique_term, "limit": 10}
         )
-        assert not search.isError, search
+        assert not search.is_error, search
         results = json.loads(search.content[0].text)["results"]
 
         ours = [r for r in results if str(r["id"]) == str(note["id"])]
@@ -102,7 +102,7 @@ async def test_context_expansion_preserves_the_chunk_link(nc_mcp_client, nc_clie
     """include_context=True rebuilds each result from scratch, which is exactly
     how rerank_score was once silently dropped. Same corpus, both flavours."""
     status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
-    if status.isError:
+    if status.is_error:
         pytest.skip("Vector sync not enabled")
 
     unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
@@ -127,7 +127,7 @@ async def test_context_expansion_preserves_the_chunk_link(nc_mcp_client, nc_clie
             "nc_semantic_search",
             {"query": unique_term, "limit": 10, "include_context": True},
         )
-        assert not search.isError, search
+        assert not search.is_error, search
         results = json.loads(search.content[0].text)["results"]
 
         ours = [r for r in results if str(r["id"]) == str(note["id"])]
@@ -172,7 +172,7 @@ async def _file_is_searchable(mcp_client, term: str, file_id: int) -> bool:
         )
     except Exception:  # transient blip — keep polling
         return False
-    if search.isError:
+    if search.is_error:
         return False
     try:
         results = json.loads(search.content[0].text).get("results", [])
@@ -190,7 +190,7 @@ async def test_file_results_also_carry_a_link_to_the_file(nc_mcp_client, nc_clie
     still holds on a live index, rather than only in the indexer's source.
     """
     status = await nc_mcp_client.call_tool("nc_get_vector_sync_status", {})
-    if status.isError:
+    if status.is_error:
         pytest.skip("Vector sync not enabled")
 
     unique_term = f"zorblat{uuid.uuid4().hex[:12]}"
@@ -225,7 +225,7 @@ async def test_file_results_also_carry_a_link_to_the_file(nc_mcp_client, nc_clie
             "nc_semantic_search",
             {"query": unique_term, "limit": 50, "doc_types": ["file"]},
         )
-        assert not search.isError, search
+        assert not search.is_error, search
         results = json.loads(search.content[0].text)["results"]
 
         ours = [r for r in results if str(r["id"]) == str(file_id)]

--- a/tests/integration/test_tool_links.py
+++ b/tests/integration/test_tool_links.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.integration
 
 def _payload(result) -> dict:
     """Parsed JSON body of an MCP tool result."""
-    assert result.isError is False, f"tool call failed: {result.content}"
+    assert result.is_error is False, f"tool call failed: {result.content}"
     return json.loads(result.content[0].text)
 
 

--- a/tests/load/benchmark.py
+++ b/tests/load/benchmark.py
@@ -19,8 +19,9 @@ from typing import Any
 
 import anyio
 import click
+import httpx2
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 from tests.load.workloads import MixedWorkload, OperationResult, WorkloadOperations
 
@@ -216,11 +217,16 @@ class BenchmarkMetrics:
 async def create_mcp_session(url: str):
     """Create an MCP client session with proper cleanup."""
     logger.info("Creating MCP client session for %s", url)
-    streamable_context = streamablehttp_client(url)
+    streamable_context = streamable_http_client(
+        url,
+        http_client=httpx2.AsyncClient(
+            timeout=httpx2.Timeout(30, read=300), follow_redirects=True
+        ),
+    )
     session_context = None
 
     try:
-        read_stream, write_stream, _ = await streamable_context.__aenter__()
+        read_stream, write_stream = await streamable_context.__aenter__()
         session_context = ClientSession(read_stream, write_stream)
         session = await session_context.__aenter__()
         await session.initialize()

--- a/tests/load/oauth_pool.py
+++ b/tests/load/oauth_pool.py
@@ -14,8 +14,9 @@ from urllib.parse import quote
 
 import anyio
 import httpx
+import httpx2
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -165,10 +166,17 @@ class OAuthUserPool:
         # Create streamable HTTP connection with OAuth token in Authorization header
         # This matches the pattern from tests/conftest.py create_mcp_client_session()
         headers = {"Authorization": f"Bearer {profile.token}"}
-        streamable_context = streamablehttp_client(mcp_url, headers=headers)
+        streamable_context = streamable_http_client(
+            mcp_url,
+            http_client=httpx2.AsyncClient(
+                headers=headers,
+                timeout=httpx2.Timeout(30, read=300),
+                follow_redirects=True,
+            ),
+        )
 
         try:
-            read_stream, write_stream, _ = await streamable_context.__aenter__()
+            read_stream, write_stream = await streamable_context.__aenter__()
 
             session = ClientSession(read_stream, write_stream)
             await session.__aenter__()

--- a/tests/server/keycloak/test_keycloak_login_flow_webdav.py
+++ b/tests/server/keycloak/test_keycloak_login_flow_webdav.py
@@ -82,7 +82,7 @@ async def test_webdav_round_trip_via_keycloak_login_flow(
     mkdir_result = await nc_mcp_keycloak_email_client.call_tool(
         "nc_webdav_create_directory", {"path": dir_path}
     )
-    assert mkdir_result.isError is False, (
+    assert mkdir_result.is_error is False, (
         "create_directory failed — Keycloak Login Flow v2 WebDAV path is broken"
     )
 
@@ -91,19 +91,19 @@ async def test_webdav_round_trip_via_keycloak_login_flow(
             "nc_webdav_write_file",
             {"path": file_path, "content": content},
         )
-        assert write_result.isError is False
+        assert write_result.is_error is False
 
         read_result = await nc_mcp_keycloak_email_client.call_tool(
             "nc_webdav_read_file", {"path": file_path}
         )
-        assert read_result.isError is False
+        assert read_result.is_error is False
         read_data = json.loads(read_result.content[0].text)
         assert content in read_data.get("content", "")
 
         list_result = await nc_mcp_keycloak_email_client.call_tool(
             "nc_webdav_list_directory", {"path": dir_path}
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
         list_data = json.loads(list_result.content[0].text)
         names = [f.get("name", "") for f in list_data.get("files", [])]
         assert "keycloak_login_flow.txt" in names

--- a/tests/server/ldap/test_ldap_dav_principal.py
+++ b/tests/server/ldap/test_ldap_dav_principal.py
@@ -43,7 +43,7 @@ async def test_webdav_round_trip_resolves_ldap_principal(
     mkdir_result = await nc_mcp_ldap_alice_client.call_tool(
         "nc_webdav_create_directory", {"path": dir_path}
     )
-    assert mkdir_result.isError is False, (
+    assert mkdir_result.is_error is False, (
         "create_directory failed — DAV path built from the LDAP loginName "
         "'alice' instead of the discovered canonical UID (GH #980 not fixed?): "
         f"{mkdir_result.content}"
@@ -54,19 +54,19 @@ async def test_webdav_round_trip_resolves_ldap_principal(
             "nc_webdav_write_file",
             {"path": file_path, "content": content},
         )
-        assert write_result.isError is False
+        assert write_result.is_error is False
 
         read_result = await nc_mcp_ldap_alice_client.call_tool(
             "nc_webdav_read_file", {"path": file_path}
         )
-        assert read_result.isError is False
+        assert read_result.is_error is False
         read_data = json.loads(read_result.content[0].text)
         assert content in read_data.get("content", "")
 
         list_result = await nc_mcp_ldap_alice_client.call_tool(
             "nc_webdav_list_directory", {"path": dir_path}
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
         list_data = json.loads(list_result.content[0].text)
         names = [f.get("name", "") for f in list_data.get("files", [])]
         assert "ldap_principal.txt" in names

--- a/tests/server/login_flow/test_ldap_dav_principal.py
+++ b/tests/server/login_flow/test_ldap_dav_principal.py
@@ -42,7 +42,7 @@ async def test_webdav_round_trip_resolves_ldap_principal_login_flow(
     mkdir_result = await client.call_tool(
         "nc_webdav_create_directory", {"path": dir_path}
     )
-    assert mkdir_result.isError is False, (
+    assert mkdir_result.is_error is False, (
         "create_directory failed — DAV path built from the LDAP loginName "
         "'alice' instead of the discovered canonical UID (GH #980 not fixed in "
         f"login-flow mode?): {mkdir_result.content}"
@@ -53,17 +53,17 @@ async def test_webdav_round_trip_resolves_ldap_principal_login_flow(
             "nc_webdav_write_file",
             {"path": file_path, "content": content},
         )
-        assert write_result.isError is False
+        assert write_result.is_error is False
 
         read_result = await client.call_tool("nc_webdav_read_file", {"path": file_path})
-        assert read_result.isError is False
+        assert read_result.is_error is False
         read_data = json.loads(read_result.content[0].text)
         assert content in read_data.get("content", "")
 
         list_result = await client.call_tool(
             "nc_webdav_list_directory", {"path": dir_path}
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
         list_data = json.loads(list_result.content[0].text)
         names = [f.get("name", "") for f in list_data.get("files", [])]
         assert "ldap_principal.txt" in names

--- a/tests/server/login_flow/test_login_flow_integration.py
+++ b/tests/server/login_flow/test_login_flow_integration.py
@@ -94,7 +94,7 @@ class TestLoginFlowNotes:
             "nc_notes_create_note",
             {"title": title, "content": content, "category": category},
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"Create failed: {create_result.content[0].text}"
         )
         note = json.loads(create_result.content[0].text)
@@ -107,7 +107,7 @@ class TestLoginFlowNotes:
             read_result = await nc_mcp_login_flow_client.call_tool(
                 "nc_notes_get_note", {"note_id": note_id}
             )
-            assert read_result.isError is False
+            assert read_result.is_error is False
             read_data = json.loads(read_result.content[0].text)
             assert read_data["title"] == title
             assert read_data["content"] == content
@@ -124,7 +124,7 @@ class TestLoginFlowNotes:
                     "etag": etag,
                 },
             )
-            assert update_result.isError is False, (
+            assert update_result.is_error is False, (
                 f"Update failed: {update_result.content[0].text}"
             )
             updated = json.loads(update_result.content[0].text)
@@ -137,13 +137,13 @@ class TestLoginFlowNotes:
                 "nc_notes_append_content",
                 {"note_id": note_id, "content": "\n\nAppended text"},
             )
-            assert append_result.isError is False
+            assert append_result.is_error is False
 
             # Search
             search_result = await nc_mcp_login_flow_client.call_tool(
                 "nc_notes_search_notes", {"query": suffix}
             )
-            assert search_result.isError is False
+            assert search_result.is_error is False
             search_data = json.loads(search_result.content[0].text)
             assert search_data["total_found"] >= 1
 
@@ -171,7 +171,7 @@ class TestLoginFlowCalendarEvents:
         cal_result = await nc_mcp_login_flow_client.call_tool(
             "nc_calendar_list_calendars", {}
         )
-        assert cal_result.isError is False
+        assert cal_result.is_error is False
         cal_data = json.loads(cal_result.content[0].text)
         calendars = cal_data.get("calendars", [])
         assert len(calendars) > 0
@@ -192,7 +192,7 @@ class TestLoginFlowCalendarEvents:
                 "description": f"Test event for login flow {suffix}",
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"Create event failed: {create_result.content[0].text}"
         )
         event_data = json.loads(create_result.content[0].text)
@@ -205,7 +205,7 @@ class TestLoginFlowCalendarEvents:
                 "nc_calendar_get_event",
                 {"calendar_name": calendar_name, "event_uid": event_uid},
             )
-            assert get_result.isError is False
+            assert get_result.is_error is False
 
         finally:
             # Delete event
@@ -245,7 +245,7 @@ class TestLoginFlowCalendarTodos:
                 "description": f"Test todo {suffix}",
             },
         )
-        if create_result.isError:
+        if create_result.is_error:
             error_text = create_result.content[0].text
             if "AuthorizationError" in error_text:
                 pytest.skip(
@@ -262,7 +262,7 @@ class TestLoginFlowCalendarTodos:
                 "nc_calendar_list_todos",
                 {"calendar_name": calendar_name},
             )
-            assert list_result.isError is False
+            assert list_result.is_error is False
 
             # Update todo
             update_result = await nc_mcp_login_flow_client.call_tool(
@@ -273,7 +273,7 @@ class TestLoginFlowCalendarTodos:
                     "percent_complete": 50,
                 },
             )
-            assert update_result.isError is False
+            assert update_result.is_error is False
 
         finally:
             await nc_mcp_login_flow_client.call_tool(
@@ -302,14 +302,14 @@ class TestLoginFlowContacts:
         ab_result = await nc_mcp_login_flow_client.call_tool(
             "nc_contacts_list_addressbooks", {}
         )
-        assert ab_result.isError is False
+        assert ab_result.is_error is False
 
         # Create a temporary address book for isolation
         create_ab_result = await nc_mcp_login_flow_client.call_tool(
             "nc_contacts_create_addressbook",
             {"name": ab_name, "display_name": f"Login Flow Test {suffix}"},
         )
-        assert create_ab_result.isError is False, (
+        assert create_ab_result.is_error is False, (
             f"Create addressbook failed: {create_ab_result.content[0].text}"
         )
         logger.info("Created address book: %s", ab_name)
@@ -327,7 +327,7 @@ class TestLoginFlowContacts:
                     },
                 },
             )
-            assert create_result.isError is False, (
+            assert create_result.is_error is False, (
                 f"Create contact failed: {create_result.content[0].text}"
             )
             logger.info("Created contact: %s", contact_uid)
@@ -339,7 +339,7 @@ class TestLoginFlowContacts:
                 "nc_contacts_list_contacts",
                 {"addressbook": ab_name},
             )
-            if list_result.isError:
+            if list_result.is_error:
                 error_text = list_result.content[0].text
                 if "ContactField" in error_text:
                     logger.warning(
@@ -390,7 +390,7 @@ class TestLoginFlowFiles:
         mkdir_result = await nc_mcp_login_flow_client.call_tool(
             "nc_webdav_create_directory", {"path": dir_path}
         )
-        assert mkdir_result.isError is False, (
+        assert mkdir_result.is_error is False, (
             f"Create dir failed: {mkdir_result.content[0].text}"
         )
         logger.info("Created directory: %s", dir_path)
@@ -401,13 +401,13 @@ class TestLoginFlowFiles:
                 "nc_webdav_write_file",
                 {"path": file_path, "content": file_content},
             )
-            assert write_result.isError is False
+            assert write_result.is_error is False
 
             # Read file
             read_result = await nc_mcp_login_flow_client.call_tool(
                 "nc_webdav_read_file", {"path": file_path}
             )
-            assert read_result.isError is False
+            assert read_result.is_error is False
             read_data = json.loads(read_result.content[0].text)
             assert file_content in read_data.get("content", "")
 
@@ -415,7 +415,7 @@ class TestLoginFlowFiles:
             list_result = await nc_mcp_login_flow_client.call_tool(
                 "nc_webdav_list_directory", {"path": dir_path}
             )
-            assert list_result.isError is False
+            assert list_result.is_error is False
             list_data = json.loads(list_result.content[0].text)
             files = list_data.get("files", [])
             file_names = [f.get("name", "") for f in files]
@@ -426,7 +426,7 @@ class TestLoginFlowFiles:
                 "nc_webdav_find_by_name",
                 {"pattern": "test_file.txt", "scope": dir_path},
             )
-            assert search_result.isError is False
+            assert search_result.is_error is False
 
         finally:
             # Clean up: delete file then directory
@@ -462,7 +462,7 @@ class TestLoginFlowDeck:
             create_result = await nc_mcp_login_flow_client.call_tool(
                 "deck_create_board", {"title": board_title, "color": "0076D1"}
             )
-            assert create_result.isError is False, (
+            assert create_result.is_error is False, (
                 f"Create board failed: {create_result.content[0].text}"
             )
             board_data = json.loads(create_result.content[0].text)
@@ -473,7 +473,7 @@ class TestLoginFlowDeck:
             list_result = await nc_mcp_login_flow_client.call_tool(
                 "deck_get_boards", {}
             )
-            assert list_result.isError is False
+            assert list_result.is_error is False
             boards_data = json.loads(list_result.content[0].text)
             boards = boards_data.get("boards", [])
             board_ids = [b.get("id") for b in boards]
@@ -483,7 +483,7 @@ class TestLoginFlowDeck:
             detail_result = await nc_mcp_login_flow_client.call_tool(
                 "deck_get_board", {"board_id": board_id}
             )
-            assert detail_result.isError is False
+            assert detail_result.is_error is False
         finally:
             # Clean up board via Deck REST API (no MCP delete_board tool exists)
             if board_id is not None:
@@ -521,7 +521,7 @@ class TestLoginFlowTables:
     async def test_tables_list(self, nc_mcp_login_flow_client: ClientSession):
         """List tables (may be empty but should not error)."""
         result = await nc_mcp_login_flow_client.call_tool("nc_tables_list_tables", {})
-        assert result.isError is False, f"List tables failed: {result.content[0].text}"
+        assert result.is_error is False, f"List tables failed: {result.content[0].text}"
         data = json.loads(result.content[0].text)
         logger.info("Tables: %s", data)
 
@@ -542,13 +542,13 @@ class TestLoginFlowCookbook:
         list_result = await nc_mcp_login_flow_client.call_tool(
             "nc_cookbook_list_recipes", {}
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
 
         # List categories
         cat_result = await nc_mcp_login_flow_client.call_tool(
             "nc_cookbook_list_categories", {}
         )
-        assert cat_result.isError is False
+        assert cat_result.is_error is False
 
     async def test_cookbook_create_and_delete(
         self, nc_mcp_login_flow_client: ClientSession
@@ -566,7 +566,7 @@ class TestLoginFlowCookbook:
                 "keywords": "test,login-flow",  # keywords is a string, not list
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"Create recipe failed: {create_result.content[0].text}"
         )
         recipe_data = json.loads(create_result.content[0].text)
@@ -578,7 +578,7 @@ class TestLoginFlowCookbook:
             get_result = await nc_mcp_login_flow_client.call_tool(
                 "nc_cookbook_get_recipe", {"recipe_id": recipe_id}
             )
-            if get_result.isError:
+            if get_result.is_error:
                 error_text = get_result.content[0].text
                 if "recipeYield" in error_text:
                     logger.warning(
@@ -658,7 +658,7 @@ class TestLoginFlowConnectivity:
     async def test_list_resources(self, nc_mcp_login_flow_client: ClientSession):
         """Verify resource templates are available."""
         templates = await nc_mcp_login_flow_client.list_resource_templates()
-        logger.info("Resource templates: %s", len(templates.resourceTemplates))
+        logger.info("Resource templates: %s", len(templates.resource_templates))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/login_flow/test_multi_user_permissions.py
+++ b/tests/server/login_flow/test_multi_user_permissions.py
@@ -44,7 +44,7 @@ class TestFilePermissions:
             "nc_webdav_write_file",
             arguments={"path": file_path, "content": file_content},
         )
-        assert not result.isError, f"Alice failed to create file: {result.content}"
+        assert not result.is_error, f"Alice failed to create file: {result.content}"
 
         share_id = None
         try:
@@ -58,7 +58,7 @@ class TestFilePermissions:
                     "permissions": 1,
                 },
             )
-            assert not result.isError, f"Share creation failed: {result.content}"
+            assert not result.is_error, f"Share creation failed: {result.content}"
             share_data = json.loads(result.content[0].text)
             share_id = share_data["id"]
 
@@ -66,7 +66,7 @@ class TestFilePermissions:
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_webdav_read_file", arguments={"path": file_path}
             )
-            assert not result.isError, (
+            assert not result.is_error, (
                 f"Bob could not read shared file: {result.content}"
             )
             response_data = json.loads(result.content[0].text)
@@ -76,7 +76,7 @@ class TestFilePermissions:
             result = await diana_login_flow_mcp_client.call_tool(
                 "nc_webdav_read_file", arguments={"path": file_path}
             )
-            assert result.isError, "Diana should not be able to read unshared file"
+            assert result.is_error, "Diana should not be able to read unshared file"
 
         finally:
             if share_id:
@@ -102,7 +102,7 @@ class TestFilePermissions:
             "nc_webdav_write_file",
             arguments={"path": file_path, "content": file_content},
         )
-        assert not result.isError
+        assert not result.is_error
 
         charlie_share_id = None
         bob_share_id = None
@@ -117,7 +117,7 @@ class TestFilePermissions:
                     "permissions": 3,
                 },
             )
-            assert not result.isError
+            assert not result.is_error
             charlie_share_id = json.loads(result.content[0].text)["id"]
 
             # Share with Bob (read-only, permissions=1)
@@ -130,7 +130,7 @@ class TestFilePermissions:
                     "permissions": 1,
                 },
             )
-            assert not result.isError
+            assert not result.is_error
             bob_share_id = json.loads(result.content[0].text)["id"]
 
             # Charlie can write. Writes are fail-closed, so overwriting the
@@ -144,7 +144,7 @@ class TestFilePermissions:
                     "if_match": "*",
                 },
             )
-            assert not result.isError, (
+            assert not result.is_error, (
                 f"Charlie should be able to write: {result.content}"
             )
 
@@ -159,7 +159,7 @@ class TestFilePermissions:
                     "if_match": "*",
                 },
             )
-            assert result.isError, "Bob should be denied write access (read-only)"
+            assert result.is_error, "Bob should be denied write access (read-only)"
 
         finally:
             for sid in (charlie_share_id, bob_share_id):
@@ -184,13 +184,13 @@ class TestFilePermissions:
         result = await alice_login_flow_mcp_client.call_tool(
             "nc_webdav_create_directory", arguments={"path": folder_path}
         )
-        assert not result.isError
+        assert not result.is_error
 
         result = await alice_login_flow_mcp_client.call_tool(
             "nc_webdav_write_file",
             arguments={"path": file_in_folder, "content": file_content},
         )
-        assert not result.isError
+        assert not result.is_error
 
         share_id = None
         try:
@@ -203,14 +203,16 @@ class TestFilePermissions:
                     "permissions": 1,
                 },
             )
-            assert not result.isError
+            assert not result.is_error
             share_id = json.loads(result.content[0].text)["id"]
 
             # Bob lists the shared folder
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_webdav_list_directory", arguments={"path": folder_path}
             )
-            assert not result.isError, f"Bob should see shared folder: {result.content}"
+            assert not result.is_error, (
+                f"Bob should see shared folder: {result.content}"
+            )
             response_data = json.loads(result.content[0].text)
             file_names = [f["name"] for f in response_data.get("files", [])]
             assert "document.txt" in file_names
@@ -219,7 +221,7 @@ class TestFilePermissions:
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_webdav_read_file", arguments={"path": file_in_folder}
             )
-            assert not result.isError
+            assert not result.is_error
             assert file_content in json.loads(result.content[0].text)["content"]
 
         finally:
@@ -245,20 +247,20 @@ class TestFilePermissions:
             "nc_webdav_write_file",
             arguments={"path": alice_file, "content": "Alice's private file"},
         )
-        assert not result.isError
+        assert not result.is_error
 
         result = await bob_login_flow_mcp_client.call_tool(
             "nc_webdav_write_file",
             arguments={"path": bob_file, "content": "Bob's private file"},
         )
-        assert not result.isError
+        assert not result.is_error
 
         try:
             # Bob lists root — should NOT see Alice's file
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_webdav_list_directory", arguments={"path": "/"}
             )
-            assert not result.isError
+            assert not result.is_error
             bob_visible = [
                 f["name"] for f in json.loads(result.content[0].text).get("files", [])
             ]
@@ -270,7 +272,7 @@ class TestFilePermissions:
             result = await alice_login_flow_mcp_client.call_tool(
                 "nc_webdav_list_directory", arguments={"path": "/"}
             )
-            assert not result.isError
+            assert not result.is_error
             alice_visible = [
                 f["name"] for f in json.loads(result.content[0].text).get("files", [])
             ]
@@ -328,7 +330,7 @@ class TestDeckPermissions:
             result = await bob_login_flow_mcp_client.call_tool(
                 "deck_get_boards", arguments={}
             )
-            assert not result.isError
+            assert not result.is_error
             board_ids = [
                 b["id"] for b in json.loads(result.content[0].text).get("boards", [])
             ]
@@ -338,7 +340,7 @@ class TestDeckPermissions:
             result = await diana_login_flow_mcp_client.call_tool(
                 "deck_get_boards", arguments={}
             )
-            assert not result.isError
+            assert not result.is_error
             board_ids = [
                 b["id"] for b in json.loads(result.content[0].text).get("boards", [])
             ]
@@ -379,7 +381,7 @@ class TestDeckPermissions:
                     "description": "Created by Charlie with edit permission",
                 },
             )
-            assert not result.isError, f"Charlie should create cards: {result.content}"
+            assert not result.is_error, f"Charlie should create cards: {result.content}"
             card_id = json.loads(result.content[0].text).get("id")
             if card_id:
                 await nc_client.deck.delete_card(board_id, stack_id, card_id)
@@ -394,7 +396,7 @@ class TestDeckPermissions:
                     "description": "Bob trying to create a card",
                 },
             )
-            assert result.isError, "Bob should be denied card creation (view-only)"
+            assert result.is_error, "Bob should be denied card creation (view-only)"
 
         finally:
             for acl_id in (charlie_acl_id, bob_acl_id):
@@ -419,7 +421,7 @@ class TestDeckPermissions:
             result = await alice_login_flow_mcp_client.call_tool(
                 "deck_get_boards", arguments={}
             )
-            assert not result.isError
+            assert not result.is_error
             board_ids = [
                 b["id"] for b in json.loads(result.content[0].text).get("boards", [])
             ]
@@ -431,7 +433,7 @@ class TestDeckPermissions:
             result = await bob_login_flow_mcp_client.call_tool(
                 "deck_get_boards", arguments={}
             )
-            assert not result.isError
+            assert not result.is_error
             board_ids = [
                 b["id"] for b in json.loads(result.content[0].text).get("boards", [])
             ]
@@ -471,7 +473,7 @@ class TestNotesPermissions:
                 "category": "PermTest",
             },
         )
-        assert not result.isError
+        assert not result.is_error
         alice_note_id = json.loads(result.content[0].text)["id"]
 
         # Bob creates a note
@@ -483,7 +485,7 @@ class TestNotesPermissions:
                 "category": "PermTest",
             },
         )
-        assert not result.isError
+        assert not result.is_error
         bob_note_id = json.loads(result.content[0].text)["id"]
 
         try:
@@ -491,7 +493,7 @@ class TestNotesPermissions:
             result = await alice_login_flow_mcp_client.call_tool(
                 "nc_notes_search_notes", arguments={"query": "PermTest"}
             )
-            assert not result.isError
+            assert not result.is_error
             alice_visible_ids = [
                 n["id"] for n in json.loads(result.content[0].text).get("results", [])
             ]
@@ -503,7 +505,7 @@ class TestNotesPermissions:
             result = await bob_login_flow_mcp_client.call_tool(
                 "nc_notes_search_notes", arguments={"query": "PermTest"}
             )
-            assert not result.isError
+            assert not result.is_error
             bob_visible_ids = [
                 n["id"] for n in json.loads(result.content[0].text).get("results", [])
             ]

--- a/tests/server/login_flow/test_scope_authorization.py
+++ b/tests/server/login_flow/test_scope_authorization.py
@@ -186,7 +186,7 @@ async def test_semantic_tool_callable_after_default_provisioning(
     """
     result = await nc_mcp_login_flow_client.call_tool("nc_get_vector_sync_status", {})
 
-    assert not result.isError, (
+    assert not result.is_error, (
         "nc_get_vector_sync_status was denied for a default-provisioned user: "
         f"{_tool_text(result)}"
     )
@@ -220,7 +220,7 @@ async def test_token_scopes_enforced_on_tool_call(
         },
     )
 
-    assert result.isError, (
+    assert result.is_error, (
         "nc_notes_create_note succeeded with a read-only token — the token "
         "layer is not enforcing on the tools/call path"
     )
@@ -270,7 +270,7 @@ async def test_stored_scopes_enforced_on_tool_call(nc_mcp_login_flow_client):
                 "category": "testing",
             },
         )
-        assert write_result.isError, (
+        assert write_result.is_error, (
             "nc_notes_create_note succeeded with stored scopes ['notes.read'] — "
             "@require_scopes is not enforcing on the tools/call path"
         )
@@ -282,7 +282,7 @@ async def test_stored_scopes_enforced_on_tool_call(nc_mcp_login_flow_client):
         read_result = await session.call_tool(
             "nc_notes_search_notes", {"query": "scope-enforcement-probe"}
         )
-        assert not read_result.isError, (
+        assert not read_result.is_error, (
             "notes.read was granted but the read tool was refused: "
             f"{_tool_text(read_result)}"
         )

--- a/tests/server/test_annotations.py
+++ b/tests/server/test_annotations.py
@@ -46,11 +46,11 @@ async def test_read_only_tools_have_correct_annotations(nc_mcp_client: ClientSes
 
         if is_likely_readonly:
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
-            assert tool.annotations.readOnlyHint is True, (
-                f"Read-only tool {tool.name} should have readOnlyHint=True"
+            assert tool.annotations.read_only_hint is True, (
+                f"Read-only tool {tool.name} should have read_only_hint=True"
             )
-            assert tool.annotations.destructiveHint is not True, (
-                f"Read-only tool {tool.name} should not have destructiveHint=True"
+            assert tool.annotations.destructive_hint is not True, (
+                f"Read-only tool {tool.name} should not have destructive_hint=True"
             )
 
 
@@ -69,8 +69,8 @@ async def test_destructive_tools_have_correct_annotations(nc_mcp_client: ClientS
 
         if has_destructive_keyword:
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
-            assert tool.annotations.destructiveHint is True, (
-                f"Destructive tool {tool.name} should have destructiveHint=True"
+            assert tool.annotations.destructive_hint is True, (
+                f"Destructive tool {tool.name} should have destructive_hint=True"
             )
 
 
@@ -91,7 +91,7 @@ async def test_delete_operations_are_idempotent(nc_mcp_client: ClientSession):
     for tool in tools.tools:
         if "delete" in tool.name.lower() and tool.name not in non_idempotent_deletes:
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
-            assert tool.annotations.idempotentHint is True, (
+            assert tool.annotations.idempotent_hint is True, (
                 f"Delete tool {tool.name} should be idempotent (same end state)"
             )
 
@@ -115,7 +115,7 @@ async def test_create_operations_not_idempotent(nc_mcp_client: ClientSession):
     for tool in tools.tools:
         if "create" in tool.name.lower() and tool.name not in idempotent_exceptions:
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
-            assert tool.annotations.idempotentHint is not True, (
+            assert tool.annotations.idempotent_hint is not True, (
                 f"Create tool {tool.name} should not be idempotent (creates new resources)"
             )
 
@@ -129,7 +129,7 @@ async def test_update_operations_not_idempotent(nc_mcp_client: ClientSession):
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
             # Most updates use etags which change each time, making them non-idempotent
             # Exception: calendar_update_event might be different
-            assert tool.annotations.idempotentHint is not True, (
+            assert tool.annotations.idempotent_hint is not True, (
                 f"Update tool {tool.name} should not be idempotent (etag changes)"
             )
 
@@ -150,13 +150,13 @@ async def test_webdav_write_is_not_idempotent(nc_mcp_client: ClientSession):
     )
     assert write_tool is not None, "nc_webdav_write_file tool not found"
     assert write_tool.annotations is not None, "write_file missing annotations"
-    assert write_tool.annotations.idempotentHint is not True, (
+    assert write_tool.annotations.idempotent_hint is not True, (
         "nc_webdav_write_file should not be idempotent (fail-closed conditional PUT)"
     )
 
 
 async def test_semantic_search_open_world(nc_mcp_client: ClientSession):
-    """Verify semantic search has openWorldHint=True (ADR-017 decision).
+    """Verify semantic search has open_world_hint=True (ADR-017 decision).
 
     Semantic search queries external Nextcloud service, consistent with other tools.
     """
@@ -169,8 +169,8 @@ async def test_semantic_search_open_world(nc_mcp_client: ClientSession):
         assert semantic_tool.annotations is not None, (
             "semantic_search missing annotations"
         )
-        assert semantic_tool.annotations.openWorldHint is True, (
-            "nc_semantic_search should have openWorldHint=True (queries external service)"
+        assert semantic_tool.annotations.open_world_hint is True, (
+            "nc_semantic_search should have open_world_hint=True (queries external service)"
         )
 
 
@@ -204,16 +204,16 @@ async def test_annotation_consistency(nc_mcp_client: ClientSession):
             if any(op in t.name for op in ["list", "search", "get"])
         ]
         for tool in read_ops:
-            assert tool.annotations.readOnlyHint is True, (
+            assert tool.annotations.read_only_hint is True, (
                 f"{tool.name} is a read operation but not marked read-only"
             )
 
         # All delete operations should be destructive and idempotent
         delete_ops = [t for t in category_tools if "delete" in t.name]
         for tool in delete_ops:
-            assert tool.annotations.destructiveHint is True, (
+            assert tool.annotations.destructive_hint is True, (
                 f"{tool.name} is a delete operation but not marked destructive"
             )
-            assert tool.annotations.idempotentHint is True, (
+            assert tool.annotations.idempotent_hint is True, (
                 f"{tool.name} is a delete operation but not marked idempotent"
             )

--- a/tests/server/test_calendar_events_mcp.py
+++ b/tests/server/test_calendar_events_mcp.py
@@ -34,7 +34,7 @@ async def test_mcp_update_event_extended_fields(
                 "description": "Base event for MCP extended-field update test",
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP event creation failed: {create_result.content}"
         )
 
@@ -54,7 +54,7 @@ async def test_mcp_update_event_extended_fields(
                 "reminder_minutes": 15,
             },
         )
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP event update failed: {update_result.content}"
         )
 
@@ -98,7 +98,7 @@ async def test_mcp_update_event_extended_fields(
                 "reminder_minutes": 0,
             },
         )
-        assert clear_result.isError is False, (
+        assert clear_result.is_error is False, (
             f"MCP event clear failed: {clear_result.content}"
         )
 
@@ -152,7 +152,7 @@ async def test_mcp_create_event_writes_previously_ignored_fields(
                 "reminder_email": True,
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP event creation failed: {create_result.content}"
         )
         event_uid = json.loads(create_result.content[0].text)["uid"]
@@ -205,7 +205,7 @@ async def test_mcp_update_event_shorthand_reminder_fields_are_independent(
                 "reminder_email": True,
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP event creation failed: {create_result.content}"
         )
         event_uid = json.loads(create_result.content[0].text)["uid"]
@@ -219,7 +219,7 @@ async def test_mcp_update_event_shorthand_reminder_fields_are_independent(
                 "reminder_minutes": 45,
             },
         )
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP event update failed: {update_result.content}"
         )
 
@@ -269,7 +269,7 @@ async def test_mcp_update_event_ordered_reminders(
                 ],
             },
         )
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP event creation failed: {create_result.content}"
         )
         event_uid = json.loads(create_result.content[0].text)["uid"]
@@ -291,7 +291,7 @@ async def test_mcp_update_event_ordered_reminders(
                 "location": "Room 2",
             },
         )
-        assert touch_result.isError is False, (
+        assert touch_result.is_error is False, (
             f"MCP event update failed: {touch_result.content}"
         )
         touched, _ = await nc_client.calendar.get_event(calendar_name, event_uid)
@@ -308,7 +308,7 @@ async def test_mcp_update_event_ordered_reminders(
                 "reminders": [],
             },
         )
-        assert clear_result.isError is False, (
+        assert clear_result.is_error is False, (
             f"MCP reminder clear failed: {clear_result.content}"
         )
         cleared, _ = await nc_client.calendar.get_event(calendar_name, event_uid)

--- a/tests/server/test_calendar_todos_mcp.py
+++ b/tests/server/test_calendar_todos_mcp.py
@@ -39,7 +39,7 @@ async def test_mcp_todo_complete_workflow(
                 "categories": "testing,mcp",
             },
         )
-        assert create_result.isError is False
+        assert create_result.is_error is False
 
         # Extract UID from the result
         result_data = create_result.content[0].text
@@ -62,7 +62,7 @@ async def test_mcp_todo_complete_workflow(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name},
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
 
         list_data = json.loads(list_result.content[0].text)
         assert "todos" in list_data
@@ -81,7 +81,7 @@ async def test_mcp_todo_complete_workflow(
                 "percent_complete": 50,
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
 
         # 5. Verify update via client
         todos = await nc_client.calendar.list_todos(calendar_name)
@@ -97,7 +97,7 @@ async def test_mcp_todo_complete_workflow(
             "nc_calendar_delete_todo",
             {"calendar_name": calendar_name, "todo_uid": todo_uid},
         )
-        assert delete_result.isError is False
+        assert delete_result.is_error is False
 
         # 7. Verify deletion via client
         todos = await nc_client.calendar.list_todos(calendar_name)
@@ -156,7 +156,7 @@ async def test_mcp_list_todos_with_filters(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name, "status": "NEEDS-ACTION"},
         )
-        assert result.isError is False
+        assert result.is_error is False
 
         data = json.loads(result.content[0].text)
         needs_action_todos = [t for t in data["todos"] if t["uid"] in created_uids]
@@ -168,7 +168,7 @@ async def test_mcp_list_todos_with_filters(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name, "min_priority": 1},
         )
-        assert result.isError is False
+        assert result.is_error is False
         data = json.loads(result.content[0].text)
         high_priority_todos = [t for t in data["todos"] if t["uid"] in created_uids]
         assert len(high_priority_todos) >= 1  # At least the priority 1 todo
@@ -179,7 +179,7 @@ async def test_mcp_list_todos_with_filters(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name, "categories": "work"},
         )
-        assert result.isError is False
+        assert result.is_error is False
         data = json.loads(result.content[0].text)
         work_todos = [t for t in data["todos"] if t["uid"] in created_uids]
         assert len(work_todos) >= 2  # Two todos with "work" category
@@ -190,7 +190,7 @@ async def test_mcp_list_todos_with_filters(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name, "summary_contains": "Priority"},
         )
-        assert result.isError is False
+        assert result.is_error is False
         data = json.loads(result.content[0].text)
         priority_todos = [t for t in data["todos"] if t["uid"] in created_uids]
         assert len(priority_todos) == 2  # Two have "Priority" in summary (High, Low)
@@ -251,7 +251,7 @@ async def test_mcp_search_todos_across_calendars(
             "nc_calendar_search_todos",
             {},
         )
-        assert search_result.isError is False
+        assert search_result.is_error is False
 
         data = json.loads(search_result.content[0].text)
         assert "todos" in data
@@ -275,7 +275,7 @@ async def test_mcp_search_todos_across_calendars(
             "nc_calendar_search_todos",
             {"status": "IN-PROCESS"},
         )
-        assert search_result.isError is False
+        assert search_result.is_error is False
         data = json.loads(search_result.content[0].text)
         in_process_todos = [
             t for t in data["todos"] if t["uid"] in [uid for _, uid in created_uids]
@@ -320,7 +320,7 @@ async def test_mcp_todo_status_transitions(
                 "percent_complete": 25,
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
 
         todos = await nc_client.calendar.list_todos(calendar_name)
         todo = next(t for t in todos if t["uid"] == todo_uid)
@@ -340,7 +340,7 @@ async def test_mcp_todo_status_transitions(
                 "completed": completed_time,
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
 
         todos = await nc_client.calendar.list_todos(calendar_name)
         todo = next(t for t in todos if t["uid"] == todo_uid)
@@ -384,7 +384,7 @@ async def test_mcp_todo_with_dates(
                 "due": due_date,
             },
         )
-        assert create_result.isError is False
+        assert create_result.is_error is False
 
         result_data = json.loads(create_result.content[0].text)
         todo_uid = result_data["uid"]
@@ -426,7 +426,7 @@ async def test_mcp_todo_categories(
                 "categories": "work,meeting,important,quarterly",
             },
         )
-        assert create_result.isError is False
+        assert create_result.is_error is False
 
         result_data = json.loads(create_result.content[0].text)
         todo_uid = result_data["uid"]
@@ -451,7 +451,7 @@ async def test_mcp_todo_categories(
                 "categories": "updated,new-category",
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
 
         # Verify updated categories
         todos = await nc_client.calendar.list_todos(calendar_name)
@@ -511,7 +511,7 @@ async def test_mcp_todo_href_mismatch(
             "nc_calendar_list_todos",
             {"calendar_name": calendar_name},
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
 
         list_data = json.loads(list_result.content[0].text)
         our_todo = next((t for t in list_data["todos"] if t["uid"] == todo_uid), None)
@@ -529,7 +529,7 @@ async def test_mcp_todo_href_mismatch(
             "nc_calendar_delete_todo",
             {"calendar_name": calendar_name, "todo_uid": todo_uid},
         )
-        assert delete_result.isError is False
+        assert delete_result.is_error is False
 
         # Verify it's really gone
         todos = await nc_client.calendar.list_todos(calendar_name)
@@ -567,14 +567,14 @@ async def test_mcp_complete_todo_sets_all_three_properties(
             "percent_complete": 25,
         },
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     todo_uid = json.loads(create_result.content[0].text)["uid"]
 
     complete_result = await nc_mcp_client.call_tool(
         "nc_calendar_complete_todo",
         {"calendar_name": calendar_name, "todo_uid": todo_uid},
     )
-    assert complete_result.isError is False
+    assert complete_result.is_error is False
     payload = json.loads(complete_result.content[0].text)
     assert payload["success"] is True
     assert payload["status"] == "COMPLETED"
@@ -599,7 +599,7 @@ async def test_mcp_complete_todo_accepts_explicit_timestamp(
         "nc_calendar_create_todo",
         {"calendar_name": calendar_name, "summary": f"Backdated {unique}"},
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     todo_uid = json.loads(create_result.content[0].text)["uid"]
 
     complete_result = await nc_mcp_client.call_tool(
@@ -610,7 +610,7 @@ async def test_mcp_complete_todo_accepts_explicit_timestamp(
             "completed": "2026-01-01T09:00:00+00:00",
         },
     )
-    assert complete_result.isError is False
+    assert complete_result.is_error is False
     assert (
         json.loads(complete_result.content[0].text)["completed"]
         == "2026-01-01T09:00:00+00:00"
@@ -639,7 +639,7 @@ async def test_stale_etag_refuses_the_write_end_to_end(
             "nc_calendar_create_todo",
             {"calendar_name": calendar_name, "summary": "ETag contention"},
         )
-        assert create_result.isError is False
+        assert create_result.is_error is False
         todo_uid = json.loads(create_result.content[0].text)["uid"]
 
         # Read the ETag the way a caller would.
@@ -668,7 +668,7 @@ async def test_stale_etag_refuses_the_write_end_to_end(
                 "etag": first_etag,
             },
         )
-        assert accepted.isError is False, accepted.content[0].text
+        assert accepted.is_error is False, accepted.content[0].text
         second_etag = json.loads(accepted.content[0].text)["etag"]
         assert second_etag and second_etag != first_etag
 
@@ -682,7 +682,7 @@ async def test_stale_etag_refuses_the_write_end_to_end(
                 "etag": first_etag,
             },
         )
-        assert refused.isError is True
+        assert refused.is_error is True
         assert "nc_calendar_list_todos" in refused.content[0].text
 
         # ...and the refusal really did leave the stored copy alone.

--- a/tests/server/test_collectives_mcp.py
+++ b/tests/server/test_collectives_mcp.py
@@ -24,7 +24,7 @@ async def temporary_collective(nc_mcp_client: ClientSession):
         "collectives_create_collective",
         {"name": name, "emoji": "🧪"},
     )
-    assert result.isError is False, f"Failed to create collective: {result.content}"
+    assert result.is_error is False, f"Failed to create collective: {result.content}"
     data = json.loads(result.content[0].text)
     collective_id = data["id"]
     logger.info("Created temporary collective: %s (ID: %s)", name, collective_id)
@@ -107,7 +107,7 @@ async def test_collectives_list(
 ):
     """Test listing collectives includes the temporary one."""
     result = await nc_mcp_client.call_tool("collectives_get_collectives", {})
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert data["success"] is True
@@ -126,7 +126,7 @@ async def test_collectives_set_collective_emoji(
         "collectives_set_collective_emoji",
         {"collective_id": temporary_collective["id"], "emoji": "📖"},
     )
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert data["success"] is True
@@ -145,14 +145,14 @@ async def test_collectives_clear_collective_emoji(
         "collectives_set_collective_emoji",
         {"collective_id": cid, "emoji": "🔬"},
     )
-    assert set_result.isError is False
+    assert set_result.is_error is False
 
     # Clear the emoji by passing null
     clear_result = await nc_mcp_client.call_tool(
         "collectives_set_collective_emoji",
         {"collective_id": cid, "emoji": None},
     )
-    assert clear_result.isError is False
+    assert clear_result.is_error is False
     data = json.loads(clear_result.content[0].text)
     assert data["collective_id"] == cid
     logger.info("Collective emoji cleared")
@@ -174,7 +174,7 @@ async def test_collectives_page_workflow(
         "collectives_create_page",
         {"collective_id": cid, "parent_id": landing_id, "title": unique_title},
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     create_data = json.loads(create_result.content[0].text)
     page_id = create_data["id"]
     assert create_data["collective_id"] == cid
@@ -186,7 +186,7 @@ async def test_collectives_page_workflow(
         "collectives_get_pages",
         {"collective_id": cid},
     )
-    assert list_result.isError is False
+    assert list_result.is_error is False
     list_data = json.loads(list_result.content[0].text)
     page_ids = [p["id"] for p in list_data["pages"]]
     assert page_id in page_ids
@@ -197,7 +197,7 @@ async def test_collectives_page_workflow(
         "collectives_get_page",
         {"collective_id": cid, "page_id": page_id},
     )
-    assert get_result.isError is False
+    assert get_result.is_error is False
     get_data = json.loads(get_result.content[0].text)
     assert get_data["page"]["id"] == page_id
     assert get_data["page"]["title"] == unique_title
@@ -209,7 +209,7 @@ async def test_collectives_page_workflow(
         "collectives_set_page_emoji",
         {"collective_id": cid, "page_id": page_id, "emoji": "🚀"},
     )
-    assert emoji_result.isError is False
+    assert emoji_result.is_error is False
     logger.info("Page emoji set")
 
     # 5. Trash the page
@@ -217,7 +217,7 @@ async def test_collectives_page_workflow(
         "collectives_trash_page",
         {"collective_id": cid, "page_id": page_id},
     )
-    assert trash_result.isError is False
+    assert trash_result.is_error is False
     logger.info("Page trashed")
 
     # 6. Verify page is in trash
@@ -225,7 +225,7 @@ async def test_collectives_page_workflow(
         "collectives_get_trashed_pages",
         {"collective_id": cid},
     )
-    assert trashed_result.isError is False
+    assert trashed_result.is_error is False
     trashed_data = json.loads(trashed_result.content[0].text)
     trashed_ids = [p["id"] for p in trashed_data["pages"]]
     assert page_id in trashed_ids
@@ -236,7 +236,7 @@ async def test_collectives_page_workflow(
         "collectives_restore_page",
         {"collective_id": cid, "page_id": page_id},
     )
-    assert restore_result.isError is False
+    assert restore_result.is_error is False
     logger.info("Page restored from trash")
 
     # 8. Verify page is back in pages list
@@ -261,7 +261,7 @@ async def test_collectives_get_landing_page_content(
         "collectives_get_page",
         {"collective_id": cid, "page_id": landing_id},
     )
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert data["page"]["fileName"] == "Readme.md"
@@ -288,7 +288,7 @@ async def test_collectives_move_page(
             "title": f"Movable Page {uuid.uuid4().hex[:8]}",
         },
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     page_id = json.loads(create_result.content[0].text)["id"]
 
     # Move (rename) the page
@@ -301,7 +301,7 @@ async def test_collectives_move_page(
             "title": new_title,
         },
     )
-    assert move_result.isError is False
+    assert move_result.is_error is False
 
     data = json.loads(move_result.content[0].text)
     assert data["page_id"] == page_id
@@ -332,7 +332,7 @@ async def test_collectives_tag_workflow(
         "collectives_create_tag",
         {"collective_id": cid, "name": tag_name, "color": "FF5733"},
     )
-    assert create_tag_result.isError is False
+    assert create_tag_result.is_error is False
     tag_data = json.loads(create_tag_result.content[0].text)
     tag_id = tag_data["id"]
     assert tag_data["name"] == tag_name
@@ -344,7 +344,7 @@ async def test_collectives_tag_workflow(
         "collectives_get_tags",
         {"collective_id": cid},
     )
-    assert list_tags_result.isError is False
+    assert list_tags_result.is_error is False
     tags_data = json.loads(list_tags_result.content[0].text)
     tag_ids = [t["id"] for t in tags_data["tags"]]
     assert tag_id in tag_ids
@@ -359,7 +359,7 @@ async def test_collectives_tag_workflow(
             "title": f"Tagged Page {uuid.uuid4().hex[:8]}",
         },
     )
-    assert page_result.isError is False
+    assert page_result.is_error is False
     page_id = json.loads(page_result.content[0].text)["id"]
 
     # 4. Assign tag to page
@@ -367,7 +367,7 @@ async def test_collectives_tag_workflow(
         "collectives_assign_tag",
         {"collective_id": cid, "page_id": page_id, "tag_id": tag_id},
     )
-    assert assign_result.isError is False
+    assert assign_result.is_error is False
     logger.info("Tag %s assigned to page %s", tag_id, page_id)
 
     # 5. Remove tag from page
@@ -375,7 +375,7 @@ async def test_collectives_tag_workflow(
         "collectives_remove_tag",
         {"collective_id": cid, "page_id": page_id, "tag_id": tag_id},
     )
-    assert remove_result.isError is False
+    assert remove_result.is_error is False
     logger.info("Tag %s removed from page %s", tag_id, page_id)
 
     # Cleanup
@@ -399,7 +399,7 @@ async def test_collectives_search(
         "collectives_search_pages",
         {"collective_id": cid, "query": "Welcome"},
     )
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert data["success"] is True
@@ -422,7 +422,7 @@ async def test_collectives_trash_restore_delete_workflow(
         "collectives_create_collective",
         {"name": name},
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     created = json.loads(create_result.content[0].text)
     cid = created["id"]
     logger.info("Created collective %s (ID: %s)", name, cid)
@@ -432,7 +432,7 @@ async def test_collectives_trash_restore_delete_workflow(
         "collectives_trash_collective",
         {"collective_id": cid},
     )
-    assert trash_result.isError is False
+    assert trash_result.is_error is False
     logger.info("Collective moved to trash")
 
     # List trashed collectives — should include ours
@@ -440,7 +440,7 @@ async def test_collectives_trash_restore_delete_workflow(
         "collectives_get_trashed_collectives",
         {},
     )
-    assert list_trash_result.isError is False
+    assert list_trash_result.is_error is False
     trash_data = json.loads(list_trash_result.content[0].text)
     trashed_ids = [c["id"] for c in trash_data["collectives"]]
     assert cid in trashed_ids
@@ -451,7 +451,7 @@ async def test_collectives_trash_restore_delete_workflow(
         "collectives_restore_collective",
         {"collective_id": cid},
     )
-    assert restore_result.isError is False
+    assert restore_result.is_error is False
     restore_data = json.loads(restore_result.content[0].text)
     assert restore_data["collective_id"] == cid
     assert "restored" in restore_data["message"].lower()
@@ -462,13 +462,13 @@ async def test_collectives_trash_restore_delete_workflow(
         "collectives_trash_collective",
         {"collective_id": cid},
     )
-    assert trash_result2.isError is False
+    assert trash_result2.is_error is False
 
     delete_result = await nc_mcp_client.call_tool(
         "collectives_delete_collective",
         {"collective_id": cid},
     )
-    assert delete_result.isError is False
+    assert delete_result.is_error is False
     delete_data = json.loads(delete_result.content[0].text)
     assert "permanently deleted" in delete_data["message"].lower()
     logger.info("Collective permanently deleted")
@@ -483,7 +483,7 @@ async def test_collectives_get_page_not_found(nc_mcp_client: ClientSession):
         "collectives_get_page",
         {"collective_id": 999999, "page_id": 999999},
     )
-    assert result.isError is True
+    assert result.is_error is True
     logger.info("Non-existent page correctly returned error")
 
 
@@ -493,5 +493,5 @@ async def test_collectives_get_pages_not_found(nc_mcp_client: ClientSession):
         "collectives_get_pages",
         {"collective_id": 999999},
     )
-    assert result.isError is True
+    assert result.is_error is True
     logger.info("Non-existent collective correctly returned error")

--- a/tests/server/test_contacts_mcp.py
+++ b/tests/server/test_contacts_mcp.py
@@ -42,7 +42,7 @@ async def test_mcp_contacts_workflow(
             "nc_contacts_create_addressbook",
             {"name": addressbook_name, "display_name": f"MCP Test {addressbook_name}"},
         )
-        assert create_ab_result.isError is False
+        assert create_ab_result.is_error is False
 
         # 2. Verify address book creation
         addressbooks = await nc_client.contacts.list_addressbooks()
@@ -58,7 +58,7 @@ async def test_mcp_contacts_workflow(
                 "contact_data": contact_data,
             },
         )
-        assert create_c_result.isError is False
+        assert create_c_result.is_error is False
 
         # 4. Verify contact creation (and that all fields — #716 — actually persisted)
         contacts = await nc_client.contacts.list_contacts(addressbook=addressbook_name)
@@ -77,7 +77,7 @@ async def test_mcp_contacts_workflow(
             "nc_contacts_search_contacts",
             {"query": unique_suffix, "addressbook": addressbook_name},
         )
-        assert search_result.isError is False
+        assert search_result.is_error is False
         search_payload = _extract_payload(search_result)
         assert search_payload["total_count"] == 1
         searched = search_payload["contacts"][0]
@@ -95,7 +95,7 @@ async def test_mcp_contacts_workflow(
                 "contact_data": {"url": "https://mcp-test.example.com"},
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
         # The tool now returns a typed UpdateContactResponse carrying the new etag.
         update_payload = _extract_payload(update_result)
         assert update_payload["success"] is True
@@ -124,7 +124,7 @@ async def test_mcp_contacts_workflow(
                 "etag": chained_etag,
             },
         )
-        assert chained_result.isError is False
+        assert chained_result.is_error is False
         contacts = await nc_client.contacts.list_contacts(addressbook=addressbook_name)
         chained_vcard = next(c for c in contacts if c["vcard_id"] == contact_uid).get(
             "addressdata", ""
@@ -144,7 +144,7 @@ async def test_mcp_contacts_workflow(
                 "etag": chained_etag,
             },
         )
-        assert stale_result.isError is True
+        assert stale_result.is_error is True
 
         # 5. Delete contact via MCP
         logger.info("Deleting contact %s via MCP", contact_uid)
@@ -152,7 +152,7 @@ async def test_mcp_contacts_workflow(
             "nc_contacts_delete_contact",
             {"addressbook": addressbook_name, "uid": contact_uid},
         )
-        assert delete_c_result.isError is False
+        assert delete_c_result.is_error is False
 
         # 6. Verify contact deletion
         contacts = await nc_client.contacts.list_contacts(addressbook=addressbook_name)
@@ -163,7 +163,7 @@ async def test_mcp_contacts_workflow(
         delete_ab_result = await nc_mcp_client.call_tool(
             "nc_contacts_delete_addressbook", {"name": addressbook_name}
         )
-        assert delete_ab_result.isError is False
+        assert delete_ab_result.is_error is False
 
         # 8. Verify address book deletion
         addressbooks = await nc_client.contacts.list_addressbooks()
@@ -233,7 +233,7 @@ async def test_mcp_contacts_surfaces_structured_fields_and_survives_bad_cards(
         list_result = await nc_mcp_client.call_tool(
             "nc_contacts_list_contacts", {"addressbook": addressbook_name}
         )
-        assert list_result.isError is False
+        assert list_result.is_error is False
         payload = _extract_payload(list_result)
 
         by_uid = {c["uid"]: c for c in payload["contacts"]}

--- a/tests/server/test_cookbook_mcp.py
+++ b/tests/server/test_cookbook_mcp.py
@@ -53,7 +53,7 @@ async def test_mcp_cookbook_create_and_read_recipe(
             },
         )
 
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP recipe creation failed: {create_result.content}"
         )
 
@@ -75,7 +75,7 @@ async def test_mcp_cookbook_create_and_read_recipe(
             "nc_cookbook_get_recipe", {"recipe_id": created_recipe_id}
         )
 
-        assert read_result.isError is False, (
+        assert read_result.is_error is False, (
             f"MCP recipe read failed: {read_result.content}"
         )
 
@@ -131,7 +131,7 @@ async def test_mcp_cookbook_update_recipe(
             },
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP recipe update failed: {update_result.content}"
         )
 
@@ -182,7 +182,7 @@ async def test_mcp_cookbook_delete_recipe(
             "nc_cookbook_delete_recipe", {"recipe_id": created_recipe_id}
         )
 
-        assert delete_result.isError is False, (
+        assert delete_result.is_error is False, (
             f"MCP recipe deletion failed: {delete_result.content}"
         )
 
@@ -228,7 +228,7 @@ async def test_mcp_cookbook_import_recipe_from_url(
             "nc_cookbook_import_recipe", {"url": test_url}
         )
 
-        assert import_result.isError is False, (
+        assert import_result.is_error is False, (
             f"MCP recipe import failed: {import_result.content}"
         )
 
@@ -292,7 +292,7 @@ async def test_mcp_cookbook_search_recipes(
             "nc_cookbook_search_recipes", {"query": unique_keyword}
         )
 
-        assert search_result.isError is False, (
+        assert search_result.is_error is False, (
             f"MCP recipe search failed: {search_result.content}"
         )
 
@@ -327,7 +327,7 @@ async def test_mcp_cookbook_list_recipes(
     logger.info("Listing all recipes via MCP")
     list_result = await nc_mcp_client.call_tool("nc_cookbook_list_recipes", {})
 
-    assert list_result.isError is False, (
+    assert list_result.is_error is False, (
         f"MCP list recipes failed: {list_result.content}"
     )
 
@@ -368,7 +368,7 @@ async def test_mcp_cookbook_categories_workflow(
             "nc_cookbook_list_categories", {}
         )
 
-        assert categories_result.isError is False, (
+        assert categories_result.is_error is False, (
             f"MCP list categories failed: {categories_result.content}"
         )
 
@@ -384,7 +384,7 @@ async def test_mcp_cookbook_categories_workflow(
             "nc_cookbook_get_recipes_in_category", {"category": unique_category}
         )
 
-        assert category_recipes_result.isError is False, (
+        assert category_recipes_result.is_error is False, (
             f"MCP get recipes in category failed: {category_recipes_result.content}"
         )
 
@@ -443,7 +443,7 @@ async def test_mcp_cookbook_keywords_workflow(
         logger.info("Listing keywords via MCP")
         keywords_result = await nc_mcp_client.call_tool("nc_cookbook_list_keywords", {})
 
-        assert keywords_result.isError is False, (
+        assert keywords_result.is_error is False, (
             f"MCP list keywords failed: {keywords_result.content}"
         )
 
@@ -459,7 +459,7 @@ async def test_mcp_cookbook_keywords_workflow(
             "nc_cookbook_get_recipes_with_keywords", {"keywords": [unique_keyword]}
         )
 
-        assert keyword_recipes_result.isError is False, (
+        assert keyword_recipes_result.is_error is False, (
             f"MCP get recipes with keywords failed: {keyword_recipes_result.content}"
         )
 
@@ -549,7 +549,7 @@ async def test_mcp_cookbook_reindex(
     logger.info("Triggering recipe reindex via MCP")
     reindex_result = await nc_mcp_client.call_tool("nc_cookbook_reindex", {})
 
-    assert reindex_result.isError is False, (
+    assert reindex_result.is_error is False, (
         f"MCP reindex failed: {reindex_result.content}"
     )
 

--- a/tests/server/test_deck_advanced_features.py
+++ b/tests/server/test_deck_advanced_features.py
@@ -27,7 +27,7 @@ async def test_deck_stack_mcp_tools(
         {"board_id": board_id, "title": stack_title, "order": stack_order},
     )
 
-    assert create_result.isError is False, (
+    assert create_result.is_error is False, (
         f"MCP stack creation failed: {create_result.content}"
     )
     created_stack_response = json.loads(create_result.content[0].text)
@@ -62,7 +62,7 @@ async def test_deck_stack_mcp_tools(
             },
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP stack update failed: {update_result.content}"
         )
         logger.info("Stack updated via MCP tool successfully")
@@ -130,7 +130,7 @@ async def test_deck_card_mcp_tools(
         },
     )
 
-    assert create_result.isError is False, (
+    assert create_result.is_error is False, (
         f"MCP card creation failed: {create_result.content}"
     )
     created_card_response = json.loads(create_result.content[0].text)
@@ -170,7 +170,7 @@ async def test_deck_card_mcp_tools(
             },
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP card update failed: {update_result.content}"
         )
         logger.info("Card updated via MCP tool successfully")
@@ -188,7 +188,7 @@ async def test_deck_card_mcp_tools(
             {"board_id": board_id, "stack_id": stack_id, "card_id": card_id},
         )
 
-        assert archive_result.isError is False, (
+        assert archive_result.is_error is False, (
             f"MCP card archive failed: {archive_result.content}"
         )
         logger.info("Card archived via MCP tool successfully")
@@ -199,7 +199,7 @@ async def test_deck_card_mcp_tools(
             {"board_id": board_id, "stack_id": stack_id, "card_id": card_id},
         )
 
-        assert unarchive_result.isError is False, (
+        assert unarchive_result.is_error is False, (
             f"MCP card unarchive failed: {unarchive_result.content}"
         )
         logger.info("Card unarchived via MCP tool successfully")
@@ -217,7 +217,7 @@ async def test_deck_card_mcp_tools(
             },
         )
 
-        assert reorder_result.isError is False, (
+        assert reorder_result.is_error is False, (
             f"MCP card reorder failed: {reorder_result.content}"
         )
         logger.info("Card reordered via MCP tool successfully")
@@ -253,7 +253,7 @@ async def test_deck_label_mcp_tools(
         {"board_id": board_id, "title": label_title, "color": label_color},
     )
 
-    assert create_result.isError is False, (
+    assert create_result.is_error is False, (
         f"MCP label creation failed: {create_result.content}"
     )
     created_label_response = json.loads(create_result.content[0].text)
@@ -288,7 +288,7 @@ async def test_deck_label_mcp_tools(
             },
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP label update failed: {update_result.content}"
         )
         logger.info("Label updated via MCP tool successfully")
@@ -345,7 +345,7 @@ async def test_deck_card_label_assignment_mcp_tools(
             },
         )
 
-        assert assign_result.isError is False, (
+        assert assign_result.is_error is False, (
             f"MCP label assignment failed: {assign_result.content}"
         )
         logger.info("Label assigned to card via MCP tool successfully")
@@ -369,7 +369,7 @@ async def test_deck_card_label_assignment_mcp_tools(
             },
         )
 
-        assert remove_result.isError is False, (
+        assert remove_result.is_error is False, (
             f"MCP label removal failed: {remove_result.content}"
         )
         logger.info("Label removed from card via MCP tool successfully")
@@ -416,7 +416,7 @@ async def test_deck_card_user_assignment_mcp_tools(
         },
     )
 
-    assert assign_result.isError is False, (
+    assert assign_result.is_error is False, (
         f"MCP user assignment failed: {assign_result.content}"
     )
     logger.info("User assigned to card via MCP tool successfully")
@@ -447,7 +447,7 @@ async def test_deck_card_user_assignment_mcp_tools(
         },
     )
 
-    assert unassign_result.isError is False, (
+    assert unassign_result.is_error is False, (
         f"MCP user unassignment failed: {unassign_result.content}"
     )
     logger.info("User unassigned from card via MCP tool successfully")
@@ -479,7 +479,7 @@ async def test_deck_mcp_tools_error_handling(nc_mcp_client: ClientSession):
         "deck_create_stack",
         {"board_id": non_existent_id, "title": "Should Fail", "order": 1},
     )
-    assert stack_result.isError is True, (
+    assert stack_result.is_error is True, (
         "Expected error for stack creation on non-existent board"
     )
 
@@ -493,7 +493,7 @@ async def test_deck_mcp_tools_error_handling(nc_mcp_client: ClientSession):
             "type": "plain",
         },
     )
-    assert card_result.isError is True, (
+    assert card_result.is_error is True, (
         "Expected error for card creation with non-existent IDs"
     )
 
@@ -502,7 +502,7 @@ async def test_deck_mcp_tools_error_handling(nc_mcp_client: ClientSession):
         "deck_create_label",
         {"board_id": non_existent_id, "title": "Should Fail", "color": "FF0000"},
     )
-    assert label_result.isError is True, (
+    assert label_result.is_error is True, (
         "Expected error for label creation on non-existent board"
     )
 
@@ -513,7 +513,7 @@ async def test_deck_mcp_tools_error_handling(nc_mcp_client: ClientSession):
 async def test_deck_mcp_resource_templates(nc_mcp_client: ClientSession):
     """Test deck MCP resource templates are properly registered."""
     templates = await nc_mcp_client.list_resource_templates()
-    template_uris = [template.uriTemplate for template in templates.resourceTemplates]
+    template_uris = [template.uri_template for template in templates.resource_templates]
 
     expected_templates = [
         "nc://Deck/boards/{board_id}/stacks/{stack_id}",

--- a/tests/server/test_deck_mcp.py
+++ b/tests/server/test_deck_mcp.py
@@ -31,7 +31,7 @@ async def test_deck_mcp_connectivity(nc_mcp_client: ClientSession):
 
     # List available resource templates
     templates = await nc_mcp_client.list_resource_templates()
-    template_uris = [template.uriTemplate for template in templates.resourceTemplates]
+    template_uris = [template.uri_template for template in templates.resource_templates]
 
     # Verify expected deck resource templates
     expected_deck_templates = [
@@ -76,7 +76,7 @@ async def test_deck_board_crud_workflow_mcp(
         {"title": board_title, "color": board_color},
     )
 
-    assert create_result.isError is False, (
+    assert create_result.is_error is False, (
         f"MCP board creation failed: {create_result.content}"
     )
     created_board_json = create_result.content[0].text
@@ -141,7 +141,7 @@ async def test_deck_board_operations_error_handling_mcp(nc_mcp_client: ClientSes
         {"title": "", "color": "FF0000"},
     )
 
-    assert create_result.isError is True, "Expected error for invalid board creation"
+    assert create_result.is_error is True, "Expected error for invalid board creation"
     logger.info("Invalid board creation correctly failed via MCP tool")
 
     # Test read non-existent board via MCP resource
@@ -168,7 +168,7 @@ async def test_deck_board_creation_validation_mcp(nc_mcp_client: ClientSession):
         {"title": "", "color": "FF0000"},
     )
 
-    assert create_result.isError is True, "Expected error for empty board title"
+    assert create_result.is_error is True, "Expected error for empty board title"
     logger.info("Empty title board creation correctly failed via MCP")
 
 
@@ -184,7 +184,7 @@ async def test_deck_board_creation_success_mcp(
         {"title": f"Valid Board {uuid.uuid4().hex[:8]}", "color": "00FF00"},
     )
 
-    assert create_result.isError is False, "Valid board creation should succeed"
+    assert create_result.is_error is False, "Valid board creation should succeed"
     created_board = json.loads(create_result.content[0].text)
     board_id = created_board["id"]
     logger.info("Valid board created successfully with ID: %s", board_id)
@@ -242,7 +242,7 @@ async def test_deck_card_comment_crud_workflow_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": "Initial comment"},
     )
-    assert create_result.isError is False, (
+    assert create_result.is_error is False, (
         f"Comment creation failed: {create_result.content}"
     )
     create_response = json.loads(create_result.content[0].text)
@@ -258,7 +258,7 @@ async def test_deck_card_comment_crud_workflow_mcp(
     list_result = await nc_mcp_client.call_tool(
         "deck_get_card_comments", {"card_id": card_id}
     )
-    assert list_result.isError is False, f"List comments failed: {list_result.content}"
+    assert list_result.is_error is False, f"List comments failed: {list_result.content}"
     listed = json.loads(list_result.content[0].text)
     assert listed["count"] >= 1
     listed_ids = [c["id"] for c in listed["results"]]
@@ -278,7 +278,7 @@ async def test_deck_card_comment_crud_workflow_mcp(
             "message": "Edited comment",
         },
     )
-    assert update_result.isError is False, (
+    assert update_result.is_error is False, (
         f"Comment update failed: {update_result.content}"
     )
     update_response = json.loads(update_result.content[0].text)
@@ -291,7 +291,7 @@ async def test_deck_card_comment_crud_workflow_mcp(
         "deck_delete_card_comment",
         {"card_id": card_id, "comment_id": comment_id},
     )
-    assert delete_result.isError is False, (
+    assert delete_result.is_error is False, (
         f"Comment delete failed: {delete_result.content}"
     )
     delete_response = json.loads(delete_result.content[0].text)
@@ -320,7 +320,7 @@ async def test_deck_card_comment_reply_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": "Parent message"},
     )
-    assert parent_result.isError is False
+    assert parent_result.is_error is False
     parent = json.loads(parent_result.content[0].text)["comment"]
     parent_id = parent["id"]
 
@@ -333,7 +333,7 @@ async def test_deck_card_comment_reply_mcp(
             "parent_id": parent_id,
         },
     )
-    assert reply_result.isError is False, f"Reply failed: {reply_result.content}"
+    assert reply_result.is_error is False, f"Reply failed: {reply_result.content}"
     reply = json.loads(reply_result.content[0].text)["comment"]
 
     assert reply["message"] == "Reply message"
@@ -354,7 +354,7 @@ async def test_deck_card_comment_message_too_long_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": too_long},
     )
-    assert result.isError is True, "Expected validation error for >1000 char message"
+    assert result.is_error is True, "Expected validation error for >1000 char message"
 
     # The error text is the agent-facing contract: it must name the escape
     # hatch, otherwise the caller falls back to guess-and-shrink retries.
@@ -390,7 +390,7 @@ async def test_deck_card_comment_split_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": message, "overflow": "split"},
     )
-    assert result.isError is False, f"Split comment failed: {result.content}"
+    assert result.is_error is False, f"Split comment failed: {result.content}"
 
     payload = json.loads(result.content[0].text)
     parts = payload["parts"]
@@ -436,7 +436,7 @@ async def test_deck_card_comment_split_under_parent_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": "Root of the thread"},
     )
-    assert root.isError is False
+    assert root.is_error is False
     root_id = json.loads(root.content[0].text)["comment"]["id"]
 
     result = await nc_mcp_client.call_tool(
@@ -448,7 +448,7 @@ async def test_deck_card_comment_split_under_parent_mcp(
             "overflow": "split",
         },
     )
-    assert result.isError is False, f"Nested split failed: {result.content}"
+    assert result.is_error is False, f"Nested split failed: {result.content}"
 
     parts = json.loads(result.content[0].text)["parts"]
     assert len(parts) > 1
@@ -472,7 +472,7 @@ async def test_deck_card_comment_exactly_1000_chars_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": message},
     )
-    assert result.isError is False, f"1000 chars should be legal: {result.content}"
+    assert result.is_error is False, f"1000 chars should be legal: {result.content}"
 
     payload = json.loads(result.content[0].text)
     assert payload["comment"]["message"] == message
@@ -511,7 +511,7 @@ async def test_deck_server_counts_unicode_spaces_php_trim_keeps_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": message},
     )
-    assert result.isError is True
+    assert result.is_error is True
     assert "1001 characters" in result.content[0].text
 
     # 3. Splitting it works, which it could not if we mismeasured the length.
@@ -519,7 +519,7 @@ async def test_deck_server_counts_unicode_spaces_php_trim_keeps_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": message, "overflow": "split"},
     )
-    assert split.isError is False, (
+    assert split.is_error is False, (
         f"Split of the padded message failed: {split.content}"
     )
     assert json.loads(split.content[0].text)["part_count"] == 2
@@ -542,14 +542,14 @@ async def test_deck_card_comment_update_too_long_mcp(
         "deck_create_card_comment",
         {"card_id": card_id, "message": "Short enough to start with"},
     )
-    assert created.isError is False
+    assert created.is_error is False
     comment_id = json.loads(created.content[0].text)["comment"]["id"]
 
     result = await nc_mcp_client.call_tool(
         "deck_update_card_comment",
         {"card_id": card_id, "comment_id": comment_id, "message": "y" * 1001},
     )
-    assert result.isError is True, "Expected client-side rejection of a long update"
+    assert result.is_error is True, "Expected client-side rejection of a long update"
 
     text = result.content[0].text
     assert "1001 characters" in text
@@ -578,7 +578,7 @@ async def test_deck_get_stacks_summary_default_omits_full_card_fields_mcp(
     board_id = board_data["id"]
 
     result = await nc_mcp_client.call_tool("deck_get_stacks", {"board_id": board_id})
-    assert result.isError is False, f"deck_get_stacks failed: {result.content}"
+    assert result.is_error is False, f"deck_get_stacks failed: {result.content}"
     payload = json.loads(result.content[0].text)
 
     cards = [c for stack in payload["stacks"] for c in (stack.get("cards") or [])]
@@ -602,7 +602,7 @@ async def test_deck_get_stacks_detail_full_keeps_card_fields_mcp(
     result = await nc_mcp_client.call_tool(
         "deck_get_stacks", {"board_id": board_id, "detail": "full"}
     )
-    assert result.isError is False, f"deck_get_stacks(full) failed: {result.content}"
+    assert result.is_error is False, f"deck_get_stacks(full) failed: {result.content}"
     payload = json.loads(result.content[0].text)
 
     cards = [c for stack in payload["stacks"] for c in (stack.get("cards") or [])]
@@ -621,7 +621,7 @@ async def test_deck_get_board_overview_mcp(
     result = await nc_mcp_client.call_tool(
         "deck_get_board_overview", {"board_id": board_id}
     )
-    assert result.isError is False, f"board overview failed: {result.content}"
+    assert result.is_error is False, f"board overview failed: {result.content}"
     payload = json.loads(result.content[0].text)
 
     assert payload["board_id"] == board_id
@@ -652,14 +652,14 @@ async def _create_and_archive_card(
             "title": f"Archived Card {uuid.uuid4().hex[:8]}",
         },
     )
-    assert create_result.isError is False, f"create failed: {create_result.content}"
+    assert create_result.is_error is False, f"create failed: {create_result.content}"
     archived_id = json.loads(create_result.content[0].text)["id"]
 
     archive_result = await nc_mcp_client.call_tool(
         "deck_archive_card",
         {"board_id": board_id, "stack_id": stack_id, "card_id": archived_id},
     )
-    assert archive_result.isError is False, f"archive failed: {archive_result.content}"
+    assert archive_result.is_error is False, f"archive failed: {archive_result.content}"
     return archived_id
 
 
@@ -679,7 +679,7 @@ async def test_deck_get_cards_status_includes_archived_mcp(
             "deck_get_cards",
             {"board_id": board_id, "stack_id": stack_id, "status": status},
         )
-        assert result.isError is False, f"deck_get_cards({status}) failed"
+        assert result.is_error is False, f"deck_get_cards({status}) failed"
         return [c["id"] for c in json.loads(result.content[0].text)["cards"]]
 
     open_ids = await card_ids("open")
@@ -712,7 +712,7 @@ async def test_deck_get_stack_status_includes_archived_mcp(
             "deck_get_stack",
             {"board_id": board_id, "stack_id": stack_id, "status": status},
         )
-        assert result.isError is False, f"deck_get_stack({status}) failed"
+        assert result.is_error is False, f"deck_get_stack({status}) failed"
         payload = json.loads(result.content[0].text)
         return [c["id"] for c in (payload.get("cards") or [])]
 
@@ -737,7 +737,7 @@ async def test_deck_get_stacks_and_overview_include_archived_mcp(
         result = await nc_mcp_client.call_tool(
             "deck_get_stacks", {"board_id": board_id, "status": status}
         )
-        assert result.isError is False, f"deck_get_stacks({status}) failed"
+        assert result.is_error is False, f"deck_get_stacks({status}) failed"
         payload = json.loads(result.content[0].text)
         stack = next(s for s in payload["stacks"] if s["id"] == stack_id)
         return [c["id"] for c in (stack.get("cards") or [])]
@@ -746,7 +746,7 @@ async def test_deck_get_stacks_and_overview_include_archived_mcp(
         result = await nc_mcp_client.call_tool(
             "deck_get_board_overview", {"board_id": board_id, "status": status}
         )
-        assert result.isError is False, f"board overview({status}) failed"
+        assert result.is_error is False, f"board overview({status}) failed"
         payload = json.loads(result.content[0].text)
         stack = next(s for s in payload["stacks"] if s["id"] == stack_id)
         assert stack["card_count"] == len(stack["cards"])

--- a/tests/server/test_error_propagation.py
+++ b/tests/server/test_error_propagation.py
@@ -138,7 +138,7 @@ async def test_calendar_missing_calendar_error(nc_mcp_client: ClientSession):
     # Note: Some modules may not have improved error handling yet
     # Check if we have structured content with success=false or isError=true
     if (
-        hasattr(response, "structuredContent")
+        hasattr(response, "structured_content")
         and response.structured_content
         and "result" in response.structured_content
     ):
@@ -161,7 +161,7 @@ async def test_webdav_read_missing_file_error(nc_mcp_client: ClientSession):
     # Note: Some modules may not have improved error handling yet
     # Check if we have structured content with success=false or isError=true
     if (
-        hasattr(response, "structuredContent")
+        hasattr(response, "structured_content")
         and response.structured_content
         and "result" in response.structured_content
     ):
@@ -184,7 +184,7 @@ async def test_tables_missing_table_error(nc_mcp_client: ClientSession):
     # Note: Some modules may not have improved error handling yet
     # Check if we have structured content with success=false or isError=true
     if (
-        hasattr(response, "structuredContent")
+        hasattr(response, "structured_content")
         and response.structured_content
         and "result" in response.structured_content
     ):

--- a/tests/server/test_error_propagation.py
+++ b/tests/server/test_error_propagation.py
@@ -18,7 +18,7 @@ async def test_missing_note_tool_error(nc_mcp_client: ClientSession):
 
     # Should return error response (not raise exception) for tools
     assert response is not None
-    assert response.isError is True
+    assert response.is_error is True
     assert "Note 999999 not found" in response.content[0].text
 
 
@@ -31,14 +31,14 @@ async def test_delete_missing_note_tool_error(nc_mcp_client: ClientSession):
 
     # Should return error response (not raise exception) for tools
     assert response is not None
-    assert response.isError is True
+    assert response.is_error is True
     assert "Note 999999 not found" in response.content[0].text
 
 
 async def test_missing_file_error_is_llm_friendly(nc_mcp_client: ClientSession):
     """A tool with no bespoke handler still returns actionable text (GH #1208).
 
-    Guards the ``NextcloudFastMCP`` boundary: httpx's raw
+    Guards the ``NextcloudMCPServer`` boundary: httpx's raw
     ``Client error '404 Not Found' for url 'http://app/remote.php/dav/...'``
     plus an MDN link must not reach the model.
     """
@@ -47,7 +47,7 @@ async def test_missing_file_error_is_llm_friendly(nc_mcp_client: ClientSession):
     )
 
     assert response is not None
-    assert response.isError is True
+    assert response.is_error is True
     text = response.content[0].text
     logger.info("Missing file response: %s", text)
 
@@ -67,7 +67,7 @@ async def test_search_with_empty_query(nc_mcp_client: ClientSession):
 
     # Should return successful response with empty or valid results
     assert response is not None
-    assert response.isError is False
+    assert response.is_error is False
 
 
 async def test_tool_missing_required_parameters(nc_mcp_client: ClientSession):
@@ -81,7 +81,7 @@ async def test_tool_missing_required_parameters(nc_mcp_client: ClientSession):
 
     # Should return error response for missing required parameters
     assert response is not None
-    assert response.isError is True
+    assert response.is_error is True
     assert (
         "required" in response.content[0].text.lower()
         or "missing" in response.content[0].text.lower()
@@ -111,7 +111,7 @@ async def test_update_note_with_invalid_etag(nc_mcp_client: ClientSession, nc_cl
 
         # Should return error response (not raise exception) for tools
         assert response is not None
-        assert response.isError is True
+        assert response.is_error is True
         assert "modified by someone else" in response.content[0].text
 
     finally:
@@ -139,12 +139,12 @@ async def test_calendar_missing_calendar_error(nc_mcp_client: ClientSession):
     # Check if we have structured content with success=false or isError=true
     if (
         hasattr(response, "structuredContent")
-        and response.structuredContent
-        and "result" in response.structuredContent
+        and response.structured_content
+        and "result" in response.structured_content
     ):
-        assert response.structuredContent["result"]["success"] is False
+        assert response.structured_content["result"]["success"] is False
     else:
-        assert response.isError is True
+        assert response.is_error is True
 
 
 async def test_webdav_read_missing_file_error(nc_mcp_client: ClientSession):
@@ -162,12 +162,12 @@ async def test_webdav_read_missing_file_error(nc_mcp_client: ClientSession):
     # Check if we have structured content with success=false or isError=true
     if (
         hasattr(response, "structuredContent")
-        and response.structuredContent
-        and "result" in response.structuredContent
+        and response.structured_content
+        and "result" in response.structured_content
     ):
-        assert response.structuredContent["result"]["success"] is False
+        assert response.structured_content["result"]["success"] is False
     else:
-        assert response.isError is True
+        assert response.is_error is True
 
 
 async def test_tables_missing_table_error(nc_mcp_client: ClientSession):
@@ -185,12 +185,12 @@ async def test_tables_missing_table_error(nc_mcp_client: ClientSession):
     # Check if we have structured content with success=false or isError=true
     if (
         hasattr(response, "structuredContent")
-        and response.structuredContent
-        and "result" in response.structuredContent
+        and response.structured_content
+        and "result" in response.structured_content
     ):
-        assert response.structuredContent["result"]["success"] is False
+        assert response.structured_content["result"]["success"] is False
     else:
-        assert response.isError is True
+        assert response.is_error is True
 
 
 async def test_calendar_list_events_requires_calendar_name(
@@ -203,7 +203,7 @@ async def test_calendar_list_events_requires_calendar_name(
     """
     response = await nc_mcp_client.call_tool("nc_calendar_list_events", {})
 
-    assert response.isError is True
+    assert response.is_error is True
     assert "calendar_name is required" in str(response.content)
 
 
@@ -215,4 +215,4 @@ async def test_calendar_list_events_calendar_name_not_schema_required(
     tools = await nc_mcp_client.list_tools()
     tool = next(t for t in tools.tools if t.name == "nc_calendar_list_events")
 
-    assert "calendar_name" not in (tool.inputSchema.get("required") or [])
+    assert "calendar_name" not in (tool.input_schema.get("required") or [])

--- a/tests/server/test_mcp.py
+++ b/tests/server/test_mcp.py
@@ -88,9 +88,9 @@ async def test_mcp_connectivity(nc_mcp_client: ClientSession):
     templates = await nc_mcp_client.list_resource_templates()
     logger.info("\nAvailable resource templates:")
     template_uris = []
-    for template in templates.resourceTemplates:
-        logger.info("  - %s", template.uriTemplate)
-        template_uris.append(template.uriTemplate)
+    for template in templates.resource_templates:
+        logger.info("  - %s", template.uri_template)
+        template_uris.append(template.uri_template)
 
     # Verify expected resource templates
     # Note: Notes attachments are now handled via tools, not resource templates
@@ -150,7 +150,7 @@ async def test_mcp_notes_crud_workflow(
             {"title": test_title, "content": test_content, "category": test_category},
         )
 
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP note creation failed: {create_result.content}"
         )
         created_note = create_result.content[0].text
@@ -199,7 +199,7 @@ async def test_mcp_notes_crud_workflow(
             },
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP note update failed: {update_result.content}"
         )
 
@@ -224,7 +224,7 @@ async def test_mcp_notes_crud_workflow(
             "nc_notes_append_content", {"note_id": note_id, "content": append_content}
         )
 
-        assert append_result.isError is False, (
+        assert append_result.is_error is False, (
             f"MCP note append failed: {append_result.content}"
         )
 
@@ -247,7 +247,7 @@ async def test_mcp_notes_crud_workflow(
             "nc_notes_search_notes", {"query": unique_suffix}
         )
 
-        assert search_result.isError is False, (
+        assert search_result.is_error is False, (
             f"MCP note search failed: {search_result.content}"
         )
         search_notes_text = search_result.content[0].text
@@ -288,7 +288,7 @@ async def test_mcp_notes_crud_workflow(
             "nc_notes_delete_note", {"note_id": note_id}
         )
 
-        assert delete_result.isError is False, (
+        assert delete_result.is_error is False, (
             f"MCP note deletion failed: {delete_result.content}"
         )
 
@@ -332,7 +332,7 @@ async def test_mcp_notes_etag_conflict(
             {"title": test_title, "content": test_content, "category": test_category},
         )
 
-        assert create_result.isError is False
+        assert create_result.is_error is False
         note_data = json.loads(create_result.content[0].text)
         note_id = note_data["id"]
         original_etag = note_data["etag"]
@@ -350,7 +350,7 @@ async def test_mcp_notes_etag_conflict(
             },
         )
 
-        assert first_update_result.isError is False
+        assert first_update_result.is_error is False
         updated_data = json.loads(first_update_result.content[0].text)
         new_etag = updated_data["etag"]
         assert new_etag != original_etag, "ETag should have changed after update"
@@ -369,8 +369,8 @@ async def test_mcp_notes_etag_conflict(
         )
 
         # 4. Verify the update was rejected with a 412 error
-        # With McpError, tools now return proper error responses
-        assert conflict_result.isError is True, "Update with stale ETag should fail"
+        # With MCPError, tools now return proper error responses
+        assert conflict_result.is_error is True, "Update with stale ETag should fail"
         response_content = conflict_result.content[0].text
         assert "modified by someone else" in response_content, (
             f"Expected conflict error message, got: {response_content}"
@@ -406,7 +406,7 @@ async def test_mcp_webdav_workflow(
             "nc_webdav_create_directory", {"path": test_dir}
         )
 
-        assert create_dir_result.isError is False, (
+        assert create_dir_result.is_error is False, (
             f"MCP directory creation failed: {create_dir_result.content}"
         )
 
@@ -426,7 +426,7 @@ async def test_mcp_webdav_workflow(
             },
         )
 
-        assert write_result.isError is False, (
+        assert write_result.is_error is False, (
             f"MCP file write failed: {write_result.content}"
         )
         # WriteFileResponse (BaseResponse) structured fields, not a raw dict.
@@ -452,7 +452,7 @@ async def test_mcp_webdav_workflow(
             "nc_webdav_read_file", {"path": test_file_path}
         )
 
-        assert read_result.isError is False, (
+        assert read_result.is_error is False, (
             f"MCP file read failed: {read_result.content}"
         )
         read_data = json.loads(read_result.content[0].text)
@@ -476,7 +476,7 @@ async def test_mcp_webdav_workflow(
             "nc_webdav_list_directory", {"path": test_dir}
         )
 
-        assert list_result.isError is False, (
+        assert list_result.is_error is False, (
             f"MCP directory listing failed: {list_result.content}"
         )
         listing_text = list_result.content[0].text
@@ -582,7 +582,7 @@ async def test_mcp_calendar_workflow(
             "nc_calendar_list_calendars", {}
         )
 
-        assert calendars_result.isError is False, (
+        assert calendars_result.is_error is False, (
             f"MCP calendar listing failed: {calendars_result.content}"
         )
 
@@ -639,7 +639,7 @@ async def test_mcp_calendar_workflow(
             "nc_calendar_create_event", event_data
         )
 
-        assert create_result.isError is False, (
+        assert create_result.is_error is False, (
             f"MCP event creation failed: {create_result.content}"
         )
 
@@ -662,7 +662,7 @@ async def test_mcp_calendar_workflow(
             {"calendar_name": calendar_name, "event_uid": event_uid},
         )
 
-        assert get_result.isError is False, (
+        assert get_result.is_error is False, (
             f"MCP event get failed: {get_result.content}"
         )
 
@@ -692,7 +692,7 @@ async def test_mcp_calendar_workflow(
             "nc_calendar_list_events", list_events_data
         )
 
-        assert list_result.isError is False, (
+        assert list_result.is_error is False, (
             f"MCP list events failed: {list_result.content}"
         )
 
@@ -735,7 +735,7 @@ async def test_mcp_calendar_workflow(
             "nc_calendar_list_events", all_calendars_data
         )
 
-        assert all_list_result.isError is False, (
+        assert all_list_result.is_error is False, (
             f"MCP list all events failed: {all_list_result.content}"
         )
 
@@ -767,7 +767,7 @@ async def test_mcp_calendar_workflow(
             "nc_calendar_update_event", update_data
         )
 
-        assert update_result.isError is False, (
+        assert update_result.is_error is False, (
             f"MCP event update failed: {update_result.content}"
         )
 
@@ -786,7 +786,7 @@ async def test_mcp_calendar_workflow(
             {"calendar_name": calendar_name, "days_ahead": 7, "limit": 10},
         )
 
-        assert upcoming_result.isError is False, (
+        assert upcoming_result.is_error is False, (
             f"MCP upcoming events failed: {upcoming_result.content}"
         )
 
@@ -804,7 +804,7 @@ async def test_mcp_calendar_workflow(
             {"calendar_name": calendar_name, "event_uid": event_uid},
         )
 
-        assert delete_result.isError is False, (
+        assert delete_result.is_error is False, (
             f"MCP event deletion failed: {delete_result.content}"
         )
 

--- a/tests/server/test_talk_mcp.py
+++ b/tests/server/test_talk_mcp.py
@@ -50,7 +50,7 @@ async def test_talk_send_and_read_workflow(
         "talk_send_message",
         {"token": token, "message": "Hello from MCP integration test"},
     )
-    assert send_result.isError is False, (
+    assert send_result.is_error is False, (
         f"talk_send_message failed: {send_result.content}"
     )
     send_payload = json.loads(send_result.content[0].text)
@@ -70,7 +70,7 @@ async def test_talk_send_and_read_workflow(
     get_result = await nc_mcp_client.call_tool(
         "talk_get_messages", {"token": token, "limit": 10}
     )
-    assert get_result.isError is False, (
+    assert get_result.is_error is False, (
         f"talk_get_messages failed: {get_result.content}"
     )
     get_payload = json.loads(get_result.content[0].text)
@@ -83,7 +83,7 @@ async def test_talk_send_and_read_workflow(
         "talk_mark_as_read",
         {"token": token, "last_read_message": posted_id},
     )
-    assert mark_result.isError is False, (
+    assert mark_result.is_error is False, (
         f"talk_mark_as_read failed: {mark_result.content}"
     )
     mark_payload = json.loads(mark_result.content[0].text)
@@ -99,7 +99,7 @@ async def test_talk_list_conversations_includes_temp_room(
     token = temporary_conversation["token"]
 
     list_result = await nc_mcp_client.call_tool("talk_list_conversations", {})
-    assert list_result.isError is False, (
+    assert list_result.is_error is False, (
         f"talk_list_conversations failed: {list_result.content}"
     )
     payload = json.loads(list_result.content[0].text)
@@ -115,7 +115,7 @@ async def test_talk_get_conversation(
     name = temporary_conversation["name"]
 
     result = await nc_mcp_client.call_tool("talk_get_conversation", {"token": token})
-    assert result.isError is False, f"talk_get_conversation failed: {result.content}"
+    assert result.is_error is False, f"talk_get_conversation failed: {result.content}"
     payload = json.loads(result.content[0].text)
     conversation = payload["conversation"]
     assert conversation["token"] == token
@@ -129,7 +129,7 @@ async def test_talk_list_participants(
     token = temporary_conversation["token"]
 
     result = await nc_mcp_client.call_tool("talk_list_participants", {"token": token})
-    assert result.isError is False, f"talk_list_participants failed: {result.content}"
+    assert result.is_error is False, f"talk_list_participants failed: {result.content}"
     payload = json.loads(result.content[0].text)
     assert payload["conversation_token"] == token
     actor_ids = [p["actorId"] for p in payload["results"]]
@@ -149,7 +149,7 @@ async def test_talk_send_message_validation_blank_text(
     result = await nc_mcp_client.call_tool(
         "talk_send_message", {"token": token, "message": blank_text}
     )
-    assert result.isError is True, (
+    assert result.is_error is True, (
         f"Expected validation error for blank message {blank_text!r}"
     )
 
@@ -164,7 +164,7 @@ async def test_talk_send_message_validation_too_long(
         "talk_send_message",
         {"token": token, "message": "x" * 32001},
     )
-    assert result.isError is True, (
+    assert result.is_error is True, (
         "Expected validation error for message longer than 32000 characters"
     )
 
@@ -184,7 +184,7 @@ async def test_talk_create_conversation_and_add_participant(
         create_result = await nc_mcp_client.call_tool(
             "talk_create_conversation", {"room_name": room_name}
         )
-        assert create_result.isError is False, create_result.content[0].text
+        assert create_result.is_error is False, create_result.content[0].text
 
         payload = json.loads(create_result.content[0].text)
         assert payload["success"] is True
@@ -196,13 +196,13 @@ async def test_talk_create_conversation_and_add_participant(
         fetched = await nc_mcp_client.call_tool(
             "talk_get_conversation", {"token": token}
         )
-        assert fetched.isError is False
+        assert fetched.is_error is False
         assert json.loads(fetched.content[0].text)["conversation"]["token"] == token
 
         add_result = await nc_mcp_client.call_tool(
             "talk_add_participant", {"token": token, "participant": "admin"}
         )
-        assert add_result.isError is False, add_result.content[0].text
+        assert add_result.is_error is False, add_result.content[0].text
         add_payload = json.loads(add_result.content[0].text)
         assert add_payload["success"] is True
         assert add_payload["participant"] == "admin"
@@ -232,7 +232,7 @@ async def test_talk_reaction_round_trip(
     listed = await nc_mcp_client.call_tool(
         "talk_list_reactions", {"token": token, "message_id": message_id}
     )
-    assert listed.isError is False, listed.content[0].text
+    assert listed.is_error is False, listed.content[0].text
     assert json.loads(listed.content[0].text)["reactions"] == {}
 
     # React, and get the updated set back without a follow-up read.
@@ -240,26 +240,26 @@ async def test_talk_reaction_round_trip(
         "talk_react",
         {"token": token, "message_id": message_id, "reaction": emoji},
     )
-    assert reacted.isError is False, reacted.content[0].text
+    assert reacted.is_error is False, reacted.content[0].text
     react_payload = json.loads(reacted.content[0].text)
     assert emoji in react_payload["reactions"]
     assert react_payload["distinct_emoji"] == 1
     assert [a["actorId"] for a in react_payload["reactions"][emoji]] == ["admin"]
 
     # Reacting again with the same emoji leaves one reaction, not two -- this
-    # is the claim talk_react's idempotentHint makes.
+    # is the claim talk_react's idempotent_hint makes.
     again = await nc_mcp_client.call_tool(
         "talk_react",
         {"token": token, "message_id": message_id, "reaction": emoji},
     )
-    assert again.isError is False
+    assert again.is_error is False
     assert len(json.loads(again.content[0].text)["reactions"][emoji]) == 1
 
     removed = await nc_mcp_client.call_tool(
         "talk_remove_reaction",
         {"token": token, "message_id": message_id, "reaction": emoji},
     )
-    assert removed.isError is False, removed.content[0].text
+    assert removed.is_error is False, removed.content[0].text
     assert json.loads(removed.content[0].text)["reactions"] == {}
 
 
@@ -272,7 +272,7 @@ async def test_talk_add_participant_rejects_blank_participant(
         {"token": temporary_conversation["token"], "participant": "   "},
     )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "whitespace" in result.content[0].text.lower()
 
 
@@ -284,7 +284,7 @@ async def test_talk_create_conversation_rejects_blank_name(
         "talk_create_conversation", {"room_name": "  "}
     )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "whitespace" in result.content[0].text.lower()
 
 
@@ -293,7 +293,7 @@ async def test_talk_add_participant_is_idempotent(
 ):
     """Adding the same participant twice is a no-op, not an error or a duplicate.
 
-    This is the claim `talk_add_participant`'s `idempotentHint=True` makes, and
+    This is the claim `talk_add_participant`'s `idempotent_hint=True` makes, and
     it was the one idempotency claim in this PR resting on a manual probe rather
     than a test -- the reaction tools got a re-apply assertion and this did not.
     """
@@ -308,7 +308,7 @@ async def test_talk_add_participant_is_idempotent(
         first = await nc_mcp_client.call_tool(
             "talk_add_participant", {"token": token, "participant": "admin"}
         )
-        assert first.isError is False, first.content[0].text
+        assert first.is_error is False, first.content[0].text
 
         before = await nc_mcp_client.call_tool(
             "talk_list_participants", {"token": token}
@@ -319,7 +319,7 @@ async def test_talk_add_participant_is_idempotent(
         second = await nc_mcp_client.call_tool(
             "talk_add_participant", {"token": token, "participant": "admin"}
         )
-        assert second.isError is False, second.content[0].text
+        assert second.is_error is False, second.content[0].text
 
         after = await nc_mcp_client.call_tool(
             "talk_list_participants", {"token": token}
@@ -345,7 +345,7 @@ async def test_talk_create_one_to_one_conversation_without_a_name(
     result = await nc_mcp_client.call_tool(
         "talk_create_conversation", {"room_type": 1, "invite": other}
     )
-    assert result.isError is False, result.content[0].text
+    assert result.is_error is False, result.content[0].text
 
     conversation = json.loads(result.content[0].text)["conversation"]
     # The wire key is "type", not the model's "room_type": that field carries
@@ -381,7 +381,7 @@ async def test_talk_create_one_to_one_requires_an_invite(
     """Without an invitee there is no second participant, so there is no room."""
     result = await nc_mcp_client.call_tool("talk_create_conversation", {"room_type": 1})
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "invite is required" in result.content[0].text
 
 
@@ -393,7 +393,7 @@ async def test_talk_create_group_room_still_requires_a_name(
         "talk_create_conversation", {"room_type": 2, "invite": "admin"}
     )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "room_name is required" in result.content[0].text
 
 
@@ -417,7 +417,7 @@ async def test_client_validation_surfaces_through_mcp(
     The blank-name and blank-participant paths raise `ToolError` at the tool
     layer and were already covered. These three validators raise plain
     `ValueError` in the client instead, and nothing asserted what that looks
-    like after FastMCP has translated it -- a readable `isError` result or an
+    like after MCPServer has translated it -- a readable `isError` result or an
     opaque internal failure. The control case is included so the assertion is
     about the *rejections* rather than about every call failing.
     """
@@ -436,8 +436,8 @@ async def test_client_validation_surfaces_through_mcp(
     result = await nc_mcp_client.call_tool("talk_react", {"token": token, **arguments})
 
     if expected is None:
-        assert result.isError is False, result.content[0].text
+        assert result.is_error is False, result.content[0].text
         return
 
-    assert result.isError is True
+    assert result.is_error is True
     assert expected in result.content[0].text.lower()

--- a/tests/server/test_webdav_comments_mcp.py
+++ b/tests/server/test_webdav_comments_mcp.py
@@ -96,5 +96,5 @@ async def test_comment_on_missing_file_is_refused(nc_mcp_client: ClientSession):
         arguments={"path": f"no_such_file_{uuid.uuid4().hex}.txt", "message": "hi"},
     )
 
-    assert result.isError
+    assert result.is_error
     assert "File not found" in result.content[0].text

--- a/tests/server/test_webdav_search_mcp.py
+++ b/tests/server/test_webdav_search_mcp.py
@@ -220,7 +220,7 @@ async def test_nc_webdav_search_files_unfiltered(
         arguments={"scope": search_test_files},
     )
 
-    assert not result.isError, f"unfiltered search failed: {result.content[0].text}"
+    assert not result.is_error, f"unfiltered search failed: {result.content[0].text}"
 
     files = normalize_search_response(json.loads(result.content[0].text))
     logger.info("Unfiltered search returned %s files", len(files))

--- a/tests/smoke/test_protocol_2026.py
+++ b/tests/smoke/test_protocol_2026.py
@@ -1,0 +1,36 @@
+"""The server served over a real 2026-07-28 Streamable HTTP connection.
+
+Every other test here drives a hand-rolled ``ClientSession`` + ``initialize()``,
+which negotiates a **2025-era** protocol version — the same thing today's real
+clients do, and worth keeping. But it means nothing else in the suite exercises
+2026-07-28 over the wire, which is the revision this SDK upgrade is about.
+
+``Client(url)`` defaults to ``mode="auto"``, so it negotiates the newest version
+both ends speak. Connecting at all proves the handshake (``server/discover``,
+no session), and a tool call proves the middleware chain, capability gating and
+result conversion all work on that path.
+"""
+
+import os
+
+import pytest
+from mcp.client import Client
+
+pytestmark = [pytest.mark.integration, pytest.mark.smoke]
+
+MCP_URL = os.environ.get("MCP_SERVER_URL", "http://localhost:8000/mcp")
+
+
+async def test_negotiates_2026_and_serves_tools():
+    async with Client(MCP_URL) as client:
+        assert client.protocol_version >= "2026-07-28", (
+            f"expected a 2026-era connection, negotiated {client.protocol_version}"
+        )
+
+        tools = await client.list_tools()
+        assert len(tools.tools) > 30, f"Expected >30 tools, got {len(tools.tools)}"
+
+        # A read-only tool with no arguments, so this asserts the call path
+        # rather than any particular Nextcloud state.
+        result = await client.call_tool("nc_calendar_list_calendars", {})
+        assert result.is_error is False, result.content

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -42,7 +42,7 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
             "category": "test",
         },
     )
-    assert create_result.isError is False
+    assert create_result.is_error is False
     data = json.loads(create_result.content[0].text)
     note_id = data["id"]
 
@@ -52,7 +52,7 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
             "nc_notes_get_note",
             arguments={"note_id": note_id},
         )
-        assert get_result.isError is False
+        assert get_result.is_error is False
 
         # Update, using the etag from the read rather than the one the create
         # returned. They are usually equal, but the Notes app can settle a
@@ -71,7 +71,7 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
                 "etag": current["etag"],
             },
         )
-        assert update_result.isError is False
+        assert update_result.is_error is False
 
     finally:
         # Delete
@@ -79,7 +79,7 @@ async def test_notes_crud_smoke(nc_mcp_client, nc_client):
             "nc_notes_delete_note",
             arguments={"note_id": note_id},
         )
-        assert delete_result.isError is False
+        assert delete_result.is_error is False
 
 
 async def test_calendar_basic_smoke(nc_mcp_client):
@@ -89,7 +89,7 @@ async def test_calendar_basic_smoke(nc_mcp_client):
         "nc_calendar_list_calendars",
         arguments={},
     )
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert "calendars" in data
@@ -103,7 +103,7 @@ async def test_webdav_basic_smoke(nc_mcp_client):
         "nc_webdav_list_directory",
         arguments={"path": "/"},
     )
-    assert result.isError is False
+    assert result.is_error is False
 
     data = json.loads(result.content[0].text)
     assert "files" in data

--- a/tests/unit/server/test_calendar_create_recurrence.py
+++ b/tests/unit/server/test_calendar_create_recurrence.py
@@ -14,7 +14,7 @@ leaves it out. CI's single-user integration lane is what surfaced it.
 from __future__ import annotations
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.server.calendar import configure_calendar_tools
 
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def create_event_tool():
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_calendar_tools(mcp)
     return mcp._tool_manager.get_tool("nc_calendar_create_event")
 

--- a/tests/unit/server/test_calendar_todo_etag.py
+++ b/tests/unit/server/test_calendar_todo_etag.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 import pytest
 from httpx import Request, Response
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
 from nextcloud_mcp_server.server.calendar import configure_calendar_tools
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def calendar_tools():
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_calendar_tools(mcp)
     return mcp._tool_manager
 

--- a/tests/unit/server/test_semantic_search_metrics.py
+++ b/tests/unit/server/test_semantic_search_metrics.py
@@ -1,7 +1,7 @@
 """`nc_semantic_search` records exactly one search metric per exit path.
 
 The MCP tool records its request metric in a `finally`, which is what makes the
-guarantee hold for success, `McpError`, and unexpected raises alike. That is a
+guarantee hold for success, `MCPError`, and unexpected raises alike. That is a
 claim about control flow, so it is only worth anything if something exercises
 each path — a `finally` that was accidentally moved inside the `try`, or an
 early `return` added above it, would still pass every other test in the suite.
@@ -13,13 +13,13 @@ two entrypoints are held to the same standard.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from mcp.shared.exceptions import McpError
+from mcp.shared.exceptions import MCPError
 
 pytestmark = pytest.mark.unit
 
 
 def _build_tool():
-    """Register the tools against a stub FastMCP and return `nc_semantic_search`."""
+    """Register the tools against a stub MCPServer and return `nc_semantic_search`."""
     from nextcloud_mcp_server.server.semantic import configure_semantic_tools
 
     captured = {}
@@ -109,7 +109,7 @@ def _run(
 
         try:
             result = anyio.run(_go)
-        except McpError as e:
+        except MCPError as e:
             return spy, e
         return spy, result
 
@@ -128,16 +128,16 @@ def test_unexpected_exception_records_an_error_sample():
     search must not simply vanish from the request counter."""
     spy, err = _run(search_side_effect=RuntimeError("qdrant exploded"))
 
-    assert isinstance(err, McpError)
+    assert isinstance(err, MCPError)
     assert spy.call_count == 1
     assert spy.call_args.kwargs["status"] == "error"
 
 
 def test_mcp_error_path_records_an_error_sample():
-    """A client-facing McpError is still a failed search."""
+    """A client-facing MCPError is still a failed search."""
     spy, err = _run(search_side_effect=ValueError("No embedding provider configured"))
 
-    assert isinstance(err, McpError)
+    assert isinstance(err, MCPError)
     assert spy.call_count == 1
     assert spy.call_args.kwargs["status"] == "error"
 

--- a/tests/unit/server/test_share_create_validation.py
+++ b/tests/unit/server/test_share_create_validation.py
@@ -11,8 +11,8 @@ would defeat the point.
 from __future__ import annotations
 
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.client.sharing import validate_share_with
 from nextcloud_mcp_server.server.sharing import configure_sharing_tools
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def share_create_tool():
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_sharing_tools(mcp)
     return mcp._tool_manager.get_tool("nc_share_create")
 

--- a/tests/unit/server/test_sharing_link_expiry.py
+++ b/tests/unit/server/test_sharing_link_expiry.py
@@ -95,6 +95,11 @@ def test_build_link_response_strips_trailing_slash():
 @pytest.mark.parametrize("share_data", [{"id": 1, "url": ""}, {"id": 1}])
 def test_build_link_response_raises_on_missing_url(share_data):
     """A payload without a usable url is a hard error, not a silent empty
-    response — OCS always returns one for shareType=3."""
-    with pytest.raises(RuntimeError, match="no url"):
+    response — OCS always returns one for shareType=3.
+
+    ToolError specifically, not a bare exception: mcp 2.x replaces an
+    unanticipated exception's message with "Error executing tool <name>", so a
+    RuntimeError here would tell the model the call failed and nothing else.
+    """
+    with pytest.raises(ToolError, match="no url"):
         _build_link_response("/f.png", share_data, "2026-06-02T12:30:00Z")

--- a/tests/unit/server/test_sharing_link_expiry.py
+++ b/tests/unit/server/test_sharing_link_expiry.py
@@ -16,6 +16,7 @@ authenticated client):
 from datetime import datetime, timezone
 
 import pytest
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.server.sharing import (
     _build_link_response,
@@ -55,7 +56,7 @@ def test_compute_link_expiry_rejects_non_positive(minutes):
     (non-expiring) public link."""
     now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
 
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ToolError, match="positive"):
         _compute_link_expiry(minutes, now)
 
 

--- a/tests/unit/server/test_webdav_search_escaping.py
+++ b/tests/unit/server/test_webdav_search_escaping.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.server.webdav import configure_webdav_tools
 
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def search_tool():
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_webdav_tools(mcp)
     return mcp._tool_manager.get_tool("nc_webdav_search_files")
 

--- a/tests/unit/test_auth_tools.py
+++ b/tests/unit/test_auth_tools.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from cryptography.fernet import Fernet
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.auth.login_flow import LoginFlowPollResult
 from nextcloud_mcp_server.auth.storage import RefreshTokenStorage
@@ -26,7 +26,7 @@ def _capture_registered_tools() -> dict:
 
     ``register_auth_tools`` only uses ``@mcp.tool(...)`` decorators, so a stub
     whose ``tool()`` returns an identity decorator captures the closures without
-    a real FastMCP instance.
+    a real MCPServer instance.
     """
     captured: dict = {}
 
@@ -38,7 +38,7 @@ def _capture_registered_tools() -> dict:
 
             return deco
 
-    register_auth_tools(cast(FastMCP, _StubMCP()))
+    register_auth_tools(cast(MCPServer, _StubMCP()))
     return captured
 
 

--- a/tests/unit/test_capability_gating.py
+++ b/tests/unit/test_capability_gating.py
@@ -4,7 +4,7 @@ Covers the three questions the gate has to get right:
 
 * does ``unmet_capability`` close only when it actually knows better (a missing
   app, a too-old version) and stay open on every unknown, and
-* does ``NextcloudFastMCP`` hide exactly the unmet tools from ``tools/list``
+* does ``NextcloudMCPServer`` hide exactly the unmet tools from ``tools/list``
   while refusing them in ``tools/call``, and
 * does an ungated tool set cost zero OCS round-trips.
 """
@@ -14,7 +14,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from packaging.version import InvalidVersion
 
 import nextcloud_mcp_server.capabilities as cap
@@ -26,7 +26,7 @@ from nextcloud_mcp_server.capabilities import (
     unmet_capability,
 )
 from nextcloud_mcp_server.config import _DEFAULTS, _reload_config, set_override
-from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.errors import NextcloudMCPServer
 
 pytestmark = pytest.mark.unit
 
@@ -198,13 +198,13 @@ async def test_capabilities_are_fetched_once_per_user():
 
 
 # ---------------------------------------------------------------------------
-# NextcloudFastMCP integration: tools/list + tools/call
+# NextcloudMCPServer integration: tools/list + tools/call
 # ---------------------------------------------------------------------------
 
 
 def _server(payload=None, raises: Exception | None = None) -> tuple:
     """A server with one gated + one ungated tool, and its fake OCS client."""
-    mcp = NextcloudFastMCP("test")
+    mcp = NextcloudMCPServer("test")
 
     @mcp.tool()
     @require_capability("deck", min_version="1.18.0")
@@ -265,7 +265,7 @@ async def test_list_tools_fails_open_when_no_client_is_available(mocker):
 
 
 async def test_list_tools_without_gates_makes_no_ocs_call(mocker):
-    mcp = NextcloudFastMCP("test")
+    mcp = NextcloudMCPServer("test")
 
     @mcp.tool()
     async def nc_notes_create_note() -> str:
@@ -417,11 +417,11 @@ def test_reaction_tools_declare_the_spreed_reactions_gate(tool_name):
     Talk hides these three tools" was inferred across two files rather than
     asserted. A typo in the app key or the flag would have passed both.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
     from nextcloud_mcp_server.server.talk import configure_talk_tools
 
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_talk_tools(mcp)
 
     tool = mcp._tool_manager.get_tool(tool_name)
@@ -435,11 +435,11 @@ def test_non_reaction_talk_tools_are_not_feature_gated():
     Gating the read/send tools on `reactions` would hide working tools on an
     older Talk -- the failure mode the fail-open contract exists to avoid.
     """
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
     from nextcloud_mcp_server.server.talk import configure_talk_tools
 
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     configure_talk_tools(mcp)
 
     for tool_name in ("talk_list_conversations", "talk_send_message"):

--- a/tests/unit/test_client_fleet_metrics.py
+++ b/tests/unit/test_client_fleet_metrics.py
@@ -7,7 +7,7 @@ upgrade's *silent* behaviour changes visible. Two things are pinned here:
    at which protocol version — deduplicated per session and with every
    client-supplied label clamped.
 2. ``instrument_call_tool_outcomes`` distinguishes a tool error the model can
-   see (``CallToolResult.isError``) from a protocol error it cannot (a JSON-RPC
+   see (``CallToolResult.is_error``) from a protocol error it cannot (a JSON-RPC
    error). On mcp 1.x the latter is 0 by construction, which is precisely what
    makes it a usable regression alarm after the upgrade.
 
@@ -22,8 +22,8 @@ from types import SimpleNamespace
 
 import pytest
 from mcp import types
-from mcp.server.lowlevel.server import request_ctx
-from mcp.shared.exceptions import McpError
+from mcp.server.context import ServerRequestContext
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.observability import metrics as metrics_module
 from nextcloud_mcp_server.observability.metrics import (
@@ -94,10 +94,20 @@ class _FakeSession:
         self.client_params = params
 
 
-def _activate(session: _FakeSession):
-    """Install a request context carrying ``session``, as the SDK does."""
-    return request_ctx.set(
-        SimpleNamespace(request_id=1, meta=None, session=session, lifespan_context=None)
+def _ctx(session: _FakeSession, protocol: str = "2025-06-18") -> ServerRequestContext:
+    """The request context the SDK hands a handler, carrying ``session``.
+
+    ``protocol_version`` is the *negotiated* version and lives on the context in
+    mcp 2.x, not on ``client_params`` — so it is populated even when the params
+    shape is one the metric does not recognise.
+    """
+    return ServerRequestContext(
+        session=session,
+        lifespan_context=None,
+        protocol_version=protocol,
+        method="tools/call",
+        params={"name": "nc_notes_create_note", "arguments": {}},
+        request_id=1,
     )
 
 
@@ -112,7 +122,7 @@ class TestRecordClientSession:
         }
         before = metric_sample(SESSIONS, labels)
 
-        record_client_session()
+        record_client_session(metric_session)
 
         assert metric_sample(SESSIONS, labels) - before == 1
         assert (
@@ -138,9 +148,9 @@ class TestRecordClientSession:
         }
         before = metric_sample(SESSIONS, labels)
 
-        record_client_session()
-        record_client_session()
-        record_client_session()
+        record_client_session(metric_session)
+        record_client_session(metric_session)
+        record_client_session(metric_session)
 
         assert metric_sample(SESSIONS, labels) - before == 1
 
@@ -152,17 +162,13 @@ class TestRecordClientSession:
         }
         before = metric_sample(SESSIONS, labels)
 
-        record_client_session()
-        token = _activate(_FakeSession(_client_params()))
-        try:
-            record_client_session()
-        finally:
-            request_ctx.reset(token)
+        record_client_session(metric_session)
+        record_client_session(_ctx(_FakeSession(_client_params())))
 
         assert metric_sample(SESSIONS, labels) - before == 2
 
     def test_no_request_context_is_a_noop(self, metric_sample):
-        """Outside a request the contextvar is unset — must not raise."""
+        """Outside a request there is no context to pass — must not raise."""
         labels = {
             "client_name": "claude-code",
             "client_version": "2.0",
@@ -170,7 +176,7 @@ class TestRecordClientSession:
         }
         before = metric_sample(SESSIONS, labels)
 
-        record_client_session()
+        record_client_session(None)
 
         assert metric_sample(SESSIONS, labels) == before
 
@@ -183,21 +189,15 @@ class TestRecordClientSession:
         }
         before = metric_sample(SESSIONS, labels)
 
-        token = _activate(_FakeSession(None))
-        try:
-            record_client_session()
-        finally:
-            request_ctx.reset(token)
+        record_client_session(_ctx(_FakeSession(None)))
 
         assert metric_sample(SESSIONS, labels) == before
 
     def test_client_labels_are_clamped(self, metric_sample):
         """clientInfo is peer-supplied; unbounded labels would be a memory DoS."""
-        token = _activate(_FakeSession(_client_params(name="x" * 200, version="1.2.3")))
-        try:
-            record_client_session()
-        finally:
-            request_ctx.reset(token)
+        record_client_session(
+            _ctx(_FakeSession(_client_params(name="x" * 200, version="1.2.3")))
+        )
 
         assert (
             metric_sample(
@@ -217,9 +217,13 @@ class TestRecordClientSession:
         The accessors use ``getattr(..., None)``, which swallows AttributeError
         by design — instrumentation must never fail a tool call. The consequence
         is that if mcp 2.x renames these fields in a way the dual-spelling block
-        does not cover, the metric keeps recording but every label reads
+        does not cover, the metric keeps recording but every client label reads
         "unknown". That is the signal to watch for after the upgrade; it is
         alerted on in docs/observability.md rather than logged.
+
+        ``protocol_version`` is exempt: mcp 2.x carries the negotiated version
+        on the request context, not on ``client_params``, so it survives a
+        params-shape change the client labels do not.
         """
 
         class _UnrecognisedParams:
@@ -228,15 +232,11 @@ class TestRecordClientSession:
         labels = {
             "client_name": "unknown",
             "client_version": "unknown",
-            "protocol_version": "unknown",
+            "protocol_version": "2025-06-18",
         }
         before = metric_sample(SESSIONS, labels)
 
-        token = _activate(_FakeSession(_UnrecognisedParams()))
-        try:
-            record_client_session()
-        finally:
-            request_ctx.reset(token)
+        record_client_session(_ctx(_FakeSession(_UnrecognisedParams())))
 
         assert metric_sample(SESSIONS, labels) - before == 1
 
@@ -286,33 +286,26 @@ class TestSilentFailureDiagnostics:
         with caplog.at_level(
             logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
         ):
-            record_client_session()
+            record_client_session(None)
 
         assert any("no request context" in r.message for r in caplog.records)
 
     def test_missing_client_params_says_so(self, caplog):
-        token = _activate(_FakeSession(None))
-        try:
-            with caplog.at_level(
-                logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
-            ):
-                record_client_session()
-        finally:
-            request_ctx.reset(token)
+        with caplog.at_level(
+            logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
+        ):
+            record_client_session(_ctx(_FakeSession(None)))
 
         assert any("no client_params" in r.message for r in caplog.records)
 
     def test_warns_once_per_process_not_per_request(self, caplog):
         """These fire on the tool-call hot path — one line, not one per call."""
-        token = _activate(_FakeSession(None))
-        try:
-            with caplog.at_level(
-                logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
-            ):
-                for _ in range(25):
-                    record_client_session()
-        finally:
-            request_ctx.reset(token)
+        ctx = _ctx(_FakeSession(None))
+        with caplog.at_level(
+            logging.WARNING, logger="nextcloud_mcp_server.observability.metrics"
+        ):
+            for _ in range(25):
+                record_client_session(ctx)
 
         assert len([r for r in caplog.records if "no client_params" in r.message]) == 1
 
@@ -322,43 +315,50 @@ class TestCallToolOutcomes:
 
     @staticmethod
     def _wrap(inner, registered=("nc_notes_create_note",)):
-        """Wrap ``inner``, with ``registered`` standing in for the tool registry."""
+        """Drive the middleware with ``inner`` as the rest of the chain.
+
+        ``registered`` stands in for the tool registry. mcp 2.x has no
+        ``request_handlers`` dict to patch, so the instrumentation is a
+        middleware and the test calls it the way the dispatcher would.
+        """
         mcp = SimpleNamespace(
-            _mcp_server=SimpleNamespace(
-                request_handlers={types.CallToolRequest: inner}
-            ),
+            middleware=[],
             _tool_manager=SimpleNamespace(
                 get_tool=lambda name: object() if name in registered else None
             ),
         )
         instrument_call_tool_outcomes(mcp)
-        return mcp._mcp_server.request_handlers[types.CallToolRequest]
+        (middleware,) = mcp.middleware
+
+        async def call(ctx):
+            return await middleware(ctx, inner)
+
+        return call
 
     @staticmethod
-    def _request(name: str = "nc_notes_create_note") -> types.CallToolRequest:
-        return types.CallToolRequest(
-            method="tools/call",
-            params=types.CallToolRequestParams(name=name, arguments={}),
-        )
+    def _request(name: str = "nc_notes_create_note") -> ServerRequestContext:
+        ctx = _ctx(_FakeSession(_client_params()))
+        ctx.params = {"name": name, "arguments": {}}
+        return ctx
 
     async def test_success(self, metric_sample):
         labels = {"tool_name": "nc_notes_create_note", "outcome": "success"}
         before = metric_sample(OUTCOMES, labels)
 
-        async def inner(_req):
-            return types.ServerResult(types.CallToolResult(content=[], isError=False))
+        async def inner(_ctx_):
+            return types.CallToolResult(content=[], is_error=False)
 
         await self._wrap(inner)(self._request())
 
         assert metric_sample(OUTCOMES, labels) - before == 1
 
     async def test_tool_error(self, metric_sample):
-        """isError=True — the model sees the message and can react."""
+        """is_error=True — the model sees the message and can react."""
         labels = {"tool_name": "nc_notes_create_note", "outcome": "tool_error"}
         before = metric_sample(OUTCOMES, labels)
 
-        async def inner(_req):
-            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+        async def inner(_ctx_):
+            return types.CallToolResult(content=[], is_error=True)
 
         await self._wrap(inner)(self._request())
 
@@ -367,20 +367,21 @@ class TestCallToolOutcomes:
     async def test_protocol_error_and_exception_propagates(self, metric_sample):
         """An escaping exception becomes a JSON-RPC error; the model sees nothing.
 
-        This is 0 on mcp 1.x by construction — the SDK converts every exception
-        except UrlElicitationRequiredError into isError=True — so any non-zero
-        reading after the 2.x upgrade is the MCPError semantics flip.
+        On mcp 2.x an MCPError raised in a tool would reach the client as a
+        JSON-RPC error, but NextcloudMCPServer.call_tool maps it back to
+        ToolError, so in production this counter should stay at zero. A
+        non-zero reading means something raised past that boundary.
         """
         labels = {"tool_name": "nc_notes_create_note", "outcome": "protocol_error"}
         before = metric_sample(OUTCOMES, labels)
 
-        async def inner(_req):
-            raise McpError(types.ErrorData(code=types.INTERNAL_ERROR, message="boom"))
+        async def inner(_ctx_):
+            raise MCPError(code=types.INTERNAL_ERROR, message="boom")
 
         handler = self._wrap(inner)
         request = self._request()
 
-        with pytest.raises(McpError):
+        with pytest.raises(MCPError):
             await handler(request)
 
         assert metric_sample(OUTCOMES, labels) - before == 1
@@ -390,7 +391,7 @@ class TestCallToolOutcomes:
         labels = {"tool_name": "nc_notes_create_note", "outcome": "protocol_error"}
         before = metric_sample(OUTCOMES, labels)
 
-        async def inner(_req):
+        async def inner(_ctx_):
             raise KeyboardInterrupt
 
         handler = self._wrap(inner)
@@ -403,13 +404,9 @@ class TestCallToolOutcomes:
 
 
 @pytest.fixture
-def metric_session():
-    """Activate a request context with an initialized client session."""
-    token = _activate(_FakeSession(_client_params()))
-    try:
-        yield
-    finally:
-        request_ctx.reset(token)
+def metric_session() -> ServerRequestContext:
+    """A request context carrying an initialized client session."""
+    return _ctx(_FakeSession(_client_params()))
 
 
 class TestLabelCardinality:
@@ -432,16 +429,11 @@ class TestLabelCardinality:
         unknown_labels = {"tool_name": "unknown", "outcome": "tool_error"}
         before_unknown = metric_sample(OUTCOMES, unknown_labels)
 
-        async def inner(_req):
-            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+        async def inner(_ctx_):
+            return types.CallToolResult(content=[], is_error=True)
 
         handler = TestCallToolOutcomes._wrap(inner)
-        await handler(
-            types.CallToolRequest(
-                method="tools/call",
-                params=types.CallToolRequestParams(name=bogus, arguments={}),
-            )
-        )
+        await handler(TestCallToolOutcomes._request(bogus))
 
         assert metric_sample(OUTCOMES, bogus_labels) == 0
         assert metric_sample(OUTCOMES, unknown_labels) - before_unknown == 1
@@ -461,13 +453,11 @@ class TestLabelCardinality:
 
         # Well past the cap, each session declaring a fresh identity.
         for i in range(_MAX_TRACKED_CLIENTS + 20):
-            token = _activate(
-                _FakeSession(_client_params(name=f"rotating-{i}", version="1.0.0"))
+            record_client_session(
+                _ctx(
+                    _FakeSession(_client_params(name=f"rotating-{i}", version="1.0.0"))
+                )
             )
-            try:
-                record_client_session()
-            finally:
-                request_ctx.reset(token)
 
         assert metric_sample(SESSIONS, overflow_labels) - before >= 20
 

--- a/tests/unit/test_compact_tool_results.py
+++ b/tests/unit/test_compact_tool_results.py
@@ -3,9 +3,9 @@
 import json
 
 import pytest
-from mcp.types import ImageContent, TextContent
+from mcp.types import CallToolResult, ImageContent, TextContent
 
-from nextcloud_mcp_server.errors import NextcloudFastMCP
+from nextcloud_mcp_server.errors import NextcloudMCPServer
 from nextcloud_mcp_server.models.base import BaseResponse
 from nextcloud_mcp_server.serialization import (
     compact_json_dumps,
@@ -18,7 +18,12 @@ pytestmark = pytest.mark.unit
 
 def _text(result) -> str:
     """The unstructured text of a call_tool result, whichever shape it has."""
-    blocks = result[0] if isinstance(result, tuple) else result
+    if isinstance(result, CallToolResult):
+        blocks = result.content
+    elif isinstance(result, tuple):
+        blocks = result[0]
+    else:
+        blocks = result
     return blocks[0].text
 
 
@@ -78,13 +83,13 @@ def test_structured_half_of_the_pair_is_preserved():
 
 
 async def test_call_tool_returns_unindented_json():
-    """The end-to-end path: FastMCP's own indent=2 must not reach the client."""
+    """The end-to-end path: MCPServer's own indent=2 must not reach the client."""
 
     class Item(BaseResponse):
         name: str
         tags: list[str]
 
-    mcp = NextcloudFastMCP("test")
+    mcp = NextcloudMCPServer("test")
 
     @mcp.tool()
     async def get_item() -> Item:

--- a/tests/unit/test_deck_comment_overflow.py
+++ b/tests/unit/test_deck_comment_overflow.py
@@ -1,6 +1,6 @@
 """Tool-layer tests for Deck comment length handling.
 
-These register the Deck tools on a fresh ``FastMCP`` and invoke each tool's
+These register the Deck tools on a fresh ``MCPServer`` and invoke each tool's
 underlying function directly, mocking the client. They cover the wiring the
 splitter's own unit tests cannot: how many POSTs happen, what ``parent_id``
 each one carries, what is *not* called on failure, and what the error text
@@ -17,8 +17,9 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.models.deck import DeckComment
 from nextcloud_mcp_server.server import deck as deck_module
@@ -49,8 +50,8 @@ def basicauth_mode():
 
 @pytest.fixture
 def deck_tools() -> dict:
-    """Register the Deck tools on a fresh FastMCP and return them by name."""
-    mcp = FastMCP(name="test-deck-tools")
+    """Register the Deck tools on a fresh MCPServer and return them by name."""
+    mcp = MCPServer(name="test-deck-tools")
     configure_deck_tools(mcp)
     return {t.name: t for t in mcp._tool_manager.list_tools()}
 
@@ -256,7 +257,7 @@ async def test_message_needing_more_than_the_cap_posts_nothing(
 
     message = long_message(_MAX_SPLIT_PARTS + 4)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     assert f"{_MAX_SPLIT_PARTS}-part limit" in str(excinfo.value)
@@ -279,7 +280,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
     patch_get_client(fake_client)
     message = long_message(_MAX_SPLIT_PARTS + 5)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message=message)
 
     text = str(excinfo.value)
@@ -288,7 +289,7 @@ async def test_error_mode_does_not_promise_a_split_that_would_be_rejected(
     assert "nc_notes_create_note" in text
 
     # And the split mode rejects the same message, for the same stated reason.
-    with pytest.raises(ValueError, match="will not work either"):
+    with pytest.raises(ToolError, match="will not work either"):
         await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
     fake_client.deck.create_comment.assert_not_awaited()
 
@@ -305,7 +306,7 @@ async def test_enormous_message_is_rejected_without_running_the_splitter(
     patch_get_client(fake_client)
     spy = mocker.spy(deck_module, "split_message")
 
-    with pytest.raises(ValueError, match="will not work either"):
+    with pytest.raises(ToolError, match="will not work either"):
         await create_comment(
             ctx=ctx, card_id=42, message="word " * 400_000, overflow=overflow
         )
@@ -321,7 +322,7 @@ async def test_500_on_delete_is_not_blamed_on_message_length(
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(500)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await delete_comment(ctx=ctx, card_id=42, comment_id=7)
 
     text = str(excinfo.value)
@@ -343,7 +344,7 @@ async def test_partial_split_failure_reports_posted_ids_and_does_not_roll_back(
 
     message = long_message(3)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     message = str(excinfo.value)
@@ -366,7 +367,7 @@ async def test_failure_on_the_first_part_reports_that_nothing_was_posted(
 
     message = long_message(3)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message=message, overflow="split")
 
     message = str(excinfo.value)
@@ -384,7 +385,7 @@ async def test_error_mode_posts_nothing_and_names_the_remedy(
     patch_get_client(fake_client)
     message = "x" * 3412
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message=message)
 
     text = str(excinfo.value)
@@ -403,7 +404,7 @@ async def test_error_is_the_default_overflow_mode(
 
     message = long_message(3)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await create_comment(ctx=ctx, card_id=42, message=message)
 
     fake_client.deck.create_comment.assert_not_awaited()
@@ -456,7 +457,7 @@ async def test_blank_message_is_rejected_in_both_modes(
 ):
     patch_get_client(fake_client)
 
-    with pytest.raises(ValueError, match="empty or whitespace-only"):
+    with pytest.raises(ToolError, match="empty or whitespace-only"):
         await create_comment(ctx=ctx, card_id=42, message=message, overflow=overflow)
 
     fake_client.deck.create_comment.assert_not_awaited()
@@ -476,7 +477,7 @@ async def test_masked_500_on_update_names_the_length_limit(
     patch_get_client(fake_client)
     fake_client.deck.update_comment.side_effect = http_error(500)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await update_comment(ctx=ctx, card_id=42, comment_id=7, message="still short")
 
     text = str(excinfo.value)
@@ -497,7 +498,7 @@ async def test_403_on_listing_blames_board_access_not_authorship(
     patch_get_client(fake_client)
     fake_client.deck.get_comments.side_effect = http_error(403)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await list_comments(ctx=ctx, card_id=42)
 
     text = str(excinfo.value)
@@ -513,7 +514,7 @@ async def test_403_on_creating_blames_board_write_access_not_authorship(
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = http_error(403)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message="hello")
 
     text = str(excinfo.value)
@@ -530,7 +531,7 @@ async def test_403_on_update_explains_the_author_restriction(
         403, ocs_message="Only authors are allowed to edit their comment."
     )
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await update_comment(ctx=ctx, card_id=42, comment_id=7, message="edit")
 
     text = str(excinfo.value)
@@ -544,7 +545,7 @@ async def test_403_on_delete_explains_the_author_restriction(
     patch_get_client(fake_client)
     fake_client.deck.delete_comment.side_effect = http_error(403)
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await delete_comment(ctx=ctx, card_id=42, comment_id=7)
 
     text = str(excinfo.value)
@@ -558,7 +559,7 @@ async def test_404_on_listing_comments_is_mapped(
     patch_get_client(fake_client)
     fake_client.deck.get_comments.side_effect = http_error(404)
 
-    with pytest.raises(McpError, match="does not exist, or you lack access"):
+    with pytest.raises(MCPError, match="does not exist, or you lack access"):
         await list_comments(ctx=ctx, card_id=42)
 
 
@@ -571,7 +572,7 @@ async def test_400_from_deck_surfaces_the_server_reason(
         400, ocs_message="Message exceeds allowed character limit of 1000"
     )
 
-    with pytest.raises(McpError) as excinfo:
+    with pytest.raises(MCPError) as excinfo:
         await create_comment(ctx=ctx, card_id=42, message="short enough")
 
     text = str(excinfo.value)
@@ -585,5 +586,5 @@ async def test_network_error_is_reported_as_such(
     patch_get_client(fake_client)
     fake_client.deck.create_comment.side_effect = httpx.ConnectError("no route")
 
-    with pytest.raises(McpError, match="Network error creating a comment"):
+    with pytest.raises(MCPError, match="Network error creating a comment"):
         await create_comment(ctx=ctx, card_id=42, message="hello")

--- a/tests/unit/test_deck_server.py
+++ b/tests/unit/test_deck_server.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.models.deck import (
     DeckACL,
@@ -200,13 +201,13 @@ def test_validate_positive_length_accepts_positive():
 
 def test_validate_positive_length_rejects_zero():
     """Zero would wipe descriptions to a single ellipsis — reject at the boundary."""
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ToolError, match="must be positive"):
         _validate_positive_length(0)
 
 
 def test_validate_positive_length_rejects_negative():
     """Negative values produce surprising slice semantics — reject at the boundary."""
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ToolError, match="must be positive"):
         _validate_positive_length(-10)
 
 

--- a/tests/unit/test_elicitation_no_back_channel.py
+++ b/tests/unit/test_elicitation_no_back_channel.py
@@ -1,0 +1,96 @@
+"""Progressive consent on a 2026-07-28 connection, verified rather than assumed.
+
+Deck card 946 asks for exactly this: *"Progressive-consent behaviour under a
+2026-07-28 client is documented and deliberate... **verify the degradation
+empirically, don't assume it.**"*
+
+The 2026-07-28 protocol has no server-initiated requests, so ``ctx.elicit()``
+cannot reach the client at all — the SDK raises ``NoBackChannelError`` instead of
+sending. ``_run_elicit`` catches that and falls back to ``message_only``, which
+means the interactive consent prompt is **gone** for modern clients.
+
+Nothing here mocks the SDK: the tool runs behind a real ``Client(server)``
+connection, which negotiates 2026-07-28 by default. That is the point — a mocked
+``ctx.elicit`` would prove only that our ``except`` clause works, not that the
+SDK actually refuses on this era.
+
+Scope: this pins the *degradation*. Getting the login URL in front of the user
+afterwards is the caller's contract, not this helper's — ``present_login_url``
+returns only an outcome, and ``server/auth_tools.py`` is what builds the
+URL-bearing message on every non-accepted branch. Asserting that here would mean
+asserting a string this file wrote itself.
+"""
+
+import pytest
+from mcp.client import Client
+from mcp.server.mcpserver import Context
+
+from nextcloud_mcp_server.auth.elicitation import present_login_url
+from nextcloud_mcp_server.errors import NextcloudMCPServer
+
+pytestmark = pytest.mark.unit
+
+LOGIN_URL = "https://nextcloud.example.com/index.php/login/flow"
+ELICITATIONS = "mcp_elicitation_total"
+NO_BACK_CHANNEL = {
+    "prompt": "login_flow",
+    "outcome": "message_only",
+    "reason": "no_back_channel",
+}
+
+
+def _server() -> NextcloudMCPServer:
+    mcp = NextcloudMCPServer("elicitation-era-test")
+
+    @mcp.tool()
+    async def start_login(ctx: Context) -> str:
+        """Drives progressive consent exactly as the auth path does."""
+        return await present_login_url(ctx, LOGIN_URL)
+
+    return mcp
+
+
+async def test_2026_connection_degrades_to_message_only(metric_sample):
+    """``ctx.elicit()`` is refused by the SDK, and the tool still succeeds."""
+    before = metric_sample(ELICITATIONS, NO_BACK_CHANNEL)
+
+    async with Client(_server()) as client:
+        assert client.protocol_version >= "2026-07-28", (
+            f"this test is meaningless on {client.protocol_version}"
+        )
+        result = await client.call_tool("start_login", {})
+
+    # Degrades rather than failing: a NoBackChannelError escaping the tool would
+    # reach the client as a JSON-RPC error and break provisioning outright.
+    assert result.is_error is False, result.content
+    assert "message_only" in str(result.content), (
+        f"expected the no-back-channel fallback, got: {result.content}"
+    )
+
+    # The counter is the only production signal that interactive consent has
+    # stopped happening, so the specific reason label matters, not just the
+    # outcome — "error" here would mean we are guessing at the cause.
+    assert metric_sample(ELICITATIONS, NO_BACK_CHANNEL) - before == 1, (
+        "the fallback must be attributed to no_back_channel"
+    )
+
+
+async def test_elicitation_callback_does_not_rescue_it():
+    """Registering a callback changes nothing: no request ever reaches it.
+
+    Worth pinning, because "set an elicitation_callback" is the obvious wrong
+    fix — on 2026-07-28 the server never gets to send, so the callback is dead
+    code rather than a workaround.
+    """
+    called = False
+
+    async def elicitation_callback(context, params):  # pragma: no cover - never runs
+        nonlocal called
+        called = True
+        raise AssertionError("a 2026-07-28 server must not reach the client")
+
+    async with Client(_server(), elicitation_callback=elicitation_callback) as client:
+        result = await client.call_tool("start_login", {})
+
+    assert called is False
+    assert "message_only" in str(result.content)

--- a/tests/unit/test_friendly_errors.py
+++ b/tests/unit/test_friendly_errors.py
@@ -3,12 +3,11 @@
 import httpx
 import pytest
 from httpx import HTTPStatusError
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.client.collectives import OCSError
-from nextcloud_mcp_server.errors import NextcloudFastMCP, friendly_tool_error
+from nextcloud_mcp_server.errors import NextcloudMCPServer, friendly_tool_error
 from nextcloud_mcp_server.server.collectives import _raise_collectives_error
 
 pytestmark = pytest.mark.unit
@@ -189,7 +188,7 @@ def test_request_error_reports_unreachable_server():
 @pytest.mark.parametrize(
     "exc",
     [
-        McpError(ErrorData(code=-1, message="Note 5 not found")),
+        MCPError(code=-1, message="Note 5 not found"),
         ValueError("bad argument"),
         None,
     ],
@@ -203,7 +202,7 @@ def test_collectives_lets_http_errors_reach_the_boundary():
     """Regression guard: re-wrapping in str(e) would shadow the new message.
 
     ``OCSError`` carries a real server message and still becomes an
-    ``McpError``; a transport-level error must arrive at the tool boundary
+    ``MCPError``; a transport-level error must arrive at the tool boundary
     intact so ``friendly_tool_error`` can render it.
     """
     http_error = _http_error(404)
@@ -211,14 +210,14 @@ def test_collectives_lets_http_errors_reach_the_boundary():
         _raise_collectives_error(http_error)
     assert raised.value is http_error
 
-    with pytest.raises(McpError) as wrapped:
+    with pytest.raises(MCPError) as wrapped:
         _raise_collectives_error(OCSError(403, "Not permitted"))
     assert "Not permitted" in str(wrapped.value)
 
 
 async def test_boundary_rewrites_http_errors_but_not_tailored_ones():
-    """The FastMCP override is what actually reaches the client."""
-    mcp = NextcloudFastMCP("test")
+    """The MCPServer override is what actually reaches the client."""
+    mcp = NextcloudMCPServer("test")
 
     @mcp.tool()
     async def leaky_tool() -> str:
@@ -226,7 +225,7 @@ async def test_boundary_rewrites_http_errors_but_not_tailored_ones():
 
     @mcp.tool()
     async def tailored_tool() -> str:
-        raise McpError(ErrorData(code=-1, message="Note 5 not found"))
+        raise MCPError(code=-1, message="Note 5 not found")
 
     with pytest.raises(ToolError) as leaky:
         await mcp.call_tool("leaky_tool", {})

--- a/tests/unit/test_links_tool_coverage.py
+++ b/tests/unit/test_links_tool_coverage.py
@@ -15,7 +15,7 @@ import inspect
 import typing
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import BaseModel
 
 from nextcloud_mcp_server.links import _URL_BUILDERS
@@ -60,7 +60,7 @@ def _linkable_models(annotation: object, seen: set[type] | None = None) -> set[t
 
 def _all_tools() -> dict:
     """Register the three link-carrying tool modules and return them by name."""
-    mcp = FastMCP(name="test-link-coverage")
+    mcp = MCPServer(name="test-link-coverage")
     configure_deck_tools(mcp)
     configure_notes_tools(mcp)
     configure_webdav_tools(mcp)

--- a/tests/unit/test_mail_write_tools.py
+++ b/tests/unit/test_mail_write_tools.py
@@ -1,6 +1,6 @@
 """Server-layer tests for the Mail write tools (GH #1148 and friends).
 
-These register the Mail tools on a fresh ``FastMCP`` and invoke each tool's
+These register the Mail tools on a fresh ``MCPServer`` and invoke each tool's
 underlying function directly, mirroring ``test_webdav_tools_exclusion.py``.
 The point is the wiring the client-layer tests can't see: which flags a tool
 forwards, that a tag name is resolved to the server's own ``imapLabel`` before
@@ -11,8 +11,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
+from mcp.server.mcpserver import MCPServer
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.models.auth import ALL_SUPPORTED_SCOPES
 from nextcloud_mcp_server.models.mail import MailActionResponse, MailTagResponse
@@ -40,8 +40,8 @@ def basicauth_mode():
 
 @pytest.fixture
 def mail_tools() -> dict:
-    """Register the Mail tools on a fresh FastMCP and return them by name."""
-    mcp = FastMCP(name="test-mail-tools")
+    """Register the Mail tools on a fresh MCPServer and return them by name."""
+    mcp = MCPServer(name="test-mail-tools")
     configure_mail_tools(mcp)
     return {t.name: t for t in mcp._tool_manager.list_tools()}
 
@@ -100,7 +100,7 @@ async def test_set_flags_without_any_flag_is_an_error(mail_tools, fake_mail):
     # (python:S5778).
     set_flags = mail_tools["nc_mail_set_flags"].fn
     ctx = _ctx()
-    with pytest.raises(McpError):
+    with pytest.raises(MCPError):
         await set_flags(42, ctx)
 
     fake_mail.set_flags.assert_not_awaited()
@@ -199,7 +199,7 @@ def test_every_tool_scope_is_grantable():
     That exclusion was the hole this test had: ``semantic.read`` shipped
     ungrantable and undetected (GH #1277).
     """
-    mcp = FastMCP(name="test-all-tools")
+    mcp = MCPServer(name="test-all-tools")
     for configure in (*AVAILABLE_APPS.values(), configure_semantic_tools):
         configure(mcp)
 

--- a/tests/unit/test_max_request_body_size.py
+++ b/tests/unit/test_max_request_body_size.py
@@ -1,0 +1,63 @@
+"""The Streamable HTTP body limit, derived from ``WEBDAV_WRITE_MAX_MB``.
+
+mcp 2.x caps POST bodies at 4 MiB and answers 413 *before* parsing the JSON, so
+without this derivation a `nc_webdav_write_file` call well under the advertised
+50 MB limit would be refused by the transport — with an opaque status code
+instead of that tool's explanatory ``ToolError``.
+
+Pure arithmetic gating a user-visible behaviour, which is exactly the kind of
+thing that regresses silently: get the base64 factor wrong and large writes
+start failing at the transport with nothing to explain why.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nextcloud_mcp_server.app import _max_request_body_size
+
+pytestmark = pytest.mark.unit
+
+MIB = 1024 * 1024
+SDK_FLOOR = 4 * MIB
+
+
+def _patch_max_mb(mocker, value):
+    mocker.patch(
+        "nextcloud_mcp_server.app.get_settings",
+        return_value=SimpleNamespace(webdav_write_max_mb=value),
+    )
+
+
+def test_default_50mb_setting_leaves_room_for_the_base64_wire_form(mocker):
+    """base64 inflates by 4/3, and the tool decodes rather than streaming."""
+    _patch_max_mb(mocker, 50.0)
+
+    limit = _max_request_body_size()
+
+    # The whole point: a 50 MB file must still fit once base64-encoded.
+    assert limit > 50 * MIB * 4 / 3
+    assert limit == int(50 * MIB * 4 / 3) + MIB
+
+
+@pytest.mark.parametrize("max_mb", [0.0, 0, None, 1.0])
+def test_never_drops_below_the_sdk_default(mocker, max_mb):
+    """A small or unset setting must not tighten the transport below 4 MiB.
+
+    ``0``/``None`` mean "no app-level cap" to the write tool, which must not be
+    read here as "no bytes allowed".
+    """
+    _patch_max_mb(mocker, max_mb)
+
+    assert _max_request_body_size() == SDK_FLOOR
+
+
+def test_scales_with_the_setting(mocker):
+    """Raising WEBDAV_WRITE_MAX_MB must actually raise the transport limit."""
+    _patch_max_mb(mocker, 50.0)
+    at_50 = _max_request_body_size()
+    _patch_max_mb(mocker, 200.0)
+    at_200 = _max_request_body_size()
+
+    assert at_200 > at_50
+    assert at_200 >= 200 * MIB, "a 200 MB file must at least fit before encoding"

--- a/tests/unit/test_oauth_tools_signatures.py
+++ b/tests/unit/test_oauth_tools_signatures.py
@@ -7,7 +7,7 @@ status-disclosure operations.
 """
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.server.oauth_tools import register_oauth_tools
 
@@ -24,13 +24,13 @@ HARDENED_TOOLS = (
 
 @pytest.fixture
 def registered_tools():
-    """Register the OAuth tools against a fresh FastMCP and return them by name.
+    """Register the OAuth tools against a fresh MCPServer and return them by name.
 
-    Uses FastMCP's `_tool_manager.list_tools()`; flagged as internal and may
+    Uses MCPServer's `_tool_manager.list_tools()`; flagged as internal and may
     break on SDK upgrades, but this is the supported way to inspect a tool's
     JSON input schema in unit tests (see tests/unit/test_stdio.py).
     """
-    mcp = FastMCP("test-oauth-tools")
+    mcp = MCPServer("test-oauth-tools")
     register_oauth_tools(mcp)
     tools = mcp._tool_manager.list_tools()
     return {t.name: t for t in tools}

--- a/tests/unit/test_request_context_bridge.py
+++ b/tests/unit/test_request_context_bridge.py
@@ -1,0 +1,85 @@
+"""The per-request Context bridge, driven through the real mcp 2.x dispatcher.
+
+mcp 2.x removed ``request_ctx`` and ``MCPServer.get_context()``, and injects
+``Context`` only into tool and *template*-resource functions. Three things here
+still need one — capability gating in ``list_tools()``, static
+``@mcp.resource()`` functions, and ``enforce_capability`` on ``tools/call`` — so
+:class:`NextcloudMCPServer` republishes it from a middleware.
+
+These go through ``Client(server)`` rather than calling the methods directly,
+because the middleware only runs on the dispatcher path: a direct
+``mcp.list_tools()`` would pass while the served one silently fails open.
+``Client(server)`` also negotiates 2026-07-28, so this pins the bridge on the
+era the upgrade is about.
+"""
+
+import json
+
+import pytest
+from mcp.client import Client
+
+from nextcloud_mcp_server.errors import NextcloudMCPServer
+from nextcloud_mcp_server.request_context import current_context
+
+pytestmark = pytest.mark.unit
+
+
+def _server() -> NextcloudMCPServer:
+    mcp = NextcloudMCPServer("bridge-test")
+
+    @mcp.resource("nc://static")
+    async def static_resource() -> dict:
+        """A static resource: the SDK refuses to inject Context into these."""
+        ctx = current_context(mcp)
+        return {"request_id": str(ctx.request_id), "method": ctx.request_context.method}
+
+    @mcp.tool()
+    async def peek() -> str:
+        """A tool, to prove the bridge is live on tools/call too."""
+        return current_context(mcp).request_context.method
+
+    return mcp
+
+
+async def test_static_resource_reaches_the_request_context():
+    async with Client(_server()) as client:
+        result = await client.read_resource("nc://static")
+
+    payload = json.loads(result.contents[0].text)
+    assert payload["method"] == "resources/read"
+    assert payload["request_id"]
+
+
+async def test_tool_call_reaches_the_request_context():
+    async with Client(_server()) as client:
+        result = await client.call_tool("peek", {})
+
+    assert result.content[0].text == "tools/call"
+
+
+async def test_list_tools_reaches_the_request_context():
+    """``list_tools()`` takes no context, so capability gating depends on this."""
+    seen: list[str] = []
+
+    mcp = _server()
+    original = mcp.list_tools
+
+    async def recording_list_tools():
+        seen.append(current_context(mcp).request_context.method)
+        return await original()
+
+    mcp.list_tools = recording_list_tools  # type: ignore[method-assign]
+
+    async with Client(mcp) as client:
+        await client.list_tools()
+
+    assert seen == ["tools/list"]
+
+
+async def test_context_is_cleared_between_requests():
+    """A leaked contextvar would let one request read another's context."""
+    async with Client(_server()) as client:
+        await client.call_tool("peek", {})
+
+    with pytest.raises(LookupError):
+        current_context()

--- a/tests/unit/test_require_scopes_enforcement.py
+++ b/tests/unit/test_require_scopes_enforcement.py
@@ -22,8 +22,9 @@ import pytest
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import Context
-from mcp.shared.context import RequestContext
+from mcp.server.context import ServerRequestContext
+from mcp.server.mcpserver import Context
+from mcp.types import LATEST_PROTOCOL_VERSION
 
 from nextcloud_mcp_server.auth.scope_authorization import (
     InsufficientScopeError,
@@ -33,17 +34,20 @@ from nextcloud_mcp_server.auth.scope_authorization import (
 )
 
 
-def _make_ctx() -> Context:
-    """A real RequestContext — not a mock shaped like one."""
-    return Context(
-        request_context=RequestContext(
-            request_id="req-test",
-            meta=None,
-            session=None,
-            lifespan_context=None,
-        ),
-        fastmcp=None,
+def _request_context() -> ServerRequestContext:
+    return ServerRequestContext(
+        session=None,
+        lifespan_context=None,
+        protocol_version=LATEST_PROTOCOL_VERSION,
+        method="tools/call",
+        request_id="req-test",
+        meta=None,
     )
+
+
+def _make_ctx() -> Context:
+    """A real ServerRequestContext — not a mock shaped like one."""
+    return Context(request_context=_request_context())
 
 
 @contextmanager
@@ -88,10 +92,7 @@ async def test_request_context_has_no_access_token_attribute():
     If a future refactor reintroduces ``ctx.request_context.access_token`` as
     the token source, this fails and points at why that is wrong.
     """
-    req_ctx = RequestContext(
-        request_id="req-test", meta=None, session=None, lifespan_context=None
-    )
-    assert not hasattr(req_ctx, "access_token")
+    assert not hasattr(_request_context(), "access_token")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_response_models.py
+++ b/tests/unit/test_response_models.py
@@ -76,7 +76,7 @@ def test_create_note_response_serialization():
 def test_search_notes_response_wraps_results():
     """Test SearchNotesResponse wraps list of results correctly.
 
-    This is critical - FastMCP mangles raw List[Dict] responses,
+    This is critical - MCPServer mangles raw List[Dict] responses,
     so we must wrap them in a response model.
     """
     results = [

--- a/tests/unit/test_scope_authorization_stored.py
+++ b/tests/unit/test_scope_authorization_stored.py
@@ -12,7 +12,7 @@ import pytest
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from nextcloud_mcp_server.auth.scope_authorization import (
     InsufficientScopeError,

--- a/tests/unit/test_scope_decorator.py
+++ b/tests/unit/test_scope_decorator.py
@@ -1,7 +1,7 @@
 """Unit tests for scope decorator metadata and classification logic."""
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.auth.scope_authorization import (
     InsufficientScopeError,
@@ -75,7 +75,7 @@ def test_discover_all_scopes_always_includes_offline_access():
     an MCP instance with a single unrelated tool. Guards the metadata exposed at
     /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server.
     """
-    mcp = FastMCP(name="test-scope-discovery")
+    mcp = MCPServer(name="test-scope-discovery")
 
     @mcp.tool()
     @require_scopes("notes.read")
@@ -92,7 +92,7 @@ def test_discover_all_scopes_always_includes_offline_access():
 @pytest.mark.unit
 def test_discover_all_scopes_offline_access_without_any_tools():
     """The offline_access invariant must not depend on any tool being registered."""
-    mcp = FastMCP(name="empty")
+    mcp = MCPServer(name="empty")
 
     scopes = discover_all_scopes(mcp)
 

--- a/tests/unit/test_stdio.py
+++ b/tests/unit/test_stdio.py
@@ -1,7 +1,7 @@
 """Unit tests for the stdio transport module."""
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from nextcloud_mcp_server.config import _reload_config
 from nextcloud_mcp_server.config_validators import AuthMode
@@ -22,10 +22,10 @@ def single_user_env(monkeypatch):
 
 
 @pytest.mark.unit
-def test_get_stdio_mcp_returns_fastmcp(single_user_env):
-    """get_stdio_mcp returns a FastMCP instance with correct env vars."""
+def test_get_stdio_mcp_returns_mcpserver(single_user_env):
+    """get_stdio_mcp returns a MCPServer instance with correct env vars."""
     mcp = get_stdio_mcp()
-    assert isinstance(mcp, FastMCP)
+    assert isinstance(mcp, MCPServer)
 
 
 @pytest.mark.unit
@@ -54,7 +54,7 @@ def test_get_stdio_mcp_rejects_non_single_user_mode(monkeypatch):
 def test_get_stdio_mcp_registers_all_apps_by_default(single_user_env):
     """All app tool groups are registered when no filter is specified."""
     mcp = get_stdio_mcp()
-    # NOTE: _tool_manager is a FastMCP internal; may break on SDK upgrades
+    # NOTE: _tool_manager is a MCPServer internal; may break on SDK upgrades
     tools = mcp._tool_manager.list_tools()
     tool_names = {t.name for t in tools}
 
@@ -75,7 +75,7 @@ def test_get_stdio_mcp_registers_all_apps_by_default(single_user_env):
 def test_get_stdio_mcp_respects_enabled_apps(single_user_env):
     """Only specified apps have their tools registered."""
     mcp = get_stdio_mcp(enabled_apps=["notes"])
-    # NOTE: _tool_manager is a FastMCP internal; may break on SDK upgrades
+    # NOTE: _tool_manager is a MCPServer internal; may break on SDK upgrades
     tools = mcp._tool_manager.list_tools()
     tool_names = {t.name for t in tools}
 
@@ -89,7 +89,7 @@ def test_get_stdio_mcp_respects_enabled_apps(single_user_env):
 def test_get_stdio_mcp_no_semantic_tools(single_user_env):
     """Semantic search tools are never registered in stdio mode."""
     mcp = get_stdio_mcp()
-    # NOTE: _tool_manager is a FastMCP internal; may break on SDK upgrades
+    # NOTE: _tool_manager is a MCPServer internal; may break on SDK upgrades
     tools = mcp._tool_manager.list_tools()
     tool_names = {t.name for t in tools}
 
@@ -101,6 +101,6 @@ def test_get_stdio_mcp_no_semantic_tools(single_user_env):
 def test_get_stdio_mcp_registers_capabilities_resource(single_user_env):
     """The nc://capabilities resource is registered."""
     mcp = get_stdio_mcp()
-    # NOTE: _resource_manager._resources is a FastMCP internal; may break on SDK upgrades
+    # NOTE: _resource_manager._resources is a MCPServer internal; may break on SDK upgrades
     resources = mcp._resource_manager._resources
     assert "nc://capabilities" in resources

--- a/tests/unit/test_token_utils_user_id.py
+++ b/tests/unit/test_token_utils_user_id.py
@@ -5,7 +5,7 @@ verified access token had no ``sub`` claim. In a multi-tenant deployment
 that would let a malformed IdP token bucket every request under a single
 sentinel user, risking cross-tenant data exposure. The fix is to keep the
 no-token fallback (BasicAuth mode legitimately calls this without an
-OAuth identity) but raise ``McpError`` whenever an access token is
+OAuth identity) but raise ``MCPError`` whenever an access token is
 present and ``resource`` is empty.
 """
 
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from mcp.server.auth.provider import AccessToken
-from mcp.shared.exceptions import McpError
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.auth.token_utils import extract_user_id_from_token
 
@@ -59,7 +59,7 @@ async def test_returns_default_user_when_no_access_token():
 
 
 async def test_raises_when_token_present_but_resource_empty():
-    """Token present but ``resource`` empty → fail closed with McpError.
+    """Token present but ``resource`` empty → fail closed with MCPError.
 
     Pins the PR #758 follow-up review fix: a malformed IdP token must
     not silently funnel users into a shared ``"default_user"`` SQLite
@@ -69,7 +69,7 @@ async def test_raises_when_token_present_but_resource_empty():
         "nextcloud_mcp_server.auth.token_utils.get_access_token",
         return_value=_token(""),
     ):
-        with pytest.raises(McpError, match="Cannot determine user identity"):
+        with pytest.raises(MCPError, match="Cannot determine user identity"):
             await extract_user_id_from_token(MagicMock())
 
 
@@ -79,5 +79,5 @@ async def test_raises_when_resource_is_none():
         "nextcloud_mcp_server.auth.token_utils.get_access_token",
         return_value=_token(None),
     ):
-        with pytest.raises(McpError, match="Cannot determine user identity"):
+        with pytest.raises(MCPError, match="Cannot determine user identity"):
             await extract_user_id_from_token(MagicMock())

--- a/tests/unit/test_tool_call_logging.py
+++ b/tests/unit/test_tool_call_logging.py
@@ -16,8 +16,9 @@ from mcp import types
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.server.auth.provider import AccessToken
-from mcp.server.fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
+from mcp.server.context import ServerRequestContext
+from mcp.server.mcpserver import MCPServer
+from mcp.shared.exceptions import MCPError
 
 from nextcloud_mcp_server.observability.metrics import (
     _sanitize_tool_args,
@@ -33,26 +34,42 @@ LOGGER = "nextcloud_mcp_server.observability.metrics"
 
 
 def _wrap(inner, registered=("nc_semantic_search",)):
-    """Wrap ``inner``, with ``registered`` standing in for the tool registry."""
+    """Drive the middleware with ``inner`` as the rest of the chain.
+
+    ``registered`` stands in for the tool registry. mcp 2.x has no
+    ``request_handlers`` dict to patch, so the instrumentation is a middleware
+    and the test calls it the way the dispatcher would.
+    """
     mcp = SimpleNamespace(
-        _mcp_server=SimpleNamespace(request_handlers={types.CallToolRequest: inner}),
+        middleware=[],
         _tool_manager=SimpleNamespace(
             get_tool=lambda name: object() if name in registered else None
         ),
     )
     instrument_call_tool_outcomes(mcp)
-    return mcp._mcp_server.request_handlers[types.CallToolRequest]
+    (middleware,) = mcp.middleware
+
+    async def call(ctx):
+        return await middleware(ctx, inner)
+
+    return call
 
 
-def _request(name: str = "nc_semantic_search", **arguments) -> types.CallToolRequest:
-    return types.CallToolRequest(
+def _request(name: str = "nc_semantic_search", **arguments) -> ServerRequestContext:
+    return ServerRequestContext(
+        # client_params=None is the "before initialize" shape; it makes
+        # record_client_session bow out without touching a real ServerSession.
+        session=SimpleNamespace(client_params=None),
+        lifespan_context=None,
+        protocol_version=types.LATEST_PROTOCOL_VERSION,
         method="tools/call",
-        params=types.CallToolRequestParams(name=name, arguments=arguments),
+        params={"name": name, "arguments": arguments},
+        request_id=1,
     )
 
 
-async def _ok(_req):
-    return types.ServerResult(types.CallToolResult(content=[], isError=False))
+async def _ok(_ctx):
+    return types.CallToolResult(content=[], is_error=False)
 
 
 def _line(caplog):
@@ -78,8 +95,8 @@ class TestToolCallLine:
         assert not hasattr(record, "mcp_tool_requested")
 
     async def test_tool_error_logs_at_warning(self, caplog):
-        async def inner(_req):
-            return types.ServerResult(types.CallToolResult(content=[], isError=True))
+        async def inner(_ctx):
+            return types.CallToolResult(content=[], is_error=True)
 
         with caplog.at_level(logging.INFO, logger=LOGGER):
             await _wrap(inner)(_request())
@@ -89,14 +106,14 @@ class TestToolCallLine:
         assert record.levelno == logging.WARNING
 
     async def test_protocol_error_logs_and_still_raises(self, caplog):
-        async def inner(_req):
-            raise McpError(types.ErrorData(code=types.INTERNAL_ERROR, message="boom"))
+        async def inner(_ctx):
+            raise MCPError(code=types.INTERNAL_ERROR, message="boom")
 
         handler = _wrap(inner)
         request = _request()
 
         with caplog.at_level(logging.INFO, logger=LOGGER):
-            with pytest.raises(McpError):
+            with pytest.raises(MCPError):
                 await handler(request)
 
         record = _line(caplog)
@@ -161,7 +178,7 @@ def test_every_tool_function_is_named_after_the_tool_it_registers():
     ``provision_nextcloud_access`` — which silently split every dashboard that
     joined them. A mismatch is invisible at runtime, so it needs a test.
     """
-    mcp = FastMCP(name="test-tool-names")
+    mcp = MCPServer(name="test-tool-names")
     for app_name in AVAILABLE_APPS:
         configure_app_tools(mcp, app_name)
     register_auth_tools(mcp)

--- a/tests/unit/test_tool_errors_stay_tool_results.py
+++ b/tests/unit/test_tool_errors_stay_tool_results.py
@@ -1,0 +1,74 @@
+"""Tool failures must reach the model as tool results, not protocol errors.
+
+This is the single behaviour most at risk in the mcp 1.x -> 2.x port. In 1.x the
+SDK turned *every* exception out of a tool into ``CallToolResult(isError=True)``,
+so the model read the message and could react. 2.x carves out ``MCPError``: it is
+passed through as a top-level JSON-RPC error, which the client *raises* — the
+model never sees it. Roughly 140 raise sites in this codebase are
+argument-and-state failures ("Note 5 not found", "Nextcloud access not
+provisioned") that must keep landing in the result.
+
+``NextcloudMCPServer.call_tool`` maps ``MCPError`` back to ``ToolError`` for
+exactly this reason. These tests pin that from the *client* side, over a real
+``Client(server)`` connection (which negotiates 2026-07-28), because that is the
+only vantage point where "raised at the caller" and "returned as content" differ.
+"""
+
+import httpx
+import pytest
+from mcp.client import Client
+from mcp.shared.exceptions import MCPError
+
+from nextcloud_mcp_server.errors import NextcloudMCPServer
+
+pytestmark = pytest.mark.unit
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "http://nc/remote.php/dav/files/admin/notes/5.md")
+    return httpx.HTTPStatusError(
+        f"{status}", request=request, response=httpx.Response(status, request=request)
+    )
+
+
+def _server() -> NextcloudMCPServer:
+    mcp = NextcloudMCPServer("tool-error-test")
+
+    @mcp.tool()
+    async def raises_mcp_error() -> str:
+        """The shape ~140 of our tool raise sites use."""
+        raise MCPError(code=-1, message="Note 5 not found")
+
+    @mcp.tool()
+    async def raises_nextcloud_404() -> str:
+        """An unhandled Nextcloud HTTP failure escaping a tool."""
+        raise _http_error(404)
+
+    return mcp
+
+
+async def test_mcp_error_lands_in_the_result_not_as_a_raise():
+    async with Client(_server()) as client:
+        result = await client.call_tool("raises_mcp_error", {})
+
+    assert result.is_error is True, "MCPError escaped as a protocol error"
+    assert "Note 5 not found" in str(result.content), (
+        f"the model cannot see why the call failed: {result.content}"
+    )
+
+
+async def test_nextcloud_404_lands_in_the_result_with_a_usable_message():
+    """2.x withholds the original text (``Error executing tool <name>``).
+
+    ``friendly_tool_error`` reads it off ``__cause__`` instead, so the model
+    still gets the resource, the status and what to do about it.
+    """
+    async with Client(_server()) as client:
+        result = await client.call_tool("raises_nextcloud_404", {})
+
+    assert result.is_error is True
+    text = str(result.content)
+    assert "Not found" in text, text
+    assert "notes/5.md" in text, text
+    # The bare SDK message, with nothing actionable in it, must not be what ships.
+    assert text.strip() != "Error executing tool raises_nextcloud_404", text

--- a/tests/unit/test_tool_errors_stay_tool_results.py
+++ b/tests/unit/test_tool_errors_stay_tool_results.py
@@ -72,3 +72,53 @@ async def test_nextcloud_404_lands_in_the_result_with_a_usable_message():
     assert "notes/5.md" in text, text
     # The bare SDK message, with nothing actionable in it, must not be what ships.
     assert text.strip() != "Error executing tool raises_nextcloud_404", text
+
+
+async def test_arbitrary_exception_keeps_its_message():
+    """The class CI caught: a plain Exception subclass raised in a tool body.
+
+    ``ScopeAuthorizationError`` and its subclasses derive from ``Exception``,
+    not ``ToolError`` — they are also raised on HTTP routes, where ``ToolError``
+    would be the wrong type. Under mcp 2.x that made them
+    ``UnexpectedToolError``, and the model was told "Error executing tool
+    nc_notes_create_note" with no mention of the missing scope. Four login-flow
+    integration tests caught it; this pins it at the unit tier so it fails in
+    seconds instead of in a Playwright lane.
+    """
+
+    class ScopeDenied(Exception):
+        pass
+
+    mcp = NextcloudMCPServer("arbitrary-exception-test")
+
+    @mcp.tool()
+    async def denied() -> str:
+        raise ScopeDenied("Missing required scopes: notes.write")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("denied", {})
+
+    assert result.is_error is True
+    text = str(result.content)
+    assert "notes.write" in text, (
+        f"the reason the call was refused must reach the model, got: {text}"
+    )
+
+
+async def test_exception_with_no_message_still_names_its_type():
+    """``str(exc)`` is empty for a bare raise; "failed: " alone says nothing."""
+
+    class Bang(Exception):
+        pass
+
+    mcp = NextcloudMCPServer("empty-message-test")
+
+    @mcp.tool()
+    async def boom() -> str:
+        raise Bang
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("boom", {})
+
+    assert result.is_error is True
+    assert "Bang" in str(result.content), result.content

--- a/tests/unit/test_webdav_comment_tools.py
+++ b/tests/unit/test_webdav_comment_tools.py
@@ -1,6 +1,6 @@
 """Tool-layer tests for the WebDAV file-comment tools (GH #1308).
 
-These register the WebDAV tools on a fresh ``FastMCP`` and invoke each tool's
+These register the WebDAV tools on a fresh ``MCPServer`` and invoke each tool's
 underlying function directly with a mocked client, covering the wiring the
 client-layer tests cannot: that the excluded-tag guard and the message
 validation run *before* anything is posted, and that a missing file is a clear
@@ -13,8 +13,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.server.webdav import configure_webdav_tools
 from nextcloud_mcp_server.utils.message_splitter import COMMENT_MAX_LENGTH
@@ -65,7 +65,7 @@ def no_excluded_tags(mocker):
 
 @pytest.fixture
 def tools() -> dict:
-    mcp = FastMCP(name="test-webdav-comment-tools")
+    mcp = MCPServer(name="test-webdav-comment-tools")
     configure_webdav_tools(mcp)
     return {t.name: t for t in mcp._tool_manager.list_tools()}
 
@@ -117,7 +117,7 @@ async def test_create_comment_at_the_limit_is_accepted(create_comment, fake_clie
     ],
 )
 async def test_create_comment_rejects_blank(create_comment, fake_client, message):
-    with pytest.raises(ValueError, match="must not be empty"):
+    with pytest.raises(ToolError, match="must not be empty"):
         await create_comment("/report.pdf", message, _ctx())
 
     fake_client.webdav.create_comment.assert_not_awaited()
@@ -125,7 +125,7 @@ async def test_create_comment_rejects_blank(create_comment, fake_client, message
 
 async def test_create_comment_rejects_over_length(create_comment, fake_client):
     """The error states the exact overage, so an agent needn't guess how much to cut."""
-    with pytest.raises(ValueError, match="5 characters over"):
+    with pytest.raises(ToolError, match="5 characters over"):
         await create_comment("/report.pdf", "x" * (COMMENT_MAX_LENGTH + 5), _ctx())
 
     fake_client.webdav.create_comment.assert_not_awaited()
@@ -181,7 +181,7 @@ async def test_list_comments_maps_to_models(list_comments, fake_client):
 async def test_list_comments_rejects_bad_paging(
     list_comments, fake_client, limit, offset, match
 ):
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ToolError, match=match):
         await list_comments("/report.pdf", _ctx(), limit=limit, offset=offset)
 
     fake_client.webdav.list_comments.assert_not_awaited()

--- a/tests/unit/test_webdav_tools_exclusion.py
+++ b/tests/unit/test_webdav_tools_exclusion.py
@@ -1,6 +1,6 @@
 """Server-layer regression tests for tag-based file exclusion (issue #710).
 
-These tests register the WebDAV tools on a fresh ``FastMCP`` instance and
+These tests register the WebDAV tools on a fresh ``MCPServer`` instance and
 invoke each tool's underlying function directly via the tool registry.
 Their purpose is **not** to re-test the path-matching logic (covered in
 ``test_tag_exclusion.py``) but to catch wiring regressions: that each
@@ -18,8 +18,8 @@ from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from nextcloud_mcp_server.models.webdav import WriteFileResponse
 from nextcloud_mcp_server.server.webdav import configure_webdav_tools
@@ -51,8 +51,8 @@ def basicauth_mode():
 
 @pytest.fixture
 def webdav_tools() -> dict:
-    """Register the WebDAV tools on a fresh FastMCP and return them by name."""
-    mcp = FastMCP(name="test-webdav-tools")
+    """Register the WebDAV tools on a fresh MCPServer and return them by name."""
+    mcp = MCPServer(name="test-webdav-tools")
     configure_webdav_tools(mcp)
     return {t.name: t for t in mcp._tool_manager.list_tools()}
 

--- a/tests/unit/test_webhook_endpoint.py
+++ b/tests/unit/test_webhook_endpoint.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``/webhooks/nextcloud`` HTTP receiver.
 
 Builds a minimal Starlette app around ``handle_nextcloud_webhook`` so we can
-drive it with ``TestClient`` without standing up the full FastMCP server.
+drive it with ``TestClient`` without standing up the full MCPServer server.
 """
 
 import anyio

--- a/tests/unit/utils/test_validation.py
+++ b/tests/unit/utils/test_validation.py
@@ -106,7 +106,7 @@ def test_parse_modified_timestamp_accepts(value, expected):
     ],
 )
 def test_parse_modified_timestamp_rejects(value, reason):
-    """Bad formats / negatives / bools raise ValueError (→ McpError or HTTP 400)."""
+    """Bad formats / negatives / bools raise ValueError (→ MCPError or HTTP 400)."""
     with pytest.raises(ValueError):
         parse_modified_timestamp(value)
 

--- a/uv.lock
+++ b/uv.lock
@@ -969,6 +969,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -989,12 +1002,29 @@ http2 = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1681,15 +1711,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1699,15 +1729,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -2026,6 +2069,7 @@ postgres = [
 dev = [
     { name = "commitizen" },
     { name = "deptry" },
+    { name = "httpx2" },
     { name = "ipython" },
     { name = "pact-python" },
     { name = "playwright" },
@@ -2063,7 +2107,7 @@ requires-dist = [
     { name = "langchain-text-splitters", specifier = ">=1.0.0" },
     { name = "lxml", specifier = ">=5.0" },
     { name = "markdownify", specifier = ">=0.14.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.29,<1.30" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1,<3" },
     { name = "mistralai", specifier = ">=2.4.5" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=2.8.1" },
@@ -2098,6 +2142,7 @@ provides-extras = ["postgres", "observability"]
 dev = [
     { name = "commitizen", specifier = ">=4.8.2" },
     { name = "deptry", specifier = ">=0.20.0" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "ipython", specifier = ">=9.2.0" },
     { name = "pact-python", specifier = ">=3.4.0" },
     { name = "playwright", specifier = ">=1.49.1" },
@@ -3244,20 +3289,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4283,6 +4314,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrates to `mcp` python-sdk **2.1.1** (protocol **2026-07-28**), from 1.29.

Closes the work planned on Deck card 946 (board 46, "MCP 2026-07-28 Spec
Adoption"), which blocks every other card on that board.

## Deviation from the card's plan — read this first

The card plans **4 stacked PRs** (spike / prep-on-v1 / mechanical bump /
semantics). This is **one PR**. Phase 1 ("prep on v1") is no longer reachable:
the `get_context()` replacement needs `ServerRequestContext`, which does not
exist in 1.x, so there is nothing forward-compatible left to land first. And
splitting the bump from the semantics would make the bottom PR knowingly
broken — without the `ToolError` conversions, tools silently stop explaining
themselves to the model.

Happy to restructure into a stack if you'd rather review it that way; say so and
I'll split it. The semantic changes are the four bullets under **Behavioural**
below, each with a comment at the site.

## Mechanical (the bulk of the diff)

| Change | Sites |
|---|---|
| `FastMCP` → `MCPServer`, `mcp.server.fastmcp*` → `mcp.server.mcpserver*` | 34 |
| `McpError(ErrorData(...))` → `MCPError(code, message)` | 141 |
| `.isError` → `.is_error`, `.structuredContent`, `.uriTemplate`, `.inputSchema` | ~310 |
| `ToolAnnotations(readOnlyHint=…)` → `read_only_hint=` | ~380 |
| `streamablehttp_client` → `streamable_http_client` + `httpx2.AsyncClient` | 3 files |
| `RequestContext` → `ServerRequestContext` / `ClientRequestContext` | 2 files |

The `ToolAnnotations` kwargs were **not** required — camelCase still constructs,
verified at runtime — but renaming them clears ~200 `ty` warnings, so `ty` is
usable again. `NextcloudFastMCP` → `NextcloudMCPServer`, since it was named
after a class that no longer exists.

## Behavioural — the actual risk

**1. `request_ctx` and `get_context()` are both gone.** v2 injects `Context`
into tools and *template* resources only. That left capability gating in
`list_tools()` and every static `@mcp.resource()` (`nc://capabilities`,
`notes://settings`, `cookbook://version`) with no route to a context — and
because both callers fail open by design, this would have **silently disabled
capability gating** rather than crashing. New `nextcloud_mcp_server/request_context.py`
republishes the context from a middleware, which is where v2 puts per-message
interception.

**2. `Server.request_handlers` is gone** — the tool-outcome metrics and
client-fleet instrumentation were patching that dict. Both are now a middleware;
`instrument_call_tool_outcomes(mcp)` keeps its signature.

**3. `MCPError` from a tool is now a JSON-RPC error, not `is_error=True`.**
The client *raises* it, so the model never sees the message. All ~140 of our
raise sites are "Note 5 not found" / "Nextcloud access not provisioned" —
failures the model should read and react to, which is precisely what `ToolError`
means in v2. Mapped back at the `call_tool` boundary rather than changing the
wire contract for 140 messages.

**4. `UnexpectedToolError` withholds the original message entirely** (`Error
executing tool <name>`, nothing more). 21 `raise ValueError` sites in tool bodies
— `"calendar_name is required when search_all_calendars is False"`, comment
length limits — were reaching the model as text in 1.x and would now reach it as
nothing. Converted to `ToolError`. A live integration test caught this one.

Also: Streamable HTTP now caps POST bodies at **4 MiB**, answering 413 *before*
parsing, while `WEBDAV_WRITE_MAX_MB` defaults to 50 MB — `max_request_body_size`
is now derived from that same setting so the size refusal stays where it can
explain itself. `transport_security` moved off the constructor onto
`streamable_http_app()` (see the note appended to
`docs/MCP-1.23-DNS-REBINDING-FIX.md`). `ctx.elicit()` raises
`NoBackChannelError` at 2026-07-28, so the fallback gained a dedicated branch
and a `mcp_elicitation_total{reason="no_back_channel"}` label. Deck resource
deprecation notices moved out of `ctx.warning()` — dropped on 2026-era
connections per SEP-2577 — into descriptions clients actually see.

## Test coverage

New:
- `tests/unit/test_request_context_bridge.py` — the middleware bridge, driven
  through a real `Client(server)` (which negotiates 2026-07-28). Calling the
  methods directly would pass while the *served* path silently failed open.
- `tests/unit/test_tool_errors_stay_tool_results.py` — the card's acceptance
  criterion: a Nextcloud 404 and a raised `MCPError` both land in
  `CallToolResult.is_error` with a usable message, asserted from the client side.
- `tests/smoke/test_protocol_2026.py` — closes a coverage gap this port
  surfaced: every existing fixture drives a hand-rolled `ClientSession` +
  `initialize()`, which negotiates a **2025-era** version, so nothing exercised
  2026-07-28 over HTTP. Uses `Client(url)` (`mode="auto"`).

The existing `ClientSession` fixtures deliberately stay on the legacy path —
that is what real clients still speak, and both eras need to keep working.

No new API surface, so no new contract tests; the existing Pact lanes should be
unaffected and are the check on that.

## Verification status — please read

Run locally before I was asked to move validation to CI:

- ✅ `ruff`, `ruff format`, `ty` (**201 → 0** diagnostics)
- ✅ `pytest -m unit` — 3727 passed
- ✅ `pytest -m contract` — 19 passed
- ✅ `pytest -m smoke` — passed against a live stack over real Streamable HTTP
- ✅ `nc://capabilities` static resource confirmed working live in single-user
  BasicAuth — the piece with no route to a `Context` under v2

**Not yet run anywhere:** `-m "integration and not oauth"` got to ~78% with all
failures traced to profiles I hadn't started (ports 8003/8004, keycloak, ldap)
rather than regressions — but I did not finish confirming that, so treat it as
unverified. `-m oauth`, `-m ldap`, `-m login_flow_ldap`, `-m keycloak` have not
run at all. The three new test files above have **never been executed** — CI is
their first run.

Auth is the surface I'd least want to take on faith here: elicitation losing its
back-channel, and `AuthenticatedUser` / `auth_context_var` still being
SDK-internal (unchanged in v2, but only the OAuth lanes prove it).

## The card's open item — now closed

> Progressive-consent behaviour under a 2026-07-28 client is documented and
> deliberate — **verify the degradation empirically, don't assume it.**

`tests/unit/test_elicitation_no_back_channel.py` does this, and passes in CI. It
drives the real `present_login_url` path behind a `Client(server)` connection
that negotiates 2026-07-28, and asserts the metric reason is specifically
`no_back_channel` rather than merely that *some* fallback fired — `reason="error"`
would mean we were guessing at the cause. It also pins that registering an
`elicitation_callback` does not rescue it, since that is the obvious wrong fix.

Confirmed, not assumed: the SDK does raise `NoBackChannelError`, our handler
catches that specific exception, and the tool degrades instead of failing.
Whether losing the clickable prompt is *acceptable* is a product call — restoring
an interactive one needs the resolver / `InputRequiredResult` route, which is
Deck card #526.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iCzZAuCMsZS7UJYfy3htd
