### PR TITLE
refactor(server): lift notes + mail tool registration to module level

### DIFF
--- a/nextcloud_mcp_server/server/mail.py
+++ b/nextcloud_mcp_server/server/mail.py
@@ -85,382 +85,524 @@ def _cap_attachment_content(content: str | None) -> str | None:
     return content
 
 
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_accounts(ctx: Context) -> ListAccountsResponse:
+    """List the user's configured mail accounts (requires mail.read scope)."""
+    client = await get_client(ctx)
+    try:
+        accounts_data = await client.mail.list_accounts()
+        accounts = [MailAccount(**a) for a in accounts_data]
+        return ListAccountsResponse(results=accounts, total_count=len(accounts))
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing accounts: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list accounts: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_mailboxes(
+    account_id: int, ctx: Context
+) -> ListMailboxesResponse:
+    """List the mailboxes (folders) of a mail account (requires mail.read scope).
+
+    Args:
+        account_id: Account ID (from nc_mail_list_accounts)
+
+    Returns:
+        ListMailboxesResponse with mailboxes. Use a mailbox's ``database_id``
+        with nc_mail_list_messages.
+    """
+    client = await get_client(ctx)
+    try:
+        mailboxes_data = await client.mail.get_mailboxes(account_id)
+        mailboxes = [MailMailbox(**m) for m in mailboxes_data]
+        return ListMailboxesResponse(results=mailboxes, total_count=len(mailboxes))
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing mailboxes: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list mailboxes: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_list_messages(
+    mailbox_id: int,
+    ctx: Context,
+    cursor: int | None = None,
+    search_filter: str | None = None,
+    limit: int = 20,
+) -> ListMessagesResponse:
+    """List message envelopes in a mailbox, newest first (requires mail.read scope).
+
+    Reads cached envelope metadata (fast). Does not fetch bodies. Use
+    nc_mail_get_message to fetch a full body.
+
+    Args:
+        mailbox_id: Numeric mailbox id (``database_id`` from nc_mail_list_mailboxes)
+        cursor: Pagination cursor from a prior page
+        search_filter: Optional filter query — space-separated ``token:value``
+            terms, ANDed together. Supported tokens:
+
+            * ``is:``/``not:`` — ``read``, ``unread``, ``starred``,
+              ``answered``, ``important``
+            * ``from:``, ``to:``, ``cc:``, ``bcc:`` — substring match on the
+              address or display name
+            * ``subject:``, ``body:`` — substring match (``body:`` searches
+              IMAP server-side and is slower)
+            * ``tags:`` — comma-separated tag *database ids* (not names,
+              get one from nc_mail_create_tag)
+            * ``start:``, ``end:`` — date bounds
+            * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
+              ``answered``/``important``/``attachments``
+            * ``match:anyof`` — OR the from/to/cc/bcc/subject/body terms
+              instead of ANDing them
+
+            Example: ``is:unread from:alice subject:invoice``
+        limit: Max messages to return (1-100, default 20)
+
+    Returns:
+        ListMessagesResponse with message summaries. ``has_more`` is a
+        heuristic (true when exactly ``limit`` messages were returned), so it
+        can be a false positive when a mailbox holds exactly ``limit``
+        messages. Page with ``cursor`` and stop on an empty result.
+    """
+    client = await get_client(ctx)
+    # Clamp to the same window the client/OCS API enforce so the has_more
+    # heuristic compares against the limit actually applied (a caller passing
+    # limit<=0 otherwise gets a misleading count).
+    effective_limit = min(max(1, limit), 100)
+    try:
+        messages_data = await client.mail.list_messages(
+            mailbox_id,
+            cursor=cursor,
+            search_filter=search_filter,
+            limit=effective_limit,
+        )
+        messages = [MailMessageSummary(**m) for m in messages_data]
+        return ListMessagesResponse(
+            results=messages,
+            total_count=len(messages),
+            has_more=len(messages) == effective_limit,
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error listing messages: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to list messages: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_message(message_id: int, ctx: Context) -> GetMessageResponse:
+    """Get a single mail message with its full body (requires mail.read scope).
+
+    The Mail app fetches the body from IMAP server-side.
+
+    Args:
+        message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
+
+    Returns:
+        GetMessageResponse with the full message including body and attachments.
+        Attachments with ``id: null`` are inline body parts and cannot be
+        fetched via nc_mail_get_attachment (which requires a string id).
+    """
+    client = await get_client(ctx)
+    try:
+        message_data = await client.mail.get_message(message_id)
+        # An empty payload (OCS data=null with a 200 meta) would make
+        # MailMessage(**{}) raise an uncaught ValidationError; treat it as
+        # not-found instead.
+        if not message_data:
+            raise MCPError(code=-1, message=f"Message {message_id} not found")
+        message = MailMessage(**message_data)
+        return GetMessageResponse(message=message)
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error getting message {message_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Message {message_id} not found")
+        raise MCPError(
+            code=-1,
+            message=f"Failed to get message {message_id}: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.send")
+@instrument_tool
+async def nc_mail_send_message(
+    account_id: int,
+    to: str,
+    subject: str,
+    body: str,
+    ctx: Context,
+    is_html: bool = False,
+    cc: str | None = None,
+    bcc: str | None = None,
+    references: str | None = None,
+) -> SendMessageResponse:
+    """Send an email through a configured Nextcloud Mail account (requires mail.send scope).
+
+    The ``From:`` identity is derived by the Mail app from ``account_id``.
+    Recipients are specified as JSON arrays of ``{"label": "...", "email": "..."}``
+    objects.  Example for ``to``::
+
+        [{"label": "John Doe", "email": "john@example.com"}]
+
+    Args:
+        account_id: Mail account ID to send from (from nc_mail_list_accounts)
+        to: JSON array of To recipients
+        subject: Email subject
+        body: Email body (plain text unless is_html is true)
+        is_html: Whether body contains HTML (default false)
+        cc: Optional JSON array of CC recipients
+        bcc: Optional JSON array of BCC recipients
+        references: Optional RFC 2822 Message-ID for reply threading
+
+    Returns:
+        SendMessageResponse with success status and optional message
+    """
+    client = await get_client(ctx)
+    try:
+        to_list = json.loads(to)  # `to` is a required JSON-array string
+        cc_list = json.loads(cc) if isinstance(cc, str) else (cc or [])
+        bcc_list = json.loads(bcc) if isinstance(bcc, str) else (bcc or [])
+
+        await client.mail.send_message(
+            account_id=account_id,
+            to=to_list,
+            subject=subject,
+            body=body,
+            is_html=is_html,
+            cc=cc_list or None,
+            bcc=bcc_list or None,
+            references=references or None,
+        )
+        return SendMessageResponse(success=True, message="Message sent successfully")
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error sending message: {str(e)}")
+    except HTTPStatusError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Failed to send message: {e.response.status_code} "
+            f"{e.response.text[:500]}",
+        )
+    except json.JSONDecodeError as e:
+        raise MCPError(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_attachment(
+    message_id: int, attachment_id: str, ctx: Context
+) -> GetAttachmentResponse:
+    """Get a single mail attachment's metadata and content (requires mail.read scope).
+
+    Args:
+        message_id: Numeric message id
+        attachment_id: Attachment id (a string, from the message's attachments)
+
+    Returns:
+        GetAttachmentResponse with name, mime, size, and content. ``content``
+        is the attachment body base64-encoded. Large attachments produce a
+        correspondingly large response, so prefer the ``size`` from the
+        message's attachment list before fetching.
+    """
+    client = await get_client(ctx)
+    try:
+        data = await client.mail.get_attachment(message_id, attachment_id)
+        return GetAttachmentResponse(
+            name=data.get("name"),
+            mime=data.get("mime"),
+            size=data.get("size"),
+            content=_cap_attachment_content(data.get("content")),
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error getting attachment: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message="Attachment not found")
+        raise MCPError(
+            code=-1,
+            message=f"Failed to get attachment: {e.response.status_code}",
+        )
+
+
+@require_scopes("mail.read")
+@instrument_tool
+async def nc_mail_get_message_source(
+    message_id: int, ctx: Context
+) -> GetMessageSourceResponse:
+    """Get a message's raw RFC 2822 source (requires mail.read scope).
+
+    The complete original message including all headers — use this when the
+    parsed view from nc_mail_get_message is not enough (checking
+    Received/DKIM headers, List-Unsubscribe, custom X- headers).
+
+    Args:
+        message_id: Numeric message id
+
+    Returns:
+        GetMessageSourceResponse with the raw source. ``source`` is None if
+        the Mail app returns no content for the message.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"getting source of message {message_id}"):
+        source = await client.mail.get_message_raw(message_id)
+    return GetMessageSourceResponse(message_id=message_id, source=source)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_set_flags(
+    message_id: int,
+    ctx: Context,
+    seen: bool | None = None,
+    flagged: bool | None = None,
+    answered: bool | None = None,
+    junk: bool | None = None,
+) -> MailActionResponse:
+    """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
+
+    Only the flags you pass are changed. Omitted ones are left alone. Use
+    ``seen=True`` after processing a message so it does not look unhandled,
+    and ``seen=False`` to mark it unread again.
+
+    Args:
+        message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
+        seen: Mark read (True) or unread (False)
+        flagged: Star (True) or unstar (False)
+        answered: Mark as replied-to
+        junk: Mark as junk/spam. Unlike the others this is a custom IMAP
+            keyword, so the mail server silently ignores it unless the
+            mailbox permits custom keywords.
+
+    Returns:
+        MailActionResponse naming the flags that were applied. Passing no
+        flags at all is an error rather than a silent no-op.
+    """
+    flags = {
+        name: value
+        for name, value in (
+            ("seen", seen),
+            ("flagged", flagged),
+            ("answered", answered),
+            ("$junk", junk),
+        )
+        if value is not None
+    }
+    if not flags:
+        raise MCPError(
+            code=-1,
+            message="No flags given; pass at least one of seen, flagged, "
+            "answered, junk",
+        )
+
+    client = await get_client(ctx)
+    with _mail_errors(f"setting flags on message {message_id}"):
+        await client.mail.set_flags(message_id, flags)
+
+    applied = ", ".join(f"{name}={value}" for name, value in flags.items())
+    return MailActionResponse(
+        message_id=message_id, message=f"Flags updated: {applied}"
+    )
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_create_tag(
+    display_name: Annotated[str, Field(max_length=128)],
+    ctx: Context,
+    color: str = DEFAULT_TAG_COLOR,
+) -> MailTagResponse:
+    """Create a mail tag, or return the existing one (requires mail.write scope).
+
+    Tags are IMAP keywords private to the user. The Mail app has no
+    tag-listing endpoint, so this is also how you look a tag up — calling it
+    for an existing name returns that tag rather than creating a duplicate.
+
+    Names normalise to a lowercase IMAP label with spaces as underscores, so
+    "AI Index", "ai index" and "ai_index" are all the same tag.
+
+    Args:
+        display_name: Tag name (max 128 characters)
+        color: Hex colour, applied only when the tag is created
+
+    Returns:
+        MailTagResponse with the tag, including the ``id`` needed for the
+        ``tags:<id>`` filter of nc_mail_list_messages.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"creating tag {display_name!r}"):
+        tag = await client.mail.ensure_tag(display_name, color)
+    return MailTagResponse(tag=MailTag(**tag))
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_set_tag(
+    message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+) -> MailTagResponse:
+    """Assign a tag to a message (requires mail.write scope).
+
+    The tag is created if it does not exist yet, so this works without a
+    separate nc_mail_create_tag call.
+
+    Args:
+        message_id: Numeric message id
+        tag: Tag display name
+
+    Returns:
+        MailTagResponse with the assigned tag.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"tagging message {message_id} with {tag!r}"):
+        # Resolve through create-or-get: it yields the server's own
+        # imapLabel, so we never have to re-derive the label encoding.
+        tag_data = await client.mail.ensure_tag(tag)
+        await client.mail.set_tag(message_id, tag_data["imapLabel"])
+    return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_remove_tag(
+    message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
+) -> MailTagResponse:
+    """Remove a tag from a message (requires mail.write scope).
+
+    Args:
+        message_id: Numeric message id
+        tag: Tag display name
+
+    Returns:
+        MailTagResponse with the removed tag.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"removing tag {tag!r} from message {message_id}"):
+        # Resolve the same way as tagging. For a name that has never been
+        # used this creates an empty tag row before removing nothing from
+        # the message — harmless, and it keeps one resolution path.
+        tag_data = await client.mail.ensure_tag(tag)
+        await client.mail.remove_tag(message_id, tag_data["imapLabel"])
+    return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_move_message(
+    message_id: int, destination_mailbox_id: int, ctx: Context
+) -> MailActionResponse:
+    """Move a message to another mailbox (requires mail.write scope).
+
+    Args:
+        message_id: Numeric message id
+        destination_mailbox_id: Target mailbox id (``database_id`` from
+            nc_mail_list_mailboxes)
+
+    Returns:
+        MailActionResponse. ``message_id`` echoes what you passed in and is
+        **stale on return**: the move invalidates it, and the message is
+        re-cached in the destination under a new id. Re-list the destination
+        mailbox to address it again — do not retry this call with the same
+        id, which fails rather than repeating the move.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"moving message {message_id}"):
+        await client.mail.move_message(message_id, destination_mailbox_id)
+    return MailActionResponse(
+        message_id=message_id,
+        message=f"Message moved to mailbox {destination_mailbox_id}",
+    )
+
+
+@require_scopes("mail.write")
+@instrument_tool
+async def nc_mail_delete_message(message_id: int, ctx: Context) -> MailActionResponse:
+    """Delete a message (requires mail.write scope).
+
+    The Mail app moves the message to the account's trash mailbox, or
+    expunges it permanently if it is already in trash. Requires the account
+    to have a trash mailbox — without one the Mail app rejects the call
+    ("No trash mailbox configured").
+
+    Args:
+        message_id: Numeric message id
+
+    Returns:
+        MailActionResponse confirming the deletion. ``message_id`` echoes
+        the input and is **stale on return** — trashing re-caches the
+        message under a new id, so retrying with the same id fails.
+    """
+    client = await get_client(ctx)
+    with _mail_errors(f"deleting message {message_id}"):
+        await client.mail.delete_message(message_id)
+    return MailActionResponse(message_id=message_id, message="Message deleted")
+
+
 def configure_mail_tools(mcp: MCPServer):
     """Configure Mail app MCP tools (read, send, flags, tags, move, delete)."""
 
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Accounts",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_accounts(ctx: Context) -> ListAccountsResponse:
-        """List the user's configured mail accounts (requires mail.read scope)."""
-        client = await get_client(ctx)
-        try:
-            accounts_data = await client.mail.list_accounts()
-            accounts = [MailAccount(**a) for a in accounts_data]
-            return ListAccountsResponse(results=accounts, total_count=len(accounts))
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error listing accounts: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list accounts: {e.response.status_code}",
-            )
+    )(nc_mail_list_accounts)
 
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Mailboxes",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_mailboxes(
-        account_id: int, ctx: Context
-    ) -> ListMailboxesResponse:
-        """List the mailboxes (folders) of a mail account (requires mail.read scope).
+    )(nc_mail_list_mailboxes)
 
-        Args:
-            account_id: Account ID (from nc_mail_list_accounts)
-
-        Returns:
-            ListMailboxesResponse with mailboxes. Use a mailbox's ``database_id``
-            with nc_mail_list_messages.
-        """
-        client = await get_client(ctx)
-        try:
-            mailboxes_data = await client.mail.get_mailboxes(account_id)
-            mailboxes = [MailMailbox(**m) for m in mailboxes_data]
-            return ListMailboxesResponse(results=mailboxes, total_count=len(mailboxes))
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error listing mailboxes: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list mailboxes: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="List Mail Messages",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_list_messages(
-        mailbox_id: int,
-        ctx: Context,
-        cursor: int | None = None,
-        search_filter: str | None = None,
-        limit: int = 20,
-    ) -> ListMessagesResponse:
-        """List message envelopes in a mailbox, newest first (requires mail.read scope).
+    )(nc_mail_list_messages)
 
-        Reads cached envelope metadata (fast). Does not fetch bodies. Use
-        nc_mail_get_message to fetch a full body.
-
-        Args:
-            mailbox_id: Numeric mailbox id (``database_id`` from nc_mail_list_mailboxes)
-            cursor: Pagination cursor from a prior page
-            search_filter: Optional filter query — space-separated ``token:value``
-                terms, ANDed together. Supported tokens:
-
-                * ``is:``/``not:`` — ``read``, ``unread``, ``starred``,
-                  ``answered``, ``important``
-                * ``from:``, ``to:``, ``cc:``, ``bcc:`` — substring match on the
-                  address or display name
-                * ``subject:``, ``body:`` — substring match (``body:`` searches
-                  IMAP server-side and is slower)
-                * ``tags:`` — comma-separated tag *database ids* (not names,
-                  get one from nc_mail_create_tag)
-                * ``start:``, ``end:`` — date bounds
-                * ``flags:`` — comma-separated ``read``/``unread``/``starred``/
-                  ``answered``/``important``/``attachments``
-                * ``match:anyof`` — OR the from/to/cc/bcc/subject/body terms
-                  instead of ANDing them
-
-                Example: ``is:unread from:alice subject:invoice``
-            limit: Max messages to return (1-100, default 20)
-
-        Returns:
-            ListMessagesResponse with message summaries. ``has_more`` is a
-            heuristic (true when exactly ``limit`` messages were returned), so it
-            can be a false positive when a mailbox holds exactly ``limit``
-            messages. Page with ``cursor`` and stop on an empty result.
-        """
-        client = await get_client(ctx)
-        # Clamp to the same window the client/OCS API enforce so the has_more
-        # heuristic compares against the limit actually applied (a caller passing
-        # limit<=0 otherwise gets a misleading count).
-        effective_limit = min(max(1, limit), 100)
-        try:
-            messages_data = await client.mail.list_messages(
-                mailbox_id,
-                cursor=cursor,
-                search_filter=search_filter,
-                limit=effective_limit,
-            )
-            messages = [MailMessageSummary(**m) for m in messages_data]
-            return ListMessagesResponse(
-                results=messages,
-                total_count=len(messages),
-                has_more=len(messages) == effective_limit,
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error listing messages: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to list messages: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Message",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_message(message_id: int, ctx: Context) -> GetMessageResponse:
-        """Get a single mail message with its full body (requires mail.read scope).
+    )(nc_mail_get_message)
 
-        The Mail app fetches the body from IMAP server-side.
-
-        Args:
-            message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
-
-        Returns:
-            GetMessageResponse with the full message including body and attachments.
-            Attachments with ``id: null`` are inline body parts and cannot be
-            fetched via nc_mail_get_attachment (which requires a string id).
-        """
-        client = await get_client(ctx)
-        try:
-            message_data = await client.mail.get_message(message_id)
-            # An empty payload (OCS data=null with a 200 meta) would make
-            # MailMessage(**{}) raise an uncaught ValidationError; treat it as
-            # not-found instead.
-            if not message_data:
-                raise MCPError(code=-1, message=f"Message {message_id} not found")
-            message = MailMessage(**message_data)
-            return GetMessageResponse(message=message)
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error getting message {message_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Message {message_id} not found")
-            raise MCPError(
-                code=-1,
-                message=f"Failed to get message {message_id}: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Send Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Stages a new outbox entry each call (ADR-017)
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.send")
-    @instrument_tool
-    async def nc_mail_send_message(
-        account_id: int,
-        to: str,
-        subject: str,
-        body: str,
-        ctx: Context,
-        is_html: bool = False,
-        cc: str | None = None,
-        bcc: str | None = None,
-        references: str | None = None,
-    ) -> SendMessageResponse:
-        """Send an email through a configured Nextcloud Mail account (requires mail.send scope).
+    )(nc_mail_send_message)
 
-        The ``From:`` identity is derived by the Mail app from ``account_id``.
-        Recipients are specified as JSON arrays of ``{"label": "...", "email": "..."}``
-        objects.  Example for ``to``::
-
-            [{"label": "John Doe", "email": "john@example.com"}]
-
-        Args:
-            account_id: Mail account ID to send from (from nc_mail_list_accounts)
-            to: JSON array of To recipients
-            subject: Email subject
-            body: Email body (plain text unless is_html is true)
-            is_html: Whether body contains HTML (default false)
-            cc: Optional JSON array of CC recipients
-            bcc: Optional JSON array of BCC recipients
-            references: Optional RFC 2822 Message-ID for reply threading
-
-        Returns:
-            SendMessageResponse with success status and optional message
-        """
-        client = await get_client(ctx)
-        try:
-            to_list = json.loads(to)  # `to` is a required JSON-array string
-            cc_list = json.loads(cc) if isinstance(cc, str) else (cc or [])
-            bcc_list = json.loads(bcc) if isinstance(bcc, str) else (bcc or [])
-
-            await client.mail.send_message(
-                account_id=account_id,
-                to=to_list,
-                subject=subject,
-                body=body,
-                is_html=is_html,
-                cc=cc_list or None,
-                bcc=bcc_list or None,
-                references=references or None,
-            )
-            return SendMessageResponse(
-                success=True, message="Message sent successfully"
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error sending message: {str(e)}")
-        except HTTPStatusError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Failed to send message: {e.response.status_code} "
-                f"{e.response.text[:500]}",
-            )
-        except json.JSONDecodeError as e:
-            raise MCPError(code=-1, message=f"Invalid JSON in recipient list: {str(e)}")
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Attachment",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_attachment(
-        message_id: int, attachment_id: str, ctx: Context
-    ) -> GetAttachmentResponse:
-        """Get a single mail attachment's metadata and content (requires mail.read scope).
+    )(nc_mail_get_attachment)
 
-        Args:
-            message_id: Numeric message id
-            attachment_id: Attachment id (a string, from the message's attachments)
-
-        Returns:
-            GetAttachmentResponse with name, mime, size, and content. ``content``
-            is the attachment body base64-encoded. Large attachments produce a
-            correspondingly large response, so prefer the ``size`` from the
-            message's attachment list before fetching.
-        """
-        client = await get_client(ctx)
-        try:
-            data = await client.mail.get_attachment(message_id, attachment_id)
-            return GetAttachmentResponse(
-                name=data.get("name"),
-                mime=data.get("mime"),
-                size=data.get("size"),
-                content=_cap_attachment_content(data.get("content")),
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error getting attachment: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message="Attachment not found")
-            raise MCPError(
-                code=-1,
-                message=f"Failed to get attachment: {e.response.status_code}",
-            )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Mail Message Source",
         annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
-    )
-    @require_scopes("mail.read")
-    @instrument_tool
-    async def nc_mail_get_message_source(
-        message_id: int, ctx: Context
-    ) -> GetMessageSourceResponse:
-        """Get a message's raw RFC 2822 source (requires mail.read scope).
+    )(nc_mail_get_message_source)
 
-        The complete original message including all headers — use this when the
-        parsed view from nc_mail_get_message is not enough (checking
-        Received/DKIM headers, List-Unsubscribe, custom X- headers).
-
-        Args:
-            message_id: Numeric message id
-
-        Returns:
-            GetMessageSourceResponse with the raw source. ``source`` is None if
-            the Mail app returns no content for the message.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"getting source of message {message_id}"):
-            source = await client.mail.get_message_raw(message_id)
-        return GetMessageSourceResponse(message_id=message_id, source=source)
-
-    @mcp.tool(
+    mcp.tool(
         title="Set Mail Message Flags",
         annotations=ToolAnnotations(
             # Same inputs -> same end state (a flag set twice stays set).
             idempotent_hint=True,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_set_flags(
-        message_id: int,
-        ctx: Context,
-        seen: bool | None = None,
-        flagged: bool | None = None,
-        answered: bool | None = None,
-        junk: bool | None = None,
-    ) -> MailActionResponse:
-        """Set IMAP flags on a message, e.g. mark it read (requires mail.write scope).
+    )(nc_mail_set_flags)
 
