### PR TITLE
refactor(server): clear the 5 SonarCloud cognitive-complexity findings

### DIFF
--- a/nextcloud_mcp_server/server/cookbook.py
+++ b/nextcloud_mcp_server/server/cookbook.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Callable, NoReturn
 
 from httpx import HTTPStatusError, RequestError
 from mcp.server.mcpserver import Context, MCPServer
@@ -28,6 +29,485 @@ from nextcloud_mcp_server.observability.metrics import instrument_tool
 from nextcloud_mcp_server.request_context import current_context
 
 logger = logging.getLogger(__name__)
+
+#: MCP argument name -> the schema.org/Recipe field Cookbook expects.
+_RECIPE_FIELDS: dict[str, str] = {
+    "name": "name",
+    "description": "description",
+    "ingredients": "recipeIngredient",
+    "instructions": "recipeInstructions",
+    "url": "url",
+    "prep_time": "prepTime",
+    "cook_time": "cookTime",
+    "total_time": "totalTime",
+    "recipe_yield": "recipeYield",
+    "category": "recipeCategory",
+    "keywords": "keywords",
+}
+
+
+def _recipe_payload(*, keep: Callable[[Any], bool], **fields: Any) -> dict[str, Any]:
+    """Map MCP arguments onto schema.org keys, keeping those ``keep`` accepts.
+
+    Create and update pass different predicates, and the difference is
+    deliberate: create keeps only truthy values, so an omitted optional is
+    simply not sent, while update keeps anything that is not ``None``, so
+    passing an empty string *clears* a field rather than being ignored.
+    """
+    return {_RECIPE_FIELDS[arg]: value for arg, value in fields.items() if keep(value)}
+
+
+def _raise_recipe_error(
+    exc: HTTPStatusError, by_status: dict[int, str], fallback: str
+) -> NoReturn:
+    """Re-raise a Cookbook HTTP failure as the message the model should act on.
+
+    A dict beats an if/elif chain here only because the branches differ in
+    nothing but the status they match -- keep it a chain if a case ever needs
+    real logic.
+    """
+    raise MCPError(code=-1, message=by_status.get(exc.response.status_code, fallback))
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_import_recipe(url: str, ctx: Context) -> ImportRecipeResponse:
+    """Import a recipe from a URL using schema.org metadata.
+
+    This extracts recipe data from websites that use schema.org Recipe markup.
+    Many popular recipe sites support this standard."""
+    client = await get_client(ctx)
+    try:
+        recipe_data = await client.cookbook.import_recipe(url)
+        recipe = Recipe(**recipe_data)
+        return ImportRecipeResponse(
+            recipe=recipe,
+            recipe_id=recipe.id or "unknown",
+        )
+    except RequestError as e:
+        # RequestError can have empty str() - get details from exception attributes
+        error_detail = (
+            str(e) or f"{type(e).__name__}: {getattr(e, '__cause__', 'unknown cause')}"
+        )
+        raise MCPError(
+            code=-1,
+            message=f"Network error importing recipe from {url}: {error_detail}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 400:
+            raise MCPError(
+                code=-1,
+                message=f"Invalid URL or missing 'url' field: {url}",
+            )
+        elif e.response.status_code == 409:
+            raise MCPError(
+                code=-1,
+                message="A recipe with this name already exists. Import aborted.",
+            )
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to import recipes",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to import recipe from {url}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_list_recipes(ctx: Context) -> ListRecipesResponse:
+    """Get all recipes in the database"""
+    client = await get_client(ctx)
+    try:
+        recipes_data = await client.cookbook.list_recipes()
+        recipes = [RecipeStub(**r) for r in recipes_data]
+        return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to list recipes",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list recipes: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_get_recipe(recipe_id: int, ctx: Context) -> Recipe:
+    """Get a specific recipe by its ID"""
+    client = await get_client(ctx)
+    try:
+        recipe_data = await client.cookbook.get_recipe(recipe_id)
+        return Recipe(**recipe_data)
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(code=-1, message=f"Access denied to recipe {recipe_id}")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
+            )
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_create_recipe(
+    name: str,
+    description: str | None = None,
+    ingredients: list[str] | None = None,
+    instructions: list[str] | None = None,
+    url: str | None = None,
+    prep_time: str | None = None,
+    cook_time: str | None = None,
+    total_time: str | None = None,
+    recipe_yield: int | None = None,
+    category: str | None = None,
+    keywords: str | None = None,
+    ctx: Context = None,  # type: ignore
+) -> CreateRecipeResponse:
+    """Create a new recipe.
+
+    Required: name
+    Optional: All other recipe fields following schema.org/Recipe format.
+
+    Times should be in ISO8601 duration format (e.g., 'PT30M' for 30 minutes)."""
+    client = await get_client(ctx)
+
+    # ``name`` is set unconditionally: it is required, and letting the predicate
+    # drop an empty one would send a payload Cookbook cannot fault clearly.
+    recipe_data = {
+        "name": name,
+        **_recipe_payload(
+            keep=bool,
+            description=description,
+            ingredients=ingredients,
+            instructions=instructions,
+            url=url,
+            prep_time=prep_time,
+            cook_time=cook_time,
+            total_time=total_time,
+            recipe_yield=recipe_yield,
+            category=category,
+            keywords=keywords,
+        ),
+    }
+
+    try:
+        recipe_id = await client.cookbook.create_recipe(recipe_data)
+        return CreateRecipeResponse(id=recipe_id)
+    except HTTPStatusError as e:
+        _raise_recipe_error(
+            e,
+            {
+                409: f"A recipe with name '{name}' already exists",
+                422: "Recipe name is required and cannot be empty",
+                403: "Access denied: insufficient permissions to create recipes",
+            },
+            f"Failed to create recipe: server error ({e.response.status_code})",
+        )
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_update_recipe(
+    recipe_id: int,
+    name: str | None = None,
+    description: str | None = None,
+    ingredients: list[str] | None = None,
+    instructions: list[str] | None = None,
+    url: str | None = None,
+    prep_time: str | None = None,
+    cook_time: str | None = None,
+    total_time: str | None = None,
+    recipe_yield: int | None = None,
+    category: str | None = None,
+    keywords: str | None = None,
+    ctx: Context = None,  # type: ignore
+) -> UpdateRecipeResponse:
+    """Update an existing recipe.
+
+    Provide only the fields you want to update. Unspecified fields remain unchanged."""
+    client = await get_client(ctx)
+
+    # First get the current recipe
+    try:
+        current_recipe = await client.cookbook.get_recipe(recipe_id)
+    except HTTPStatusError as e:
+        _raise_recipe_error(
+            e,
+            {404: f"Recipe {recipe_id} not found"},
+            f"Failed to fetch recipe {recipe_id}: {e.response.reason_phrase}",
+        )
+
+    # Update only specified fields. ``is not None`` rather than truthiness, so
+    # an explicit "" or 0 clears a field instead of being silently ignored.
+    recipe_data = {
+        **current_recipe,
+        **_recipe_payload(
+            keep=lambda value: value is not None,
+            name=name,
+            description=description,
+            ingredients=ingredients,
+            instructions=instructions,
+            url=url,
+            prep_time=prep_time,
+            cook_time=cook_time,
+            total_time=total_time,
+            recipe_yield=recipe_yield,
+            category=category,
+            keywords=keywords,
+        ),
+    }
+
+    try:
+        updated_id = await client.cookbook.update_recipe(recipe_id, recipe_data)
+        return UpdateRecipeResponse(id=updated_id)
+    except HTTPStatusError as e:
+        _raise_recipe_error(
+            e,
+            {
+                422: "Recipe name is required and cannot be empty",
+                403: f"Access denied: insufficient permissions to update recipe {recipe_id}",
+            },
+            f"Failed to update recipe {recipe_id}: server error ({e.response.status_code})",
+        )
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_delete_recipe(
+    recipe_id: int, ctx: Context
+) -> DeleteRecipeResponse:
+    """Delete a recipe permanently"""
+    logger.info("Deleting recipe %s", recipe_id)
+    client = await get_client(ctx)
+    try:
+        message = await client.cookbook.delete_recipe(recipe_id)
+        return DeleteRecipeResponse(
+            status_code=200,
+            message=message,
+            deleted_id=recipe_id,
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to delete recipe {recipe_id}",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to delete recipe {recipe_id}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_search_recipes(query: str, ctx: Context) -> SearchRecipesResponse:
+    """Search for recipes by keywords, tags, and categories"""
+    client = await get_client(ctx)
+    try:
+        recipes_data = await client.cookbook.search_recipes(query)
+        recipes = [RecipeStub(**r) for r in recipes_data]
+        return SearchRecipesResponse(
+            recipes=recipes, query=query, total_found=len(recipes)
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to search recipes",
+            )
+        elif e.response.status_code == 500:
+            raise MCPError(
+                code=-1,
+                message="Search failed: server error",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Search failed: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_list_categories(ctx: Context) -> ListCategoriesResponse:
+    """Get all known categories.
+
+    Note: A category name of '*' indicates recipes with no category."""
+    client = await get_client(ctx)
+    try:
+        categories_data = await client.cookbook.list_categories()
+        categories = [Category(**c) for c in categories_data]
+        return ListCategoriesResponse(categories=categories)
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to list categories",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list categories: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_get_recipes_in_category(
+    category: str, ctx: Context
+) -> ListRecipesResponse:
+    """Get all recipes in a specific category.
+
+    Use '_' as the category name to get recipes with no category."""
+    client = await get_client(ctx)
+    try:
+        recipes_data = await client.cookbook.get_recipes_in_category(category)
+        recipes = [RecipeStub(**r) for r in recipes_data]
+        return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to access recipes",
+            )
+        elif e.response.status_code == 500:
+            raise MCPError(
+                code=-1,
+                message=f"Could not find category '{category}'",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get recipes in category: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_list_keywords(ctx: Context) -> ListKeywordsResponse:
+    """Get all known keywords/tags"""
+    client = await get_client(ctx)
+    try:
+        keywords_data = await client.cookbook.list_keywords()
+        keywords = [Keyword(**k) for k in keywords_data]
+        return ListKeywordsResponse(keywords=keywords)
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to list keywords",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to list keywords: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.read")
+@instrument_tool
+async def nc_cookbook_get_recipes_with_keywords(
+    keywords: list[str], ctx: Context
+) -> ListRecipesResponse:
+    """Get all recipes that have specific keywords/tags"""
+    client = await get_client(ctx)
+    try:
+        recipes_data = await client.cookbook.get_recipes_with_keywords(keywords)
+        recipes = [RecipeStub(**r) for r in recipes_data]
+        return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to access recipes",
+            )
+        elif e.response.status_code == 500:
+            raise MCPError(
+                code=-1,
+                message="Failed to get recipes with keywords: server error",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to get recipes with keywords: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_set_config(
+    folder: str | None = None,
+    update_interval: int | None = None,
+    print_image: bool | None = None,
+    ctx: Context = None,  # type: ignore
+) -> ReindexResponse:
+    """Set Cookbook app configuration.
+
+    Args:
+        folder: Recipe folder path in user's files
+        update_interval: Automatic rescan interval in minutes
+        print_image: Whether to print images with recipes"""
+    client = await get_client(ctx)
+
+    config_data = {}
+    if folder is not None:
+        config_data["folder"] = folder
+    if update_interval is not None:
+        config_data["update_interval"] = update_interval
+    if print_image is not None:
+        config_data["print_image"] = print_image
+
+    try:
+        result = await client.cookbook.set_config(config_data)
+        return ReindexResponse(status_code=200, message=str(result))
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to set configuration",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to set configuration: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("cookbook.write")
+@instrument_tool
+async def nc_cookbook_reindex(ctx: Context) -> ReindexResponse:
+    """Trigger a rescan of all recipes into the caching database.
+
+    This rebuilds the search index and should be used after manual file changes."""
+    client = await get_client(ctx)
+    try:
+        message = await client.cookbook.reindex()
+        return ReindexResponse(status_code=200, message=message)
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to reindex",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to reindex: server error ({e.response.status_code})",
+            )
 
 
 def configure_cookbook_tools(mcp: MCPServer):
@@ -66,515 +546,69 @@ def configure_cookbook_tools(mcp: MCPServer):
                     message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
                 )
 
