### PR TITLE
ci: let the Claude review fan out, and make an unfinished review visible

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,7 +60,29 @@ jobs:
             `mcp__github_comment__update_claude_comment`. Do not create a
             separate PR comment — the tracking comment is the sticky review.
 
+            If you cannot finish the review — a tool call is denied, the diff is
+            too large, you run short of turns — say so explicitly in the tracking
+            comment, naming what blocked you. Do NOT leave it showing an unticked
+            "Review in progress" checklist. The `claude-review` check goes green
+            whenever this action completes, so a half-written comment reads as a
+            finished review that found nothing, and the PR looks reviewed when it
+            was not.
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          #
+          # `Task` is allowed so the reviewer can fan a large diff out into
+          # parallel sub-reviews. Without it a big PR fails *silently*: on #1437
+          # (~3800 lines across 6 files) the reviewer announced "dispatched
+          # parallel sub-reviews", had all 12 of those calls denied, and then
+          # finished with `is_error: false` — leaving a sticky comment that still
+          # read "Review in progress" with an unticked checklist and no findings.
+          # The `claude-review` check went green regardless, so the PR looked
+          # reviewed when nothing had been reviewed. Two runs failed identically.
+          #
+          # Cost note: fan-out means several sub-agents per review. A single
+          # non-fanned-out run on that PR cost ~$1, so budget for a multiple of
+          # that on large diffs; drop `Task` again if that proves too expensive
+          # (accepting that large PRs then need splitting to be reviewable).
+          claude_args: '--allowed-tools "Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
Based on `master`, independent of stack #1438, so it can merge first — the other
two PRs then rebase onto it and get a review that can actually complete.

## The bug

The `claude-review` allowlist had no `Task`, so on a large diff the reviewer
fails **silently**.

On #1437 (~3800 lines across 6 files) it announced *"Dispatched parallel
sub-reviews of the three logical chunks"*, had all **12** of those calls denied
(`permission_denials_count: 12`), then exited `is_error: false` after 17 turns —
leaving the sticky comment reading:

```
### Review in progress
- [x] Gather context
- [ ] Review server/cookbook.py refactor
- [ ] Review server/semantic.py extraction
- [ ] ...
- [ ] Post final review

Dispatched parallel sub-reviews … Will compile findings once they land.
```

…and no findings, ever.

**The check went `SUCCESS` regardless**, because it reports that the *action*
ran, not that a *review* happened. So the PR presented as reviewed-and-clean
while nothing had been reviewed. Two runs failed identically ~2 minutes apart
(2m20s and 1m49s), so it is not a flake.

Smaller diffs are unaffected: #1433 reviewed fine because it never chose to fan
out. That is what makes this nasty — it only bites the PRs most in need of
review, and it looks like success.

## The fix

**1. Allow `Task`.** The reviewer already tries to fan out on large diffs; this
lets it. Effective allowlist was `Glob, Grep, LS, Read,
mcp__github_comment__update_claude_comment, Bash(git …)` plus the workflow's `gh`
commands — no `Task`.

**2. Tell it to report an unfinished review.** Its system prompt already asks it
to explain missing permissions ("*so that the user can update your
`--allowedTools`*") and it did not. The prompt now says explicitly: if you cannot
finish, name what blocked you in the tracking comment, and do not leave an
unticked "Review in progress" checklist.

That second change is the more general one. `Task` fixes this instance; a green
check over a half-written comment is the failure *class*, and the next cause
won't be permissions.

## Cost — worth a conscious decision

Fan-out means several sub-agents per review. The single non-fanned-out run on
#1437 cost **~$1**, so budget a multiple of that on large diffs. Recorded in an
inline comment next to the setting, with the fallback stated: drop `Task` again
if it proves too expensive, accepting that large PRs then need splitting to be
reviewable at all.

## Verification

- YAML parses; `claude_args` and the `on.pull_request.types: [opened,
  synchronize]` triggers confirmed unchanged via `yq`.
- No application code touched — workflow only.
- The real proof is behavioural: once merged and the stack is rebased, #1437's
  review should complete instead of stalling. Worth watching that specific PR
  rather than assuming.

## Follow-up

`reopened` is not in the trigger types, which is why closing/reopening a PR
re-runs `Tests` but not the review. Not changed here — adding it would re-run a
billed review on every reopen. Noting it because it cost me a confusing round.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iCzZAuCMsZS7UJYfy3htd