-        Only the flags you pass are changed. Omitted ones are left alone. Use
-        ``seen=True`` after processing a message so it does not look unhandled,
-        and ``seen=False`` to mark it unread again.
-
-        Args:
-            message_id: Numeric message id (``database_id`` from nc_mail_list_messages)
-            seen: Mark read (True) or unread (False)
-            flagged: Star (True) or unstar (False)
-            answered: Mark as replied-to
-            junk: Mark as junk/spam. Unlike the others this is a custom IMAP
-                keyword, so the mail server silently ignores it unless the
-                mailbox permits custom keywords.
-
-        Returns:
-            MailActionResponse naming the flags that were applied. Passing no
-            flags at all is an error rather than a silent no-op.
-        """
-        flags = {
-            name: value
-            for name, value in (
-                ("seen", seen),
-                ("flagged", flagged),
-                ("answered", answered),
-                ("$junk", junk),
-            )
-            if value is not None
-        }
-        if not flags:
-            raise MCPError(
-                code=-1,
-                message="No flags given; pass at least one of seen, flagged, "
-                "answered, junk",
-            )
-
-        client = await get_client(ctx)
-        with _mail_errors(f"setting flags on message {message_id}"):
-            await client.mail.set_flags(message_id, flags)
-
-        applied = ", ".join(f"{name}={value}" for name, value in flags.items())
-        return MailActionResponse(
-            message_id=message_id, message=f"Flags updated: {applied}"
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Create Mail Tag",
         annotations=ToolAnnotations(
             # Create-or-get: the Mail app returns the existing tag for a name
@@ -468,99 +610,25 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=True,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_create_tag(
-        display_name: Annotated[str, Field(max_length=128)],
-        ctx: Context,
-        color: str = DEFAULT_TAG_COLOR,
-    ) -> MailTagResponse:
-        """Create a mail tag, or return the existing one (requires mail.write scope).
+    )(nc_mail_create_tag)
 