-    @mcp.tool(
+    mcp.tool(
         title="Import Recipe from URL",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_import_recipe(url: str, ctx: Context) -> ImportRecipeResponse:
-        """Import a recipe from a URL using schema.org metadata.
+    )(nc_cookbook_import_recipe)
 
-        This extracts recipe data from websites that use schema.org Recipe markup.
-        Many popular recipe sites support this standard."""
-        client = await get_client(ctx)
-        try:
-            recipe_data = await client.cookbook.import_recipe(url)
-            recipe = Recipe(**recipe_data)
-            return ImportRecipeResponse(
-                recipe=recipe,
-                recipe_id=recipe.id or "unknown",
-            )
-        except RequestError as e:
-            # RequestError can have empty str() - get details from exception attributes
-            error_detail = (
-                str(e)
-                or f"{type(e).__name__}: {getattr(e, '__cause__', 'unknown cause')}"
-            )
-            raise MCPError(
-                code=-1,
-                message=f"Network error importing recipe from {url}: {error_detail}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 400:
-                raise MCPError(
-                    code=-1,
-                    message=f"Invalid URL or missing 'url' field: {url}",
-                )
-            elif e.response.status_code == 409:
-                raise MCPError(
-                    code=-1,
-                    message="A recipe with this name already exists. Import aborted.",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to import recipes",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to import recipe from {url}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Recipes",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_list_recipes(ctx: Context) -> ListRecipesResponse:
-        """Get all recipes in the database"""
-        client = await get_client(ctx)
-        try:
-            recipes_data = await client.cookbook.list_recipes()
-            recipes = [RecipeStub(**r) for r in recipes_data]
-            return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to list recipes",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to list recipes: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_list_recipes)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Recipe",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_get_recipe(recipe_id: int, ctx: Context) -> Recipe:
-        """Get a specific recipe by its ID"""
-        client = await get_client(ctx)
-        try:
-            recipe_data = await client.cookbook.get_recipe(recipe_id)
-            return Recipe(**recipe_data)
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(code=-1, message=f"Access denied to recipe {recipe_id}")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to retrieve recipe {recipe_id}: {e.response.reason_phrase}",
-                )
+    )(nc_cookbook_get_recipe)
 
-    @mcp.tool(
+    mcp.tool(
         title="Create Recipe",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_create_recipe(
-        name: str,
-        description: str | None = None,
-        ingredients: list[str] | None = None,
-        instructions: list[str] | None = None,
-        url: str | None = None,
-        prep_time: str | None = None,
-        cook_time: str | None = None,
-        total_time: str | None = None,
-        recipe_yield: int | None = None,
-        category: str | None = None,
-        keywords: str | None = None,
-        ctx: Context = None,  # type: ignore
-    ) -> CreateRecipeResponse:
-        """Create a new recipe.
+    )(nc_cookbook_create_recipe)
 
-        Required: name
-        Optional: All other recipe fields following schema.org/Recipe format.
-
-        Times should be in ISO8601 duration format (e.g., 'PT30M' for 30 minutes)."""
-        client = await get_client(ctx)
-
-        recipe_data = {"name": name}
-        if description:
-            recipe_data["description"] = description
-        if ingredients:
-            recipe_data["recipeIngredient"] = ingredients
-        if instructions:
-            recipe_data["recipeInstructions"] = instructions
-        if url:
-            recipe_data["url"] = url
-        if prep_time:
-            recipe_data["prepTime"] = prep_time
-        if cook_time:
-            recipe_data["cookTime"] = cook_time
-        if total_time:
-            recipe_data["totalTime"] = total_time
-        if recipe_yield:
-            recipe_data["recipeYield"] = recipe_yield
-        if category:
-            recipe_data["recipeCategory"] = category
-        if keywords:
-            recipe_data["keywords"] = keywords
-
-        try:
-            recipe_id = await client.cookbook.create_recipe(recipe_data)
-            return CreateRecipeResponse(id=recipe_id)
-        except HTTPStatusError as e:
-            if e.response.status_code == 409:
-                raise MCPError(
-                    code=-1,
-                    message=f"A recipe with name '{name}' already exists",
-                )
-            elif e.response.status_code == 422:
-                raise MCPError(
-                    code=-1,
-                    message="Recipe name is required and cannot be empty",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to create recipes",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to create recipe: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Update Recipe",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_update_recipe(
-        recipe_id: int,
-        name: str | None = None,
-        description: str | None = None,
-        ingredients: list[str] | None = None,
-        instructions: list[str] | None = None,
-        url: str | None = None,
-        prep_time: str | None = None,
-        cook_time: str | None = None,
-        total_time: str | None = None,
-        recipe_yield: int | None = None,
-        category: str | None = None,
-        keywords: str | None = None,
-        ctx: Context = None,  # type: ignore
-    ) -> UpdateRecipeResponse:
-        """Update an existing recipe.
+    )(nc_cookbook_update_recipe)
 
-        Provide only the fields you want to update. Unspecified fields remain unchanged."""
-        client = await get_client(ctx)
-
-        # First get the current recipe
-        try:
-            current_recipe = await client.cookbook.get_recipe(recipe_id)
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to fetch recipe {recipe_id}: {e.response.reason_phrase}",
-                )
-
-        # Update only specified fields
-        recipe_data = current_recipe.copy()
-        if name is not None:
-            recipe_data["name"] = name
-        if description is not None:
-            recipe_data["description"] = description
-        if ingredients is not None:
-            recipe_data["recipeIngredient"] = ingredients
-        if instructions is not None:
-            recipe_data["recipeInstructions"] = instructions
-        if url is not None:
-            recipe_data["url"] = url
-        if prep_time is not None:
-            recipe_data["prepTime"] = prep_time
-        if cook_time is not None:
-            recipe_data["cookTime"] = cook_time
-        if total_time is not None:
-            recipe_data["totalTime"] = total_time
-        if recipe_yield is not None:
-            recipe_data["recipeYield"] = recipe_yield
-        if category is not None:
-            recipe_data["recipeCategory"] = category
-        if keywords is not None:
-            recipe_data["keywords"] = keywords
-
-        try:
-            updated_id = await client.cookbook.update_recipe(recipe_id, recipe_data)
-            return UpdateRecipeResponse(id=updated_id)
-        except HTTPStatusError as e:
-            if e.response.status_code == 422:
-                raise MCPError(
-                    code=-1,
-                    message="Recipe name is required and cannot be empty",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to update recipe {recipe_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to update recipe {recipe_id}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Recipe",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_delete_recipe(
-        recipe_id: int, ctx: Context
-    ) -> DeleteRecipeResponse:
-        """Delete a recipe permanently"""
-        logger.info("Deleting recipe %s", recipe_id)
-        client = await get_client(ctx)
-        try:
-            message = await client.cookbook.delete_recipe(recipe_id)
-            return DeleteRecipeResponse(
-                status_code=200,
-                message=message,
-                deleted_id=recipe_id,
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Recipe {recipe_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to delete recipe {recipe_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to delete recipe {recipe_id}: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_delete_recipe)
 
-    @mcp.tool(
+    mcp.tool(
         title="Search Recipes",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_search_recipes(
-        query: str, ctx: Context
-    ) -> SearchRecipesResponse:
-        """Search for recipes by keywords, tags, and categories"""
-        client = await get_client(ctx)
-        try:
-            recipes_data = await client.cookbook.search_recipes(query)
-            recipes = [RecipeStub(**r) for r in recipes_data]
-            return SearchRecipesResponse(
-                recipes=recipes, query=query, total_found=len(recipes)
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to search recipes",
-                )
-            elif e.response.status_code == 500:
-                raise MCPError(
-                    code=-1,
-                    message="Search failed: server error",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Search failed: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_search_recipes)
 
-    @mcp.tool(
+    mcp.tool(
         title="List Recipe Categories",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_list_categories(ctx: Context) -> ListCategoriesResponse:
-        """Get all known categories.
+    )(nc_cookbook_list_categories)
 
-        Note: A category name of '*' indicates recipes with no category."""
-        client = await get_client(ctx)
-        try:
-            categories_data = await client.cookbook.list_categories()
-            categories = [Category(**c) for c in categories_data]
-            return ListCategoriesResponse(categories=categories)
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to list categories",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to list categories: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Recipes in Category",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_get_recipes_in_category(
-        category: str, ctx: Context
-    ) -> ListRecipesResponse:
-        """Get all recipes in a specific category.
+    )(nc_cookbook_get_recipes_in_category)
 
-        Use '_' as the category name to get recipes with no category."""
-        client = await get_client(ctx)
-        try:
-            recipes_data = await client.cookbook.get_recipes_in_category(category)
-            recipes = [RecipeStub(**r) for r in recipes_data]
-            return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to access recipes",
-                )
-            elif e.response.status_code == 500:
-                raise MCPError(
-                    code=-1,
-                    message=f"Could not find category '{category}'",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to get recipes in category: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Recipe Keywords",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_list_keywords(ctx: Context) -> ListKeywordsResponse:
-        """Get all known keywords/tags"""
-        client = await get_client(ctx)
-        try:
-            keywords_data = await client.cookbook.list_keywords()
-            keywords = [Keyword(**k) for k in keywords_data]
-            return ListKeywordsResponse(keywords=keywords)
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to list keywords",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to list keywords: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_list_keywords)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Recipes with Keywords",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("cookbook.read")
-    @instrument_tool
-    async def nc_cookbook_get_recipes_with_keywords(
-        keywords: list[str], ctx: Context
-    ) -> ListRecipesResponse:
-        """Get all recipes that have specific keywords/tags"""
-        client = await get_client(ctx)
-        try:
-            recipes_data = await client.cookbook.get_recipes_with_keywords(keywords)
-            recipes = [RecipeStub(**r) for r in recipes_data]
-            return ListRecipesResponse(recipes=recipes, total_count=len(recipes))
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to access recipes",
-                )
-            elif e.response.status_code == 500:
-                raise MCPError(
-                    code=-1,
-                    message="Failed to get recipes with keywords: server error",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to get recipes with keywords: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_get_recipes_with_keywords)
 
-    @mcp.tool(
+    mcp.tool(
         title="Set Cookbook Configuration",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_set_config(
-        folder: str | None = None,
-        update_interval: int | None = None,
-        print_image: bool | None = None,
-        ctx: Context = None,  # type: ignore
-    ) -> ReindexResponse:
-        """Set Cookbook app configuration.
+    )(nc_cookbook_set_config)
 
-        Args:
-            folder: Recipe folder path in user's files
-            update_interval: Automatic rescan interval in minutes
-            print_image: Whether to print images with recipes"""
-        client = await get_client(ctx)
-
-        config_data = {}
-        if folder is not None:
-            config_data["folder"] = folder
-        if update_interval is not None:
-            config_data["update_interval"] = update_interval
-        if print_image is not None:
-            config_data["print_image"] = print_image
-
-        try:
-            result = await client.cookbook.set_config(config_data)
-            return ReindexResponse(status_code=200, message=str(result))
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to set configuration",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to set configuration: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Reindex Recipes",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("cookbook.write")
-    @instrument_tool
-    async def nc_cookbook_reindex(ctx: Context) -> ReindexResponse:
-        """Trigger a rescan of all recipes into the caching database.
-
-        This rebuilds the search index and should be used after manual file changes."""
-        client = await get_client(ctx)
-        try:
-            message = await client.cookbook.reindex()
-            return ReindexResponse(status_code=200, message=message)
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to reindex",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to reindex: server error ({e.response.status_code})",
-                )
+    )(nc_cookbook_reindex)

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -687,6 +687,1382 @@ async def _resolve_note_attach_path(client, note_id: int) -> str:
     )
 
 
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_boards(ctx: Context) -> ListBoardsResponse:
+    """Get all Nextcloud Deck boards"""
+    client = await get_client(ctx)
+    boards = await client.deck.get_boards()
+    return ListBoardsResponse(boards=boards, total=len(boards))
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_board(
+    ctx: Context,
+    board_id: int,
+    include_acl: bool = True,
+    include_users: bool = True,
+    include_labels: bool = True,
+) -> DeckBoard:
+    """Get details of a specific Nextcloud Deck board.
+
+    Args:
+        board_id: The ID of the board
+        include_acl: Include the board's ACL entries (default True). Set
+            False to reduce response size when ACLs are not needed.
+        include_users: Include the board's user list (default True). Set
+            False to reduce response size when users are not needed.
+        include_labels: Include the board's label definitions (default
+            True). Set False to reduce response size. Labels can still be
+            retrieved via deck_get_labels.
+    """
+    client = await get_client(ctx)
+    board = await client.deck.get_board(board_id)
+    return _apply_board_filters(
+        board,
+        include_acl=include_acl,
+        include_users=include_users,
+        include_labels=include_labels,
+    )
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_stacks(
+    ctx: Context,
+    board_id: int,
+    include_cards: bool = True,
+    detail: DetailLevel = "summary",
+    status: CardStatus = "open",
+    label: str | None = None,
+    assigned_to: str | None = None,
+    description_max_length: int | None = None,
+    description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
+) -> ListStacksResponse:
+    """Get all stacks in a Nextcloud Deck board.
+
+    Cards are returned as compact summaries by default to keep the
+    response small on large boards. Filtering/projection happen
+    client-side after the API returns the full board, so they reduce the
+    tokens the caller sees but not network bandwidth.
+
+    Args:
+        board_id: The ID of the board
+        include_cards: Include cards inside each stack (default True). Set
+            False for a lightweight stack listing. Fetch cards separately
+            via deck_get_cards.
+        detail: "summary" (default) returns compact card rows. "full"
+            returns the complete card objects (the old behavior).
+        status: Which cards to include — "open" (default), "done",
+            "archived", or "all". The first three partition the board
+            (a card that is both done and archived counts as "archived").
+            "archived"/"all" include archived cards, which the active
+            listing endpoint omits — this costs one extra API call.
+        label: If set, only cards carrying a label with this exact title.
+        assigned_to: If set, only cards assigned to this user UID.
+        description_max_length: In detail="full", truncate each card's
+            description to this many characters.
+        description_preview_length: In detail="summary", length of the
+            description preview carried on each card (default 140).
+    """
+    _validate_positive_length(description_max_length)
+    _validate_positive_length(description_preview_length, "description_preview_length")
+    client = await get_client(ctx)
+
+    # Fetch active stacks and (when archived cards are in scope) the
+    # archived endpoint concurrently, then merge archived cards onto each
+    # stack by id before filtering. The active endpoint omits archived
+    # cards, so without this merge status="archived"/"all" would drop them.
+    stacks_holder: list[list[DeckStack]] = []
+    archived_by_stack: dict[int, list[DeckCard]] = {}
+    merge_archived = include_cards and status in _ARCHIVED_STATUSES
+
+    async def _get_active() -> None:
+        stacks_holder.append(await client.deck.get_stacks(board_id))
+
+    async def _get_archived() -> None:
+        archived_by_stack.update(await _archived_cards_by_stack(client, board_id))
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_get_active)
+        if merge_archived:
+            tg.start_soon(_get_archived)
+
+    stacks = stacks_holder[0]
+    if merge_archived:
+        for stack in stacks:
+            extra = archived_by_stack.get(stack.id)
+            if extra:
+                _append_archived_cards(stack, extra)
+
+    stacks = [
+        _apply_stack_filters(
+            stack,
+            include_cards=include_cards,
+            detail=detail,
+            status=status,
+            label=label,
+            assigned_to=assigned_to,
+            description_max_length=description_max_length,
+            description_preview_length=description_preview_length,
+        )
+        for stack in stacks
+    ]
+    return ListStacksResponse(stacks=stacks, total=len(stacks))
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_stack(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    include_cards: bool = True,
+    detail: DetailLevel = "summary",
+    status: CardStatus = "open",
+    label: str | None = None,
+    assigned_to: str | None = None,
+    description_max_length: int | None = None,
+    description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
+) -> DeckStack:
+    """Get details of a specific Nextcloud Deck stack.
+
+    Cards are returned as compact summaries by default. See
+    deck_get_stacks for the shared parameter semantics.
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        include_cards: Include cards in the stack (default True).
+        detail: "summary" (default) or "full".
+        status: "open" (default), "done", "archived", or "all"
+            (non-overlapping, a done+archived card counts as "archived").
+            "archived"/"all" include archived cards, which the active
+            listing endpoint omits — this costs one extra API call.
+        label: If set, only cards carrying a label with this exact title.
+        assigned_to: If set, only cards assigned to this user UID.
+        description_max_length: In detail="full", truncate descriptions.
+        description_preview_length: In detail="summary", preview length.
+    """
+    _validate_positive_length(description_max_length)
+    _validate_positive_length(description_preview_length, "description_preview_length")
+    client = await get_client(ctx)
+    if status == "archived" and include_cards:
+        # Archived-only: the /stacks/archived endpoint already returns the
+        # stack (metadata + archived cards) in one call, so skip the active
+        # fetch whose open cards would all be filtered out anyway.
+        archived = await client.deck.get_archived_stacks(board_id)
+        stack = next((s for s in archived if s.id == stack_id), None)
+        if stack is None:
+            # findAllArchived returns every stack, so this is defensive;
+            # fall back to the active endpoint for the stack metadata.
+            stack = await client.deck.get_stack(board_id, stack_id)
+    else:
+        # Active stack always needed (for metadata + open cards); fetch the
+        # archived cards concurrently when status="all" needs both sets.
+        stack_holder: list[DeckStack] = []
+        archived_by_stack: dict[int, list[DeckCard]] = {}
+        merge_archived = include_cards and status == "all"
+
+        async def _get_active() -> None:
+            stack_holder.append(await client.deck.get_stack(board_id, stack_id))
+
+        async def _get_archived() -> None:
+            archived_by_stack.update(await _archived_cards_by_stack(client, board_id))
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_get_active)
+            if merge_archived:
+                tg.start_soon(_get_archived)
+
+        stack = stack_holder[0]
+        extra = archived_by_stack.get(stack_id)
+        if extra:
+            _append_archived_cards(stack, extra)
+    return _apply_stack_filters(
+        stack,
+        include_cards=include_cards,
+        detail=detail,
+        status=status,
+        label=label,
+        assigned_to=assigned_to,
+        description_max_length=description_max_length,
+        description_preview_length=description_preview_length,
+    )
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_archived_stacks(
+    ctx: Context,
+    board_id: int,
+    detail: DetailLevel = "summary",
+    label: str | None = None,
+    assigned_to: str | None = None,
+    description_max_length: int | None = None,
+    description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
+) -> ListStacksResponse:
+    """List archived stacks (with their archived cards) for a Nextcloud
+    Deck board.
+
+    This is the archived-only shortcut: it returns *only* archived cards
+    in a single call. The active list tools (deck_get_cards,
+    deck_get_stacks, deck_get_board_overview) also include archived cards
+    when called with status="archived"/"all". Use this tool when you want
+    archived cards exclusively and don't need the open ones. Typical use:
+    auditing completed work archived off the active board (e.g. cards moved
+    through a "Done" stack and then archived via deck_archive_card). The
+    shape mirrors deck_get_stacks.
+
+    Cards are always included on the returned stacks (an archived stack
+    without its cards would have no audit value) and returned as compact
+    summaries by default. There is no ``status`` filter — every card here
+    is archived by definition — but ``label``/``assigned_to`` narrow the
+    set just like the active-stack tools.
+
+    Args:
+        board_id: The ID of the board
+        detail: "summary" (default) or "full".
+        label: If set, only cards carrying a label with this exact title.
+        assigned_to: If set, only cards assigned to this user UID.
+        description_max_length: In detail="full", truncate descriptions.
+        description_preview_length: In detail="summary", preview length.
+    """
+    _validate_positive_length(description_max_length)
+    _validate_positive_length(description_preview_length, "description_preview_length")
+    client = await get_client(ctx)
+    stacks = await client.deck.get_archived_stacks(board_id)
+    # All cards in archived stacks are themselves archived; status="all"
+    # keeps them (an "open"/"done" filter would drop the whole point).
+    # label/assigned_to still apply for targeted audits.
+    stacks = [
+        _apply_stack_filters(
+            stack,
+            include_cards=True,
+            detail=detail,
+            status="all",
+            label=label,
+            assigned_to=assigned_to,
+            description_max_length=description_max_length,
+            description_preview_length=description_preview_length,
+        )
+        for stack in stacks
+    ]
+    return ListStacksResponse(stacks=stacks, total=len(stacks))
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_cards(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    detail: DetailLevel = "summary",
+    status: CardStatus = "open",
+    label: str | None = None,
+    assigned_to: str | None = None,
+    description_max_length: int | None = None,
+    description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
+) -> ListCardsResponse:
+    """Get all cards in a Nextcloud Deck stack.
+
+    Cards are returned as compact summaries by default. Filtering and
+    projection are applied client-side after the API returns the full
+    stack, so they reduce the tokens the caller sees but not network
+    bandwidth — network-wise this tool is equivalent to
+    deck_get_stack(include_cards=True).
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        detail: "summary" (default) returns compact card rows. "full"
+            returns the complete card objects.
+        status: "open" (default), "done", "archived", or "all". The first
+            three partition the board (a done+archived card counts as
+            "archived"). "archived"/"all" include archived cards, which the
+            active listing endpoint omits — this costs one extra API call.
+        label: If set, only cards carrying a label with this exact title.
+        assigned_to: If set, only cards assigned to this user UID.
+        description_max_length: In detail="full", truncate descriptions.
+        description_preview_length: In detail="summary", preview length.
+    """
+    _validate_positive_length(description_max_length)
+    _validate_positive_length(description_preview_length, "description_preview_length")
+    client = await get_client(ctx)
+
+    # Archived cards are excluded by the active stack endpoint, so for
+    # statuses that can include them we also fetch /stacks/archived and
+    # merge. "open"/"done" need only the active stack (no extra call).
+    active_cards: list[DeckCard] = []
+    archived_cards: list[DeckCard] = []
+    need_active = status != "archived"
+    need_archived = status in _ARCHIVED_STATUSES
+
+    async def _get_active() -> None:
+        stack = await client.deck.get_stack(board_id, stack_id)
+        active_cards.extend(cast(list[DeckCard], stack.cards or []))
+
+    async def _get_archived() -> None:
+        by_stack = await _archived_cards_by_stack(client, board_id)
+        archived_cards.extend(by_stack.get(stack_id, []))
+
+    async with anyio.create_task_group() as tg:
+        if need_active:
+            tg.start_soon(_get_active)
+        if need_archived:
+            tg.start_soon(_get_archived)
+
+    cards = _shape_cards(
+        active_cards + archived_cards,
+        detail=detail,
+        status=status,
+        label=label,
+        assigned_to=assigned_to,
+        description_max_length=description_max_length,
+        description_preview_length=description_preview_length,
+    )
+    return ListCardsResponse(cards=cards, total=len(cards))
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_board_overview(
+    ctx: Context,
+    board_id: int,
+    status: CardStatus = "open",
+    label: str | None = None,
+    assigned_to: str | None = None,
+    description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
+) -> BoardOverviewResponse:
+    """Get a compact, whole-board snapshot in a single call.
+
+    Returns the board title, its label legend, and every stack with its
+    cards projected to compact summary rows. Prefer it for "show me the
+    board" / "what's in progress" style requests on large boards — it is
+    the token-efficient way to view board *state*. It intentionally omits
+    the board-management fields (ACL, user list, full label objects) that
+    deck_get_board exposes. Reach for deck_get_board when you need those.
+
+    Args:
+        board_id: The ID of the board
+        status: Which cards to include — "open" (default), "done",
+            "archived", or "all". The first three partition the board
+            (a card that is both done and archived counts as "archived").
+            "archived"/"all" include archived cards, which the active
+            listing endpoint omits — this costs one extra API call.
+        label: If set, only cards carrying a label with this exact title.
+        assigned_to: If set, only cards assigned to this user UID.
+        description_preview_length: Length of the description preview
+            carried on each card summary (default 140).
+    """
+    _validate_positive_length(description_preview_length, "description_preview_length")
+    client = await get_client(ctx)
+
+    board_holder: list[DeckBoard] = []
+    stacks_holder: list[list[DeckStack]] = []
+    archived_by_stack: dict[int, list[DeckCard]] = {}
+    merge_archived = status in _ARCHIVED_STATUSES
+
+    async def _get_board() -> None:
+        board_holder.append(await client.deck.get_board(board_id))
+
+    async def _get_stacks() -> None:
+        stacks_holder.append(await client.deck.get_stacks(board_id))
+
+    async def _get_archived() -> None:
+        archived_by_stack.update(await _archived_cards_by_stack(client, board_id))
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_get_board)
+        tg.start_soon(_get_stacks)
+        if merge_archived:
+            tg.start_soon(_get_archived)
+
+    board = board_holder[0]
+    stacks = stacks_holder[0]
+
+    stack_overviews: list[StackOverview] = []
+    total_cards = 0
+    for stack in stacks:
+        cards = cast(list[DeckCard], stack.cards or [])
+        if merge_archived:
+            cards = cards + archived_by_stack.get(stack.id, [])
+        summaries = [
+            _summarize_card(c, description_preview_length)
+            for c in _filter_cards(
+                cards,
+                status=status,
+                label=label,
+                assigned_to=assigned_to,
+            )
+        ]
+        total_cards += len(summaries)
+        stack_overviews.append(
+            StackOverview(
+                id=stack.id,
+                title=stack.title,
+                order=stack.order,
+                card_count=len(summaries),
+                cards=summaries,
+            )
+        )
+
+    return BoardOverviewResponse(
+        board_id=board.id,
+        title=board.title,
+        labels=[lbl.title for lbl in (board.labels or [])],
+        stacks=stack_overviews,
+        total_cards=total_cards,
+    )
+
+
+@require_scopes("deck.read")
+@with_links
+@instrument_tool
+async def deck_get_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int
+) -> DeckCard:
+    """Get details of a specific Nextcloud Deck card"""
+    client = await get_client(ctx)
+    card = await client.deck.get_card(board_id, stack_id, card_id)
+    return card
+
+
+@require_scopes("deck.read")
+@instrument_tool
+async def deck_get_labels(ctx: Context, board_id: int) -> ListLabelsResponse:
+    """Get all labels in a Nextcloud Deck board"""
+    client = await get_client(ctx)
+    board = await client.deck.get_board(board_id)
+    labels = board.labels or []
+    return ListLabelsResponse(labels=labels, total=len(labels))
+
+
+@require_scopes("deck.read")
+@instrument_tool
+async def deck_get_label(ctx: Context, board_id: int, label_id: int) -> DeckLabel:
+    """Get details of a specific Nextcloud Deck label"""
+    client = await get_client(ctx)
+    label = await client.deck.get_label(board_id, label_id)
+    return label
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_create_board(
+    ctx: Context, title: str, color: str
+) -> CreateBoardResponse:
+    """Create a new Nextcloud Deck board
+
+    Args:
+        title: The title of the new board
+        color: The hexadecimal color of the new board (e.g. FF0000)
+    """
+    client = await get_client(ctx)
+    board = await client.deck.create_board(title, color)
+    return CreateBoardResponse(id=board.id, title=board.title, color=board.color)
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_create_stack(
+    ctx: Context, board_id: int, title: str, order: int
+) -> CreateStackResponse:
+    """Create a new stack in a Nextcloud Deck board
+
+    Args:
+        board_id: The ID of the board
+        title: The title of the new stack
+        order: Order for sorting the stacks
+    """
+    client = await get_client(ctx)
+    stack = await client.deck.create_stack(board_id, title, order)
+    return CreateStackResponse(id=stack.id, title=stack.title, order=stack.order)
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_update_stack(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    title: str | None = None,
+    order: int | None = None,
+) -> StackOperationResponse:
+    """Update a Nextcloud Deck stack
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        title: New title for the stack
+        order: New order for the stack
+    """
+    client = await get_client(ctx)
+    await client.deck.update_stack(board_id, stack_id, title, order)
+    return StackOperationResponse(
+        success=True,
+        message="Stack updated successfully",
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_delete_stack(
+    ctx: Context, board_id: int, stack_id: int
+) -> StackOperationResponse:
+    """Delete a Nextcloud Deck stack
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+    """
+    client = await get_client(ctx)
+    await client.deck.delete_stack(board_id, stack_id)
+    return StackOperationResponse(
+        success=True,
+        message="Stack deleted successfully",
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_create_card(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    title: str,
+    type: str = "plain",
+    order: int = 999,
+    description: str | None = None,
+    duedate: str | None = None,
+) -> CreateCardResponse:
+    """Create a new card in a Nextcloud Deck stack
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        title: The title of the new card
+        type: Type of the card (default: plain)
+        order: Order for sorting the cards
+        description: Description of the card
+        duedate: Due date of the card (ISO-8601 format)
+    """
+    client = await get_client(ctx)
+    card = await client.deck.create_card(
+        board_id, stack_id, title, type, order, description, duedate
+    )
+    return CreateCardResponse(
+        id=card.id,
+        title=card.title,
+        stackId=card.stackId,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_update_card(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    card_id: int,
+    title: str | None = None,
+    description: str | None = None,
+    type: str | None = None,
+    owner: str | None = None,
+    order: int | None = None,
+    duedate: str | None = None,
+    archived: bool | None = None,
+    done: str | None = None,
+) -> CardOperationResponse:
+    """Update a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        title: New title for the card
+        description: New description for the card
+        type: New type for the card
+        owner: New owner for the card
+        order: New order for the card
+        duedate: New due date for the card (ISO-8601 format)
+        archived: Whether the card should be archived
+        done: Completion date for the card (ISO-8601 format)
+    """
+    client = await get_client(ctx)
+    await client.deck.update_card(
+        board_id,
+        stack_id,
+        card_id,
+        title,
+        description,
+        type,
+        owner,
+        order,
+        duedate,
+        archived,
+        done,
+    )
+    return CardOperationResponse(
+        success=True,
+        message="Card updated successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+# No @with_links here, deliberately: the card is gone by the time this
+# returns, so a link to it would 404. Every other CardOperationResponse tool
+# leaves the card in place and does carry one. Asserted by
+# tests/unit/test_links_tool_coverage.py.
+@instrument_tool
+async def deck_delete_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int
+) -> CardOperationResponse:
+    """Delete a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+    """
+    client = await get_client(ctx)
+    await client.deck.delete_card(board_id, stack_id, card_id)
+    return CardOperationResponse(
+        success=True,
+        message="Card deleted successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_archive_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int
+) -> CardOperationResponse:
+    """Archive a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+    """
+    client = await get_client(ctx)
+    await client.deck.archive_card(board_id, stack_id, card_id)
+    return CardOperationResponse(
+        success=True,
+        message="Card archived successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_unarchive_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int
+) -> CardOperationResponse:
+    """Unarchive a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+    """
+    client = await get_client(ctx)
+    await client.deck.unarchive_card(board_id, stack_id, card_id)
+    return CardOperationResponse(
+        success=True,
+        message="Card unarchived successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_reorder_card(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    card_id: int,
+    order: int,
+    target_stack_id: int,
+) -> CardOperationResponse:
+    """Reorder a Nextcloud Deck card within a board.
+
+    Moves a card to a new position, optionally into a different stack on
+    the SAME board. To move a card to a stack on a DIFFERENT board, use
+    deck_move_card_to_board instead — reordering across boards is rejected
+    because it would orphan the card's board-scoped labels.
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the current stack
+        card_id: The ID of the card
+        order: New position in the target stack
+        target_stack_id: The ID of the target stack (must be on board_id)
+    """
+    client = await get_client(ctx)
+    await client.deck.reorder_card(board_id, stack_id, card_id, order, target_stack_id)
+    return CardOperationResponse(
+        success=True,
+        message="Card reordered successfully",
+        card_id=card_id,
+        stack_id=target_stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_move_card_to_board(
+    ctx: Context,
+    source_board_id: int,
+    source_stack_id: int,
+    card_id: int,
+    target_board_id: int,
+    target_stack_id: int,
+    order: int = 0,
+) -> CardOperationResponse:
+    """Move a Nextcloud Deck card to a stack on a different board.
+
+    The card keeps its identity (same id, comments, attachments), along
+    with its archived state, due date and user assignments (an assignee
+    without access to the target board stays assigned but cannot act on the
+    card). Deck remaps the card's board-scoped labels to the destination
+    board by title — reusing a same-titled label there, or cloning it when
+    you have board-manage permission. Use deck_reorder_card for moves
+    within a single board.
+
+    Two caveats from Deck's move route: the card's owner is reassigned to
+    the user performing the move (the original owner is not preserved), and
+    a card marked done keeps its done state but its done timestamp is reset
+    to the time of the move.
+
+    target_stack_id must be a stack on target_board_id. The move is
+    rejected otherwise.
+
+    Args:
+        source_board_id: The ID of the board the card currently lives on
+        source_stack_id: The ID of the stack the card currently lives in
+        card_id: The ID of the card to move
+        target_board_id: The ID of the destination board
+        target_stack_id: The ID of the destination stack (must be on target_board_id)
+        order: Position within the destination stack (default 0 = top)
+    """
+    client = await get_client(ctx)
+    moved = await client.deck.move_card_to_board(
+        source_board_id,
+        source_stack_id,
+        card_id,
+        target_board_id,
+        target_stack_id,
+        order,
+    )
+    # Surface the post-move labels so callers can confirm the remap without
+    # a follow-up get_card (label remapping is this tool's whole point).
+    return CardOperationResponse(
+        success=True,
+        message="Card moved to board successfully",
+        card_id=card_id,
+        stack_id=target_stack_id,
+        board_id=target_board_id,
+        labels=[label.title for label in (moved.labels or [])],
+    )
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_create_label(
+    ctx: Context, board_id: int, title: str, color: str
+) -> CreateLabelResponse:
+    """Create a new label in a Nextcloud Deck board
+
+    Args:
+        board_id: The ID of the board
+        title: The title of the new label
+        color: The color of the new label (hex format without #)
+    """
+    client = await get_client(ctx)
+    label = await client.deck.create_label(board_id, title, color)
+    return CreateLabelResponse(id=label.id, title=label.title, color=label.color)
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_update_label(
+    ctx: Context,
+    board_id: int,
+    label_id: int,
+    title: str | None = None,
+    color: str | None = None,
+) -> LabelOperationResponse:
+    """Update a Nextcloud Deck label
+
+    Args:
+        board_id: The ID of the board
+        label_id: The ID of the label
+        title: New title for the label
+        color: New color for the label (hex format without #)
+    """
+    client = await get_client(ctx)
+    await client.deck.update_label(board_id, label_id, title, color)
+    return LabelOperationResponse(
+        success=True,
+        message="Label updated successfully",
+        label_id=label_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_delete_label(
+    ctx: Context, board_id: int, label_id: int
+) -> LabelOperationResponse:
+    """Delete a Nextcloud Deck label
+
+    Args:
+        board_id: The ID of the board
+        label_id: The ID of the label
+    """
+    client = await get_client(ctx)
+    await client.deck.delete_label(board_id, label_id)
+    return LabelOperationResponse(
+        success=True,
+        message="Label deleted successfully",
+        label_id=label_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_assign_label_to_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int, label_id: int
+) -> CardOperationResponse:
+    """Assign a label to a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        label_id: The ID of the label to assign
+    """
+    client = await get_client(ctx)
+    await client.deck.assign_label_to_card(board_id, stack_id, card_id, label_id)
+    return CardOperationResponse(
+        success=True,
+        message="Label assigned to card successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_remove_label_from_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int, label_id: int
+) -> CardOperationResponse:
+    """Remove a label from a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        label_id: The ID of the label to remove
+    """
+    client = await get_client(ctx)
+    await client.deck.remove_label_from_card(board_id, stack_id, card_id, label_id)
+    return CardOperationResponse(
+        success=True,
+        message="Label removed from card successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_assign_user_to_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int, user_id: str
+) -> CardOperationResponse:
+    """Assign a user to a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        user_id: The user ID to assign
+    """
+    client = await get_client(ctx)
+    await client.deck.assign_user_to_card(board_id, stack_id, card_id, user_id)
+    return CardOperationResponse(
+        success=True,
+        message="User assigned to card successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@with_links
+@instrument_tool
+async def deck_unassign_user_from_card(
+    ctx: Context, board_id: int, stack_id: int, card_id: int, user_id: str
+) -> CardOperationResponse:
+    """Unassign a user from a Nextcloud Deck card
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        user_id: The user ID to unassign
+    """
+    client = await get_client(ctx)
+    await client.deck.unassign_user_from_card(board_id, stack_id, card_id, user_id)
+    return CardOperationResponse(
+        success=True,
+        message="User unassigned from card successfully",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@require_capability("deck", min_version="1.18.0")
+@with_links
+@instrument_tool
+async def deck_assign_dependent_card(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    card_id: int,
+    dependent_card_id: int,
+) -> CardOperationResponse:
+    """Mark a Nextcloud Deck card as depending on another card.
+
+    Mirrors Deck's "Add dependent card" action. The dependency is
+    directional and stored on ``card_id``: it surfaces in that card's
+    ``dependentCards`` list (visible via deck_get_card). You need read
+    access to the dependent card.
+
+    Args:
+        board_id: The ID of the board containing the depending card
+        stack_id: The ID of the stack containing the depending card
+        card_id: The ID of the card that depends on another card
+        dependent_card_id: The ID of the card that card_id depends on
+    """
+    client = await get_client(ctx)
+    await client.deck.assign_dependent_card(
+        board_id, stack_id, card_id, dependent_card_id
+    )
+    return CardOperationResponse(
+        success=True,
+        message=f"Card {dependent_card_id} added as a dependency of card {card_id}",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.write")
+@require_capability("deck", min_version="1.18.0")
+@with_links
+@instrument_tool
+async def deck_remove_dependent_card(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    card_id: int,
+    dependent_card_id: int,
+) -> CardOperationResponse:
+    """Remove a dependency between two Nextcloud Deck cards.
+
+    Removes the dependency of ``card_id`` on ``dependent_card_id`` that was
+    created by deck_assign_dependent_card.
+
+    Args:
+        board_id: The ID of the board containing the depending card
+        stack_id: The ID of the stack containing the depending card
+        card_id: The ID of the card that depends on another card
+        dependent_card_id: The ID of the dependency to remove
+    """
+    client = await get_client(ctx)
+    await client.deck.remove_dependent_card(
+        board_id, stack_id, card_id, dependent_card_id
+    )
+    return CardOperationResponse(
+        success=True,
+        message=f"Card {dependent_card_id} removed as a dependency of card {card_id}",
+        card_id=card_id,
+        stack_id=stack_id,
+        board_id=board_id,
+    )
+
+
+@require_scopes("deck.read")
+@instrument_tool
+async def deck_get_card_comments(
+    ctx: Context,
+    card_id: int,
+    limit: int = 20,
+    offset: int = 0,
+    detail: DetailLevel = "summary",
+    message_max_length: int | None = None,
+    order: Literal["newest", "oldest"] = "newest",
+) -> ListCardCommentsResponse:
+    """List comments on a Nextcloud Deck card.
+
+    Returns compact comments by default (dropping mentions, actor type and
+    display name). Ordering and truncation apply within the returned page.
+
+    Args:
+        card_id: The ID of the card
+        limit: Maximum number of comments to return (default 20, max 200)
+        offset: Pagination offset (default 0)
+        detail: "summary" (default) returns compact comments. "full"
+            returns the complete comment objects.
+        message_max_length: If set, truncate each comment message to this
+            many characters.
+        order: "newest" (default) or "oldest" — sort the page by creation
+            time.
+    """
+    _validate_positive_length(message_max_length, "message_max_length")
+    client = await get_client(ctx)
+    try:
+        comments = await client.deck.get_comments(card_id, limit=limit, offset=offset)
+    except HTTPStatusError as e:
+        raise _comment_http_error(e, operation="list", card_id=card_id) from e
+    except RequestError as e:
+        raise MCPError(
+            code=-32603,
+            message=(f"Network error listing comments on card {card_id}: {e}"),
+        ) from e
+    shaped = _shape_comments(
+        comments,
+        detail=detail,
+        message_max_length=message_max_length,
+        order=order,
+    )
+    return ListCardCommentsResponse(results=shaped, count=len(shaped))
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_create_card_comment(
+    ctx: Context,
+    card_id: int,
+    message: str,
+    parent_id: int | None = None,
+    overflow: CommentOverflow = "error",
+) -> CardCommentResponse:
+    """Create a comment on a Nextcloud Deck card.
+
+    Deck caps a comment at 1000 characters, measured after trimming
+    whitespace and counted in Unicode code points. Markdown and @-mentions
+    are NOT expanded before that check, so what you pass is what is counted.
+
+    Check the length before calling and pick `overflow` accordingly:
+
+    - 1000 characters or fewer: call as-is. `overflow` is ignored.
+    - Longer, and the text is meant to be read on the card (activity
+      updates, run summaries, changelogs): pass overflow="split" up front
+      rather than guessing a shorter message. The text is cut at markdown
+      heading, then paragraph, then line, then sentence, then word
+      boundaries -- never mid-word -- each part is prefixed "(i/N)", and
+      parts 2..N are posted as replies to part 1 so the card shows one
+      thread. @-mentions are never split across parts. At most 10 parts.
+      Past that, write the content to a note (nc_notes_create_note) or a
+      file (nc_webdav_write_file), attach it with deck_attach_note /
+      deck_attach_file, and post a short pointer comment instead.
+    - Longer, and you would rather shorten it yourself: leave the default
+      overflow="error". Nothing is posted and the error states the exact
+      overage.
+
+    Splitting is not atomic. If a later part fails, the earlier parts stay
+    posted and the error names their comment ids -- resume from there
+    instead of re-sending the whole message, which would duplicate them.
+
+    Supports @-mentions: "@alice", or @"alice smith" for ids with spaces.
+
+    Args:
+        card_id: The ID of the card to comment on
+        message: The comment text (max 1000 characters unless
+            overflow="split")
+        parent_id: Optional ID of a parent comment to reply to. When
+            splitting, part 1 replies to this comment and parts 2..N reply
+            to part 1.
+        overflow: What to do when the message exceeds 1000 characters.
+            "error" (the default) posts nothing and explains the overage.
+            "split" posts the message as multiple threaded comments.
+
+    Returns:
+        CardCommentResponse. For a single comment, `comment` is it, `parts`
+        is null and `part_count` is 1. When split, `comment` is part 1,
+        `parts` lists every posted part in order (parts[0] is part 1), and
+        `part_count` is how many were posted.
+    """
+    if overflow == "error" or measured_length(message) <= _COMMENT_MAX_LENGTH:
+        _validate_comment_message(message)
+        client = await get_client(ctx)
+        try:
+            comment = await client.deck.create_comment(
+                card_id, message, parent_id=parent_id
+            )
+        except HTTPStatusError as e:
+            raise _comment_http_error(e, operation="create", card_id=card_id) from e
+        except RequestError as e:
+            raise MCPError(
+                code=-32603,
+                message=(f"Network error creating a comment on card {card_id}: {e}"),
+            ) from e
+        return CardCommentResponse(comment=comment)
+
+    client = await get_client(ctx)
+    return await _post_split_comment(client, card_id, message, parent_id)
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_update_card_comment(
+    ctx: Context, card_id: int, comment_id: int, message: str
+) -> CardCommentResponse:
+    """Update a Nextcloud Deck card comment.
+
+    The same 1000-character limit applies as for creation (measured after
+    trimming, in Unicode code points), but the message CANNOT be split: an
+    update replaces one comment in place. To add more than fits, post a
+    follow-up comment with deck_create_card_comment instead of growing an
+    existing one past the limit.
+
+    Only the comment's author can update it. The server returns 403
+    otherwise.
+
+    Args:
+        card_id: The ID of the card the comment belongs to
+        comment_id: The ID of the comment to update
+        message: The new comment text (max 1000 characters)
+    """
+    _validate_comment_message(message)
+    client = await get_client(ctx)
+    try:
+        comment = await client.deck.update_comment(card_id, comment_id, message)
+    except HTTPStatusError as e:
+        raise _comment_http_error(
+            e,
+            operation="update",
+            card_id=card_id,
+            comment_id=comment_id,
+            message=message,
+        ) from e
+    except RequestError as e:
+        raise MCPError(
+            code=-32603,
+            message=(
+                f"Network error updating comment {comment_id} on card {card_id}: {e}"
+            ),
+        ) from e
+    return CardCommentResponse(comment=comment)
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_delete_card_comment(
+    ctx: Context, card_id: int, comment_id: int
+) -> CardCommentOperationResponse:
+    """Delete a Nextcloud Deck card comment
+
+    Only the comment's author can delete it. The server returns 403 otherwise.
+
+    Args:
+        card_id: The ID of the card the comment belongs to
+        comment_id: The ID of the comment to delete
+    """
+    client = await get_client(ctx)
+    try:
+        await client.deck.delete_comment(card_id, comment_id)
+    except HTTPStatusError as e:
+        raise _comment_http_error(
+            e, operation="delete", card_id=card_id, comment_id=comment_id
+        ) from e
+    except RequestError as e:
+        raise MCPError(
+            code=-32603,
+            message=(
+                f"Network error deleting comment {comment_id} on card {card_id}: {e}"
+            ),
+        ) from e
+    return CardCommentOperationResponse(
+        success=True,
+        message="Comment deleted successfully",
+        card_id=card_id,
+        comment_id=comment_id,
+    )
+
+
+@require_scopes("deck.write", "files.read")
+@instrument_tool
+async def deck_attach_file(ctx: Context, card_id: int, path: str) -> AttachFileResponse:
+    """Attach an existing Nextcloud file to a Deck card without copying.
+
+    Creates a share of ``path`` with the card (``shareType=12``,
+    ``shareWith=<card_id>``). The file stays in its original location.
+    Clicking the attachment in the Deck UI opens the file in place.
+
+    Generic over the user's Files: works for any file the caller can
+    read — markdown notes, PDFs, images, spreadsheets, etc. Use
+    :func:`deck_attach_note` if you have a Notes-app note ID and want
+    the path resolved automatically. Calling twice with the same
+    ``path`` creates two distinct shares — caller is responsible for
+    de-duping.
+
+    Args:
+        card_id: The ID of the Deck card to attach to
+        path: Path to the file in the user's Nextcloud Files (must start
+            with "/", e.g. "/Documents/spec.pdf" or "/Notes/My Note.md")
+    """
+    if not path.startswith("/"):
+        raise ToolError(
+            f"path must start with '/', got: {path!r} "
+            "(paths are relative to the user's Files root)"
+        )
+    client = await get_client(ctx)
+    share = await client.sharing.create_share(
+        path=path,
+        share_with=str(card_id),
+        share_type=_SHARE_TYPE_DECK,
+        permissions=1,
+    )
+    return AttachFileResponse(
+        attachment_id=int(share["id"]),
+        card_id=card_id,
+        path=path,
+    )
+
+
+@require_scopes("deck.write", "files.read", "notes.read")
+@instrument_tool
+async def deck_attach_note(
+    ctx: Context, card_id: int, note_id: int
+) -> AttachFileResponse:
+    """Attach a Nextcloud Note to a Deck card without copying.
+
+    Convenience wrapper: looks up the note's filesystem path from the
+    Notes app settings + note metadata, then shares the file with the
+    card (same mechanism as :func:`deck_attach_file`). The note remains
+    editable in the Notes app. The card just shows a clickable link to
+    it.
+
+    Path is reconstructed as ``<notes_folder>/<category>/<title>.md``.
+    If the note's title contains characters that the Notes app sanitises
+    differently (rare), use :func:`deck_attach_file` with the explicit
+    path instead.
+
+    Args:
+        card_id: The ID of the Deck card to attach to
+        note_id: The ID of the Note to attach
+    """
+    client = await get_client(ctx)
+    path = await _resolve_note_attach_path(client, note_id)
+    share = await client.sharing.create_share(
+        path=path,
+        share_with=str(card_id),
+        share_type=_SHARE_TYPE_DECK,
+        permissions=1,
+    )
+    return AttachFileResponse(
+        attachment_id=int(share["id"]),
+        card_id=card_id,
+        path=path,
+    )
+
+
+@require_scopes("deck.read")
+@instrument_tool
+async def deck_list_attachments(
+    ctx: Context, board_id: int, stack_id: int, card_id: int
+) -> ListAttachmentsResponse:
+    """List attachments on a Nextcloud Deck card.
+
+    Returns both shared-file attachments (``type="file"``, created via
+    :func:`deck_attach_file` / :func:`deck_attach_note`) and uploaded
+    binary attachments (``type="deck_file"``).
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+    """
+    client = await get_client(ctx)
+    attachments = await client.deck.get_attachments(board_id, stack_id, card_id)
+    return ListAttachmentsResponse(results=attachments, count=len(attachments))
+
+
+@require_scopes("deck.write")
+@instrument_tool
+async def deck_delete_attachment(
+    ctx: Context,
+    board_id: int,
+    stack_id: int,
+    card_id: int,
+    attachment_id: int,
+) -> AttachmentOperationResponse:
+    """Delete an attachment from a Nextcloud Deck card.
+
+    For ``type="file"`` attachments this removes the share linking the
+    file to the card. The underlying file in the user's Files is left
+    untouched. For ``type="deck_file"`` blobs the binary is deleted from
+    Deck's storage.
+
+    Args:
+        board_id: The ID of the board
+        stack_id: The ID of the stack
+        card_id: The ID of the card
+        attachment_id: The ID of the attachment to delete
+    """
+    client = await get_client(ctx)
+    await client.deck.delete_attachment(board_id, stack_id, card_id, attachment_id)
+    return AttachmentOperationResponse(
+        success=True,
+        message="Attachment deleted successfully",
+        card_id=card_id,
+        attachment_id=attachment_id,
+    )
+
+
 def configure_deck_tools(mcp: MCPServer):
     """Configure Nextcloud Deck tools and resources for the MCP server."""
 
@@ -783,1539 +2159,217 @@ def configure_deck_tools(mcp: MCPServer):
 
     # Read Tools (converted from resources)
 
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Boards",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_boards(ctx: Context) -> ListBoardsResponse:
-        """Get all Nextcloud Deck boards"""
-        client = await get_client(ctx)
-        boards = await client.deck.get_boards()
-        return ListBoardsResponse(boards=boards, total=len(boards))
+    )(deck_get_boards)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Deck Board",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_board(
-        ctx: Context,
-        board_id: int,
-        include_acl: bool = True,
-        include_users: bool = True,
-        include_labels: bool = True,
-    ) -> DeckBoard:
-        """Get details of a specific Nextcloud Deck board.
+    )(deck_get_board)
 
-        Args:
-            board_id: The ID of the board
-            include_acl: Include the board's ACL entries (default True). Set
-                False to reduce response size when ACLs are not needed.
-            include_users: Include the board's user list (default True). Set
-                False to reduce response size when users are not needed.
-            include_labels: Include the board's label definitions (default
-                True). Set False to reduce response size. Labels can still be
-                retrieved via deck_get_labels.
-        """
-        client = await get_client(ctx)
-        board = await client.deck.get_board(board_id)
-        return _apply_board_filters(
-            board,
-            include_acl=include_acl,
-            include_users=include_users,
-            include_labels=include_labels,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Stacks",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_stacks(
-        ctx: Context,
-        board_id: int,
-        include_cards: bool = True,
-        detail: DetailLevel = "summary",
-        status: CardStatus = "open",
-        label: str | None = None,
-        assigned_to: str | None = None,
-        description_max_length: int | None = None,
-        description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
-    ) -> ListStacksResponse:
-        """Get all stacks in a Nextcloud Deck board.
+    )(deck_get_stacks)
 
-        Cards are returned as compact summaries by default to keep the
-        response small on large boards. Filtering/projection happen
-        client-side after the API returns the full board, so they reduce the
-        tokens the caller sees but not network bandwidth.
-
-        Args:
-            board_id: The ID of the board
-            include_cards: Include cards inside each stack (default True). Set
-                False for a lightweight stack listing. Fetch cards separately
-                via deck_get_cards.
-            detail: "summary" (default) returns compact card rows. "full"
-                returns the complete card objects (the old behavior).
-            status: Which cards to include — "open" (default), "done",
-                "archived", or "all". The first three partition the board
-                (a card that is both done and archived counts as "archived").
-                "archived"/"all" include archived cards, which the active
-                listing endpoint omits — this costs one extra API call.
-            label: If set, only cards carrying a label with this exact title.
-            assigned_to: If set, only cards assigned to this user UID.
-            description_max_length: In detail="full", truncate each card's
-                description to this many characters.
-            description_preview_length: In detail="summary", length of the
-                description preview carried on each card (default 140).
-        """
-        _validate_positive_length(description_max_length)
-        _validate_positive_length(
-            description_preview_length, "description_preview_length"
-        )
-        client = await get_client(ctx)
-
-        # Fetch active stacks and (when archived cards are in scope) the
-        # archived endpoint concurrently, then merge archived cards onto each
-        # stack by id before filtering. The active endpoint omits archived
-        # cards, so without this merge status="archived"/"all" would drop them.
-        stacks_holder: list[list[DeckStack]] = []
-        archived_by_stack: dict[int, list[DeckCard]] = {}
-        merge_archived = include_cards and status in _ARCHIVED_STATUSES
-
-        async def _get_active() -> None:
-            stacks_holder.append(await client.deck.get_stacks(board_id))
-
-        async def _get_archived() -> None:
-            archived_by_stack.update(await _archived_cards_by_stack(client, board_id))
-
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(_get_active)
-            if merge_archived:
-                tg.start_soon(_get_archived)
-
-        stacks = stacks_holder[0]
-        if merge_archived:
-            for stack in stacks:
-                extra = archived_by_stack.get(stack.id)
-                if extra:
-                    _append_archived_cards(stack, extra)
-
-        stacks = [
-            _apply_stack_filters(
-                stack,
-                include_cards=include_cards,
-                detail=detail,
-                status=status,
-                label=label,
-                assigned_to=assigned_to,
-                description_max_length=description_max_length,
-                description_preview_length=description_preview_length,
-            )
-            for stack in stacks
-        ]
-        return ListStacksResponse(stacks=stacks, total=len(stacks))
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Deck Stack",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_stack(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        include_cards: bool = True,
-        detail: DetailLevel = "summary",
-        status: CardStatus = "open",
-        label: str | None = None,
-        assigned_to: str | None = None,
-        description_max_length: int | None = None,
-        description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
-    ) -> DeckStack:
-        """Get details of a specific Nextcloud Deck stack.
+    )(deck_get_stack)
 
-        Cards are returned as compact summaries by default. See
-        deck_get_stacks for the shared parameter semantics.
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            include_cards: Include cards in the stack (default True).
-            detail: "summary" (default) or "full".
-            status: "open" (default), "done", "archived", or "all"
-                (non-overlapping, a done+archived card counts as "archived").
-                "archived"/"all" include archived cards, which the active
-                listing endpoint omits — this costs one extra API call.
-            label: If set, only cards carrying a label with this exact title.
-            assigned_to: If set, only cards assigned to this user UID.
-            description_max_length: In detail="full", truncate descriptions.
-            description_preview_length: In detail="summary", preview length.
-        """
-        _validate_positive_length(description_max_length)
-        _validate_positive_length(
-            description_preview_length, "description_preview_length"
-        )
-        client = await get_client(ctx)
-        if status == "archived" and include_cards:
-            # Archived-only: the /stacks/archived endpoint already returns the
-            # stack (metadata + archived cards) in one call, so skip the active
-            # fetch whose open cards would all be filtered out anyway.
-            archived = await client.deck.get_archived_stacks(board_id)
-            stack = next((s for s in archived if s.id == stack_id), None)
-            if stack is None:
-                # findAllArchived returns every stack, so this is defensive;
-                # fall back to the active endpoint for the stack metadata.
-                stack = await client.deck.get_stack(board_id, stack_id)
-        else:
-            # Active stack always needed (for metadata + open cards); fetch the
-            # archived cards concurrently when status="all" needs both sets.
-            stack_holder: list[DeckStack] = []
-            archived_by_stack: dict[int, list[DeckCard]] = {}
-            merge_archived = include_cards and status == "all"
-
-            async def _get_active() -> None:
-                stack_holder.append(await client.deck.get_stack(board_id, stack_id))
-
-            async def _get_archived() -> None:
-                archived_by_stack.update(
-                    await _archived_cards_by_stack(client, board_id)
-                )
-
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(_get_active)
-                if merge_archived:
-                    tg.start_soon(_get_archived)
-
-            stack = stack_holder[0]
-            extra = archived_by_stack.get(stack_id)
-            if extra:
-                _append_archived_cards(stack, extra)
-        return _apply_stack_filters(
-            stack,
-            include_cards=include_cards,
-            detail=detail,
-            status=status,
-            label=label,
-            assigned_to=assigned_to,
-            description_max_length=description_max_length,
-            description_preview_length=description_preview_length,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Archived Deck Stacks",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_archived_stacks(
-        ctx: Context,
-        board_id: int,
-        detail: DetailLevel = "summary",
-        label: str | None = None,
-        assigned_to: str | None = None,
-        description_max_length: int | None = None,
-        description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
-    ) -> ListStacksResponse:
-        """List archived stacks (with their archived cards) for a Nextcloud
-        Deck board.
+    )(deck_get_archived_stacks)
 
-        This is the archived-only shortcut: it returns *only* archived cards
-        in a single call. The active list tools (deck_get_cards,
-        deck_get_stacks, deck_get_board_overview) also include archived cards
-        when called with status="archived"/"all". Use this tool when you want
-        archived cards exclusively and don't need the open ones. Typical use:
-        auditing completed work archived off the active board (e.g. cards moved
-        through a "Done" stack and then archived via deck_archive_card). The
-        shape mirrors deck_get_stacks.
-
-        Cards are always included on the returned stacks (an archived stack
-        without its cards would have no audit value) and returned as compact
-        summaries by default. There is no ``status`` filter — every card here
-        is archived by definition — but ``label``/``assigned_to`` narrow the
-        set just like the active-stack tools.
-
-        Args:
-            board_id: The ID of the board
-            detail: "summary" (default) or "full".
-            label: If set, only cards carrying a label with this exact title.
-            assigned_to: If set, only cards assigned to this user UID.
-            description_max_length: In detail="full", truncate descriptions.
-            description_preview_length: In detail="summary", preview length.
-        """
-        _validate_positive_length(description_max_length)
-        _validate_positive_length(
-            description_preview_length, "description_preview_length"
-        )
-        client = await get_client(ctx)
-        stacks = await client.deck.get_archived_stacks(board_id)
-        # All cards in archived stacks are themselves archived; status="all"
-        # keeps them (an "open"/"done" filter would drop the whole point).
-        # label/assigned_to still apply for targeted audits.
-        stacks = [
-            _apply_stack_filters(
-                stack,
-                include_cards=True,
-                detail=detail,
-                status="all",
-                label=label,
-                assigned_to=assigned_to,
-                description_max_length=description_max_length,
-                description_preview_length=description_preview_length,
-            )
-            for stack in stacks
-        ]
-        return ListStacksResponse(stacks=stacks, total=len(stacks))
-
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Cards",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_cards(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        detail: DetailLevel = "summary",
-        status: CardStatus = "open",
-        label: str | None = None,
-        assigned_to: str | None = None,
-        description_max_length: int | None = None,
-        description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
-    ) -> ListCardsResponse:
-        """Get all cards in a Nextcloud Deck stack.
+    )(deck_get_cards)
 
-        Cards are returned as compact summaries by default. Filtering and
-        projection are applied client-side after the API returns the full
-        stack, so they reduce the tokens the caller sees but not network
-        bandwidth — network-wise this tool is equivalent to
-        deck_get_stack(include_cards=True).
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            detail: "summary" (default) returns compact card rows. "full"
-                returns the complete card objects.
-            status: "open" (default), "done", "archived", or "all". The first
-                three partition the board (a done+archived card counts as
-                "archived"). "archived"/"all" include archived cards, which the
-                active listing endpoint omits — this costs one extra API call.
-            label: If set, only cards carrying a label with this exact title.
-            assigned_to: If set, only cards assigned to this user UID.
-            description_max_length: In detail="full", truncate descriptions.
-            description_preview_length: In detail="summary", preview length.
-        """
-        _validate_positive_length(description_max_length)
-        _validate_positive_length(
-            description_preview_length, "description_preview_length"
-        )
-        client = await get_client(ctx)
-
-        # Archived cards are excluded by the active stack endpoint, so for
-        # statuses that can include them we also fetch /stacks/archived and
-        # merge. "open"/"done" need only the active stack (no extra call).
-        active_cards: list[DeckCard] = []
-        archived_cards: list[DeckCard] = []
-        need_active = status != "archived"
-        need_archived = status in _ARCHIVED_STATUSES
-
-        async def _get_active() -> None:
-            stack = await client.deck.get_stack(board_id, stack_id)
-            active_cards.extend(cast(list[DeckCard], stack.cards or []))
-
-        async def _get_archived() -> None:
-            by_stack = await _archived_cards_by_stack(client, board_id)
-            archived_cards.extend(by_stack.get(stack_id, []))
-
-        async with anyio.create_task_group() as tg:
-            if need_active:
-                tg.start_soon(_get_active)
-            if need_archived:
-                tg.start_soon(_get_archived)
-
-        cards = _shape_cards(
-            active_cards + archived_cards,
-            detail=detail,
-            status=status,
-            label=label,
-            assigned_to=assigned_to,
-            description_max_length=description_max_length,
-            description_preview_length=description_preview_length,
-        )
-        return ListCardsResponse(cards=cards, total=len(cards))
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Deck Board Overview",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_board_overview(
-        ctx: Context,
-        board_id: int,
-        status: CardStatus = "open",
-        label: str | None = None,
-        assigned_to: str | None = None,
-        description_preview_length: int = _DEFAULT_DESCRIPTION_PREVIEW,
-    ) -> BoardOverviewResponse:
-        """Get a compact, whole-board snapshot in a single call.
+    )(deck_get_board_overview)
 
-        Returns the board title, its label legend, and every stack with its
-        cards projected to compact summary rows. Prefer it for "show me the
-        board" / "what's in progress" style requests on large boards — it is
-        the token-efficient way to view board *state*. It intentionally omits
-        the board-management fields (ACL, user list, full label objects) that
-        deck_get_board exposes. Reach for deck_get_board when you need those.
-
-        Args:
-            board_id: The ID of the board
-            status: Which cards to include — "open" (default), "done",
-                "archived", or "all". The first three partition the board
-                (a card that is both done and archived counts as "archived").
-                "archived"/"all" include archived cards, which the active
-                listing endpoint omits — this costs one extra API call.
-            label: If set, only cards carrying a label with this exact title.
-            assigned_to: If set, only cards assigned to this user UID.
-            description_preview_length: Length of the description preview
-                carried on each card summary (default 140).
-        """
-        _validate_positive_length(
-            description_preview_length, "description_preview_length"
-        )
-        client = await get_client(ctx)
-
-        board_holder: list[DeckBoard] = []
-        stacks_holder: list[list[DeckStack]] = []
-        archived_by_stack: dict[int, list[DeckCard]] = {}
-        merge_archived = status in _ARCHIVED_STATUSES
-
-        async def _get_board() -> None:
-            board_holder.append(await client.deck.get_board(board_id))
-
-        async def _get_stacks() -> None:
-            stacks_holder.append(await client.deck.get_stacks(board_id))
-
-        async def _get_archived() -> None:
-            archived_by_stack.update(await _archived_cards_by_stack(client, board_id))
-
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(_get_board)
-            tg.start_soon(_get_stacks)
-            if merge_archived:
-                tg.start_soon(_get_archived)
-
-        board = board_holder[0]
-        stacks = stacks_holder[0]
-
-        stack_overviews: list[StackOverview] = []
-        total_cards = 0
-        for stack in stacks:
-            cards = cast(list[DeckCard], stack.cards or [])
-            if merge_archived:
-                cards = cards + archived_by_stack.get(stack.id, [])
-            summaries = [
-                _summarize_card(c, description_preview_length)
-                for c in _filter_cards(
-                    cards,
-                    status=status,
-                    label=label,
-                    assigned_to=assigned_to,
-                )
-            ]
-            total_cards += len(summaries)
-            stack_overviews.append(
-                StackOverview(
-                    id=stack.id,
-                    title=stack.title,
-                    order=stack.order,
-                    card_count=len(summaries),
-                    cards=summaries,
-                )
-            )
-
-        return BoardOverviewResponse(
-            board_id=board.id,
-            title=board.title,
-            labels=[lbl.title for lbl in (board.labels or [])],
-            stacks=stack_overviews,
-            total_cards=total_cards,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Deck Card",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @with_links
-    @instrument_tool
-    async def deck_get_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int
-    ) -> DeckCard:
-        """Get details of a specific Nextcloud Deck card"""
-        client = await get_client(ctx)
-        card = await client.deck.get_card(board_id, stack_id, card_id)
-        return card
+    )(deck_get_card)
 
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Labels",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @instrument_tool
-    async def deck_get_labels(ctx: Context, board_id: int) -> ListLabelsResponse:
-        """Get all labels in a Nextcloud Deck board"""
-        client = await get_client(ctx)
-        board = await client.deck.get_board(board_id)
-        labels = board.labels or []
-        return ListLabelsResponse(labels=labels, total=len(labels))
+    )(deck_get_labels)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Deck Label",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @instrument_tool
-    async def deck_get_label(ctx: Context, board_id: int, label_id: int) -> DeckLabel:
-        """Get details of a specific Nextcloud Deck label"""
-        client = await get_client(ctx)
-        label = await client.deck.get_label(board_id, label_id)
-        return label
+    )(deck_get_label)
 
     # Create/Update/Delete Tools
 
-    @mcp.tool(
+    mcp.tool(
         title="Create Deck Board",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_create_board(
-        ctx: Context, title: str, color: str
-    ) -> CreateBoardResponse:
-        """Create a new Nextcloud Deck board
-
-        Args:
-            title: The title of the new board
-            color: The hexadecimal color of the new board (e.g. FF0000)
-        """
-        client = await get_client(ctx)
-        board = await client.deck.create_board(title, color)
-        return CreateBoardResponse(id=board.id, title=board.title, color=board.color)
+    )(deck_create_board)
 
     # Stack Tools
 
-    @mcp.tool(
+    mcp.tool(
         title="Create Deck Stack",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_create_stack(
-        ctx: Context, board_id: int, title: str, order: int
-    ) -> CreateStackResponse:
-        """Create a new stack in a Nextcloud Deck board
+    )(deck_create_stack)
 
-        Args:
-            board_id: The ID of the board
-            title: The title of the new stack
-            order: Order for sorting the stacks
-        """
-        client = await get_client(ctx)
-        stack = await client.deck.create_stack(board_id, title, order)
-        return CreateStackResponse(id=stack.id, title=stack.title, order=stack.order)
-
-    @mcp.tool(
+    mcp.tool(
         title="Update Deck Stack",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_update_stack(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        title: str | None = None,
-        order: int | None = None,
-    ) -> StackOperationResponse:
-        """Update a Nextcloud Deck stack
+    )(deck_update_stack)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            title: New title for the stack
-            order: New order for the stack
-        """
-        client = await get_client(ctx)
-        await client.deck.update_stack(board_id, stack_id, title, order)
-        return StackOperationResponse(
-            success=True,
-            message="Stack updated successfully",
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Deck Stack",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_delete_stack(
-        ctx: Context, board_id: int, stack_id: int
-    ) -> StackOperationResponse:
-        """Delete a Nextcloud Deck stack
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-        """
-        client = await get_client(ctx)
-        await client.deck.delete_stack(board_id, stack_id)
-        return StackOperationResponse(
-            success=True,
-            message="Stack deleted successfully",
-            stack_id=stack_id,
-            board_id=board_id,
-        )
+    )(deck_delete_stack)
 
     # Card Tools
-    @mcp.tool(
+    mcp.tool(
         title="Create Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_create_card(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        title: str,
-        type: str = "plain",
-        order: int = 999,
-        description: str | None = None,
-        duedate: str | None = None,
-    ) -> CreateCardResponse:
-        """Create a new card in a Nextcloud Deck stack
+    )(deck_create_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            title: The title of the new card
-            type: Type of the card (default: plain)
-            order: Order for sorting the cards
-            description: Description of the card
-            duedate: Due date of the card (ISO-8601 format)
-        """
-        client = await get_client(ctx)
-        card = await client.deck.create_card(
-            board_id, stack_id, title, type, order, description, duedate
-        )
-        return CreateCardResponse(
-            id=card.id,
-            title=card.title,
-            stackId=card.stackId,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Update Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_update_card(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        card_id: int,
-        title: str | None = None,
-        description: str | None = None,
-        type: str | None = None,
-        owner: str | None = None,
-        order: int | None = None,
-        duedate: str | None = None,
-        archived: bool | None = None,
-        done: str | None = None,
-    ) -> CardOperationResponse:
-        """Update a Nextcloud Deck card
+    )(deck_update_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            title: New title for the card
-            description: New description for the card
-            type: New type for the card
-            owner: New owner for the card
-            order: New order for the card
-            duedate: New due date for the card (ISO-8601 format)
-            archived: Whether the card should be archived
-            done: Completion date for the card (ISO-8601 format)
-        """
-        client = await get_client(ctx)
-        await client.deck.update_card(
-            board_id,
-            stack_id,
-            card_id,
-            title,
-            description,
-            type,
-            owner,
-            order,
-            duedate,
-            archived,
-            done,
-        )
-        return CardOperationResponse(
-            success=True,
-            message="Card updated successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Deck Card",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    # No @with_links here, deliberately: the card is gone by the time this
-    # returns, so a link to it would 404. Every other CardOperationResponse tool
-    # leaves the card in place and does carry one. Asserted by
-    # tests/unit/test_links_tool_coverage.py.
-    @instrument_tool
-    async def deck_delete_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int
-    ) -> CardOperationResponse:
-        """Delete a Nextcloud Deck card
+    )(deck_delete_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-        """
-        client = await get_client(ctx)
-        await client.deck.delete_card(board_id, stack_id, card_id)
-        return CardOperationResponse(
-            success=True,
-            message="Card deleted successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Archive Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_archive_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int
-    ) -> CardOperationResponse:
-        """Archive a Nextcloud Deck card
+    )(deck_archive_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-        """
-        client = await get_client(ctx)
-        await client.deck.archive_card(board_id, stack_id, card_id)
-        return CardOperationResponse(
-            success=True,
-            message="Card archived successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Unarchive Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_unarchive_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int
-    ) -> CardOperationResponse:
-        """Unarchive a Nextcloud Deck card
+    )(deck_unarchive_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-        """
-        client = await get_client(ctx)
-        await client.deck.unarchive_card(board_id, stack_id, card_id)
-        return CardOperationResponse(
-            success=True,
-            message="Card unarchived successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Reorder Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_reorder_card(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        card_id: int,
-        order: int,
-        target_stack_id: int,
-    ) -> CardOperationResponse:
-        """Reorder a Nextcloud Deck card within a board.
+    )(deck_reorder_card)
 
-        Moves a card to a new position, optionally into a different stack on
-        the SAME board. To move a card to a stack on a DIFFERENT board, use
-        deck_move_card_to_board instead — reordering across boards is rejected
-        because it would orphan the card's board-scoped labels.
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the current stack
-            card_id: The ID of the card
-            order: New position in the target stack
-            target_stack_id: The ID of the target stack (must be on board_id)
-        """
-        client = await get_client(ctx)
-        await client.deck.reorder_card(
-            board_id, stack_id, card_id, order, target_stack_id
-        )
-        return CardOperationResponse(
-            success=True,
-            message="Card reordered successfully",
-            card_id=card_id,
-            stack_id=target_stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Move Deck Card to Another Board",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_move_card_to_board(
-        ctx: Context,
-        source_board_id: int,
-        source_stack_id: int,
-        card_id: int,
-        target_board_id: int,
-        target_stack_id: int,
-        order: int = 0,
-    ) -> CardOperationResponse:
-        """Move a Nextcloud Deck card to a stack on a different board.
-
-        The card keeps its identity (same id, comments, attachments), along
-        with its archived state, due date and user assignments (an assignee
-        without access to the target board stays assigned but cannot act on the
-        card). Deck remaps the card's board-scoped labels to the destination
-        board by title — reusing a same-titled label there, or cloning it when
-        you have board-manage permission. Use deck_reorder_card for moves
-        within a single board.
-
-        Two caveats from Deck's move route: the card's owner is reassigned to
-        the user performing the move (the original owner is not preserved), and
-        a card marked done keeps its done state but its done timestamp is reset
-        to the time of the move.
-
-        target_stack_id must be a stack on target_board_id. The move is
-        rejected otherwise.
-
-        Args:
-            source_board_id: The ID of the board the card currently lives on
-            source_stack_id: The ID of the stack the card currently lives in
-            card_id: The ID of the card to move
-            target_board_id: The ID of the destination board
-            target_stack_id: The ID of the destination stack (must be on target_board_id)
-            order: Position within the destination stack (default 0 = top)
-        """
-        client = await get_client(ctx)
-        moved = await client.deck.move_card_to_board(
-            source_board_id,
-            source_stack_id,
-            card_id,
-            target_board_id,
-            target_stack_id,
-            order,
-        )
-        # Surface the post-move labels so callers can confirm the remap without
-        # a follow-up get_card (label remapping is this tool's whole point).
-        return CardOperationResponse(
-            success=True,
-            message="Card moved to board successfully",
-            card_id=card_id,
-            stack_id=target_stack_id,
-            board_id=target_board_id,
-            labels=[label.title for label in (moved.labels or [])],
-        )
+    )(deck_move_card_to_board)
 
     # Label Tools
-    @mcp.tool(
+    mcp.tool(
         title="Create Deck Label",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_create_label(
-        ctx: Context, board_id: int, title: str, color: str
-    ) -> CreateLabelResponse:
-        """Create a new label in a Nextcloud Deck board
+    )(deck_create_label)
 
-        Args:
-            board_id: The ID of the board
-            title: The title of the new label
-            color: The color of the new label (hex format without #)
-        """
-        client = await get_client(ctx)
-        label = await client.deck.create_label(board_id, title, color)
-        return CreateLabelResponse(id=label.id, title=label.title, color=label.color)
-
-    @mcp.tool(
+    mcp.tool(
         title="Update Deck Label",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_update_label(
-        ctx: Context,
-        board_id: int,
-        label_id: int,
-        title: str | None = None,
-        color: str | None = None,
-    ) -> LabelOperationResponse:
-        """Update a Nextcloud Deck label
+    )(deck_update_label)
 
-        Args:
-            board_id: The ID of the board
-            label_id: The ID of the label
-            title: New title for the label
-            color: New color for the label (hex format without #)
-        """
-        client = await get_client(ctx)
-        await client.deck.update_label(board_id, label_id, title, color)
-        return LabelOperationResponse(
-            success=True,
-            message="Label updated successfully",
-            label_id=label_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Deck Label",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_delete_label(
-        ctx: Context, board_id: int, label_id: int
-    ) -> LabelOperationResponse:
-        """Delete a Nextcloud Deck label
-
-        Args:
-            board_id: The ID of the board
-            label_id: The ID of the label
-        """
-        client = await get_client(ctx)
-        await client.deck.delete_label(board_id, label_id)
-        return LabelOperationResponse(
-            success=True,
-            message="Label deleted successfully",
-            label_id=label_id,
-            board_id=board_id,
-        )
+    )(deck_delete_label)
 
     # Card-Label Assignment Tools
-    @mcp.tool(
+    mcp.tool(
         title="Assign Label to Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_assign_label_to_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int, label_id: int
-    ) -> CardOperationResponse:
-        """Assign a label to a Nextcloud Deck card
+    )(deck_assign_label_to_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            label_id: The ID of the label to assign
-        """
-        client = await get_client(ctx)
-        await client.deck.assign_label_to_card(board_id, stack_id, card_id, label_id)
-        return CardOperationResponse(
-            success=True,
-            message="Label assigned to card successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Remove Label from Deck Card",
         annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_remove_label_from_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int, label_id: int
-    ) -> CardOperationResponse:
-        """Remove a label from a Nextcloud Deck card
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            label_id: The ID of the label to remove
-        """
-        client = await get_client(ctx)
-        await client.deck.remove_label_from_card(board_id, stack_id, card_id, label_id)
-        return CardOperationResponse(
-            success=True,
-            message="Label removed from card successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
+    )(deck_remove_label_from_card)
 
     # Card-User Assignment Tools
-    @mcp.tool(
+    mcp.tool(
         title="Assign User to Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_assign_user_to_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int, user_id: str
-    ) -> CardOperationResponse:
-        """Assign a user to a Nextcloud Deck card
+    )(deck_assign_user_to_card)
 
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            user_id: The user ID to assign
-        """
-        client = await get_client(ctx)
-        await client.deck.assign_user_to_card(board_id, stack_id, card_id, user_id)
-        return CardOperationResponse(
-            success=True,
-            message="User assigned to card successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Unassign User from Deck Card",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @with_links
-    @instrument_tool
-    async def deck_unassign_user_from_card(
-        ctx: Context, board_id: int, stack_id: int, card_id: int, user_id: str
-    ) -> CardOperationResponse:
-        """Unassign a user from a Nextcloud Deck card
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            user_id: The user ID to unassign
-        """
-        client = await get_client(ctx)
-        await client.deck.unassign_user_from_card(board_id, stack_id, card_id, user_id)
-        return CardOperationResponse(
-            success=True,
-            message="User unassigned from card successfully",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
+    )(deck_unassign_user_from_card)
 
     # Card Dependency Tools
-    @mcp.tool(
+    mcp.tool(
         title="Add Dependent Card to Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @require_capability("deck", min_version="1.18.0")
-    @with_links
-    @instrument_tool
-    async def deck_assign_dependent_card(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        card_id: int,
-        dependent_card_id: int,
-    ) -> CardOperationResponse:
-        """Mark a Nextcloud Deck card as depending on another card.
+    )(deck_assign_dependent_card)
 
-        Mirrors Deck's "Add dependent card" action. The dependency is
-        directional and stored on ``card_id``: it surfaces in that card's
-        ``dependentCards`` list (visible via deck_get_card). You need read
-        access to the dependent card.
-
-        Args:
-            board_id: The ID of the board containing the depending card
-            stack_id: The ID of the stack containing the depending card
-            card_id: The ID of the card that depends on another card
-            dependent_card_id: The ID of the card that card_id depends on
-        """
-        client = await get_client(ctx)
-        await client.deck.assign_dependent_card(
-            board_id, stack_id, card_id, dependent_card_id
-        )
-        return CardOperationResponse(
-            success=True,
-            message=f"Card {dependent_card_id} added as a dependency of card {card_id}",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Remove Dependent Card from Deck Card",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @require_capability("deck", min_version="1.18.0")
-    @with_links
-    @instrument_tool
-    async def deck_remove_dependent_card(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        card_id: int,
-        dependent_card_id: int,
-    ) -> CardOperationResponse:
-        """Remove a dependency between two Nextcloud Deck cards.
-
-        Removes the dependency of ``card_id`` on ``dependent_card_id`` that was
-        created by deck_assign_dependent_card.
-
-        Args:
-            board_id: The ID of the board containing the depending card
-            stack_id: The ID of the stack containing the depending card
-            card_id: The ID of the card that depends on another card
-            dependent_card_id: The ID of the dependency to remove
-        """
-        client = await get_client(ctx)
-        await client.deck.remove_dependent_card(
-            board_id, stack_id, card_id, dependent_card_id
-        )
-        return CardOperationResponse(
-            success=True,
-            message=f"Card {dependent_card_id} removed as a dependency of card {card_id}",
-            card_id=card_id,
-            stack_id=stack_id,
-            board_id=board_id,
-        )
+    )(deck_remove_dependent_card)
 
     # Card Comment Tools
 
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Card Comments",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @instrument_tool
-    async def deck_get_card_comments(
-        ctx: Context,
-        card_id: int,
-        limit: int = 20,
-        offset: int = 0,
-        detail: DetailLevel = "summary",
-        message_max_length: int | None = None,
-        order: Literal["newest", "oldest"] = "newest",
-    ) -> ListCardCommentsResponse:
-        """List comments on a Nextcloud Deck card.
+    )(deck_get_card_comments)
 
-        Returns compact comments by default (dropping mentions, actor type and
-        display name). Ordering and truncation apply within the returned page.
-
-        Args:
-            card_id: The ID of the card
-            limit: Maximum number of comments to return (default 20, max 200)
-            offset: Pagination offset (default 0)
-            detail: "summary" (default) returns compact comments. "full"
-                returns the complete comment objects.
-            message_max_length: If set, truncate each comment message to this
-                many characters.
-            order: "newest" (default) or "oldest" — sort the page by creation
-                time.
-        """
-        _validate_positive_length(message_max_length, "message_max_length")
-        client = await get_client(ctx)
-        try:
-            comments = await client.deck.get_comments(
-                card_id, limit=limit, offset=offset
-            )
-        except HTTPStatusError as e:
-            raise _comment_http_error(e, operation="list", card_id=card_id) from e
-        except RequestError as e:
-            raise MCPError(
-                code=-32603,
-                message=(f"Network error listing comments on card {card_id}: {e}"),
-            ) from e
-        shaped = _shape_comments(
-            comments,
-            detail=detail,
-            message_max_length=message_max_length,
-            order=order,
-        )
-        return ListCardCommentsResponse(results=shaped, count=len(shaped))
-
-    @mcp.tool(
+    mcp.tool(
         title="Create Deck Card Comment",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_create_card_comment(
-        ctx: Context,
-        card_id: int,
-        message: str,
-        parent_id: int | None = None,
-        overflow: CommentOverflow = "error",
-    ) -> CardCommentResponse:
-        """Create a comment on a Nextcloud Deck card.
+    )(deck_create_card_comment)
 
-        Deck caps a comment at 1000 characters, measured after trimming
-        whitespace and counted in Unicode code points. Markdown and @-mentions
-        are NOT expanded before that check, so what you pass is what is counted.
-
-        Check the length before calling and pick `overflow` accordingly:
-
-        - 1000 characters or fewer: call as-is. `overflow` is ignored.
-        - Longer, and the text is meant to be read on the card (activity
-          updates, run summaries, changelogs): pass overflow="split" up front
-          rather than guessing a shorter message. The text is cut at markdown
-          heading, then paragraph, then line, then sentence, then word
-          boundaries -- never mid-word -- each part is prefixed "(i/N)", and
-          parts 2..N are posted as replies to part 1 so the card shows one
-          thread. @-mentions are never split across parts. At most 10 parts.
-          Past that, write the content to a note (nc_notes_create_note) or a
-          file (nc_webdav_write_file), attach it with deck_attach_note /
-          deck_attach_file, and post a short pointer comment instead.
-        - Longer, and you would rather shorten it yourself: leave the default
-          overflow="error". Nothing is posted and the error states the exact
-          overage.
-
-        Splitting is not atomic. If a later part fails, the earlier parts stay
-        posted and the error names their comment ids -- resume from there
-        instead of re-sending the whole message, which would duplicate them.
-
-        Supports @-mentions: "@alice", or @"alice smith" for ids with spaces.
-
-        Args:
-            card_id: The ID of the card to comment on
-            message: The comment text (max 1000 characters unless
-                overflow="split")
-            parent_id: Optional ID of a parent comment to reply to. When
-                splitting, part 1 replies to this comment and parts 2..N reply
-                to part 1.
-            overflow: What to do when the message exceeds 1000 characters.
-                "error" (the default) posts nothing and explains the overage.
-                "split" posts the message as multiple threaded comments.
-
-        Returns:
-            CardCommentResponse. For a single comment, `comment` is it, `parts`
-            is null and `part_count` is 1. When split, `comment` is part 1,
-            `parts` lists every posted part in order (parts[0] is part 1), and
-            `part_count` is how many were posted.
-        """
-        if overflow == "error" or measured_length(message) <= _COMMENT_MAX_LENGTH:
-            _validate_comment_message(message)
-            client = await get_client(ctx)
-            try:
-                comment = await client.deck.create_comment(
-                    card_id, message, parent_id=parent_id
-                )
-            except HTTPStatusError as e:
-                raise _comment_http_error(e, operation="create", card_id=card_id) from e
-            except RequestError as e:
-                raise MCPError(
-                    code=-32603,
-                    message=(
-                        f"Network error creating a comment on card {card_id}: {e}"
-                    ),
-                ) from e
-            return CardCommentResponse(comment=comment)
-
-        client = await get_client(ctx)
-        return await _post_split_comment(client, card_id, message, parent_id)
-
-    @mcp.tool(
+    mcp.tool(
         title="Update Deck Card Comment",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_update_card_comment(
-        ctx: Context, card_id: int, comment_id: int, message: str
-    ) -> CardCommentResponse:
-        """Update a Nextcloud Deck card comment.
+    )(deck_update_card_comment)
 
-        The same 1000-character limit applies as for creation (measured after
-        trimming, in Unicode code points), but the message CANNOT be split: an
-        update replaces one comment in place. To add more than fits, post a
-        follow-up comment with deck_create_card_comment instead of growing an
-        existing one past the limit.
-
-        Only the comment's author can update it. The server returns 403
-        otherwise.
-
-        Args:
-            card_id: The ID of the card the comment belongs to
-            comment_id: The ID of the comment to update
-            message: The new comment text (max 1000 characters)
-        """
-        _validate_comment_message(message)
-        client = await get_client(ctx)
-        try:
-            comment = await client.deck.update_comment(card_id, comment_id, message)
-        except HTTPStatusError as e:
-            raise _comment_http_error(
-                e,
-                operation="update",
-                card_id=card_id,
-                comment_id=comment_id,
-                message=message,
-            ) from e
-        except RequestError as e:
-            raise MCPError(
-                code=-32603,
-                message=(
-                    f"Network error updating comment {comment_id} on card "
-                    f"{card_id}: {e}"
-                ),
-            ) from e
-        return CardCommentResponse(comment=comment)
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Deck Card Comment",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_delete_card_comment(
-        ctx: Context, card_id: int, comment_id: int
-    ) -> CardCommentOperationResponse:
-        """Delete a Nextcloud Deck card comment
+    )(deck_delete_card_comment)
 
-        Only the comment's author can delete it. The server returns 403 otherwise.
-
-        Args:
-            card_id: The ID of the card the comment belongs to
-            comment_id: The ID of the comment to delete
-        """
-        client = await get_client(ctx)
-        try:
-            await client.deck.delete_comment(card_id, comment_id)
-        except HTTPStatusError as e:
-            raise _comment_http_error(
-                e, operation="delete", card_id=card_id, comment_id=comment_id
-            ) from e
-        except RequestError as e:
-            raise MCPError(
-                code=-32603,
-                message=(
-                    f"Network error deleting comment {comment_id} on card "
-                    f"{card_id}: {e}"
-                ),
-            ) from e
-        return CardCommentOperationResponse(
-            success=True,
-            message="Comment deleted successfully",
-            card_id=card_id,
-            comment_id=comment_id,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Attach File to Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write", "files.read")
-    @instrument_tool
-    async def deck_attach_file(
-        ctx: Context, card_id: int, path: str
-    ) -> AttachFileResponse:
-        """Attach an existing Nextcloud file to a Deck card without copying.
+    )(deck_attach_file)
 
-        Creates a share of ``path`` with the card (``shareType=12``,
-        ``shareWith=<card_id>``). The file stays in its original location.
-        Clicking the attachment in the Deck UI opens the file in place.
-
-        Generic over the user's Files: works for any file the caller can
-        read — markdown notes, PDFs, images, spreadsheets, etc. Use
-        :func:`deck_attach_note` if you have a Notes-app note ID and want
-        the path resolved automatically. Calling twice with the same
-        ``path`` creates two distinct shares — caller is responsible for
-        de-duping.
-
-        Args:
-            card_id: The ID of the Deck card to attach to
-            path: Path to the file in the user's Nextcloud Files (must start
-                with "/", e.g. "/Documents/spec.pdf" or "/Notes/My Note.md")
-        """
-        if not path.startswith("/"):
-            raise ToolError(
-                f"path must start with '/', got: {path!r} "
-                "(paths are relative to the user's Files root)"
-            )
-        client = await get_client(ctx)
-        share = await client.sharing.create_share(
-            path=path,
-            share_with=str(card_id),
-            share_type=_SHARE_TYPE_DECK,
-            permissions=1,
-        )
-        return AttachFileResponse(
-            attachment_id=int(share["id"]),
-            card_id=card_id,
-            path=path,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Attach Note to Deck Card",
         annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
-    )
-    @require_scopes("deck.write", "files.read", "notes.read")
-    @instrument_tool
-    async def deck_attach_note(
-        ctx: Context, card_id: int, note_id: int
-    ) -> AttachFileResponse:
-        """Attach a Nextcloud Note to a Deck card without copying.
+    )(deck_attach_note)
 
-        Convenience wrapper: looks up the note's filesystem path from the
-        Notes app settings + note metadata, then shares the file with the
-        card (same mechanism as :func:`deck_attach_file`). The note remains
-        editable in the Notes app. The card just shows a clickable link to
-        it.
-
-        Path is reconstructed as ``<notes_folder>/<category>/<title>.md``.
-        If the note's title contains characters that the Notes app sanitises
-        differently (rare), use :func:`deck_attach_file` with the explicit
-        path instead.
-
-        Args:
-            card_id: The ID of the Deck card to attach to
-            note_id: The ID of the Note to attach
-        """
-        client = await get_client(ctx)
-        path = await _resolve_note_attach_path(client, note_id)
-        share = await client.sharing.create_share(
-            path=path,
-            share_with=str(card_id),
-            share_type=_SHARE_TYPE_DECK,
-            permissions=1,
-        )
-        return AttachFileResponse(
-            attachment_id=int(share["id"]),
-            card_id=card_id,
-            path=path,
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Deck Card Attachments",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("deck.read")
-    @instrument_tool
-    async def deck_list_attachments(
-        ctx: Context, board_id: int, stack_id: int, card_id: int
-    ) -> ListAttachmentsResponse:
-        """List attachments on a Nextcloud Deck card.
+    )(deck_list_attachments)
 
-        Returns both shared-file attachments (``type="file"``, created via
-        :func:`deck_attach_file` / :func:`deck_attach_note`) and uploaded
-        binary attachments (``type="deck_file"``).
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-        """
-        client = await get_client(ctx)
-        attachments = await client.deck.get_attachments(board_id, stack_id, card_id)
-        return ListAttachmentsResponse(results=attachments, count=len(attachments))
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Deck Card Attachment",
         annotations=ToolAnnotations(
             destructive_hint=True, idempotent_hint=True, open_world_hint=True
         ),
-    )
-    @require_scopes("deck.write")
-    @instrument_tool
-    async def deck_delete_attachment(
-        ctx: Context,
-        board_id: int,
-        stack_id: int,
-        card_id: int,
-        attachment_id: int,
-    ) -> AttachmentOperationResponse:
-        """Delete an attachment from a Nextcloud Deck card.
-
-        For ``type="file"`` attachments this removes the share linking the
-        file to the card. The underlying file in the user's Files is left
-        untouched. For ``type="deck_file"`` blobs the binary is deleted from
-        Deck's storage.
-
-        Args:
-            board_id: The ID of the board
-            stack_id: The ID of the stack
-            card_id: The ID of the card
-            attachment_id: The ID of the attachment to delete
-        """
-        client = await get_client(ctx)
-        await client.deck.delete_attachment(board_id, stack_id, card_id, attachment_id)
-        return AttachmentOperationResponse(
-            success=True,
-            message="Attachment deleted successfully",
-            card_id=card_id,
-            attachment_id=attachment_id,
-        )
+    )(deck_delete_attachment)

--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -85,382 +85,524 @@ def _cap_attachment_content(content: str | None) -> str | None:
     return content
 
 
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_accounts(ctx: Context) -> ListAccountsResponse:
+    """List the user's configured mail accounts (requires mail.read scope)."""
+    client = await get_client(ctx)
+    try:
+        accounts_data = await client.mail.list_accounts()
+        accounts = [MailAccount(**a) for a in accounts_data]
+        return ListAccountsResponse(results=accounts, total_count=len(accounts))
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing accounts: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list accounts: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_mailboxes(
+    account_id: int, ctx: Context
+) -> ListMailboxesResponse:
+    """List the mailboxes (folders) of a mail account (requires mail.read scope).
+
+    Args:
+        account_id: Account ID (from nc_mail_list_accounts)
+
+    Returns:
+        ListMailboxesResponse with mailboxes. Use a mailbox's ``database_id``
+        with nc_mail_list_messages.
+    """
+    client = await get_client(ctx)
+    try:
+        mailboxes_data = await client.mail.get_mailboxes(account_id)
+        mailboxes = [MailMailbox(**m) for m in mailboxes_data]
+        return ListMailboxesResponse(results=mailboxes, total_count=len(mailboxes))
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing mailboxes: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list mailboxes: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_messages(
+    mailbox_id: int,
+    ctx: Context,
+    cursor: int | None = None,
+    search_filter: str | None = None,
+    limit: int = 20,
+) -> ListMessagesResponse:
+    """List message envelopes in a mailbox, newest first (requires mail.read scope).
+
+    Reads cached envelope metadata (fast). Does not fetch bodies. Use
+    nc_mail_get_message to fetch a full body.
+
+    Args:
+        mailbox_id: Numeric mailbox id (``database_id`` from nc_mail_list_mailboxes)
+        cursor: Pagination cursor from a prior page
+        search_filter: Optional filter query — space-separated ``token:value``
+            terms, ANDed together. Supported tokens:
+
+            * ``is:``/``not:`` — ``read``, ``unread``, ``starred``,
+              ``answered``, ``important``
+            * ``from:``, ``to:``, ``cc:``, ``bcc:`` — substring match on the
+              address or display name
+            * ``subject:``, ``body:`` — substring match (``body:`` searches
+              IMAP server-side and is slower)
+            * ``tags:`` — comma-separated tag *database ids* (not names,
+              get one from nc_mail_create_tag)
+            * ``start:``, ``end:`` — date bounds
+            * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
+              ``answered``/``important``/``attachments``
+            * ``match:anyof`` — OR the from/to/cc/bcc/subject/body terms
+              instead of ANDing them
+
+            Example: ``is:unread from:alice subject:invoice``
+        limit: Max messages to return (1-100, default 20)
+
+    Returns:
+        ListMessagesResponse with message summaries. ``has_more`` is a
+        heuristic (true when exactly ``limit`` messages were returned), so it
+        can be a false positive when a mailbox holds exactly ``limit``
+        messages. Page with ``cursor`` and stop on an empty result.
+    """
+    client = await get_client(ctx)
+    # Clamp to the same window the client/OCS API enforce so the has_more
+    # heuristic compares against the limit actually applied (a caller passing
+    # limit<=0 otherwise gets a misleading count).
+    effective_limit = min(max(1, limit), 100)
+    try:
+        messages_data = await client.mail.list_messages(
+            mailbox_id,
+            cursor=cursor,
+            search_filter=search_filter,
+            limit=effective_limit,
+        )
+        messages = [MailMessageSummary(**m) for m in messages_data]
+        return ListMessagesResponse(
+            results=messages,
+            total_count=len(messages),
+            has_more=len(messages) == effective_limit,
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing messages: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list messages: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_message(message_id: int, ctx: Context) -> GetMessageResponse:
+    """Get a single mail message with its full body (requires mail.read scope).
+
+    The Mail app fetches the body from IMAP server-side.
+
+    Args:
+        message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
+
+    Returns:
+        GetMessageResponse with the full message including body and attachments.
+        Attachments with ``id: null`` are inline body parts and cannot be
+        fetched via nc_mail_get_attachment (which requires a string id).
+    """
+    client = await get_client(ctx)
+    try:
+        message_data = await client.mail.get_message(message_id)
+        # An empty payload (OCS data=null with a 200 meta) would make
+        # MailMessage(**{}) raise an uncaught ValidationError; treat it as
+        # not-found instead.
+        if not message_data:
+            raise MCPError(code=-1, message=f"Message {message_id} not found")
+        message = MailMessage(**message_data)
+        return GetMessageResponse(message=message)
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error getting message {message_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Message {message_id} not found")
+        raise MCPError(
+            code=-1,
+            message=f"Failed to get message {message_id}: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.send")
+@instrument_tool
+async def nc_mail_send_message(
+    account_id: int,
+    to: str,
+    subject: str,
+    body: str,
+    ctx: Context,
+    is_html: bool = False,
+    cc: str | None = None,
+    bcc: str | None = None,
+    references: str | None = None,
+) -> SendMessageResponse:
+    """Send an email through a configured Nextcloud Mail account (requires mail.send scope).
+
+    The ``From:`` identity is derived by the Mail app from ``account_id``.
+    Recipients are specified as JSON arrays of ``{"label": "...", "email": "..."}``
+    objects.  Example for ``to``::
+
+        [{"label": "John Doe", "email": "john@example.com"}]
+
+    Args:
+        account_id: Mail account ID to send from (from nc_mail_list_accounts)
+        to: JSON array of To recipients
+        subject: Email subject
+        body: Email body (plain text unless is_html is true)
+        is_html: Whether body contains HTML (default false)
+        cc: Optional JSON array of CC recipients
+        bcc: Optional JSON array of BCC recipients
+        references: Optional RFC 2822 Message-ID for reply threading
+
+    Returns:
+        SendMessageResponse with success status and optional message
+    """
+    client = await get_client(ctx)
+    try:
+        to_list = json.loads(to)  # `to` is a required JSON-array string
+        cc_list = json.loads(cc) if isinstance(cc, str) else (cc or [])
+        bcc_list = json.loads(bcc) if isinstance(bcc, str) else (bcc or [])
+
+        await client.mail.send_message(
+            account_id=account_id,
+            to=to_list,
+            subject=subject,
+            body=body,
+            is_html=is_html,
+            cc=cc_list or None,
+            bcc=bcc_list or None,
+            references=references or None,
+        )
+        return SendMessageResponse(success=True, message="Message sent successfully")
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error sending message: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to send message: {e.response.status_code} "
+            f"{e.response.text[:500]}",
+        )
+    except json.JSONDecodeError as e:
+        raise MCPError(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_attachment(
+    message_id: int, attachment_id: str, ctx: Context
+) -> GetAttachmentResponse:
+    """Get a single mail attachment's metadata and content (requires mail.read scope).
+
+    Args:
+        message_id: Numeric message id
+        attachment_id: Attachment id (a string, from the message's attachments)
+
+    Returns:
+        GetAttachmentResponse with name, mime, size, and content. ``content``
+        is the attachment body base64-encoded. Large attachments produce a
+        correspondingly large response, so prefer the ``size`` from the
+        message's attachment list before fetching.
+    """
+    client = await get_client(ctx)
+    try:
+        data = await client.mail.get_attachment(message_id, attachment_id)
+        return GetAttachmentResponse(
+            name=data.get("name"),
+            mime=data.get("mime"),
+            size=data.get("size"),
+            content=_cap_attachment_content(data.get("content")),
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error getting attachment: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message="Attachment not found")
+        raise MCPError(
+            code=-1,
+            message=f"Failed to get attachment: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_message_source(
+    message_id: int, ctx: Context
+) -> GetMessageSourceResponse:
+    """Get a message's raw RFC 2822 source (requires mail.read scope).
+
+    The complete original message including all headers — use this when the
+    parsed view from nc_mail_get_message is not enough (checking
+    Received/DKIM headers, List-Unsubscribe, custom X- headers).
+
+    Args:
+        message_id: Numeric message id
+
+    Returns:
+        GetMessageSourceResponse with the raw source. ``source`` is None if
+        the Mail app returns no content for the message.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"getting source of message {message_id}"):
+        source = await client.mail.get_message_raw(message_id)
+    return GetMessageSourceResponse(message_id=message_id, source=source)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_set_flags(
+    message_id: int,
+    ctx: Context,
+    seen: bool | None = None,
+    flagged: bool | None = None,
+    answered: bool | None = None,
+    junk: bool | None = None,
+) -> MailActionResponse:
+    """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
+
+    Only the flags you pass are changed. Omitted ones are left alone. Use
+    ``seen=True`` after processing a message so it does not look unhandled,
+    and ``seen=False`` to mark it unread again.
+
+    Args:
+        message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
+        seen: Mark read (True) or unread (False)
+        flagged: Star (True) or unstar (False)
+        answered: Mark as replied-to
+        junk: Mark as junk/spam. Unlike the others this is a custom IMAP
+            keyword, so the mail server silently ignores it unless the
+            mailbox permits custom keywords.
+
+    Returns:
+        MailActionResponse naming the flags that were applied. Passing no
+        flags at all is an error rather than a silent no-op.
+    """
+    flags = {
+        name: value
+        for name, value in (
+            ("seen", seen),
+            ("flagged", flagged),
+            ("answered", answered),
+            ("$junk", junk),
+        )
+        if value is not None
+    }
+    if not flags:
+        raise MCPError(
+            code=-1,
+            message="No flags given; pass at least one of seen, flagged, "
+            "answered, junk",
+        )
+
+    client = await get_client(ctx)
+    with _mail_errors(f"setting flags on message {message_id}"):
+        await client.mail.set_flags(message_id, flags)
+
+    applied = ", ".join(f"{name}={value}" for name, value in flags.items())
+    return MailActionResponse(
+        message_id=message_id, message=f"Flags updated: {applied}"
+    )
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_create_tag(
+    display_name: Annotated[str, Field(max_length=128)],
+    ctx: Context,
+    color: str = DEFAULT_TAG_COLOR,
+) -> MailTagResponse:
+    """Create a mail tag, or return the existing one (requires mail.write scope).
+
+    Tags are IMAP keywords private to the user. The Mail app has no
+    tag-listing endpoint, so this is also how you look a tag up — calling it
+    for an existing name returns that tag rather than creating a duplicate.
+
+    Names normalise to a lowercase IMAP label with spaces as underscores, so
+    "AI Index", "ai index" and "ai_index" are all the same tag.
+
+    Args:
+        display_name: Tag name (max 128 characters)
+        color: Hex colour, applied only when the tag is created
+
+    Returns:
+        MailTagResponse with the tag, including the ``id`` needed for the
+        ``tags:<id>`` filter of nc_mail_list_messages.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"creating tag {display_name!r}"):
+        tag = await client.mail.ensure_tag(display_name, color)
+    return MailTagResponse(tag=MailTag(**tag))
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_set_tag(
+    message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+) -> MailTagResponse:
+    """Assign a tag to a message (requires mail.write scope).
+
+    The tag is created if it does not exist yet, so this works without a
+    separate nc_mail_create_tag call.
+
+    Args:
+        message_id: Numeric message id
+        tag: Tag display name
+
+    Returns:
+        MailTagResponse with the assigned tag.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"tagging message {message_id} with {tag!r}"):
+        # Resolve through create-or-get: it yields the server's own
+        # imapLabel, so we never have to re-derive the label encoding.
+        tag_data = await client.mail.ensure_tag(tag)
+        await client.mail.set_tag(message_id, tag_data["imapLabel"])
+    return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_remove_tag(
+    message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+) -> MailTagResponse:
+    """Remove a tag from a message (requires mail.write scope).
+
+    Args:
+        message_id: Numeric message id
+        tag: Tag display name
+
+    Returns:
+        MailTagResponse with the removed tag.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"removing tag {tag!r} from message {message_id}"):
+        # Resolve the same way as tagging. For a name that has never been
+        # used this creates an empty tag row before removing nothing from
+        # the message — harmless, and it keeps one resolution path.
+        tag_data = await client.mail.ensure_tag(tag)
+        await client.mail.remove_tag(message_id, tag_data["imapLabel"])
+    return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_move_message(
+    message_id: int, destination_mailbox_id: int, ctx: Context
+) -> MailActionResponse:
+    """Move a message to another mailbox (requires mail.write scope).
+
+    Args:
+        message_id: Numeric message id
+        destination_mailbox_id: Target mailbox id (``database_id`` from
+            nc_mail_list_mailboxes)
+
+    Returns:
+        MailActionResponse. ``message_id`` echoes what you passed in and is
+        **stale on return**: the move invalidates it, and the message is
+        re-cached in the destination under a new id. Re-list the destination
+        mailbox to address it again — do not retry this call with the same
+        id, which fails rather than repeating the move.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"moving message {message_id}"):
+        await client.mail.move_message(message_id, destination_mailbox_id)
+    return MailActionResponse(
+        message_id=message_id,
+        message=f"Message moved to mailbox {destination_mailbox_id}",
+    )
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_delete_message(message_id: int, ctx: Context) -> MailActionResponse:
+    """Delete a message (requires mail.write scope).
+
+    The Mail app moves the message to the account's trash mailbox, or
+    expunges it permanently if it is already in trash. Requires the account
+    to have a trash mailbox — without one the Mail app rejects the call
+    ("No trash mailbox configured").
+
+    Args:
+        message_id: Numeric message id
+
+    Returns:
+        MailActionResponse confirming the deletion. ``message_id`` echoes
+        the input and is **stale on return** — trashing re-caches the
+        message under a new id, so retrying with the same id fails.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"deleting message {message_id}"):
+        await client.mail.delete_message(message_id)
+    return MailActionResponse(message_id=message_id, message="Message deleted")
+
+
 def configure_mail_tools(mcp: MCPServer):
     """Configure Mail app MCP tools (read, send, flags, tags, move, delete)."""
 
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Accounts",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_accounts(ctx: Context) -> ListAccountsResponse:
-        """List the user's configured mail accounts (requires mail.read scope)."""
-        client = await get_client(ctx)
-        try:
-            accounts_data = await client.mail.list_accounts()
-            accounts = [MailAccount(**a) for a in accounts_data]
-            return ListAccountsResponse(results=accounts, total_count=len(accounts))
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error listing accounts: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list accounts: {e.response.status_code}",
-            )
+    )(nc_mail_list_accounts)
 
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Mailboxes",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_mailboxes(
-        account_id: int, ctx: Context
-    ) -> ListMailboxesResponse:
-        """List the mailboxes (folders) of a mail account (requires mail.read scope).
+    )(nc_mail_list_mailboxes)
 
-        Args:
-            account_id: Account ID (from nc_mail_list_accounts)
-
-        Returns:
-            ListMailboxesResponse with mailboxes. Use a mailbox's ``database_id``
-            with nc_mail_list_messages.
-        """
-        client = await get_client(ctx)
-        try:
-            mailboxes_data = await client.mail.get_mailboxes(account_id)
-            mailboxes = [MailMailbox(**m) for m in mailboxes_data]
-            return ListMailboxesResponse(results=mailboxes, total_count=len(mailboxes))
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error listing mailboxes: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list mailboxes: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Messages",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_messages(
-        mailbox_id: int,
-        ctx: Context,
-        cursor: int | None = None,
-        search_filter: str | None = None,
-        limit: int = 20,
-    ) -> ListMessagesResponse:
-        """List message envelopes in a mailbox, newest first (requires mail.read scope).
+    )(nc_mail_list_messages)
 
-        Reads cached envelope metadata (fast). Does not fetch bodies. Use
-        nc_mail_get_message to fetch a full body.
-
-        Args:
-            mailbox_id: Numeric mailbox id (``database_id`` from nc_mail_list_mailboxes)
-            cursor: Pagination cursor from a prior page
-            search_filter: Optional filter query — space-separated ``token:value``
-                terms, ANDed together. Supported tokens:
-
-                * ``is:``/``not:`` — ``read``, ``unread``, ``starred``,
-                  ``answered``, ``important``
-                * ``from:``, ``to:``, ``cc:``, ``bcc:`` — substring match on the
-                  address or display name
-                * ``subject:``, ``body:`` — substring match (``body:`` searches
-                  IMAP server-side and is slower)
-                * ``tags:`` — comma-separated tag *database ids* (not names,
-                  get one from nc_mail_create_tag)
-                * ``start:``, ``end:`` — date bounds
-                * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
-                  ``answered``/``important``/``attachments``
-                * ``match:anyof`` — OR the from/to/cc/bcc/subject/body terms
-                  instead of ANDing them
-
-                Example: ``is:unread from:alice subject:invoice``
-            limit: Max messages to return (1-100, default 20)
-
-        Returns:
-            ListMessagesResponse with message summaries. ``has_more`` is a
-            heuristic (true when exactly ``limit`` messages were returned), so it
-            can be a false positive when a mailbox holds exactly ``limit``
-            messages. Page with ``cursor`` and stop on an empty result.
-        """
-        client = await get_client(ctx)
-        # Clamp to the same window the client/OCS API enforce so the has_more
-        # heuristic compares against the limit actually applied (a caller passing
-        # limit<=0 otherwise gets a misleading count).
-        effective_limit = min(max(1, limit), 100)
-        try:
-            messages_data = await client.mail.list_messages(
-                mailbox_id,
-                cursor=cursor,
-                search_filter=search_filter,
-                limit=effective_limit,
-            )
-            messages = [MailMessageSummary(**m) for m in messages_data]
-            return ListMessagesResponse(
-                results=messages,
-                total_count=len(messages),
-                has_more=len(messages) == effective_limit,
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error listing messages: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list messages: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Message",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_message(message_id: int, ctx: Context) -> GetMessageResponse:
-        """Get a single mail message with its full body (requires mail.read scope).
+    )(nc_mail_get_message)
 
-        The Mail app fetches the body from IMAP server-side.
-
-        Args:
-            message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
-
-        Returns:
-            GetMessageResponse with the full message including body and attachments.
-            Attachments with ``id: null`` are inline body parts and cannot be
-            fetched via nc_mail_get_attachment (which requires a string id).
-        """
-        client = await get_client(ctx)
-        try:
-            message_data = await client.mail.get_message(message_id)
-            # An empty payload (OCS data=null with a 200 meta) would make
-            # MailMessage(**{}) raise an uncaught ValidationError; treat it as
-            # not-found instead.
-            if not message_data:
-                raise MCPError(code=-1, message=f"Message {message_id} not found")
-            message = MailMessage(**message_data)
-            return GetMessageResponse(message=message)
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error getting message {message_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Message {message_id} not found")
-            raise MCPError(
-                code=-1,
-                message=f"Failed to get message {message_id}: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Send Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Stages a new outbox entry each call (ADR-017)
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.send")
-    @instrument_tool
-    async def nc_mail_send_message(
-        account_id: int,
-        to: str,
-        subject: str,
-        body: str,
-        ctx: Context,
-        is_html: bool = False,
-        cc: str | None = None,
-        bcc: str | None = None,
-        references: str | None = None,
-    ) -> SendMessageResponse:
-        """Send an email through a configured Nextcloud Mail account (requires mail.send scope).
+    )(nc_mail_send_message)
 
-        The ``From:`` identity is derived by the Mail app from ``account_id``.
-        Recipients are specified as JSON arrays of ``{"label": "...", "email": "..."}``
-        objects.  Example for ``to``::
-
-            [{"label": "John Doe", "email": "john@example.com"}]
-
-        Args:
-            account_id: Mail account ID to send from (from nc_mail_list_accounts)
-            to: JSON array of To recipients
-            subject: Email subject
-            body: Email body (plain text unless is_html is true)
-            is_html: Whether body contains HTML (default false)
-            cc: Optional JSON array of CC recipients
-            bcc: Optional JSON array of BCC recipients
-            references: Optional RFC 2822 Message-ID for reply threading
-
-        Returns:
-            SendMessageResponse with success status and optional message
-        """
-        client = await get_client(ctx)
-        try:
-            to_list = json.loads(to)  # `to` is a required JSON-array string
-            cc_list = json.loads(cc) if isinstance(cc, str) else (cc or [])
-            bcc_list = json.loads(bcc) if isinstance(bcc, str) else (bcc or [])
-
-            await client.mail.send_message(
-                account_id=account_id,
-                to=to_list,
-                subject=subject,
-                body=body,
-                is_html=is_html,
-                cc=cc_list or None,
-                bcc=bcc_list or None,
-                references=references or None,
-            )
-            return SendMessageResponse(
-                success=True, message="Message sent successfully"
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error sending message: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to send message: {e.response.status_code} "
-                f"{e.response.text[:500]}",
-            )
-        except json.JSONDecodeError as e:
-            raise MCPError(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Attachment",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_attachment(
-        message_id: int, attachment_id: str, ctx: Context
-    ) -> GetAttachmentResponse:
-        """Get a single mail attachment's metadata and content (requires mail.read scope).
+    )(nc_mail_get_attachment)
 
-        Args:
-            message_id: Numeric message id
-            attachment_id: Attachment id (a string, from the message's attachments)
-
-        Returns:
-            GetAttachmentResponse with name, mime, size, and content. ``content``
-            is the attachment body base64-encoded. Large attachments produce a
-            correspondingly large response, so prefer the ``size`` from the
-            message's attachment list before fetching.
-        """
-        client = await get_client(ctx)
-        try:
-            data = await client.mail.get_attachment(message_id, attachment_id)
-            return GetAttachmentResponse(
-                name=data.get("name"),
-                mime=data.get("mime"),
-                size=data.get("size"),
-                content=_cap_attachment_content(data.get("content")),
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error getting attachment: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message="Attachment not found")
-            raise MCPError(
-                code=-1,
-                message=f"Failed to get attachment: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Message Source",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_message_source(
-        message_id: int, ctx: Context
-    ) -> GetMessageSourceResponse:
-        """Get a message's raw RFC 2822 source (requires mail.read scope).
+    )(nc_mail_get_message_source)
 
-        The complete original message including all headers — use this when the
-        parsed view from nc_mail_get_message is not enough (checking
-        Received/DKIM headers, List-Unsubscribe, custom X- headers).
-
-        Args:
-            message_id: Numeric message id
-
-        Returns:
-            GetMessageSourceResponse with the raw source. ``source`` is None if
-            the Mail app returns no content for the message.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"getting source of message {message_id}"):
-            source = await client.mail.get_message_raw(message_id)
-        return GetMessageSourceResponse(message_id=message_id, source=source)
-
-    @mcp.tool(
+    mcp.tool(
         title="Set Mail Message Flags",
         annotations=ToolAnnotations(
             # Same inputs -> same end state (a flag set twice stays set).
             idempotent_hint=True,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_set_flags(
-        message_id: int,
-        ctx: Context,
-        seen: bool | None = None,
-        flagged: bool | None = None,
-        answered: bool | None = None,
-        junk: bool | None = None,
-    ) -> MailActionResponse:
-        """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
+    )(nc_mail_set_flags)
 
-        Only the flags you pass are changed. Omitted ones are left alone. Use
-        ``seen=True`` after processing a message so it does not look unhandled,
-        and ``seen=False`` to mark it unread again.
-
-        Args:
-            message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
-            seen: Mark read (True) or unread (False)
-            flagged: Star (True) or unstar (False)
-            answered: Mark as replied-to
-            junk: Mark as junk/spam. Unlike the others this is a custom IMAP
-                keyword, so the mail server silently ignores it unless the
-                mailbox permits custom keywords.
-
-        Returns:
-            MailActionResponse naming the flags that were applied. Passing no
-            flags at all is an error rather than a silent no-op.
-        """
-        flags = {
-            name: value
-            for name, value in (
-                ("seen", seen),
-                ("flagged", flagged),
-                ("answered", answered),
-                ("$junk", junk),
-            )
-            if value is not None
-        }
-        if not flags:
-            raise MCPError(
-                code=-1,
-                message="No flags given; pass at least one of seen, flagged, "
-                "answered, junk",
-            )
-
-        client = await get_client(ctx)
-        with _mail_errors(f"setting flags on message {message_id}"):
-            await client.mail.set_flags(message_id, flags)
-
-        applied = ", ".join(f"{name}={value}" for name, value in flags.items())
-        return MailActionResponse(
-            message_id=message_id, message=f"Flags updated: {applied}"
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Create Mail Tag",
         annotations=ToolAnnotations(
             # Create-or-get: the Mail app returns the existing tag for a name
@@ -468,99 +610,25 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=True,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_create_tag(
-        display_name: Annotated[str, Field(max_length=128)],
-        ctx: Context,
-        color: str = DEFAULT_TAG_COLOR,
-    ) -> MailTagResponse:
-        """Create a mail tag, or return the existing one (requires mail.write scope).
+    )(nc_mail_create_tag)
 
-        Tags are IMAP keywords private to the user. The Mail app has no
-        tag-listing endpoint, so this is also how you look a tag up — calling it
-        for an existing name returns that tag rather than creating a duplicate.
-
-        Names normalise to a lowercase IMAP label with spaces as underscores, so
-        "AI Index", "ai index" and "ai_index" are all the same tag.
-
-        Args:
-            display_name: Tag name (max 128 characters)
-            color: Hex colour, applied only when the tag is created
-
-        Returns:
-            MailTagResponse with the tag, including the ``id`` needed for the
-            ``tags:<id>`` filter of nc_mail_list_messages.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"creating tag {display_name!r}"):
-            tag = await client.mail.ensure_tag(display_name, color)
-        return MailTagResponse(tag=MailTag(**tag))
-
-    @mcp.tool(
+    mcp.tool(
         title="Tag Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=True,  # Re-tagging a tagged message is a no-op
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_set_tag(
-        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
-    ) -> MailTagResponse:
-        """Assign a tag to a message (requires mail.write scope).
+    )(nc_mail_set_tag)
 
-        The tag is created if it does not exist yet, so this works without a
-        separate nc_mail_create_tag call.
-
-        Args:
-            message_id: Numeric message id
-            tag: Tag display name
-
-        Returns:
-            MailTagResponse with the assigned tag.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"tagging message {message_id} with {tag!r}"):
-            # Resolve through create-or-get: it yields the server's own
-            # imapLabel, so we never have to re-derive the label encoding.
-            tag_data = await client.mail.ensure_tag(tag)
-            await client.mail.set_tag(message_id, tag_data["imapLabel"])
-        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
-
-    @mcp.tool(
+    mcp.tool(
         title="Untag Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=True,  # Removing an absent tag leaves the same state
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_remove_tag(
-        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
-    ) -> MailTagResponse:
-        """Remove a tag from a message (requires mail.write scope).
+    )(nc_mail_remove_tag)
 
-        Args:
-            message_id: Numeric message id
-            tag: Tag display name
-
-        Returns:
-            MailTagResponse with the removed tag.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"removing tag {tag!r} from message {message_id}"):
-            # Resolve the same way as tagging. For a name that has never been
-            # used this creates an empty tag row before removing nothing from
-            # the message — harmless, and it keeps one resolution path.
-            tag_data = await client.mail.ensure_tag(tag)
-            await client.mail.remove_tag(message_id, tag_data["imapLabel"])
-        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
-
-    @mcp.tool(
+    mcp.tool(
         title="Move Mail Message",
         annotations=ToolAnnotations(
             # NOT idempotent. The move drops the cached row and the message is
@@ -571,35 +639,9 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=False,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_move_message(
-        message_id: int, destination_mailbox_id: int, ctx: Context
-    ) -> MailActionResponse:
-        """Move a message to another mailbox (requires mail.write scope).
+    )(nc_mail_move_message)
 
-        Args:
-            message_id: Numeric message id
-            destination_mailbox_id: Target mailbox id (``database_id`` from
-                nc_mail_list_mailboxes)
-
-        Returns:
-            MailActionResponse. ``message_id`` echoes what you passed in and is
-            **stale on return**: the move invalidates it, and the message is
-            re-cached in the destination under a new id. Re-list the destination
-            mailbox to address it again — do not retry this call with the same
-            id, which fails rather than repeating the move.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"moving message {message_id}"):
-            await client.mail.move_message(message_id, destination_mailbox_id)
-        return MailActionResponse(
-            message_id=message_id,
-            message=f"Message moved to mailbox {destination_mailbox_id}",
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Mail Message",
         annotations=ToolAnnotations(
             destructive_hint=True,  # Removes the message from its mailbox
@@ -610,28 +652,4 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=False,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_delete_message(
-        message_id: int, ctx: Context
-    ) -> MailActionResponse:
-        """Delete a message (requires mail.write scope).
-
-        The Mail app moves the message to the account's trash mailbox, or
-        expunges it permanently if it is already in trash. Requires the account
-        to have a trash mailbox — without one the Mail app rejects the call
-        ("No trash mailbox configured").
-
-        Args:
-            message_id: Numeric message id
-
-        Returns:
-            MailActionResponse confirming the deletion. ``message_id`` echoes
-            the input and is **stale on return** — trashing re-caches the
-            message under a new id, so retrying with the same id fails.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"deleting message {message_id}"):
-            await client.mail.delete_message(message_id)
-        return MailActionResponse(message_id=message_id, message="Message deleted")
+    )(nc_mail_delete_message)

--- a/nextcloud_mcp_server/server/notes.py
+++ b/nextcloud_mcp_server/server/notes.py
@@ -24,6 +24,281 @@ from nextcloud_mcp_server.request_context import current_context
 logger = logging.getLogger(__name__)
 
 
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_create_note(
+    title: str, content: str, category: str, ctx: Context
+) -> CreateNoteResponse:
+    """Create a new note (requires notes.write scope)"""
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.create_note(
+            title=title,
+            content=content,
+            category=category,
+        )
+        note = Note(**note_data)
+        return CreateNoteResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error creating note: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to create notes",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(code=-1, message="Note content too large")
+        elif e.response.status_code == 409:
+            raise MCPError(
+                code=-1,
+                message=f"A note with title '{title}' already exists in this category",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to create note: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_update_note(
+    note_id: int,
+    etag: str,
+    title: str | None,
+    content: str | None,
+    category: str | None,
+    ctx: Context,
+) -> UpdateNoteResponse:
+    """Update an existing note's title, content, or category (requires notes.write scope).
+
+    REQUIRED: etag parameter must be provided to prevent overwriting concurrent changes.
+    Get the current ETag by first retrieving the note using nc_notes_get_note tool.
+    If the note has been modified by someone else since you retrieved it,
+    the update will fail with a 412 error."""
+    logger.info("Updating note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.update(
+            note_id=note_id,
+            etag=etag,
+            title=title,
+            content=content,
+            category=category,
+        )
+        note = Note(**note_data)
+        return UpdateNoteResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error updating note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 412:
+            raise MCPError(
+                code=-1,
+                message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
+            )
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to update note {note_id}",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(code=-1, message="Updated note content is too large")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_append_content(
+    note_id: int, content: str, ctx: Context
+) -> AppendContentResponse:
+    """Append content to an existing note. The tool adds a `\n---\n`
+    between the note and what will be appended."""
+
+    logger.info("Appending content to note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.append_content(note_id=note_id, content=content)
+        note = Note(**note_data)
+        return AppendContentResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error appending to note {note_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to modify note {note_id}",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(
+                code=-1,
+                message="Content to append would make the note too large",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.read")
+@with_links
+@instrument_tool
+async def nc_notes_search_notes(query: str, ctx: Context) -> SearchNotesResponse:
+    """Search notes by title or content, returning only id, title, and category (requires notes.read scope)."""
+    client = await get_client(ctx)
+    try:
+        search_results_raw = await client.notes_search_notes(query=query)
+
+        # Convert to NoteSearchResult models, including the _score field
+        results = [
+            NoteSearchResult(
+                id=result["id"],
+                title=result["title"],
+                category=result["category"],
+                score=result.get("_score"),  # Include search score if available
+            )
+            for result in search_results_raw
+        ]
+
+        return SearchNotesResponse(
+            results=results, query=query, total_found=len(results)
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error searching notes: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to search notes",
+            )
+        elif e.response.status_code == 400:
+            raise MCPError(code=-1, message="Invalid search query format")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Search failed: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.read")
+@with_links
+@instrument_tool
+async def nc_notes_get_note(note_id: int, ctx: Context) -> Note:
+    """Get a specific note by its ID (requires notes.read scope)"""
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.get_note(note_id)
+        return Note(**note_data)
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error getting note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(code=-1, message=f"Access denied to note {note_id}")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
+            )
+
+
+@require_scopes("notes.read")
+@instrument_tool
+async def nc_notes_get_attachment(
+    note_id: int, attachment_filename: str, ctx: Context
+) -> dict[str, str]:
+    """Get a specific attachment from a note"""
+    client = await get_client(ctx)
+    try:
+        content, mime_type = await client.webdav.get_note_attachment(
+            note_id=note_id, filename=attachment_filename
+        )
+        return {  # type: ignore
+            "uri": f"nc://Notes/{note_id}/attachments/{attachment_filename}",
+            "mimeType": mime_type,
+            "data": content,
+        }
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(
+                code=-1,
+                message=f"Attachment {attachment_filename} not found for note {note_id}",
+            )
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied to attachment {attachment_filename} for note {note_id}",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
+            )
+
+
+@require_scopes("notes.write")
+@instrument_tool
+async def nc_notes_delete_note(note_id: int, ctx: Context) -> DeleteNoteResponse:
+    """Delete a note permanently"""
+    logger.info("Deleting note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        await client.notes.delete_note(note_id)
+        return DeleteNoteResponse(
+            status_code=200,
+            message=f"Note {note_id} deleted successfully",
+            deleted_id=note_id,
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to delete note {note_id}",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
+            )
+
+
 def configure_notes_tools(mcp: MCPServer):
     @mcp.resource("notes://settings")
     async def notes_get_settings():
@@ -81,322 +356,59 @@ def configure_notes_tools(mcp: MCPServer):
                     message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
                 )
 
-    @mcp.tool(
+    mcp.tool(
         title="Create Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Multiple calls create multiple notes
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_create_note(
-        title: str, content: str, category: str, ctx: Context
-    ) -> CreateNoteResponse:
-        """Create a new note (requires notes.write scope)"""
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.create_note(
-                title=title,
-                content=content,
-                category=category,
-            )
-            note = Note(**note_data)
-            return CreateNoteResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error creating note: {str(e)}")
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to create notes",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(code=-1, message="Note content too large")
-            elif e.response.status_code == 409:
-                raise MCPError(
-                    code=-1,
-                    message=f"A note with title '{title}' already exists in this category",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to create note: server error ({e.response.status_code})",
-                )
+    )(nc_notes_create_note)
 
-    @mcp.tool(
+    mcp.tool(
         title="Update Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Requires etag which changes = not idempotent
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_update_note(
-        note_id: int,
-        etag: str,
-        title: str | None,
-        content: str | None,
-        category: str | None,
-        ctx: Context,
-    ) -> UpdateNoteResponse:
-        """Update an existing note's title, content, or category (requires notes.write scope).
+    )(nc_notes_update_note)
 
-        REQUIRED: etag parameter must be provided to prevent overwriting concurrent changes.
-        Get the current ETag by first retrieving the note using nc_notes_get_note tool.
-        If the note has been modified by someone else since you retrieved it,
-        the update will fail with a 412 error."""
-        logger.info("Updating note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.update(
-                note_id=note_id,
-                etag=etag,
-                title=title,
-                content=content,
-                category=category,
-            )
-            note = Note(**note_data)
-            return UpdateNoteResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error updating note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 412:
-                raise MCPError(
-                    code=-1,
-                    message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to update note {note_id}",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(code=-1, message="Updated note content is too large")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Append to Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Each call adds content = not idempotent
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_append_content(
-        note_id: int, content: str, ctx: Context
-    ) -> AppendContentResponse:
-        """Append content to an existing note. The tool adds a `\n---\n`
-        between the note and what will be appended."""
+    )(nc_notes_append_content)
 
-        logger.info("Appending content to note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.append_content(
-                note_id=note_id, content=content
-            )
-            note = Note(**note_data)
-            return AppendContentResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error appending to note {note_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to modify note {note_id}",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(
-                    code=-1,
-                    message="Content to append would make the note too large",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Search Notes",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Search doesn't modify data
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @with_links
-    @instrument_tool
-    async def nc_notes_search_notes(query: str, ctx: Context) -> SearchNotesResponse:
-        """Search notes by title or content, returning only id, title, and category (requires notes.read scope)."""
-        client = await get_client(ctx)
-        try:
-            search_results_raw = await client.notes_search_notes(query=query)
+    )(nc_notes_search_notes)
 
-            # Convert to NoteSearchResult models, including the _score field
-            results = [
-                NoteSearchResult(
-                    id=result["id"],
-                    title=result["title"],
-                    category=result["category"],
-                    score=result.get("_score"),  # Include search score if available
-                )
-                for result in search_results_raw
-            ]
-
-            return SearchNotesResponse(
-                results=results, query=query, total_found=len(results)
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error searching notes: {str(e)}")
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to search notes",
-                )
-            elif e.response.status_code == 400:
-                raise MCPError(code=-1, message="Invalid search query format")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Search failed: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Note",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Read operation only
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @with_links
-    @instrument_tool
-    async def nc_notes_get_note(note_id: int, ctx: Context) -> Note:
-        """Get a specific note by its ID (requires notes.read scope)"""
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.get_note(note_id)
-            return Note(**note_data)
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error getting note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(code=-1, message=f"Access denied to note {note_id}")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
-                )
+    )(nc_notes_get_note)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Note Attachment",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Read operation only
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @instrument_tool
-    async def nc_notes_get_attachment(
-        note_id: int, attachment_filename: str, ctx: Context
-    ) -> dict[str, str]:
-        """Get a specific attachment from a note"""
-        client = await get_client(ctx)
-        try:
-            content, mime_type = await client.webdav.get_note_attachment(
-                note_id=note_id, filename=attachment_filename
-            )
-            return {  # type: ignore
-                "uri": f"nc://Notes/{note_id}/attachments/{attachment_filename}",
-                "mimeType": mime_type,
-                "data": content,
-            }
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(
-                    code=-1,
-                    message=f"Attachment {attachment_filename} not found for note {note_id}",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied to attachment {attachment_filename} for note {note_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
-                )
+    )(nc_notes_get_attachment)
 
-    @mcp.tool(
+    mcp.tool(
         title="Delete Note",
         annotations=ToolAnnotations(
             destructive_hint=True,  # Permanently deletes data
             idempotent_hint=True,  # Deleting deleted note = same end state
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @instrument_tool
-    async def nc_notes_delete_note(note_id: int, ctx: Context) -> DeleteNoteResponse:
-        """Delete a note permanently"""
-        logger.info("Deleting note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            await client.notes.delete_note(note_id)
-            return DeleteNoteResponse(
-                status_code=200,
-                message=f"Note {note_id} deleted successfully",
-                deleted_id=note_id,
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to delete note {note_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
-                )
+    )(nc_notes_delete_note)

--- a/nextcloud_mcp_server/server/semantic.py
+++ b/nextcloud_mcp_server/server/semantic.py
@@ -83,974 +83,1032 @@ def _consent_narrowed_doc_types(
     return [dt for dt in doc_types if dt in allowed]
 
 
+def _parse_modified_bounds(
+    modified_after: str | int | None, modified_before: str | int | None
+) -> tuple[int | None, int | None]:
+    """Normalise the ADR-027 date bounds to int Unix seconds.
+
+    The numeric ``modified_at`` Range filter needs seconds, and a bad format
+    must surface as a clean MCPError rather than a 500.
+
+    The ordering check lives here rather than on the signature because a
+    per-parameter pydantic ``Field`` constraint bounds each date on its own but
+    cannot express the relationship between them; unguarded, an inverted range
+    silently returns zero results.
+    """
+    try:
+        after_ts = parse_modified_timestamp(modified_after, param_name="modified_after")
+        before_ts = parse_modified_timestamp(
+            modified_before, param_name="modified_before"
+        )
+    except ValueError as exc:
+        raise MCPError(code=-1, message=str(exc)) from exc
+
+    if after_ts is not None and before_ts is not None and after_ts > before_ts:
+        raise MCPError(
+            code=-1,
+            message=(
+                "modified_after must be <= modified_before "
+                f"(got modified_after={modified_after!r}, "
+                f"modified_before={modified_before!r})"
+            ),
+        )
+    return after_ts, before_ts
+
+
+async def _retrieve_candidates(
+    search_algo: Any,
+    *,
+    doc_types: list[str] | None,
+    fetch_limit: int,
+    **search_kwargs: Any,
+) -> list[Any]:
+    """The unverified candidate pool for one search.
+
+    ``doc_types=None`` is a single cross-app query. A list issues ONE query per
+    type, so the pre-merge pool is N x ``fetch_limit`` rather than
+    ``fetch_limit`` -- more Qdrant work than the cross-app branch. The trim
+    below clamps it back so verification (and the Nextcloud round-trips it
+    triggers) sees the same budget either way; the per-type Qdrant cost stays
+    higher and scales with ``len(doc_types)``.
+
+    Extracted from ``nc_semantic_search`` for nesting rather than reuse.
+    """
+    if doc_types is None:
+        # ADR-019: the caller over-fetches to absorb ghost-record drops during
+        # verify-on-read; the trim to the requested ``limit`` happens after
+        # verification, not here.
+        return list(await search_algo.search(doc_type=None, **search_kwargs))
+
+    all_results: list[Any] = []
+    for dtype in doc_types:
+        all_results.extend(await search_algo.search(doc_type=dtype, **search_kwargs))
+
+    # Sort then cap to match the cross-app branch's over-fetch budget. Without
+    # this, N doc_types x fetch_limit results would all flow into verification,
+    # multiplying the Nextcloud round-trip cost by N.
+    all_results.sort(key=lambda r: r.score, reverse=True)
+    return all_results[:fetch_limit]
+
+
+def _fetch_limit(
+    settings: Any, *, overfetch: int, rerank: bool, granularity: str
+) -> int:
+    """How many candidates to retrieve before verification.
+
+    Reranking can only reorder what retrieval supplied, so it needs a deeper
+    pool than the verification over-fetch — never smaller than that over-fetch,
+    and clamped for grouped search (see ``effective_pool_size``). Without
+    reranking the over-fetch is the whole budget.
+    """
+    if not rerank:
+        return overfetch
+    return effective_pool_size(
+        settings, floor=overfetch, grouped=granularity == GRANULARITY_DOCUMENT
+    )
+
+
+async def _rerank_pool(
+    all_results: list[Any],
+    query: str,
+    *,
+    settings: Any,
+    verification_budget: int,
+) -> tuple[list[Any], str, str]:
+    """Rerank the merged candidate pool and report how it went.
+
+    Returns ``(results, outcome, metric_label)``. SKIPPED — nothing to reorder —
+    reports as ``"false"`` rather than ``"unavailable"``, otherwise every query
+    returning 0-1 rows would register as a reranker outage.
+
+    The trim back to ``verification_budget`` keeps verify-on-read at the same
+    number of Nextcloud round-trips as an unreranked search: the deep pool
+    exists for the reranker, not for verification.
+    """
+    all_results, outcome = await rerank_results(
+        all_results, query, settings=settings, surface="mcp"
+    )
+    metric_reranked = {
+        RERANK_APPLIED: "true",
+        RERANK_DEGRADED: "unavailable",
+    }.get(outcome, "false")
+    return all_results[:verification_budget], outcome, metric_reranked
+
+
+def _log_top_results(verified_results: list[Any]) -> None:
+    """Log the top few results, titles included.
+
+    Safe only *after* verify-on-read: the caller is confirmed to have access to
+    these. Unverified titles are never logged — see the search algorithms.
+    """
+    if not verified_results:
+        return
+    logger.debug(
+        "Top verified results: %s",
+        ", ".join(
+            f"{r.doc_type}_{r.id} (score={r.score:.3f}, title='{r.title}')"
+            for r in verified_results[:5]
+        ),
+    )
+
+
+def _to_semantic_results(
+    search_results: list[Any],
+    *,
+    browser_base: str | None,
+    fusion: str,
+    rerank_model: str | None,
+) -> list[SemanticSearchResult]:
+    """Map retrieved rows onto the public response model.
+
+    Extracted from ``nc_semantic_search`` for nesting rather than reuse: the
+    ``file_url`` ternary sat five levels deep inside that function.
+    """
+    # Convert SearchResult objects to SemanticSearchResult for response.
+    # SearchResult.id is `str` (Qdrant keyword-indexed payload), but
+    # every currently indexed type uses numeric ids and the MCP response
+    # model narrows to `int`. Casting here makes the narrowing explicit
+    # and surfaces any future non-numeric-id type as a loud failure at
+    # the boundary instead of silently widening the public API.
+    results = []
+    for r in search_results:
+        try:
+            narrowed_id = int(r.id)
+        except (TypeError, ValueError) as e:
+            # Re-raise with explicit context so the outer handler logs
+            # something operators can act on (the generic "Search
+            # failed: invalid literal for int()" is opaque).
+            raise TypeError(
+                f"SemanticSearchResult.id must be int-convertible, "
+                f"got {r.id!r} (type={type(r.id).__name__}) for "
+                f"doc_type={r.doc_type!r}. This indicates a doc_type "
+                f"with non-numeric ids has been indexed but the "
+                f"public response model has not been widened. Add "
+                f"the doc_type to the SemanticSearchResult.id type "
+                f"or convert at the verifier layer."
+            ) from e
+        relevance, relevance_source = relevance_for(
+            rerank_score=r.rerank_score,
+            score=r.score,
+            fusion=fusion,
+            # This tool always runs BM25HybridSearchAlgorithm, so the
+            # fused-score branch is the right one; it never takes the
+            # dense-only cosine path.
+            algorithm="hybrid",
+            rerank_model=rerank_model,
+        )
+        metadata = r.metadata or {}
+        # board_id is the only one of Astrolabe's access-recheck
+        # identifiers the chunk payload carries (see
+        # build_search_result_from_point); the others fall through to
+        # its MCP backstop. Tested against None rather than falsiness to
+        # match chunk_url's handling of a legitimate 0 — Nextcloud ids
+        # are 1-based, so this is consistency, not a live bug.
+        board_id = metadata.get("board_id")
+        link_extra = None if board_id is None else {"board_id": str(board_id)}
+        results.append(
+            SemanticSearchResult(
+                id=narrowed_id,
+                doc_type=r.doc_type,
+                title=r.title,
+                rerank_score=r.rerank_score,
+                relevance=relevance,
+                relevance_source=relevance_source,
+                category=metadata.get("category", ""),
+                excerpt=r.excerpt,
+                score=r.score,
+                chunk_index=metadata.get("chunk_index", 0),
+                total_chunks=metadata.get("total_chunks", 1),
+                chunk_start_offset=r.chunk_start_offset,
+                chunk_end_offset=r.chunk_end_offset,
+                page_number=r.page_number,
+                page_end=r.page_end,
+                url=chunk_url(
+                    browser_base,
+                    doc_type=r.doc_type,
+                    doc_id=narrowed_id,
+                    chunk_start=r.chunk_start_offset,
+                    chunk_end=r.chunk_end_offset,
+                    title=r.title,
+                    path=metadata.get("path"),
+                    page_number=r.page_number,
+                    chunk_index=metadata.get("chunk_index"),
+                    total_chunks=metadata.get("total_chunks"),
+                    extra=link_extra,
+                ),
+                # For doc_type="file" the doc_id IS the Nextcloud
+                # fileid (vector/scanner.py indexes it as such), so the
+                # /f/ link needs no extra lookup. Guarded on doc_type
+                # because no other indexed type's id is a fileid — a
+                # note id fed to /f/ would open an unrelated file or
+                # 404.
+                file_url=(
+                    file_url(browser_base, narrowed_id)
+                    if r.doc_type == "file"
+                    else None
+                ),
+            )
+        )
+    return results
+
+
+async def _expand_results_with_context(
+    results: list[SemanticSearchResult],
+    *,
+    include_context: bool,
+    client,
+    username: str,
+    context_chars: int,
+    accessible_owners,
+) -> list[SemanticSearchResult]:
+    """Return ``results`` with surrounding document context filled in.
+
+    A no-op unless ``include_context`` is set, or when there is nothing to
+    expand — the guard lives here so the caller reads as a single step.
+
+    Extracted from ``nc_semantic_search`` because it carried most of that
+    function's nesting, not because it is reused. Failure here is never fatal:
+    a result whose context cannot be fetched is returned unchanged, so context
+    expansion degrades to the plain excerpt rather than failing the search.
+    """
+    if not include_context or not results:
+        return results
+
+    logger.info(
+        "Expanding %d results with context (context_chars=%d)",
+        len(results),
+        context_chars,
+    )
+
+    # Fetch context for all results in parallel.
+    # Limit concurrent requests to prevent connection pool exhaustion.
+    #
+    # Intentionally distinct from settings.verification_concurrency:
+    # that knob bounds Nextcloud round-trips during access
+    # verification (ADR-019); this one bounds context-expansion
+    # fetches that run only when ``include_context=True``. Operators
+    # tuning one rarely want the other in lockstep, so they share
+    # the default value (20) but not the env var.
+    max_concurrent = 20
+    semaphore = anyio.Semaphore(max_concurrent)
+    expanded_results = [None] * len(results)
+
+    async def fetch_context(index: int, result: SemanticSearchResult):
+        """Fetch context for a single result (parallel with semaphore)."""
+        async with semaphore:
+            # Only expand if we have valid chunk offsets
+            if result.chunk_start_offset is None or result.chunk_end_offset is None:
+                # Keep result as-is without context expansion
+                expanded_results[index] = result
+                return
+
+            try:
+                chunk_context = await get_chunk_with_context(
+                    nc_client=client,
+                    user_id=username,
+                    # SemanticSearchResult.id is the int-narrowed
+                    # public form; get_chunk_with_context queries
+                    # Qdrant where doc_id is keyword-indexed as str.
+                    doc_id=str(result.id),
+                    doc_type=result.doc_type,
+                    chunk_start=result.chunk_start_offset,
+                    chunk_end=result.chunk_end_offset,
+                    page_number=result.page_number,
+                    chunk_index=result.chunk_index,
+                    total_chunks=result.total_chunks,
+                    context_chars=context_chars,
+                    # Forward the share-expanded owner set so context
+                    # expansion works for shared files (the per-file
+                    # file_accessible_by_id gate inside still enforces
+                    # access). Without this the lookup stays self-only
+                    # and silently falls back to the plain excerpt.
+                    accessible_owners=accessible_owners,
+                )
+
+                if chunk_context:
+                    # Create new result with context fields populated
+                    expanded_results[index] = SemanticSearchResult(
+                        id=result.id,
+                        doc_type=result.doc_type,
+                        title=result.title,
+                        category=result.category,
+                        excerpt=result.excerpt,
+                        score=result.score,
+                        # This site REBUILDS the row rather than
+                        # copying it, so any field omitted here
+                        # silently reverts to its default. Dropping
+                        # this one produced a response reporting
+                        # reranked=true whose every row carried
+                        # rerank_score=null. See
+                        # test_semantic_result_field_parity.py.
+                        rerank_score=result.rerank_score,
+                        relevance=result.relevance,
+                        relevance_source=result.relevance_source,
+                        chunk_index=result.chunk_index,
+                        total_chunks=result.total_chunks,
+                        chunk_start_offset=result.chunk_start_offset,
+                        chunk_end_offset=result.chunk_end_offset,
+                        page_number=result.page_number,
+                        page_end=result.page_end,
+                        url=result.url,
+                        file_url=result.file_url,
+                        # Context expansion fields
+                        has_context_expansion=True,
+                        marked_text=chunk_context.marked_text,
+                        before_context=chunk_context.before_context,
+                        after_context=chunk_context.after_context,
+                        has_before_truncation=chunk_context.has_before_truncation,
+                        has_after_truncation=chunk_context.has_after_truncation,
+                    )
+                    logger.debug(
+                        "Expanded context for %s %s",
+                        result.doc_type,
+                        result.id,
+                    )
+                else:
+                    # Context expansion failed, keep original result
+                    expanded_results[index] = result
+                    logger.debug(
+                        "Failed to expand context for %s %s, keeping original result",
+                        result.doc_type,
+                        result.id,
+                    )
+            except Exception as e:
+                # Context expansion failed, keep original result
+                expanded_results[index] = result
+                logger.warning(
+                    "Error expanding context for %s %s: %s",
+                    result.doc_type,
+                    result.id,
+                    e,
+                )
+
+    # Run all context fetches in parallel using anyio task group
+    async with anyio.create_task_group() as tg:
+        for idx, result in enumerate(results):
+            tg.start_soon(fetch_context, idx, result)
+
+    # Replace results with expanded versions
+    results = [r for r in expanded_results if r is not None]
+    logger.info(
+        "Context expansion completed: %d results with context",
+        len(results),
+    )
+    return results
+
+
+@require_scopes("semantic.read")
+@instrument_tool
+async def nc_semantic_search(  # NOSONAR(S107)
+    # S107 (too many parameters) is suppressed deliberately: for an MCP tool
+    # the parameter list IS the wire schema that MCPServer publishes to
+    # clients. Grouping these into a settings object to satisfy the rule
+    # would change the tool's advertised interface and break every caller,
+    # so the smell is inherent to the surface rather than to this function.
+    query: str,
+    ctx: Context,
+    limit: Annotated[int, Field(ge=1, le=100)] = 10,
+    doc_types: list[str] | None = None,
+    score_threshold: Annotated[float, Field(ge=0.0)] = 0.0,
+    min_relevance: Annotated[
+        float,
+        Field(
+            ge=0.0,
+            le=1.0,
+            description=(
+                "Drop results whose `relevance` falls below this. Unlike "
+                "`score_threshold` — which Qdrant applies to the raw "
+                "retrieval score BEFORE deduplication, reranking and "
+                "access verification, and which is therefore a recall cut "
+                "that can remove the row reranking would have promoted to "
+                "the top — this filters at the end, on the same [0,1] "
+                "number reported on each result. Use it to ask for 'only "
+                "results at least this relevant'. 0.0 (default) filters "
+                "nothing. Note that relevance is relative to what was "
+                "retrieved: search cannot abstain, so raising this is how "
+                "you get an empty answer for a query the corpus has no "
+                "answer to."
+            ),
+        ),
+    ] = 0.0,
+    fusion: str = "rrf",
+    granularity: Annotated[
+        Literal["chunk", "document"],
+        Field(
+            description=(
+                "Result granularity. 'chunk' (default) returns the "
+                "best-matching passages, so a long document can occupy "
+                "several result slots. 'document' returns one row per "
+                "document (its best-matching chunk), which is the right "
+                "shape for 'which files mention X' / 'list documents "
+                "about Y' — `limit` then counts documents rather than "
+                "passages. Use 'chunk' when you want the passage text to "
+                "answer from, 'document' when you want to enumerate "
+                "sources. Note 'document' improves result diversity, not "
+                "recall: a document whose best chunk ranks too low to be "
+                "retrieved is absent under both settings. Caveat when "
+                "combined with the default doc_types=None (search all "
+                "types): grouping keys on the numeric document id, which "
+                "is not unique across types, so a note and a file that "
+                "happen to share an id can be merged into one result. "
+                "Pass an explicit doc_types (e.g. ['file']) to avoid this."
+            ),
+        ),
+    ] = "chunk",
+    rerank: Annotated[
+        bool,
+        Field(
+            description=(
+                "Re-score the retrieved candidates with a cross-encoder "
+                "before returning them. This is the single largest "
+                "available improvement to result ordering — it reads each "
+                "candidate against the query directly, rather than relying "
+                "on the rank fusion that retrieval produced — and it is "
+                "most worth using for questions where the right answer may "
+                "not be the closest lexical or semantic match. It costs "
+                "roughly a second of extra latency, so prefer it for "
+                "precision-sensitive questions over quick lookups. "
+                "Requires the server to have reranking configured; asking "
+                "for it on a server without it is an error rather than a "
+                "silent downgrade. The response's `reranked` field reports "
+                "whether it actually applied — reranking never fails a "
+                "search, so a reranker outage degrades to retrieval order "
+                "with `reranked=false`."
+            ),
+        ),
+    ] = False,
+    include_context: bool = False,
+    context_chars: Annotated[int, Field(ge=0)] = 300,
+    modified_after: Annotated[
+        str | int | None,
+        Field(
+            description=(
+                "Only return documents modified at or after this time. "
+                "RFC 3339 / ISO 8601 datetime (e.g. '2026-01-01T00:00:00Z') "
+                "or Unix seconds. None = no lower bound."
+            ),
+        ),
+    ] = None,
+    modified_before: Annotated[
+        str | int | None,
+        Field(
+            description=(
+                "Only return documents modified at or before this time. "
+                "RFC 3339 / ISO 8601 datetime or Unix seconds. "
+                "None = no upper bound."
+            ),
+        ),
+    ] = None,
+    path_prefix: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Deprecated single-folder filter; prefer path_prefixes. "
+                "Restrict to files under this folder/path "
+                "(e.g. '/Projects/Reports'). Matches the file_path of "
+                "indexed files only, so setting it implicitly limits "
+                "results to files. None = no path filter."
+            ),
+        ),
+    ] = None,
+    path_prefixes: Annotated[
+        list[str] | None,
+        Field(
+            max_length=MAX_PATH_PREFIXES,
+            description=(
+                "Restrict to files under any of these folders/paths "
+                "(e.g. ['/Projects/Reports', '/Shared/Specs']). Folders are "
+                "OR-ed together. Matches the file_path of indexed files "
+                "only, so setting it implicitly limits results to files. "
+                f"Capped at {MAX_PATH_PREFIXES} folders to bound the "
+                "OR-filter width. None or empty = no path filter."
+            ),
+        ),
+    ] = None,
+) -> SemanticSearchResponse:
+    """
+    Search Nextcloud content across apps, indexed in Qdrant.
+
+    Qdrant native hybrid search combining dense semantic vectors (conceptual
+    similarity, natural language) and BM25 sparse vectors (precise
+    keyword/acronym matching), fused in the database for optimal relevance.
+    Documents indexed keyword-only (``keyword-index`` tag) carry no dense
+    vector and so contribute via the BM25 sparse side only. They appear in the
+    same unified result set.
+
+    Requires VECTOR_SYNC_ENABLED=true. Supports indexing of notes, files,
+    news items, deck cards, and mail messages.
+
+    Args:
+        query: Natural language or keyword search query
+        limit: Maximum number of results to return (default: 10)
+        doc_types: Document types to search (e.g., ["note", "file", "deck_card", "news_item", "mail_message"]). None = search all indexed types (default)
+        score_threshold: Minimum fusion score. NOT a relevance percentage —
+            the fused score is a rank artifact, not a calibrated measure.
+            With RRF the top result scores about 2/VECTOR_SEARCH_RRF_K
+            (~0.033 at the default k=60), so a "10% relevant" reading of
+            0.1 returns nothing at all. Leave at 0.0 (the default) and cut
+            by rank via `limit` instead. DBSF scores are distribution-
+            normalized and can exceed 1.0.
+            Two further reasons not to drive a UI control from this. It is
+            only meaningful for dense-only search, where the score is a
+            cosine similarity genuinely in [0, 1]. And it is applied by
+            Qdrant on the fused score BEFORE deduplication, reranking and
+            verify-on-read, so it is a recall cut taken before reranking can
+            reorder anything — a threshold that merely looks conservative
+            can silently remove the result the reranker would have promoted
+            to the top.
+        fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion)
+               RRF: Good general-purpose fusion using reciprocal ranks
+               DBSF: Uses distribution-based normalization, may better balance different score ranges
+        include_context: Whether to expand results with surrounding context (default: False)
+        context_chars: Number of characters to include before/after matched chunk (default: 300)
+        modified_after: Only return documents whose last-modified time is at or after this
+            instant. Accepts an RFC 3339 / ISO 8601 datetime (e.g. "2026-01-01T00:00:00Z",
+            a naive datetime is treated as UTC) or Unix seconds. None = no lower bound
+            (default).
+        modified_before: Only return documents whose last-modified time is at or before this
+            instant. Same formats as modified_after. None = no upper bound (default). Must be
+            >= modified_after when both are supplied.
+        path_prefix: Deprecated single-folder filter. Prefer path_prefixes. Restrict to files
+            under this folder/path (e.g. "/Projects/Reports"). Folded into path_prefixes.
+        path_prefixes: Restrict to files under any of these folders/paths (OR-ed), e.g.
+            ["/Projects/Reports", "/Shared/Specs"]. Matches the file_path of indexed files
+            only — setting it implicitly limits results to files. None/empty = no path filter
+            (default).
+
+    To scope a search to one or more folders, pass `path_prefixes` — that is
+    the supported way to search "just this subdirectory".
+
+    Returns:
+        SemanticSearchResponse with matching documents ranked by fusion scores.
+
+        Each result carries a `url` that opens that exact chunk in the
+        Astrolabe UI. Offer it alongside anything you quote from `excerpt`
+        so the user can read the passage in place. It is None when the
+        server has no browser-reachable Nextcloud base URL configured.
+
+        Verification fields (ADR-019 verify-on-read):
+        - verified_chunk_count: chunk rows that passed access checks
+          (sized in chunks, counted before trimming to ``limit``, so it
+          can exceed ``len(results)`` when a doc has multiple matching
+          chunks).
+        - dropped_document_count: unique ``(doc_id, doc_type)`` pairs
+          evicted as ghost records during this search (sized in
+          documents, not chunks).
+    """
+    settings = get_settings()
+    client = await get_client(ctx)
+    username = client.username
+
+    # Self-describing method label, mirroring BM25HybridSearchAlgorithm: the
+    # query always fuses dense + sparse prefetches (keyword-only documents
+    # contribute via the sparse side), so the label is always the fusion one.
+    # Derived from the BOUNDED label helper, not by interpolating the raw
+    # parameter. `fusion` is caller-controlled and is not validated until
+    # the algorithm is constructed inside the try below — but this value
+    # becomes a Prometheus label on every exit path including the error one,
+    # so an arbitrary string here would mint a permanent time series per
+    # distinct value. An invalid mode still raises when the algorithm is
+    # built; this only bounds what gets reported.
+    search_method = search_method_label(fusion)
+
+    logger.info(
+        "%s: query=%r, user=%s, limit=%d, score_threshold=%s, fusion=%s",
+        search_method,
+        query,
+        username,
+        limit,
+        score_threshold,
+        fusion,
+    )
+
+    # Check that vector sync is enabled — search queries the Qdrant index.
+    if not settings.vector_sync_enabled:
+        raise MCPError(
+            code=-1,
+            message="Cross-app search requires VECTOR_SYNC_ENABLED=true",
+        )
+
+    modified_after_ts, modified_before_ts = _parse_modified_bounds(
+        modified_after, modified_before
+    )
+
+    # Capability gate. Rejecting is deliberate: silently returning
+    # unreranked results to a caller that explicitly asked for reranking
+    # would be indistinguishable from a ranking bug. Servers advertise the
+    # capability on GET /api/v1/status so callers can check rather than
+    # probe. (A reranker that is configured but momentarily unavailable is
+    # a different case — that degrades, and the response says so.)
+    if rerank and not rerank_available(settings):
+        raise MCPError(
+            code=-1,
+            message=(
+                "Reranking is not configured on this server. Set "
+                "SEARCH_RERANK_ENABLED=true (requires "
+                "EMBEDDING_GATEWAY_URL), or omit rerank to use "
+                "retrieval ordering."
+            ),
+        )
+
+    # Merge the legacy single path_prefix and the path_prefixes list into one
+    # cleaned list, dropping blank/whitespace entries so an empty UI field
+    # doesn't filter out every result (ADR-027 Phase 2).
+    folder_prefixes = normalize_path_prefixes(path_prefix, path_prefixes)
+
+    # ADR-033 Phase 3: resolve each folder prefix to its canonical Nextcloud
+    # fileid so the query can scope by folder_ancestors — a true left-anchored
+    # containment that is correct for every reader of a shared folder (its
+    # fileid is user-agnostic). Best-effort: unresolved prefixes fall back to
+    # the file_path MatchText branch inside build_base_filter_conditions.
+    folder_ids = (
+        await resolve_prefix_folder_ids(client.webdav, path_prefixes=folder_prefixes)
+        if folder_prefixes
+        else []
+    )
+
+    # Expand the caller's identity to every owner whose content they
+    # have read access to via Nextcloud shares. Lets a user find files
+    # owners have shared with them without having to re-index those
+    # files under their own user_id. ``share_root_ids`` scopes that
+    # expansion to the shared subtrees, so one incoming share does not
+    # admit the whole owner's corpus as candidates for verify-on-read to
+    # reject (which silently shortened result pages).
+    accessible_scope = await list_accessible_scope(client.sharing, username)
+    accessible_owners = accessible_scope.owners
+    shared_root_ids = accessible_scope.share_root_ids
+
+    # Admin consent gate: restrict to source types the Astrolabe admin has
+    # approved (and that are installed for this user). This mirrors
+    # Astrolabe's own server-side enforcement but is independent because
+    # this tool queries Qdrant directly. ``None`` = no restriction
+    # (fail-open / Astrolabe predating this feature). An empty allow-set
+    # means the admin disabled every source.
+    #
+    # Perf trade-off (accepted): when Astrolabe is present and the caller
+    # passed no doc_types, narrowing turns ``None`` into a concrete list, so
+    # the search takes the per-type query branch (N queries) instead of the
+    # single cross-type query. N is the count of admin-approved types
+    # (typically 1-4), so the overhead is small; left as-is rather than
+    # adding a "search all approved in one query" fast path.
+    allowed = await allowed_doc_types(client, username)
+    if allowed is not None:
+        doc_types = _consent_narrowed_doc_types(doc_types, allowed)
+        if not doc_types:
+            logger.info(
+                "Semantic search short-circuited for user %s: no requested "
+                "doc_type is admin-approved for semantic search",
+                username,
+            )
+            # A short-circuit is a successful search that found nothing, not
+            # an error — recording it keeps the zero-result distribution
+            # honest about how often consent narrowing is the cause.
+            record_search_request(
+                surface="mcp",
+                algorithm=search_method,
+                granularity=granularity,
+                reranked="false",
+                status="success",
+                results_returned=0,
+            )
+            return SemanticSearchResponse(
+                results=[],
+                query=query,
+                total_found=0,
+                search_method=search_method,
+                granularity=granularity,
+                verified_chunk_count=0,
+                dropped_document_count=0,
+            )
+
+    # Search-metric state, recorded in the ``finally`` below so every exit —
+    # success, MCPError, or an unexpected raise — lands exactly one
+    # ``astrolabe_search_requests_total`` sample. Defaults describe the
+    # failure case; the success path overwrites them.
+    metric_status = "error"
+    metric_results: int | None = None
+    metric_dropped = 0
+    metric_reranked = "false"
+
+    try:
+        # The nc_semantic_search tool deliberately uses BM25-hybrid (dense +
+        # sparse with RRF/DBSF fusion) as the single tool-layer algorithm.
+        # SemanticSearchAlgorithm is not dead code — it backs the dense-only
+        # option that the API surface exposes explicitly
+        # (api/visualization.py). Both algorithms take accessible_owners,
+        # so ACL-aware search works on every surface.
+        search_algo = BM25HybridSearchAlgorithm(
+            score_threshold=score_threshold, fusion=fusion
+        )
+
+        overfetch = limit * 2
+        fetch_limit = _fetch_limit(
+            settings, overfetch=overfetch, rerank=rerank, granularity=granularity
+        )
+
+        retrieve_start = anyio.current_time()
+
+        # Execute search across requested document types
+        all_results = await _retrieve_candidates(
+            search_algo,
+            doc_types=doc_types,
+            fetch_limit=fetch_limit,
+            query=query,
+            user_id=username,
+            limit=fetch_limit,
+            score_threshold=score_threshold,
+            accessible_owners=accessible_owners,
+            shared_root_ids=shared_root_ids,
+            granularity=granularity,
+            modified_after=modified_after_ts,
+            modified_before=modified_before_ts,
+            path_prefixes=folder_prefixes,
+            path_prefix_folder_ids=folder_ids,
+        )
+
+        # Covers query embedding + Qdrant across every branch above, so the
+        # per-doc_type loop's higher cost is visible rather than averaged
+        # away against the single-query branch.
+        record_search_stage("mcp", "retrieve", anyio.current_time() - retrieve_start)
+
+        # Rerank the merged pool BEFORE verification, and before trimming to
+        # the verification budget. After the merge so one cross-encoder pass
+        # covers every doc_type — which also makes the merge meaningful,
+        # since fused scores from separate per-type queries were computed
+        # against different candidate populations and are not really
+        # comparable, whereas one reranker's scores are.
+        rerank_outcome = RERANK_SKIPPED
+        if rerank:
+            all_results, rerank_outcome, metric_reranked = await _rerank_pool(
+                all_results, query, settings=settings, verification_budget=limit * 2
+            )
+
+        # ADR-019: Verify-on-read. The vector index is a recall layer;
+        # Nextcloud is the source of truth for access. Filter out ghost
+        # records (deleted/unshared docs not yet reconciled by webhooks)
+        # BEFORE trimming to `limit`, so we don't lose accessible results
+        # to the limit slot that ghosts would otherwise occupy. We also
+        # run this BEFORE context expansion to avoid re-fetching docs that
+        # are about to be dropped. Pass the lifespan-owned task group so
+        # eviction of dropped points is fire-and-forget (does not block
+        # the response).
+        # Direct attribute access — both AppContext and OAuthAppContext
+        # expose ``eviction_task_group`` as a @property (see app.py),
+        # reading dynamically from the module-level VectorSyncState
+        # singleton. A defensive ``getattr(..., None)`` here would mask
+        # typos; if a future lifespan-context type forgets the property,
+        # AttributeError surfaces during the first search rather than
+        # silently degrading to inline eviction for the life of the
+        # process.
+        lifespan_ctx: Any = ctx.request_context.lifespan_context
+        eviction_task_group = lifespan_ctx.eviction_task_group
+        verification_start = anyio.current_time()
+        verified_results, dropped_count = await verify_search_results(
+            client,
+            all_results,
+            eviction_task_group=eviction_task_group,
+        )
+        record_search_stage("mcp", "verify", anyio.current_time() - verification_start)
+        verified_chunk_count = len(verified_results)
+        logger.debug(
+            "Verification completed in %.2fs: kept %d chunk(s), dropped %d doc(s)",
+            anyio.current_time() - verification_start,
+            verified_chunk_count,
+            dropped_count,
+        )
+        _log_top_results(verified_results)
+        # Relevance cut before the trim to `limit`, so a filtered search
+        # still fills the page with qualifying rows rather than returning
+        # whatever survives out of the top `limit`. Distinct from
+        # `score_threshold`, which Qdrant applies to the raw retrieval score
+        # before reranking has had a chance to reorder anything.
+        verified_results = filter_by_relevance(
+            verified_results,
+            min_relevance=min_relevance,
+            fusion=fusion,
+            algorithm="hybrid",
+            rerank_model=settings.search_rerank_model,
+        )
+        search_results = verified_results[:limit]
+
+        # Resolved once per search rather than once per result: it reads
+        # config and logs a warning when the base URL is unusable, and doing
+        # that per row would repeat the warning `limit` times.
+        browser_base = astrolabe_browser_base()
+
+        results = _to_semantic_results(
+            search_results,
+            browser_base=browser_base,
+            fusion=fusion,
+            rerank_model=settings.search_rerank_model,
+        )
+        # Expand results with surrounding context if requested
+        results = await _expand_results_with_context(
+            results,
+            include_context=include_context,
+            client=client,
+            username=username,
+            context_chars=context_chars,
+            accessible_owners=accessible_owners,
+        )
+
+        logger.info("Returning %d results from %s", len(results), search_method)
+
+        # Usage metering (Deck #67): record the query embedding's token
+        # count as a billable 'tokens_embedded' event. query_token_count
+        # is set by BM25HybridSearchAlgorithm during the search() above; the
+        # doc_types loop reuses one search_algo instance for the same query
+        # and the algorithm caches the dense embedding per query, so the
+        # query is embedded — and metered — exactly once regardless of how
+        # many doc_types were searched. See record_search_usage for the
+        # metric/privacy details.
+        #
+        # NOTE (v1 billing gap): this fires only on a fully successful
+        # search. If the query embed succeeded (provider billed the tokens,
+        # and Prometheus recorded them via record_embedding_tokens) but a
+        # later step (Qdrant/verify) raised, no tokens_embedded row is
+        # written — the embed cost is real but absent from the billing
+        # ledger. Acceptable for v1 (search failures are rare and the meter
+        # is not billed today); revisit if billing accuracy needs it.
+        await record_search_usage(
+            enabled=settings.usage_metering_enabled,
+            user_id=username,
+            fusion=fusion,
+            doc_types=doc_types,
+            token_count=search_algo.query_token_count,
+            surface="mcp",
+        )
+
+        metric_status = "success"
+        metric_results = len(results)
+        metric_dropped = dropped_count
+
+        return SemanticSearchResponse(
+            results=results,
+            query=query,
+            total_found=len(results),
+            search_method=search_method,
+            granularity=granularity,
+            reranked=rerank_outcome == RERANK_APPLIED,
+            rerank_model=(
+                settings.search_rerank_model
+                if rerank_outcome == RERANK_APPLIED
+                else None
+            ),
+            verified_chunk_count=verified_chunk_count,
+            dropped_document_count=dropped_count,
+        )
+
+    except ValueError as e:
+        error_msg = str(e)
+        if "No embedding provider configured" in error_msg:
+            raise MCPError(
+                code=-1,
+                message="Embedding service not configured. Set OLLAMA_BASE_URL environment variable.",
+            )
+        raise MCPError(code=-1, message=f"Configuration error: {error_msg}")
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error during search: {str(e)}")
+    except Exception as e:
+        # Genuinely-unexpected bucket (after the ValueError / RequestError
+        # cases above). We convert it to an MCPError so the reason survives:
+        # NextcloudMCPServer.call_tool maps that back to ToolError, which the
+        # SDK delivers as is_error=True content the model can read. Raised
+        # bare, mcp 2.x would replace the message with "Error executing tool
+        # <name>". Neither path logs a server-side traceback, so — like the
+        # sampling catch-all below — keep the stack here for triage.
+        logger.exception("Search error: %s", e)
+        raise MCPError(code=-1, message=f"Search failed: {str(e)}")
+    finally:
+        # One sample per search, on every exit path. Paired with the
+        # identical call in api/visualization.py so the MCP and HTTP
+        # entrypoints are directly comparable on one dashboard.
+        record_search_request(
+            surface="mcp",
+            algorithm=search_method,
+            granularity=granularity,
+            reranked=metric_reranked,
+            status=metric_status,
+            results_returned=metric_results,
+            verification_dropped=metric_dropped,
+        )
+
+
+@require_scopes("semantic.read")
+@instrument_tool
+async def nc_get_vector_sync_status(ctx: Context) -> VectorSyncStatusResponse:
+    """Get the current vector sync status.
+
+    Returns information about the vector sync process, including:
+    - Number of documents indexed in the vector database
+    - Number of documents pending processing
+    - Current sync status (idle, syncing, or disabled)
+
+    This is useful for determining when vector indexing is complete
+    after creating or updating content across all indexed apps.
+    """
+
+    # Check if vector sync is enabled (supports both old and new env var names)
+    settings = get_settings()
+    if not settings.vector_sync_enabled:
+        return VectorSyncStatusResponse(
+            indexed_count=0,
+            pending_count=0,
+            status="disabled",
+            enabled=False,
+        )
+
+    try:
+        # Get document receive stream from lifespan context. Direct
+        # attribute access matches the eviction_task_group pattern at
+        # ``nc_semantic_search`` (see comment there): both AppContext
+        # and OAuthAppContext define ``document_receive_stream``, so a
+        # missing attribute is a typo that should fail loudly. The
+        # value itself can legitimately be ``None`` before sync starts,
+        # which the check below handles.
+        # Outstanding-work view depends on the queue backend (Deck #183):
+        # memory → stream buffer depth; postgres → procrastinate job counts.
+        # Direct attribute access matches the eviction_task_group pattern at
+        # ``nc_semantic_search``: both AppContext and OAuthAppContext define
+        # these, so a missing attribute is a typo that should fail loudly.
+        from nextcloud_mcp_server.vector.ingest_status import (  # noqa: PLC0415
+            get_ingest_pending,
+        )
+
+        lifespan_ctx: Any = ctx.request_context.lifespan_context
+        pending = await get_ingest_pending(
+            task_producer=lifespan_ctx.task_producer,
+            document_receive_stream=lifespan_ctx.document_receive_stream,
+            ingest_queue=settings.ingest_queue,
+        )
+
+        # Corpus size: distinct documents AND total chunks (placeholders
+        # excluded). A single "indexed" figure is ambiguous because each
+        # document fans out to ~N chunks.
+        indexed_documents = 0
+        indexed_chunks = 0
+        hybrid_chunks = 0
+        estimated_vector_bytes = 0
+        try:
+            qdrant_client = await get_qdrant_client()
+            indexed_documents, indexed_chunks = await count_indexed(
+                qdrant_client, settings.get_collection_name()
+            )
+            # Hybrid chunks (dense-bearing) drive the vector-RAM footprint;
+            # keyword-index chunks are sparse-only and cost no dense RAM (#624).
+            # Shared helper so this and the HTTP status route can't drift.
+            (
+                hybrid_chunks,
+                estimated_vector_bytes,
+            ) = await estimate_hybrid_vector_bytes(
+                qdrant_client,
+                settings.get_collection_name(),
+                settings.vector_ram_hnsw_overhead_factor,
+            )
+        except Exception as e:
+            logger.warning("Failed to query Qdrant for indexed counts: %s", e)
+            # Continue with zeroed counts
+
+        # Determine status
+        status = "syncing" if pending.pending > 0 else "idle"
+
+        return VectorSyncStatusResponse(
+            indexed_documents=indexed_documents,
+            indexed_chunks=indexed_chunks,
+            indexed_count=indexed_chunks,  # deprecated alias
+            pending_count=pending.pending,
+            status=status,
+            enabled=True,
+            ingest_queue=settings.ingest_queue,
+            job_counts=pending.job_counts,
+            job_counts_by_queue=pending.job_counts_by_queue,
+            hybrid_chunks=hybrid_chunks,
+            estimated_vector_bytes=estimated_vector_bytes,
+        )
+
+    except Exception as e:
+        logger.error("Error getting vector sync status: %s", e)
+        raise MCPError(
+            code=-1,
+            message=f"Failed to retrieve vector sync status: {str(e)}",
+        )
+
+
 def configure_semantic_tools(mcp: MCPServer):
     """Configure semantic search tools for MCP server."""
 
-    @mcp.tool(
+    mcp.tool(
         title="Semantic Search",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Search doesn't modify data
             open_world_hint=True,  # Queries external Nextcloud service
         ),
-    )
-    @require_scopes("semantic.read")
-    @instrument_tool
-    async def nc_semantic_search(  # NOSONAR(S107)
-        # S107 (too many parameters) is suppressed deliberately: for an MCP tool
-        # the parameter list IS the wire schema that MCPServer publishes to
-        # clients. Grouping these into a settings object to satisfy the rule
-        # would change the tool's advertised interface and break every caller,
-        # so the smell is inherent to the surface rather than to this function.
-        query: str,
-        ctx: Context,
-        limit: Annotated[int, Field(ge=1, le=100)] = 10,
-        doc_types: list[str] | None = None,
-        score_threshold: Annotated[float, Field(ge=0.0)] = 0.0,
-        min_relevance: Annotated[
-            float,
-            Field(
-                ge=0.0,
-                le=1.0,
-                description=(
-                    "Drop results whose `relevance` falls below this. Unlike "
-                    "`score_threshold` — which Qdrant applies to the raw "
-                    "retrieval score BEFORE deduplication, reranking and "
-                    "access verification, and which is therefore a recall cut "
-                    "that can remove the row reranking would have promoted to "
-                    "the top — this filters at the end, on the same [0,1] "
-                    "number reported on each result. Use it to ask for 'only "
-                    "results at least this relevant'. 0.0 (default) filters "
-                    "nothing. Note that relevance is relative to what was "
-                    "retrieved: search cannot abstain, so raising this is how "
-                    "you get an empty answer for a query the corpus has no "
-                    "answer to."
-                ),
-            ),
-        ] = 0.0,
-        fusion: str = "rrf",
-        granularity: Annotated[
-            Literal["chunk", "document"],
-            Field(
-                description=(
-                    "Result granularity. 'chunk' (default) returns the "
-                    "best-matching passages, so a long document can occupy "
-                    "several result slots. 'document' returns one row per "
-                    "document (its best-matching chunk), which is the right "
-                    "shape for 'which files mention X' / 'list documents "
-                    "about Y' — `limit` then counts documents rather than "
-                    "passages. Use 'chunk' when you want the passage text to "
-                    "answer from, 'document' when you want to enumerate "
-                    "sources. Note 'document' improves result diversity, not "
-                    "recall: a document whose best chunk ranks too low to be "
-                    "retrieved is absent under both settings. Caveat when "
-                    "combined with the default doc_types=None (search all "
-                    "types): grouping keys on the numeric document id, which "
-                    "is not unique across types, so a note and a file that "
-                    "happen to share an id can be merged into one result. "
-                    "Pass an explicit doc_types (e.g. ['file']) to avoid this."
-                ),
-            ),
-        ] = "chunk",
-        rerank: Annotated[
-            bool,
-            Field(
-                description=(
-                    "Re-score the retrieved candidates with a cross-encoder "
-                    "before returning them. This is the single largest "
-                    "available improvement to result ordering — it reads each "
-                    "candidate against the query directly, rather than relying "
-                    "on the rank fusion that retrieval produced — and it is "
-                    "most worth using for questions where the right answer may "
-                    "not be the closest lexical or semantic match. It costs "
-                    "roughly a second of extra latency, so prefer it for "
-                    "precision-sensitive questions over quick lookups. "
-                    "Requires the server to have reranking configured; asking "
-                    "for it on a server without it is an error rather than a "
-                    "silent downgrade. The response's `reranked` field reports "
-                    "whether it actually applied — reranking never fails a "
-                    "search, so a reranker outage degrades to retrieval order "
-                    "with `reranked=false`."
-                ),
-            ),
-        ] = False,
-        include_context: bool = False,
-        context_chars: Annotated[int, Field(ge=0)] = 300,
-        modified_after: Annotated[
-            str | int | None,
-            Field(
-                description=(
-                    "Only return documents modified at or after this time. "
-                    "RFC 3339 / ISO 8601 datetime (e.g. '2026-01-01T00:00:00Z') "
-                    "or Unix seconds. None = no lower bound."
-                ),
-            ),
-        ] = None,
-        modified_before: Annotated[
-            str | int | None,
-            Field(
-                description=(
-                    "Only return documents modified at or before this time. "
-                    "RFC 3339 / ISO 8601 datetime or Unix seconds. "
-                    "None = no upper bound."
-                ),
-            ),
-        ] = None,
-        path_prefix: Annotated[
-            str | None,
-            Field(
-                description=(
-                    "Deprecated single-folder filter; prefer path_prefixes. "
-                    "Restrict to files under this folder/path "
-                    "(e.g. '/Projects/Reports'). Matches the file_path of "
-                    "indexed files only, so setting it implicitly limits "
-                    "results to files. None = no path filter."
-                ),
-            ),
-        ] = None,
-        path_prefixes: Annotated[
-            list[str] | None,
-            Field(
-                max_length=MAX_PATH_PREFIXES,
-                description=(
-                    "Restrict to files under any of these folders/paths "
-                    "(e.g. ['/Projects/Reports', '/Shared/Specs']). Folders are "
-                    "OR-ed together. Matches the file_path of indexed files "
-                    "only, so setting it implicitly limits results to files. "
-                    f"Capped at {MAX_PATH_PREFIXES} folders to bound the "
-                    "OR-filter width. None or empty = no path filter."
-                ),
-            ),
-        ] = None,
-    ) -> SemanticSearchResponse:
-        """
-        Search Nextcloud content across apps, indexed in Qdrant.
+    )(nc_semantic_search)
 
-        Qdrant native hybrid search combining dense semantic vectors (conceptual
-        similarity, natural language) and BM25 sparse vectors (precise
-        keyword/acronym matching), fused in the database for optimal relevance.
-        Documents indexed keyword-only (``keyword-index`` tag) carry no dense
-        vector and so contribute via the BM25 sparse side only. They appear in the
-        same unified result set.
-
-        Requires VECTOR_SYNC_ENABLED=true. Supports indexing of notes, files,
-        news items, deck cards, and mail messages.
-
-        Args:
-            query: Natural language or keyword search query
-            limit: Maximum number of results to return (default: 10)
-            doc_types: Document types to search (e.g., ["note", "file", "deck_card", "news_item", "mail_message"]). None = search all indexed types (default)
-            score_threshold: Minimum fusion score. NOT a relevance percentage —
-                the fused score is a rank artifact, not a calibrated measure.
-                With RRF the top result scores about 2/VECTOR_SEARCH_RRF_K
-                (~0.033 at the default k=60), so a "10% relevant" reading of
-                0.1 returns nothing at all. Leave at 0.0 (the default) and cut
-                by rank via `limit` instead. DBSF scores are distribution-
-                normalized and can exceed 1.0.
-                Two further reasons not to drive a UI control from this. It is
-                only meaningful for dense-only search, where the score is a
-                cosine similarity genuinely in [0, 1]. And it is applied by
-                Qdrant on the fused score BEFORE deduplication, reranking and
-                verify-on-read, so it is a recall cut taken before reranking can
-                reorder anything — a threshold that merely looks conservative
-                can silently remove the result the reranker would have promoted
-                to the top.
-            fusion: Fusion algorithm: "rrf" (Reciprocal Rank Fusion, default) or "dbsf" (Distribution-Based Score Fusion)
-                   RRF: Good general-purpose fusion using reciprocal ranks
-                   DBSF: Uses distribution-based normalization, may better balance different score ranges
-            include_context: Whether to expand results with surrounding context (default: False)
-            context_chars: Number of characters to include before/after matched chunk (default: 300)
-            modified_after: Only return documents whose last-modified time is at or after this
-                instant. Accepts an RFC 3339 / ISO 8601 datetime (e.g. "2026-01-01T00:00:00Z",
-                a naive datetime is treated as UTC) or Unix seconds. None = no lower bound
-                (default).
-            modified_before: Only return documents whose last-modified time is at or before this
-                instant. Same formats as modified_after. None = no upper bound (default). Must be
-                >= modified_after when both are supplied.
-            path_prefix: Deprecated single-folder filter. Prefer path_prefixes. Restrict to files
-                under this folder/path (e.g. "/Projects/Reports"). Folded into path_prefixes.
-            path_prefixes: Restrict to files under any of these folders/paths (OR-ed), e.g.
-                ["/Projects/Reports", "/Shared/Specs"]. Matches the file_path of indexed files
-                only — setting it implicitly limits results to files. None/empty = no path filter
-                (default).
-
-        To scope a search to one or more folders, pass `path_prefixes` — that is
-        the supported way to search "just this subdirectory".
-
-        Returns:
-            SemanticSearchResponse with matching documents ranked by fusion scores.
-
-            Each result carries a `url` that opens that exact chunk in the
-            Astrolabe UI. Offer it alongside anything you quote from `excerpt`
-            so the user can read the passage in place. It is None when the
-            server has no browser-reachable Nextcloud base URL configured.
-
-            Verification fields (ADR-019 verify-on-read):
-            - verified_chunk_count: chunk rows that passed access checks
-              (sized in chunks, counted before trimming to ``limit``, so it
-              can exceed ``len(results)`` when a doc has multiple matching
-              chunks).
-            - dropped_document_count: unique ``(doc_id, doc_type)`` pairs
-              evicted as ghost records during this search (sized in
-              documents, not chunks).
-        """
-        settings = get_settings()
-        client = await get_client(ctx)
-        username = client.username
-
-        # Self-describing method label, mirroring BM25HybridSearchAlgorithm: the
-        # query always fuses dense + sparse prefetches (keyword-only documents
-        # contribute via the sparse side), so the label is always the fusion one.
-        # Derived from the BOUNDED label helper, not by interpolating the raw
-        # parameter. `fusion` is caller-controlled and is not validated until
-        # the algorithm is constructed inside the try below — but this value
-        # becomes a Prometheus label on every exit path including the error one,
-        # so an arbitrary string here would mint a permanent time series per
-        # distinct value. An invalid mode still raises when the algorithm is
-        # built; this only bounds what gets reported.
-        search_method = search_method_label(fusion)
-
-        logger.info(
-            "%s: query=%r, user=%s, limit=%d, score_threshold=%s, fusion=%s",
-            search_method,
-            query,
-            username,
-            limit,
-            score_threshold,
-            fusion,
-        )
-
-        # Check that vector sync is enabled — search queries the Qdrant index.
-        if not settings.vector_sync_enabled:
-            raise MCPError(
-                code=-1,
-                message="Cross-app search requires VECTOR_SYNC_ENABLED=true",
-            )
-
-        # Normalize the RFC 3339 / Unix-seconds date bounds to int Unix seconds
-        # for the numeric ``modified_at`` Range filter (ADR-027). A bad format
-        # surfaces as a clean MCPError rather than a 500.
-        try:
-            modified_after_ts = parse_modified_timestamp(
-                modified_after, param_name="modified_after"
-            )
-            modified_before_ts = parse_modified_timestamp(
-                modified_before, param_name="modified_before"
-            )
-        except ValueError as exc:
-            raise MCPError(code=-1, message=str(exc)) from exc
-
-        # Cross-field invariant: a per-parameter pydantic ``Field`` constraint
-        # (validated by MCPServer from the signature) bounds each date on its own
-        # but cannot express the relationship between them. Guard it here so an
-        # inverted range surfaces a clean MCPError rather than silently
-        # returning zero results (ADR-027).
-        if (
-            modified_after_ts is not None
-            and modified_before_ts is not None
-            and modified_after_ts > modified_before_ts
-        ):
-            raise MCPError(
-                code=-1,
-                message=(
-                    "modified_after must be <= modified_before "
-                    f"(got modified_after={modified_after!r}, "
-                    f"modified_before={modified_before!r})"
-                ),
-            )
-
-        # Capability gate. Rejecting is deliberate: silently returning
-        # unreranked results to a caller that explicitly asked for reranking
-        # would be indistinguishable from a ranking bug. Servers advertise the
-        # capability on GET /api/v1/status so callers can check rather than
-        # probe. (A reranker that is configured but momentarily unavailable is
-        # a different case — that degrades, and the response says so.)
-        if rerank and not rerank_available(settings):
-            raise MCPError(
-                code=-1,
-                message=(
-                    "Reranking is not configured on this server. Set "
-                    "SEARCH_RERANK_ENABLED=true (requires "
-                    "EMBEDDING_GATEWAY_URL), or omit rerank to use "
-                    "retrieval ordering."
-                ),
-            )
-
-        # Merge the legacy single path_prefix and the path_prefixes list into one
-        # cleaned list, dropping blank/whitespace entries so an empty UI field
-        # doesn't filter out every result (ADR-027 Phase 2).
-        folder_prefixes = normalize_path_prefixes(path_prefix, path_prefixes)
-
-        # ADR-033 Phase 3: resolve each folder prefix to its canonical Nextcloud
-        # fileid so the query can scope by folder_ancestors — a true left-anchored
-        # containment that is correct for every reader of a shared folder (its
-        # fileid is user-agnostic). Best-effort: unresolved prefixes fall back to
-        # the file_path MatchText branch inside build_base_filter_conditions.
-        folder_ids = (
-            await resolve_prefix_folder_ids(
-                client.webdav, path_prefixes=folder_prefixes
-            )
-            if folder_prefixes
-            else []
-        )
-
-        # Expand the caller's identity to every owner whose content they
-        # have read access to via Nextcloud shares. Lets a user find files
-        # owners have shared with them without having to re-index those
-        # files under their own user_id. ``share_root_ids`` scopes that
-        # expansion to the shared subtrees, so one incoming share does not
-        # admit the whole owner's corpus as candidates for verify-on-read to
-        # reject (which silently shortened result pages).
-        accessible_scope = await list_accessible_scope(client.sharing, username)
-        accessible_owners = accessible_scope.owners
-        shared_root_ids = accessible_scope.share_root_ids
-
-        # Admin consent gate: restrict to source types the Astrolabe admin has
-        # approved (and that are installed for this user). This mirrors
-        # Astrolabe's own server-side enforcement but is independent because
-        # this tool queries Qdrant directly. ``None`` = no restriction
-        # (fail-open / Astrolabe predating this feature). An empty allow-set
-        # means the admin disabled every source.
-        #
-        # Perf trade-off (accepted): when Astrolabe is present and the caller
-        # passed no doc_types, narrowing turns ``None`` into a concrete list, so
-        # the search takes the per-type query branch (N queries) instead of the
-        # single cross-type query. N is the count of admin-approved types
-        # (typically 1-4), so the overhead is small; left as-is rather than
-        # adding a "search all approved in one query" fast path.
-        allowed = await allowed_doc_types(client, username)
-        if allowed is not None:
-            doc_types = _consent_narrowed_doc_types(doc_types, allowed)
-            if not doc_types:
-                logger.info(
-                    "Semantic search short-circuited for user %s: no requested "
-                    "doc_type is admin-approved for semantic search",
-                    username,
-                )
-                # A short-circuit is a successful search that found nothing, not
-                # an error — recording it keeps the zero-result distribution
-                # honest about how often consent narrowing is the cause.
-                record_search_request(
-                    surface="mcp",
-                    algorithm=search_method,
-                    granularity=granularity,
-                    reranked="false",
-                    status="success",
-                    results_returned=0,
-                )
-                return SemanticSearchResponse(
-                    results=[],
-                    query=query,
-                    total_found=0,
-                    search_method=search_method,
-                    granularity=granularity,
-                    verified_chunk_count=0,
-                    dropped_document_count=0,
-                )
-
-        # Search-metric state, recorded in the ``finally`` below so every exit —
-        # success, MCPError, or an unexpected raise — lands exactly one
-        # ``astrolabe_search_requests_total`` sample. Defaults describe the
-        # failure case; the success path overwrites them.
-        metric_status = "error"
-        metric_results: int | None = None
-        metric_dropped = 0
-        metric_reranked = "false"
-
-        try:
-            # The nc_semantic_search tool deliberately uses BM25-hybrid (dense +
-            # sparse with RRF/DBSF fusion) as the single tool-layer algorithm.
-            # SemanticSearchAlgorithm is not dead code — it backs the dense-only
-            # option that the API surface exposes explicitly
-            # (api/visualization.py). Both algorithms take accessible_owners,
-            # so ACL-aware search works on every surface.
-            search_algo = BM25HybridSearchAlgorithm(
-                score_threshold=score_threshold, fusion=fusion
-            )
-
-            # Reranking can only reorder what retrieval supplied, so it needs a
-            # deeper pool than the verification over-fetch. Never smaller than
-            # that over-fetch, and clamped for grouped search — see
-            # effective_pool_size.
-            overfetch = limit * 2
-            fetch_limit = (
-                effective_pool_size(
-                    settings,
-                    floor=overfetch,
-                    grouped=granularity == GRANULARITY_DOCUMENT,
-                )
-                if rerank
-                else overfetch
-            )
-
-            retrieve_start = anyio.current_time()
-
-            # Execute search across requested document types
-            # If doc_types is None, search all indexed types (cross-app search)
-            # If doc_types is a list, search only those types
-            all_results = []
-
-            if doc_types is None:
-                # Cross-app search: search all indexed types
-                # Get unverified results from Qdrant.
-                #
-                # NOTE (ADR-019): Over-fetch by 2× to absorb ghost-record drops
-                # during verify-on-read. When ghost density is high (e.g. a
-                # large board share was just revoked) this budget can still
-                # under-deliver against the requested ``limit``; the index
-                # self-heals via lazy eviction so subsequent searches recover.
-                # The 2× factor is a deliberate v1 trade-off — raising it
-                # costs Nextcloud round-trips on every search. Trim to
-                # ``limit`` happens AFTER verification.
-                # TODO(ADR-019): expose VERIFICATION_OVERFETCH so operators
-                # with persistent high ghost density can tune this without a
-                # code change.
-                unverified_results = await search_algo.search(
-                    query=query,
-                    user_id=username,
-                    limit=fetch_limit,
-                    doc_type=None,  # Signal to search all types
-                    score_threshold=score_threshold,
-                    accessible_owners=accessible_owners,
-                    shared_root_ids=shared_root_ids,
-                    granularity=granularity,
-                    modified_after=modified_after_ts,
-                    modified_before=modified_before_ts,
-                    path_prefixes=folder_prefixes,
-                    path_prefix_folder_ids=folder_ids,
-                )
-                all_results.extend(unverified_results)
-            else:
-                # Search specific document types.
-                #
-                # Per-Qdrant-query cost: this branch issues ONE query per
-                # requested doc_type, each capped at `limit * 2`. With N
-                # types in `doc_types`, the pre-merge result pool is
-                # therefore N × `limit * 2`, NOT `limit * 2`. That is more
-                # Qdrant work than the cross-app branch above (which makes a
-                # single multi-type query returning `limit * 2` total).
-                #
-                # The post-merge trim below clamps the pool back down to
-                # `limit * 2` so verification (and the Nextcloud round-trips
-                # it triggers) sees the same budget as the cross-app branch.
-                # The per-type Qdrant cost remains higher; pre-trim cost
-                # scales linearly with len(doc_types).
-                for dtype in doc_types:
-                    unverified_results = await search_algo.search(
-                        query=query,
-                        user_id=username,
-                        limit=fetch_limit,
-                        doc_type=dtype,
-                        score_threshold=score_threshold,
-                        accessible_owners=accessible_owners,
-                        shared_root_ids=shared_root_ids,
-                        granularity=granularity,
-                        modified_after=modified_after_ts,
-                        modified_before=modified_before_ts,
-                        path_prefixes=folder_prefixes,
-                        path_prefix_folder_ids=folder_ids,
-                    )
-                    all_results.extend(unverified_results)
-
-                # Sort combined results by score, then cap to `limit * 2` to
-                # match the cross-app branch's over-fetch budget. Without this
-                # cap, N requested doc_types × `limit * 2` results would all
-                # flow into verification, multiplying the Nextcloud round-trip
-                # cost by N.
-                all_results.sort(key=lambda r: r.score, reverse=True)
-                all_results = all_results[:fetch_limit]
-
-            # Covers query embedding + Qdrant across every branch above, so the
-            # per-doc_type loop's higher cost is visible rather than averaged
-            # away against the single-query branch.
-            record_search_stage(
-                "mcp", "retrieve", anyio.current_time() - retrieve_start
-            )
-
-            # Rerank the merged pool BEFORE verification, and before trimming to
-            # the verification budget. After the merge so one cross-encoder pass
-            # covers every doc_type — which also makes the merge meaningful,
-            # since fused scores from separate per-type queries were computed
-            # against different candidate populations and are not really
-            # comparable, whereas one reranker's scores are.
-            rerank_outcome = RERANK_SKIPPED
-            if rerank:
-                all_results, rerank_outcome = await rerank_results(
-                    all_results, query, settings=settings, surface="mcp"
-                )
-                # SKIPPED (nothing to reorder) reports as "false", not
-                # "unavailable" — otherwise every query returning 0-1 rows would
-                # register as a reranker outage.
-                metric_reranked = {
-                    RERANK_APPLIED: "true",
-                    RERANK_DEGRADED: "unavailable",
-                }.get(rerank_outcome, "false")
-                # Back down to the verification budget so verify-on-read still
-                # sees the same number of Nextcloud round-trips as an unreranked
-                # search — the deep pool exists for the reranker, not for
-                # verification.
-                all_results = all_results[: limit * 2]
-
-            # ADR-019: Verify-on-read. The vector index is a recall layer;
-            # Nextcloud is the source of truth for access. Filter out ghost
-            # records (deleted/unshared docs not yet reconciled by webhooks)
-            # BEFORE trimming to `limit`, so we don't lose accessible results
-            # to the limit slot that ghosts would otherwise occupy. We also
-            # run this BEFORE context expansion to avoid re-fetching docs that
-            # are about to be dropped. Pass the lifespan-owned task group so
-            # eviction of dropped points is fire-and-forget (does not block
-            # the response).
-            # Direct attribute access — both AppContext and OAuthAppContext
-            # expose ``eviction_task_group`` as a @property (see app.py),
-            # reading dynamically from the module-level VectorSyncState
-            # singleton. A defensive ``getattr(..., None)`` here would mask
-            # typos; if a future lifespan-context type forgets the property,
-            # AttributeError surfaces during the first search rather than
-            # silently degrading to inline eviction for the life of the
-            # process.
-            lifespan_ctx: Any = ctx.request_context.lifespan_context
-            eviction_task_group = lifespan_ctx.eviction_task_group
-            verification_start = anyio.current_time()
-            verified_results, dropped_count = await verify_search_results(
-                client,
-                all_results,
-                eviction_task_group=eviction_task_group,
-            )
-            record_search_stage(
-                "mcp", "verify", anyio.current_time() - verification_start
-            )
-            verified_chunk_count = len(verified_results)
-            logger.debug(
-                "Verification completed in %.2fs: kept %d chunk(s), dropped %d doc(s)",
-                anyio.current_time() - verification_start,
-                verified_chunk_count,
-                dropped_count,
-            )
-            # Safe to log titles now: these results passed verify-on-read, so the
-            # caller is confirmed to have access (unverified titles were never
-            # logged — see the search algorithms).
-            if verified_results:
-                logger.debug(
-                    "Top verified results: %s",
-                    ", ".join(
-                        f"{r.doc_type}_{r.id} (score={r.score:.3f}, title='{r.title}')"
-                        for r in verified_results[:5]
-                    ),
-                )
-            # Relevance cut before the trim to `limit`, so a filtered search
-            # still fills the page with qualifying rows rather than returning
-            # whatever survives out of the top `limit`. Distinct from
-            # `score_threshold`, which Qdrant applies to the raw retrieval score
-            # before reranking has had a chance to reorder anything.
-            verified_results = filter_by_relevance(
-                verified_results,
-                min_relevance=min_relevance,
-                fusion=fusion,
-                algorithm="hybrid",
-                rerank_model=settings.search_rerank_model,
-            )
-            search_results = verified_results[:limit]
-
-            # Resolved once per search rather than once per result: it reads
-            # config and logs a warning when the base URL is unusable, and doing
-            # that per row would repeat the warning `limit` times.
-            browser_base = astrolabe_browser_base()
-
-            # Convert SearchResult objects to SemanticSearchResult for response.
-            # SearchResult.id is `str` (Qdrant keyword-indexed payload), but
-            # every currently indexed type uses numeric ids and the MCP response
-            # model narrows to `int`. Casting here makes the narrowing explicit
-            # and surfaces any future non-numeric-id type as a loud failure at
-            # the boundary instead of silently widening the public API.
-            results = []
-            for r in search_results:
-                try:
-                    narrowed_id = int(r.id)
-                except (TypeError, ValueError) as e:
-                    # Re-raise with explicit context so the outer handler logs
-                    # something operators can act on (the generic "Search
-                    # failed: invalid literal for int()" is opaque).
-                    raise TypeError(
-                        f"SemanticSearchResult.id must be int-convertible, "
-                        f"got {r.id!r} (type={type(r.id).__name__}) for "
-                        f"doc_type={r.doc_type!r}. This indicates a doc_type "
-                        f"with non-numeric ids has been indexed but the "
-                        f"public response model has not been widened. Add "
-                        f"the doc_type to the SemanticSearchResult.id type "
-                        f"or convert at the verifier layer."
-                    ) from e
-                relevance, relevance_source = relevance_for(
-                    rerank_score=r.rerank_score,
-                    score=r.score,
-                    fusion=fusion,
-                    # This tool always runs BM25HybridSearchAlgorithm, so the
-                    # fused-score branch is the right one; it never takes the
-                    # dense-only cosine path.
-                    algorithm="hybrid",
-                    rerank_model=settings.search_rerank_model,
-                )
-                metadata = r.metadata or {}
-                # board_id is the only one of Astrolabe's access-recheck
-                # identifiers the chunk payload carries (see
-                # build_search_result_from_point); the others fall through to
-                # its MCP backstop. Tested against None rather than falsiness to
-                # match chunk_url's handling of a legitimate 0 — Nextcloud ids
-                # are 1-based, so this is consistency, not a live bug.
-                board_id = metadata.get("board_id")
-                link_extra = None if board_id is None else {"board_id": str(board_id)}
-                results.append(
-                    SemanticSearchResult(
-                        id=narrowed_id,
-                        doc_type=r.doc_type,
-                        title=r.title,
-                        rerank_score=r.rerank_score,
-                        relevance=relevance,
-                        relevance_source=relevance_source,
-                        category=metadata.get("category", ""),
-                        excerpt=r.excerpt,
-                        score=r.score,
-                        chunk_index=metadata.get("chunk_index", 0),
-                        total_chunks=metadata.get("total_chunks", 1),
-                        chunk_start_offset=r.chunk_start_offset,
-                        chunk_end_offset=r.chunk_end_offset,
-                        page_number=r.page_number,
-                        page_end=r.page_end,
-                        url=chunk_url(
-                            browser_base,
-                            doc_type=r.doc_type,
-                            doc_id=narrowed_id,
-                            chunk_start=r.chunk_start_offset,
-                            chunk_end=r.chunk_end_offset,
-                            title=r.title,
-                            path=metadata.get("path"),
-                            page_number=r.page_number,
-                            chunk_index=metadata.get("chunk_index"),
-                            total_chunks=metadata.get("total_chunks"),
-                            extra=link_extra,
-                        ),
-                        # For doc_type="file" the doc_id IS the Nextcloud
-                        # fileid (vector/scanner.py indexes it as such), so the
-                        # /f/ link needs no extra lookup. Guarded on doc_type
-                        # because no other indexed type's id is a fileid — a
-                        # note id fed to /f/ would open an unrelated file or
-                        # 404.
-                        file_url=(
-                            file_url(browser_base, narrowed_id)
-                            if r.doc_type == "file"
-                            else None
-                        ),
-                    )
-                )
-
-            # Expand results with surrounding context if requested
-            if include_context and results:
-                logger.info(
-                    "Expanding %d results with context (context_chars=%d)",
-                    len(results),
-                    context_chars,
-                )
-
-                # Fetch context for all results in parallel.
-                # Limit concurrent requests to prevent connection pool exhaustion.
-                #
-                # Intentionally distinct from settings.verification_concurrency:
-                # that knob bounds Nextcloud round-trips during access
-                # verification (ADR-019); this one bounds context-expansion
-                # fetches that run only when ``include_context=True``. Operators
-                # tuning one rarely want the other in lockstep, so they share
-                # the default value (20) but not the env var.
-                max_concurrent = 20
-                semaphore = anyio.Semaphore(max_concurrent)
-                expanded_results = [None] * len(results)
-
-                async def fetch_context(index: int, result: SemanticSearchResult):
-                    """Fetch context for a single result (parallel with semaphore)."""
-                    async with semaphore:
-                        # Only expand if we have valid chunk offsets
-                        if (
-                            result.chunk_start_offset is None
-                            or result.chunk_end_offset is None
-                        ):
-                            # Keep result as-is without context expansion
-                            expanded_results[index] = result
-                            return
-
-                        try:
-                            chunk_context = await get_chunk_with_context(
-                                nc_client=client,
-                                user_id=username,
-                                # SemanticSearchResult.id is the int-narrowed
-                                # public form; get_chunk_with_context queries
-                                # Qdrant where doc_id is keyword-indexed as str.
-                                doc_id=str(result.id),
-                                doc_type=result.doc_type,
-                                chunk_start=result.chunk_start_offset,
-                                chunk_end=result.chunk_end_offset,
-                                page_number=result.page_number,
-                                chunk_index=result.chunk_index,
-                                total_chunks=result.total_chunks,
-                                context_chars=context_chars,
-                                # Forward the share-expanded owner set so context
-                                # expansion works for shared files (the per-file
-                                # file_accessible_by_id gate inside still enforces
-                                # access). Without this the lookup stays self-only
-                                # and silently falls back to the plain excerpt.
-                                accessible_owners=accessible_owners,
-                            )
-
-                            if chunk_context:
-                                # Create new result with context fields populated
-                                expanded_results[index] = SemanticSearchResult(
-                                    id=result.id,
-                                    doc_type=result.doc_type,
-                                    title=result.title,
-                                    category=result.category,
-                                    excerpt=result.excerpt,
-                                    score=result.score,
-                                    # This site REBUILDS the row rather than
-                                    # copying it, so any field omitted here
-                                    # silently reverts to its default. Dropping
-                                    # this one produced a response reporting
-                                    # reranked=true whose every row carried
-                                    # rerank_score=null. See
-                                    # test_semantic_result_field_parity.py.
-                                    rerank_score=result.rerank_score,
-                                    relevance=result.relevance,
-                                    relevance_source=result.relevance_source,
-                                    chunk_index=result.chunk_index,
-                                    total_chunks=result.total_chunks,
-                                    chunk_start_offset=result.chunk_start_offset,
-                                    chunk_end_offset=result.chunk_end_offset,
-                                    page_number=result.page_number,
-                                    page_end=result.page_end,
-                                    url=result.url,
-                                    file_url=result.file_url,
-                                    # Context expansion fields
-                                    has_context_expansion=True,
-                                    marked_text=chunk_context.marked_text,
-                                    before_context=chunk_context.before_context,
-                                    after_context=chunk_context.after_context,
-                                    has_before_truncation=chunk_context.has_before_truncation,
-                                    has_after_truncation=chunk_context.has_after_truncation,
-                                )
-                                logger.debug(
-                                    "Expanded context for %s %s",
-                                    result.doc_type,
-                                    result.id,
-                                )
-                            else:
-                                # Context expansion failed, keep original result
-                                expanded_results[index] = result
-                                logger.debug(
-                                    "Failed to expand context for %s %s, "
-                                    "keeping original result",
-                                    result.doc_type,
-                                    result.id,
-                                )
-                        except Exception as e:
-                            # Context expansion failed, keep original result
-                            expanded_results[index] = result
-                            logger.warning(
-                                "Error expanding context for %s %s: %s",
-                                result.doc_type,
-                                result.id,
-                                e,
-                            )
-
-                # Run all context fetches in parallel using anyio task group
-                async with anyio.create_task_group() as tg:
-                    for idx, result in enumerate(results):
-                        tg.start_soon(fetch_context, idx, result)
-
-                # Replace results with expanded versions
-                results = [r for r in expanded_results if r is not None]
-                logger.info(
-                    "Context expansion completed: %d results with context",
-                    len(results),
-                )
-
-            logger.info("Returning %d results from %s", len(results), search_method)
-
-            # Usage metering (Deck #67): record the query embedding's token
-            # count as a billable 'tokens_embedded' event. query_token_count
-            # is set by BM25HybridSearchAlgorithm during the search() above; the
-            # doc_types loop reuses one search_algo instance for the same query
-            # and the algorithm caches the dense embedding per query, so the
-            # query is embedded — and metered — exactly once regardless of how
-            # many doc_types were searched. See record_search_usage for the
-            # metric/privacy details.
-            #
-            # NOTE (v1 billing gap): this fires only on a fully successful
-            # search. If the query embed succeeded (provider billed the tokens,
-            # and Prometheus recorded them via record_embedding_tokens) but a
-            # later step (Qdrant/verify) raised, no tokens_embedded row is
-            # written — the embed cost is real but absent from the billing
-            # ledger. Acceptable for v1 (search failures are rare and the meter
-            # is not billed today); revisit if billing accuracy needs it.
-            await record_search_usage(
-                enabled=settings.usage_metering_enabled,
-                user_id=username,
-                fusion=fusion,
-                doc_types=doc_types,
-                token_count=search_algo.query_token_count,
-                surface="mcp",
-            )
-
-            metric_status = "success"
-            metric_results = len(results)
-            metric_dropped = dropped_count
-
-            return SemanticSearchResponse(
-                results=results,
-                query=query,
-                total_found=len(results),
-                search_method=search_method,
-                granularity=granularity,
-                reranked=rerank_outcome == RERANK_APPLIED,
-                rerank_model=(
-                    settings.search_rerank_model
-                    if rerank_outcome == RERANK_APPLIED
-                    else None
-                ),
-                verified_chunk_count=verified_chunk_count,
-                dropped_document_count=dropped_count,
-            )
-
-        except ValueError as e:
-            error_msg = str(e)
-            if "No embedding provider configured" in error_msg:
-                raise MCPError(
-                    code=-1,
-                    message="Embedding service not configured. Set OLLAMA_BASE_URL environment variable.",
-                )
-            raise MCPError(code=-1, message=f"Configuration error: {error_msg}")
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error during search: {str(e)}")
-        except Exception as e:
-            # Genuinely-unexpected bucket (after the ValueError / RequestError
-            # cases above). We convert it to an MCPError so the reason survives:
-            # NextcloudMCPServer.call_tool maps that back to ToolError, which the
-            # SDK delivers as is_error=True content the model can read. Raised
-            # bare, mcp 2.x would replace the message with "Error executing tool
-            # <name>". Neither path logs a server-side traceback, so — like the
-            # sampling catch-all below — keep the stack here for triage.
-            logger.exception("Search error: %s", e)
-            raise MCPError(code=-1, message=f"Search failed: {str(e)}")
-        finally:
-            # One sample per search, on every exit path. Paired with the
-            # identical call in api/visualization.py so the MCP and HTTP
-            # entrypoints are directly comparable on one dashboard.
-            record_search_request(
-                surface="mcp",
-                algorithm=search_method,
-                granularity=granularity,
-                reranked=metric_reranked,
-                status=metric_status,
-                results_returned=metric_results,
-                verification_dropped=metric_dropped,
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Check Indexing Status",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Only checks status
             open_world_hint=True,
         ),
-    )
-    @require_scopes("semantic.read")
-    @instrument_tool
-    async def nc_get_vector_sync_status(ctx: Context) -> VectorSyncStatusResponse:
-        """Get the current vector sync status.
-
-        Returns information about the vector sync process, including:
-        - Number of documents indexed in the vector database
-        - Number of documents pending processing
-        - Current sync status (idle, syncing, or disabled)
-
-        This is useful for determining when vector indexing is complete
-        after creating or updating content across all indexed apps.
-        """
-
-        # Check if vector sync is enabled (supports both old and new env var names)
-        settings = get_settings()
-        if not settings.vector_sync_enabled:
-            return VectorSyncStatusResponse(
-                indexed_count=0,
-                pending_count=0,
-                status="disabled",
-                enabled=False,
-            )
-
-        try:
-            # Get document receive stream from lifespan context. Direct
-            # attribute access matches the eviction_task_group pattern at
-            # ``nc_semantic_search`` (see comment there): both AppContext
-            # and OAuthAppContext define ``document_receive_stream``, so a
-            # missing attribute is a typo that should fail loudly. The
-            # value itself can legitimately be ``None`` before sync starts,
-            # which the check below handles.
-            # Outstanding-work view depends on the queue backend (Deck #183):
-            # memory → stream buffer depth; postgres → procrastinate job counts.
-            # Direct attribute access matches the eviction_task_group pattern at
-            # ``nc_semantic_search``: both AppContext and OAuthAppContext define
-            # these, so a missing attribute is a typo that should fail loudly.
-            from nextcloud_mcp_server.vector.ingest_status import (  # noqa: PLC0415
-                get_ingest_pending,
-            )
-
-            lifespan_ctx: Any = ctx.request_context.lifespan_context
-            pending = await get_ingest_pending(
-                task_producer=lifespan_ctx.task_producer,
-                document_receive_stream=lifespan_ctx.document_receive_stream,
-                ingest_queue=settings.ingest_queue,
-            )
-
-            # Corpus size: distinct documents AND total chunks (placeholders
-            # excluded). A single "indexed" figure is ambiguous because each
-            # document fans out to ~N chunks.
-            indexed_documents = 0
-            indexed_chunks = 0
-            hybrid_chunks = 0
-            estimated_vector_bytes = 0
-            try:
-                qdrant_client = await get_qdrant_client()
-                indexed_documents, indexed_chunks = await count_indexed(
-                    qdrant_client, settings.get_collection_name()
-                )
-                # Hybrid chunks (dense-bearing) drive the vector-RAM footprint;
-                # keyword-index chunks are sparse-only and cost no dense RAM (#624).
-                # Shared helper so this and the HTTP status route can't drift.
-                (
-                    hybrid_chunks,
-                    estimated_vector_bytes,
-                ) = await estimate_hybrid_vector_bytes(
-                    qdrant_client,
-                    settings.get_collection_name(),
-                    settings.vector_ram_hnsw_overhead_factor,
-                )
-            except Exception as e:
-                logger.warning("Failed to query Qdrant for indexed counts: %s", e)
-                # Continue with zeroed counts
-
-            # Determine status
-            status = "syncing" if pending.pending > 0 else "idle"
-
-            return VectorSyncStatusResponse(
-                indexed_documents=indexed_documents,
-                indexed_chunks=indexed_chunks,
-                indexed_count=indexed_chunks,  # deprecated alias
-                pending_count=pending.pending,
-                status=status,
-                enabled=True,
-                ingest_queue=settings.ingest_queue,
-                job_counts=pending.job_counts,
-                job_counts_by_queue=pending.job_counts_by_queue,
-                hybrid_chunks=hybrid_chunks,
-                estimated_vector_bytes=estimated_vector_bytes,
-            )
-
-        except Exception as e:
-            logger.error("Error getting vector sync status: %s", e)
-            raise MCPError(
-                code=-1,
-                message=f"Failed to retrieve vector sync status: {str(e)}",
-            )
+    )(nc_get_vector_sync_status)

--- a/tests/unit/test_tool_registration_isolation.py
+++ b/tests/unit/test_tool_registration_isolation.py
@@ -1,0 +1,73 @@
+"""Module-level tool functions must not leak state between MCPServer instances.
+
+Tools used to be closures rebuilt on every ``configure_*_tools(mcp)`` call, so
+each server got its own function objects. They are now defined at module level
+and registered with ``mcp.tool(...)(fn)``, which means every server shares the
+*same* function objects.
+
+That matters because ``configure_app_tools`` calls
+``stamp_required_capability(tool.fn, ...)``, which **mutates the function**. It
+is safe only because the stamp is idempotent and deterministic per app — it sets
+the attribute once, and a tool belongs to exactly one app. This pins that
+reasoning, since the failure mode is a server hiding tools based on another
+server's capability gate rather than an exception.
+"""
+
+import pytest
+from mcp.server.mcpserver import MCPServer
+
+from nextcloud_mcp_server.capabilities import get_required_capability
+from nextcloud_mcp_server.server import AVAILABLE_APPS, configure_app_tools
+
+pytestmark = pytest.mark.unit
+
+
+def _tools(app: str) -> list:
+    mcp = MCPServer(f"srv-{app}")
+    configure_app_tools(mcp, app)
+    return mcp._tool_manager.list_tools()
+
+
+def test_capability_stamps_do_not_leak_between_servers():
+    """Two servers configured with different apps keep separate gates."""
+    notes = _tools("notes")
+    deck = _tools("deck")
+
+    assert {get_required_capability(t.fn)[0] for t in notes} == {"notes"}
+    assert {get_required_capability(t.fn)[0] for t in deck} == {"deck"}
+
+
+def test_reconfiguring_the_same_app_is_stable():
+    """Registering twice must not accumulate or rewrite gates.
+
+    A non-idempotent stamp would show up here as a second server disagreeing
+    with the first about the same tool.
+    """
+    first = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+    second = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+
+    assert first == second
+
+
+def test_per_tool_capability_still_beats_the_module_stamp():
+    """``@require_capability`` with a version floor must survive registration.
+
+    ``deck_assign_dependent_card`` declares a Deck 1.18.0 floor; the whole-app
+    stamp must not overwrite it with the unversioned gate.
+    """
+    gates = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+
+    assert gates["deck_assign_dependent_card"] == ("deck", "1.18.0", None)
+
+
+def test_every_app_registers_at_least_one_tool():
+    """A registration call that silently no-ops would be invisible otherwise.
+
+    The extraction rewrote every ``configure_*_tools`` body, and a dropped
+    ``mcp.tool(...)(fn)`` line removes a tool from the wire without failing
+    anything else.
+    """
+    for app in AVAILABLE_APPS:
+        mcp = MCPServer("srv")
+        configure_app_tools(mcp, app)
+        assert mcp._tool_manager.list_tools(), f"{app} registered no tools"


### PR DESCRIPTION
Clears the 5 CRITICAL `python:S3776` findings SonarCloud reports on #1433.
They are **pre-existing debt**, surfaced there only because that PR's rename
sweep touched lines inside these functions, and they do not fail the gate
(S3776 is maintainability, not reliability).

Stacked on #1433 because it must build on the v2 renames — and per CLAUDE.md,
stacking is also what gets this PR the full CI matrix rather than only the
always-on checks.

| file | before | after (max in file) |
|---|---:|---:|
| `server/cookbook.py` | 153 | **9** |
| `server/semantic.py` | 80 | **13** |
| `server/notes.py` | 76 | **9** |
| `server/deck.py` | 68 | **11** |
| `server/mail.py` | 45 | **10** |

## Two causes, two fixes

**Four of them measure the registration idiom, not the code.** Every tool is a
nested closure, and S3776 charges a nesting penalty per level, so the outer
function accumulates the complexity of every tool it contains — even though no
individual tool in `notes`/`deck`/`mail` exceeds McCabe 8. Lifting the 71 tools
to module level and registering them with `mcp.tool(...)(fn)` is
behaviour-identical: `@mcp.tool()` is simply the outermost decorator, applied
last either way. Resource functions stay nested — they call
`current_context(mcp)` and genuinely close over it.

**`semantic.py` is real complexity.** `nc_semantic_search` was an 850-line
function, so extraction alone would have *relocated* the finding rather than
fixed it. Pulled out five cohesive pieces it was carrying — candidate retrieval,
result mapping, context expansion, the ADR-027 date-bound guards, and the rerank
pass — each documented with why it moved.

Cookbook's two outliers (`create_recipe` 16, `update_recipe` 20 on their own)
needed a separate pass: ten sequential `if field:` assignments became one
field-mapping table, and the HTTP-status `if/elif` chains a status→message dict.
**The create/update guard difference is preserved and now stated explicitly** —
create drops falsy values, update drops only `None`, so passing an empty string
still *clears* a field rather than being ignored.

## The one real risk, and its test

Module-level functions are shared across `MCPServer` instances, and
`configure_app_tools` calls `stamp_required_capability(tool.fn, ...)` which
**mutates the function**. That is safe only because the stamp is idempotent and
deterministic per app.

I verified it rather than assuming, and pinned it in
`tests/unit/test_tool_registration_isolation.py`: two servers configured with
different apps keep separate gates, re-registration is stable, and a per-tool
`@require_capability("deck", min_version="1.18.0")` still beats the whole-app
stamp. The failure mode would be a server hiding tools based on *another*
server's capability gate — silent, not an exception.

## Verification

- 160 tools register, zero name mismatches, zero duplicates, `deck` still
  exactly 38; 75 capability-gated tools carry the right app keys.
- `ruff`, `ruff format`, `ty` clean.
- Complexity measured with a cognitive-complexity calculator written for this,
  calibrated against Sonar's own numbers: **exact** matches on cookbook (153),
  notes (76) and mail (45), within 5% on deck and semantic.
- Tests run in CI, not locally, per the repo owner's instruction.

## Deliberately out of scope

`calendar.py` (McCabe 127), `collectives.py`, `news.py` and `webdav.py` have the
same shape but were not flagged, because Sonar attributes S3776 to changed lines
only. Fixing exactly the flagged five is somewhat arbitrary; worth the same
treatment later. Noted on card 1203.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iCzZAuCMsZS7UJYfy3htd