-        Tags are IMAP keywords private to the user. The Mail app has no
-        tag-listing endpoint, so this is also how you look a tag up — calling it
-        for an existing name returns that tag rather than creating a duplicate.
-
-        Names normalise to a lowercase IMAP label with spaces as underscores, so
-        "AI Index", "ai index" and "ai_index" are all the same tag.
-
-        Args:
-            display_name: Tag name (max 128 characters)
-            color: Hex colour, applied only when the tag is created
-
-        Returns:
-            MailTagResponse with the tag, including the ``id`` needed for the
-            ``tags:<id>`` filter of nc_mail_list_messages.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"creating tag {display_name!r}"):
-            tag = await client.mail.ensure_tag(display_name, color)
-        return MailTagResponse(tag=MailTag(**tag))
-
-    @mcp.tool(
+    mcp.tool(
         title="Tag Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=True,  # Re-tagging a tagged message is a no-op
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_set_tag(
-        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
-    ) -> MailTagResponse:
-        """Assign a tag to a message (requires mail.write scope).
+    )(nc_mail_set_tag)
 
-        The tag is created if it does not exist yet, so this works without a
-        separate nc_mail_create_tag call.
-
-        Args:
-            message_id: Numeric message id
-            tag: Tag display name
-
-        Returns:
-            MailTagResponse with the assigned tag.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"tagging message {message_id} with {tag!r}"):
-            # Resolve through create-or-get: it yields the server's own
-            # imapLabel, so we never have to re-derive the label encoding.
-            tag_data = await client.mail.ensure_tag(tag)
-            await client.mail.set_tag(message_id, tag_data["imapLabel"])
-        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
-
-    @mcp.tool(
+    mcp.tool(
         title="Untag Mail Message",
         annotations=ToolAnnotations(
             idempotent_hint=True,  # Removing an absent tag leaves the same state
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_remove_tag(
-        message_id: int, tag: Annotated[str, Field(max_length=128)], ctx: Context
-    ) -> MailTagResponse:
-        """Remove a tag from a message (requires mail.write scope).
+    )(nc_mail_remove_tag)
 
-        Args:
-            message_id: Numeric message id
-            tag: Tag display name
-
-        Returns:
-            MailTagResponse with the removed tag.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"removing tag {tag!r} from message {message_id}"):
-            # Resolve the same way as tagging. For a name that has never been
-            # used this creates an empty tag row before removing nothing from
-            # the message — harmless, and it keeps one resolution path.
-            tag_data = await client.mail.ensure_tag(tag)
-            await client.mail.remove_tag(message_id, tag_data["imapLabel"])
-        return MailTagResponse(tag=MailTag(**tag_data), message_id=message_id)
-
-    @mcp.tool(
+    mcp.tool(
         title="Move Mail Message",
         annotations=ToolAnnotations(
             # NOT idempotent. The move drops the cached row and the message is
@@ -571,35 +639,9 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=False,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_move_message(
-        message_id: int, destination_mailbox_id: int, ctx: Context
-    ) -> MailActionResponse:
-        """Move a message to another mailbox (requires mail.write scope).
+    )(nc_mail_move_message)
 
-        Args:
-            message_id: Numeric message id
-            destination_mailbox_id: Target mailbox id (``database_id`` from
-                nc_mail_list_mailboxes)
-
-        Returns:
-            MailActionResponse. ``message_id`` echoes what you passed in and is
-            **stale on return**: the move invalidates it, and the message is
-            re-cached in the destination under a new id. Re-list the destination
-            mailbox to address it again — do not retry this call with the same
-            id, which fails rather than repeating the move.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"moving message {message_id}"):
-            await client.mail.move_message(message_id, destination_mailbox_id)
-        return MailActionResponse(
-            message_id=message_id,
-            message=f"Message moved to mailbox {destination_mailbox_id}",
-        )
-
-    @mcp.tool(
+    mcp.tool(
         title="Delete Mail Message",
         annotations=ToolAnnotations(
             destructive_hint=True,  # Removes the message from its mailbox
@@ -610,28 +652,4 @@ def configure_mail_tools(mcp: MCPServer):
             idempotent_hint=False,
             open_world_hint=True,
         ),
-    )
-    @require_scopes("mail.write")
-    @instrument_tool
-    async def nc_mail_delete_message(
-        message_id: int, ctx: Context
-    ) -> MailActionResponse:
-        """Delete a message (requires mail.write scope).
-
-        The Mail app moves the message to the account's trash mailbox, or
-        expunges it permanently if it is already in trash. Requires the account
-        to have a trash mailbox — without one the Mail app rejects the call
-        ("No trash mailbox configured").
-
-        Args:
-            message_id: Numeric message id
-
-        Returns:
-            MailActionResponse confirming the deletion. ``message_id`` echoes
-            the input and is **stale on return** — trashing re-caches the
-            message under a new id, so retrying with the same id fails.
-        """
-        client = await get_client(ctx)
-        with _mail_errors(f"deleting message {message_id}"):
-            await client.mail.delete_message(message_id)
-        return MailActionResponse(message_id=message_id, message="Message deleted")
+    )(nc_mail_delete_message)

--- a/nextcloud_mcp_server/server/notes.py
+++ b/nextcloud_mcp_server/server/notes.py
@@ -24,6 +24,281 @@ from nextcloud_mcp_server.request_context import current_context
 logger = logging.getLogger(__name__)
 
 
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_create_note(
+    title: str, content: str, category: str, ctx: Context
+) -> CreateNoteResponse:
+    """Create a new note (requires notes.write scope)"""
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.create_note(
+            title=title,
+            content=content,
+            category=category,
+        )
+        note = Note(**note_data)
+        return CreateNoteResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error creating note: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to create notes",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(code=-1, message="Note content too large")
+        elif e.response.status_code == 409:
+            raise MCPError(
+                code=-1,
+                message=f"A note with title '{title}' already exists in this category",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to create note: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_update_note(
+    note_id: int,
+    etag: str,
+    title: str | None,
+    content: str | None,
+    category: str | None,
+    ctx: Context,
+) -> UpdateNoteResponse:
+    """Update an existing note's title, content, or category (requires notes.write scope).
+
+    REQUIRED: etag parameter must be provided to prevent overwriting concurrent changes.
+    Get the current ETag by first retrieving the note using nc_notes_get_note tool.
+    If the note has been modified by someone else since you retrieved it,
+    the update will fail with a 412 error."""
+    logger.info("Updating note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.update(
+            note_id=note_id,
+            etag=etag,
+            title=title,
+            content=content,
+            category=category,
+        )
+        note = Note(**note_data)
+        return UpdateNoteResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error updating note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 412:
+            raise MCPError(
+                code=-1,
+                message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
+            )
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to update note {note_id}",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(code=-1, message="Updated note content is too large")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.write")
+@with_links
+@instrument_tool
+async def nc_notes_append_content(
+    note_id: int, content: str, ctx: Context
+) -> AppendContentResponse:
+    """Append content to an existing note. The tool adds a `\n---\n`
+    between the note and what will be appended."""
+
+    logger.info("Appending content to note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.append_content(note_id=note_id, content=content)
+        note = Note(**note_data)
+        return AppendContentResponse(
+            id=note.id, title=note.title, category=note.category, etag=note.etag
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error appending to note {note_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to modify note {note_id}",
+            )
+        elif e.response.status_code == 413:
+            raise MCPError(
+                code=-1,
+                message="Content to append would make the note too large",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.read")
+@with_links
+@instrument_tool
+async def nc_notes_search_notes(query: str, ctx: Context) -> SearchNotesResponse:
+    """Search notes by title or content, returning only id, title, and category (requires notes.read scope)."""
+    client = await get_client(ctx)
+    try:
+        search_results_raw = await client.notes_search_notes(query=query)
+
+        # Convert to NoteSearchResult models, including the _score field
+        results = [
+            NoteSearchResult(
+                id=result["id"],
+                title=result["title"],
+                category=result["category"],
+                score=result.get("_score"),  # Include search score if available
+            )
+            for result in search_results_raw
+        ]
+
+        return SearchNotesResponse(
+            results=results, query=query, total_found=len(results)
+        )
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error searching notes: {str(e)}")
+    except HTTPStatusError as e:
+        if e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message="Access denied: insufficient permissions to search notes",
+            )
+        elif e.response.status_code == 400:
+            raise MCPError(code=-1, message="Invalid search query format")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Search failed: server error ({e.response.status_code})",
+            )
+
+
+@require_scopes("notes.read")
+@with_links
+@instrument_tool
+async def nc_notes_get_note(note_id: int, ctx: Context) -> Note:
+    """Get a specific note by its ID (requires notes.read scope)"""
+    client = await get_client(ctx)
+    try:
+        note_data = await client.notes.get_note(note_id)
+        return Note(**note_data)
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error getting note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(code=-1, message=f"Access denied to note {note_id}")
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
+            )
+
+
+@require_scopes("notes.read")
+@instrument_tool
+async def nc_notes_get_attachment(
+    note_id: int, attachment_filename: str, ctx: Context
+) -> dict[str, str]:
+    """Get a specific attachment from a note"""
+    client = await get_client(ctx)
+    try:
+        content, mime_type = await client.webdav.get_note_attachment(
+            note_id=note_id, filename=attachment_filename
+        )
+        return {  # type: ignore
+            "uri": f"nc://Notes/{note_id}/attachments/{attachment_filename}",
+            "mimeType": mime_type,
+            "data": content,
+        }
+    except RequestError as e:
+        raise MCPError(
+            code=-1,
+            message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(
+                code=-1,
+                message=f"Attachment {attachment_filename} not found for note {note_id}",
+            )
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied to attachment {attachment_filename} for note {note_id}",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
+            )
+
+
+@require_scopes("notes.write")
+@instrument_tool
+async def nc_notes_delete_note(note_id: int, ctx: Context) -> DeleteNoteResponse:
+    """Delete a note permanently"""
+    logger.info("Deleting note %s", note_id)
+    client = await get_client(ctx)
+    try:
+        await client.notes.delete_note(note_id)
+        return DeleteNoteResponse(
+            status_code=200,
+            message=f"Note {note_id} deleted successfully",
+            deleted_id=note_id,
+        )
+    except RequestError as e:
+        raise MCPError(
+            code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
+        )
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise MCPError(code=-1, message=f"Note {note_id} not found")
+        elif e.response.status_code == 403:
+            raise MCPError(
+                code=-1,
+                message=f"Access denied: insufficient permissions to delete note {note_id}",
+            )
+        else:
+            raise MCPError(
+                code=-1,
+                message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
+            )
+
+
 def configure_notes_tools(mcp: MCPServer):
     @mcp.resource("notes://settings")
     async def notes_get_settings():
@@ -81,322 +356,59 @@ def configure_notes_tools(mcp: MCPServer):
                     message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
                 )
 
-    @mcp.tool(
+    mcp.tool(
         title="Create Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Multiple calls create multiple notes
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_create_note(
-        title: str, content: str, category: str, ctx: Context
-    ) -> CreateNoteResponse:
-        """Create a new note (requires notes.write scope)"""
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.create_note(
-                title=title,
-                content=content,
-                category=category,
-            )
-            note = Note(**note_data)
-            return CreateNoteResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error creating note: {str(e)}")
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to create notes",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(code=-1, message="Note content too large")
-            elif e.response.status_code == 409:
-                raise MCPError(
-                    code=-1,
-                    message=f"A note with title '{title}' already exists in this category",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to create note: server error ({e.response.status_code})",
-                )
+    )(nc_notes_create_note)
 
-    @mcp.tool(
+    mcp.tool(
         title="Update Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Requires etag which changes = not idempotent
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_update_note(
-        note_id: int,
-        etag: str,
-        title: str | None,
-        content: str | None,
-        category: str | None,
-        ctx: Context,
-    ) -> UpdateNoteResponse:
-        """Update an existing note's title, content, or category (requires notes.write scope).
+    )(nc_notes_update_note)
 
-        REQUIRED: etag parameter must be provided to prevent overwriting concurrent changes.
-        Get the current ETag by first retrieving the note using nc_notes_get_note tool.
-        If the note has been modified by someone else since you retrieved it,
-        the update will fail with a 412 error."""
-        logger.info("Updating note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.update(
-                note_id=note_id,
-                etag=etag,
-                title=title,
-                content=content,
-                category=category,
-            )
-            note = Note(**note_data)
-            return UpdateNoteResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error updating note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 412:
-                raise MCPError(
-                    code=-1,
-                    message=f"Note {note_id} has been modified by someone else. Please refresh and try again.",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to update note {note_id}",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(code=-1, message="Updated note content is too large")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to update note {note_id}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Append to Note",
         annotations=ToolAnnotations(
             idempotent_hint=False,  # Each call adds content = not idempotent
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @with_links
-    @instrument_tool
-    async def nc_notes_append_content(
-        note_id: int, content: str, ctx: Context
-    ) -> AppendContentResponse:
-        """Append content to an existing note. The tool adds a `\n---\n`
-        between the note and what will be appended."""
+    )(nc_notes_append_content)
 
-        logger.info("Appending content to note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.append_content(
-                note_id=note_id, content=content
-            )
-            note = Note(**note_data)
-            return AppendContentResponse(
-                id=note.id, title=note.title, category=note.category, etag=note.etag
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error appending to note {note_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to modify note {note_id}",
-                )
-            elif e.response.status_code == 413:
-                raise MCPError(
-                    code=-1,
-                    message="Content to append would make the note too large",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to append content to note {note_id}: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Search Notes",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Search doesn't modify data
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @with_links
-    @instrument_tool
-    async def nc_notes_search_notes(query: str, ctx: Context) -> SearchNotesResponse:
-        """Search notes by title or content, returning only id, title, and category (requires notes.read scope)."""
-        client = await get_client(ctx)
-        try:
-            search_results_raw = await client.notes_search_notes(query=query)
+    )(nc_notes_search_notes)
 
-            # Convert to NoteSearchResult models, including the _score field
-            results = [
-                NoteSearchResult(
-                    id=result["id"],
-                    title=result["title"],
-                    category=result["category"],
-                    score=result.get("_score"),  # Include search score if available
-                )
-                for result in search_results_raw
-            ]
-
-            return SearchNotesResponse(
-                results=results, query=query, total_found=len(results)
-            )
-        except RequestError as e:
-            raise MCPError(code=-1, message=f"Network error searching notes: {str(e)}")
-        except HTTPStatusError as e:
-            if e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message="Access denied: insufficient permissions to search notes",
-                )
-            elif e.response.status_code == 400:
-                raise MCPError(code=-1, message="Invalid search query format")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Search failed: server error ({e.response.status_code})",
-                )
-
-    @mcp.tool(
+    mcp.tool(
         title="Get Note",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Read operation only
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @with_links
-    @instrument_tool
-    async def nc_notes_get_note(note_id: int, ctx: Context) -> Note:
-        """Get a specific note by its ID (requires notes.read scope)"""
-        client = await get_client(ctx)
-        try:
-            note_data = await client.notes.get_note(note_id)
-            return Note(**note_data)
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error getting note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(code=-1, message=f"Access denied to note {note_id}")
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to retrieve note {note_id}: {e.response.reason_phrase}",
-                )
+    )(nc_notes_get_note)
 
-    @mcp.tool(
+    mcp.tool(
         title="Get Note Attachment",
         annotations=ToolAnnotations(
             read_only_hint=True,  # Read operation only
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.read")
-    @instrument_tool
-    async def nc_notes_get_attachment(
-        note_id: int, attachment_filename: str, ctx: Context
-    ) -> dict[str, str]:
-        """Get a specific attachment from a note"""
-        client = await get_client(ctx)
-        try:
-            content, mime_type = await client.webdav.get_note_attachment(
-                note_id=note_id, filename=attachment_filename
-            )
-            return {  # type: ignore
-                "uri": f"nc://Notes/{note_id}/attachments/{attachment_filename}",
-                "mimeType": mime_type,
-                "data": content,
-            }
-        except RequestError as e:
-            raise MCPError(
-                code=-1,
-                message=f"Network error getting attachment {attachment_filename} for note {note_id}: {str(e)}",
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(
-                    code=-1,
-                    message=f"Attachment {attachment_filename} not found for note {note_id}",
-                )
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied to attachment {attachment_filename} for note {note_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to retrieve attachment: {e.response.reason_phrase}",
-                )
+    )(nc_notes_get_attachment)
 
-    @mcp.tool(
+    mcp.tool(
         title="Delete Note",
         annotations=ToolAnnotations(
             destructive_hint=True,  # Permanently deletes data
             idempotent_hint=True,  # Deleting deleted note = same end state
             open_world_hint=True,
         ),
-    )
-    @require_scopes("notes.write")
-    @instrument_tool
-    async def nc_notes_delete_note(note_id: int, ctx: Context) -> DeleteNoteResponse:
-        """Delete a note permanently"""
-        logger.info("Deleting note %s", note_id)
-        client = await get_client(ctx)
-        try:
-            await client.notes.delete_note(note_id)
-            return DeleteNoteResponse(
-                status_code=200,
-                message=f"Note {note_id} deleted successfully",
-                deleted_id=note_id,
-            )
-        except RequestError as e:
-            raise MCPError(
-                code=-1, message=f"Network error deleting note {note_id}: {str(e)}"
-            )
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise MCPError(code=-1, message=f"Note {note_id} not found")
-            elif e.response.status_code == 403:
-                raise MCPError(
-                    code=-1,
-                    message=f"Access denied: insufficient permissions to delete note {note_id}",
-                )
-            else:
-                raise MCPError(
-                    code=-1,
-                    message=f"Failed to delete note {note_id}: server error ({e.response.status_code})",
-                )
+    )(nc_notes_delete_note)

--- a/tests/unit/test_tool_registration_isolation.py
+++ b/tests/unit/test_tool_registration_isolation.py
@@ -1,0 +1,73 @@
+"""Module-level tool functions must not leak state between MCPServer instances.
+
+Tools used to be closures rebuilt on every ``configure_*_tools(mcp)`` call, so
+each server got its own function objects. They are now defined at module level
+and registered with ``mcp.tool(...)(fn)``, which means every server shares the
+*same* function objects.
+
+That matters because ``configure_app_tools`` calls
+``stamp_required_capability(tool.fn, ...)``, which **mutates the function**. It
+is safe only because the stamp is idempotent and deterministic per app — it sets
+the attribute once, and a tool belongs to exactly one app. This pins that
+reasoning, since the failure mode is a server hiding tools based on another
+server's capability gate rather than an exception.
+"""
+
+import pytest
+from mcp.server.mcpserver import MCPServer
+
+from nextcloud_mcp_server.capabilities import get_required_capability
+from nextcloud_mcp_server.server import AVAILABLE_APPS, configure_app_tools
+
+pytestmark = pytest.mark.unit
+
+
+def _tools(app: str) -> list:
+    mcp = MCPServer(f"srv-{app}")
+    configure_app_tools(mcp, app)
+    return mcp._tool_manager.list_tools()
+
+
+def test_capability_stamps_do_not_leak_between_servers():
+    """Two servers configured with different apps keep separate gates."""
+    notes = _tools("notes")
+    deck = _tools("deck")
+
+    assert {get_required_capability(t.fn)[0] for t in notes} == {"notes"}
+    assert {get_required_capability(t.fn)[0] for t in deck} == {"deck"}
+
+
+def test_reconfiguring_the_same_app_is_stable():
+    """Registering twice must not accumulate or rewrite gates.
+
+    A non-idempotent stamp would show up here as a second server disagreeing
+    with the first about the same tool.
+    """
+    first = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+    second = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+
+    assert first == second
+
+
+def test_per_tool_capability_still_beats_the_module_stamp():
+    """``@require_capability`` with a version floor must survive registration.
+
+    ``deck_assign_dependent_card`` declares a Deck 1.18.0 floor; the whole-app
+    stamp must not overwrite it with the unversioned gate.
+    """
+    gates = {t.name: get_required_capability(t.fn) for t in _tools("deck")}
+
+    assert gates["deck_assign_dependent_card"] == ("deck", "1.18.0", None)
+
+
+def test_every_app_registers_at_least_one_tool():
+    """A registration call that silently no-ops would be invisible otherwise.
+
+    The extraction rewrote every ``configure_*_tools`` body, and a dropped
+    ``mcp.tool(...)(fn)`` line removes a tool from the wire without failing
+    anything else.
+    """
+    for app in AVAILABLE_APPS:
+        mcp = MCPServer("srv")
+        configure_app_tools(mcp, app)
+        assert mcp._tool_manager.list_tools(), f"{app} registered no tools"


### PR DESCRIPTION
Part 1 of 3, splitting the SonarCloud S3776 work that was #1437.

**Why split:** #1437 was 7,407 line-changes across 6 files, and the automated
reviewer could not finish it — three attempts each ended with an unticked
"Review in progress" checklist and no findings. For contrast it reviews #1433
(~3,750 changes across 106 files) fine, so the limit is churn, not file count.
Each part here lands under that demonstrated-working size.

## What this does

`configure_notes_tools` (cognitive complexity **76**) and `configure_mail_tools`
(**45**) were flagged against the 15 allowed. Neither is measuring the code —
**no individual tool in either file exceeds McCabe 8**. Every tool is a nested
closure, and S3776 charges a nesting penalty per level, so the outer function
accumulates the complexity of every tool it contains.

20 tools lifted to module level, registered with `mcp.tool(...)(fn)`.
Behaviour-identical: `@mcp.tool()` is simply the outermost decorator, applied
last either way. Resource functions stay nested — they call
`current_context(mcp)` and genuinely close over it.

## The one real risk, and its test

Module-level functions are **shared across `MCPServer` instances**, and
`configure_app_tools` calls `stamp_required_capability(tool.fn, ...)` which
*mutates the function*. That is safe only because the stamp is idempotent and
deterministic per app.

`tests/unit/test_tool_registration_isolation.py` pins it rather than leaving it
to that argument: two servers configured with different apps keep separate
gates, re-registration is stable, and a per-tool `@require_capability` version
floor still beats the whole-app stamp. The failure mode would be **silent** — a
server hiding tools based on another server's capability gate, not an exception.

The test is here rather than in part 2 or 3 because this is the PR that first
introduces module-level tool functions.

## Verification

`ruff`, `ruff format`, `ty` clean. Tests run in CI per the repo owner's
instruction. The three parts together are byte-identical to the #1437 tree that
previously passed the full 28-check matrix and cleared all five Sonar findings.

Refs Deck card 1203.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iCzZAuCMsZS7UJYfy3htd
