### PR TITLE
fix(auth): resolve the Login Flow caller's UID from Nextcloud, not IdP claims

### DIFF
--- a/docs/login-flow-v2.md
+++ b/docs/login-flow-v2.md
@@ -261,11 +261,23 @@ asked for it. Before storing anything, the server therefore checks that the
 account that granted is the OAuth caller who started the flow
 (`nextcloud_mcp_server/auth/grant_ownership.py`, GHSA-84qv-22q6-x82r):
 
-- the **granter** is resolved by authenticating the fresh app password against
-  OCS `/cloud/user`, which maps the Login Flow `loginName` (possibly an email
-  alias, or an LDAP login that differs from the UID) onto a canonical UID;
-- the **caller** is the OAuth `sub`, plus the IdP's `preferred_username` when an
-  external IdP issues opaque UUID subjects.
+Both sides are resolved the same way — by asking Nextcloud who a credential
+authenticates as (OCS `/cloud/user`) — and the canonical UIDs are compared:
+
+- the **granter** is authenticated with the fresh app password, which maps the
+  Login Flow `loginName` (possibly an email alias, or an LDAP login that differs
+  from the UID) onto a canonical UID;
+- the **caller** is authenticated with their own OAuth bearer token. The OAuth
+  `sub` is also accepted, since it *is* the UID when Nextcloud is the IdP.
+
+An IdP-supplied `preferred_username` is deliberately not accepted as a caller
+identity: it is a claim the IdP — and on some IdPs the user — controls, so
+honouring it would let an attacker name the victim's UID as their own. External
+IdPs are handled by the bearer lookup instead, which means **Nextcloud must be
+configured to accept the IdP's bearer tokens** (`user_oidc --check-bearer=1`, as
+ADR-002 already requires). Without it the caller's UID cannot be established and
+provisioning fails closed. Note that no token claim can substitute: with
+`user_oidc --unique-uid` the Nextcloud UID is a hash of the IdP `sub`.
 
 A grant that does not match — or that cannot be verified at all — is refused:
 nothing is stored, and the app password it produced is revoked. Both the browser

--- a/nextcloud_mcp_server/auth/grant_ownership.py
+++ b/nextcloud_mcp_server/auth/grant_ownership.py
@@ -17,8 +17,8 @@ GHSA-x88r-fhx7-52h6) — and the canonical UIDs it returns are compared:
   Nextcloud can answer this one: with ``user_oidc``'s ``--unique-uid`` (the
   documented external-IdP setup, and what this repo's own Keycloak hook
   configures) the UID is a *hash* of the IdP ``sub``, so no claim in the token
-  equals it. Deployments where Nextcloud is itself the IdP need no lookup —
-  ``sub`` is already the UID, and is always accepted.
+  equals it. The OAuth ``sub`` is accepted alongside whatever the lookup
+  returns, since it is itself the UID when Nextcloud is the IdP.
 
 An IdP-supplied ``preferred_username`` is deliberately *not* accepted as an
 identity: it is a claim the IdP — and on some IdPs the user themselves —
@@ -85,7 +85,9 @@ async def caller_identities(user_id: str, access_token: str | None = None) -> se
     Always contains the OAuth ``sub`` — that *is* the UID when Nextcloud is the
     IdP. With an external IdP it is not, and the UID cannot be derived from the
     token at all (``user_oidc --unique-uid`` hashes the ``sub``), so Nextcloud
-    is asked directly, using the caller's own bearer token.
+    is also asked directly, using the caller's own bearer token. That lookup
+    runs for every token, native IdP included: telling the two deployments apart
+    here would cost more than the one request a completed grant makes.
     """
     identities = {user_id.casefold()}
     if not access_token:

--- a/nextcloud_mcp_server/auth/grant_ownership.py
+++ b/nextcloud_mcp_server/auth/grant_ownership.py
@@ -6,17 +6,26 @@ that person to the OAuth caller who started it. Storing the result under the
 caller's identity without checking hands an attacker the victim's Nextcloud
 credential after a single click.
 
-The check compares canonical Nextcloud UIDs, never names:
+Both sides are resolved the same way — by asking Nextcloud who a credential
+authenticates as (OCS ``/cloud/user``, the move ``api/passwords.py`` makes for
+GHSA-x88r-fhx7-52h6) — and the canonical UIDs it returns are compared:
 
-* the **granter** is resolved by authenticating the fresh app password against
-  OCS ``/cloud/user`` — the same move ``api/passwords.py`` makes for
-  GHSA-x88r-fhx7-52h6. This maps the Login Flow ``loginName`` (which may be an
-  email alias, or an LDAP login that differs from the UID — GH #980) onto the
-  account Nextcloud will actually act as.
-* the **caller** is the OAuth ``sub``. When Nextcloud is the IdP that already
-  *is* the UID. With an external IdP (Keycloak) ``sub`` is an opaque UUID, so
-  the IdP's ``preferred_username`` is consulted as well — that is the claim
-  ``user_oidc`` maps onto the Nextcloud account.
+* the **granter** is authenticated with the fresh app password. This maps the
+  Login Flow ``loginName`` (which may be an email alias, or an LDAP login that
+  differs from the UID — GH #980) onto the account Nextcloud will act as.
+* the **caller** is authenticated with their own OAuth bearer token. Only
+  Nextcloud can answer this one: with ``user_oidc``'s ``--unique-uid`` (the
+  documented external-IdP setup, and what this repo's own Keycloak hook
+  configures) the UID is a *hash* of the IdP ``sub``, so no claim in the token
+  equals it. Deployments where Nextcloud is itself the IdP need no lookup —
+  ``sub`` is already the UID, and is always accepted.
+
+An IdP-supplied ``preferred_username`` is deliberately *not* accepted as an
+identity: it is a claim the IdP — and on some IdPs the user themselves —
+controls, so honouring it would let an attacker name the victim's UID as their
+own and walk straight back into the advisory. External-IdP deployments
+therefore need Nextcloud to accept the IdP's bearer tokens
+(``user_oidc --check-bearer=1``), which ADR-002 already requires.
 
 Anything we cannot verify is refused: a grant that fails the check is never
 stored, and the app password it produced is revoked so nobody keeps it.
@@ -33,98 +42,59 @@ logger = logging.getLogger(__name__)
 _OCS_HEADERS = {"OCS-APIRequest": "true"}
 _TIMEOUT = 10.0
 
-# Userinfo endpoint per discovery URL. It does not change while the process
-# runs, and this path is only reached in external-IdP mode.
-_userinfo_endpoints: dict[str, str] = {}
 
-
-def _discovery_url() -> str | None:
-    """OIDC discovery URL, mirroring how ``app.py`` derives it at startup."""
-    settings = get_settings()
-    if settings.oidc_discovery_url:
-        return settings.oidc_discovery_url
-    host = settings.nextcloud_host
-    return f"{host.rstrip('/')}/.well-known/openid-configuration" if host else None
-
-
-async def _userinfo_endpoint() -> str | None:
-    discovery_url = _discovery_url()
-    if not discovery_url:
-        return None
-    if discovery_url in _userinfo_endpoints:
-        return _userinfo_endpoints[discovery_url]
-    try:
-        async with nextcloud_httpx_client(timeout=_TIMEOUT) as client:
-            response = await client.get(discovery_url)
-            response.raise_for_status()
-            endpoint = response.json().get("userinfo_endpoint")
-    except Exception as e:
-        logger.warning("Could not read userinfo_endpoint from %s: %s", discovery_url, e)
-        return None
-    if not isinstance(endpoint, str) or not endpoint:
-        return None
-    _userinfo_endpoints[discovery_url] = endpoint
-    return endpoint
-
-
-async def caller_identities(user_id: str, access_token: str | None = None) -> set[str]:
-    """Casefolded Nextcloud identifiers the OAuth caller may legitimately be.
-
-    Always contains the OAuth ``sub``. In external-IdP deployments ``sub`` is an
-    opaque UUID, so ``preferred_username`` from the IdP's userinfo endpoint is
-    added when an access token is available — that is the claim ``user_oidc``
-    maps onto the Nextcloud account.
-    """
-    identities = {user_id.casefold()}
-    if not access_token:
-        return identities
-
-    endpoint = await _userinfo_endpoint()
-    if not endpoint:
-        return identities
-
-    try:
-        async with nextcloud_httpx_client(timeout=_TIMEOUT) as client:
-            response = await client.get(
-                endpoint, headers={"Authorization": f"Bearer {access_token}"}
-            )
-            response.raise_for_status()
-            claims: Any = response.json()
-    except Exception as e:
-        logger.warning("Could not query IdP userinfo for caller identity: %s", e)
-        return identities
-
-    if isinstance(claims, dict):
-        for claim in ("sub", "preferred_username"):
-            value = claims.get(claim)
-            if isinstance(value, str) and value:
-                identities.add(value.casefold())
-    return identities
-
-
-async def _ocs_whoami(login_name: str, app_password: str) -> str | None:
+async def _ocs_whoami(
+    *,
+    auth: tuple[str, str] | None = None,
+    bearer: str | None = None,
+) -> str | None:
     """Canonical Nextcloud UID a credential authenticates as, else ``None``."""
     host = get_settings().nextcloud_host
     if not host:
         return None
+
+    headers = dict(_OCS_HEADERS)
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
     try:
         async with nextcloud_httpx_client(timeout=_TIMEOUT) as client:
             response = await client.get(
                 f"{host.rstrip('/')}/ocs/v2.php/cloud/user",
-                auth=(login_name, app_password),
+                auth=auth,
                 params={"format": "json"},
-                headers=_OCS_HEADERS,
+                headers=headers,
             )
             response.raise_for_status()
             payload: Any = response.json()
     except Exception as e:
-        logger.warning("Could not resolve Nextcloud UID for a Login Flow grant: %s", e)
+        logger.warning(
+            "Could not resolve a Nextcloud UID for a Login Flow grant: %s", e
+        )
         return None
 
     ocs = payload.get("ocs") if isinstance(payload, dict) else None
     data = ocs.get("data") if isinstance(ocs, dict) else None
     uid = data.get("id") if isinstance(data, dict) else None
     return uid if isinstance(uid, str) and uid else None
+
+
+async def caller_identities(user_id: str, access_token: str | None = None) -> set[str]:
+    """Casefolded Nextcloud identifiers the OAuth caller may legitimately be.
+
+    Always contains the OAuth ``sub`` — that *is* the UID when Nextcloud is the
+    IdP. With an external IdP it is not, and the UID cannot be derived from the
+    token at all (``user_oidc --unique-uid`` hashes the ``sub``), so Nextcloud
+    is asked directly, using the caller's own bearer token.
+    """
+    identities = {user_id.casefold()}
+    if not access_token:
+        return identities
+
+    caller_uid = await _ocs_whoami(bearer=access_token)
+    if caller_uid:
+        identities.add(caller_uid.casefold())
+    return identities
 
 
 async def revoke_app_password(login_name: str, app_password: str) -> None:
@@ -161,7 +131,7 @@ async def grant_belongs_to_caller(
         logger.warning("Login Flow v2 grant carried no loginName; refusing to store it")
         return False
 
-    granter_uid = await _ocs_whoami(login_name, app_password)
+    granter_uid = await _ocs_whoami(auth=(login_name, app_password))
     if not granter_uid:
         return False
 

--- a/nextcloud_mcp_server/auth/token_utils.py
+++ b/nextcloud_mcp_server/auth/token_utils.py
@@ -295,7 +295,7 @@ async def extract_user_id_from_token(_ctx: Context) -> str:
 def current_access_token() -> str | None:
     """Raw bearer token of the in-flight request, or ``None`` outside OAuth mode.
 
-    Needed where the IdP has to be asked something about the caller that the
+    Needed where Nextcloud has to be asked something about the caller that the
     verified claims do not carry — see
     :func:`nextcloud_mcp_server.auth.grant_ownership.caller_identities`.
     """

--- a/tests/server/keycloak/conftest.py
+++ b/tests/server/keycloak/conftest.py
@@ -71,10 +71,11 @@ KEYCLOAK_CLIENT_ID = "nextcloud-mcp-server"
 # not a real secret. NOSONAR suppresses the hardcoded-credentials hotspot.
 KEYCLOAK_CLIENT_SECRET = "mcp-secret-change-in-production"  # NOSONAR(S2068)
 
-# Keycloak user used only for the OAuth leg (session identity key). It does not
-# have to match the Nextcloud data user — the app password minted by the Login
-# Flow leg is what authenticates DAV requests. Direct Access Grants (ROPC) are
-# enabled for the `nextcloud-mcp-server` client in realm-export.json.
+# Keycloak user for the OAuth leg. Its identity is load-bearing since
+# GHSA-84qv-22q6-x82r: the Nextcloud account it resolves to must be the one that
+# completes the Login Flow leg, or the grant is refused (see
+# `divergent_email_user`, which asserts exactly that). Direct Access Grants
+# (ROPC) are enabled for the `nextcloud-mcp-server` client in realm-export.json.
 KEYCLOAK_OAUTH_USER = "admin"
 KEYCLOAK_OAUTH_PASSWORD = "admin"  # NOSONAR(S2068) - dev-only Keycloak bootstrap creds
 
@@ -177,12 +178,15 @@ async def keycloak_service_oauth_token(anyio_backend) -> str:
     """Obtain a Keycloak access token accepted by the ``mcp-keycloak`` session.
 
     Uses the OAuth 2.0 Resource Owner Password Credentials (direct access)
-    grant against the static ``nextcloud-mcp-server`` client. The OAuth leg's
-    identity is irrelevant to the reproduction — the Login Flow v2 app password
-    is what authenticates DAV requests — so there is no need to drive Keycloak's
-    browser login form here. Direct grant is faster and avoids the flakiness of
-    the auth-code + Playwright flow (whose native ``#username`` login page also
-    breaks when the request carries scopes the client does not know about).
+    grant against the static ``nextcloud-mcp-server`` client. Direct grant is
+    faster than driving Keycloak's browser login form and avoids the flakiness
+    of the auth-code + Playwright flow (whose native ``#username`` login page
+    also breaks when the request carries scopes the client does not know about).
+
+    *Which* user this authenticates as does matter, though — since
+    GHSA-84qv-22q6-x82r the Nextcloud account this token resolves to has to be
+    the one that completes the Login Flow leg, or the grant is refused. That is
+    what ``divergent_email_user`` asserts before anything else runs.
     """
     async with httpx.AsyncClient(timeout=30.0) as http:
         discovery = await http.get(

--- a/tests/server/keycloak/conftest.py
+++ b/tests/server/keycloak/conftest.py
@@ -106,6 +106,7 @@ async def _nextcloud_uid_for_bearer(token: str) -> str | None:
     ``--unique-uid``, so the UID is a hash of the IdP ``sub``.
     """
     host = os.getenv("NEXTCLOUD_HOST")
+    assert host, "NEXTCLOUD_HOST must be set for the keycloak lane"
     async with httpx.AsyncClient(timeout=30.0) as http:
         response = await http.get(
             f"{host.rstrip('/')}/ocs/v2.php/cloud/user",

--- a/tests/server/keycloak/conftest.py
+++ b/tests/server/keycloak/conftest.py
@@ -9,12 +9,16 @@ issued a real Nextcloud API call. These fixtures fill that gap end-to-end:
 
 * **OAuth leg** — a Keycloak direct-grant (ROPC) obtains an access token that the
   ``mcp-keycloak`` session accepts. This exercises the keycloak service without
-  driving Keycloak's browser login form (its identity is irrelevant here — the
-  Login Flow v2 app password is what authenticates DAV requests).
+  driving Keycloak's browser login form.
 * **Login Flow v2 leg** — the browser completes Nextcloud Login Flow v2 by logging
-  in as a *local* Nextcloud user using its **email address**. Nextcloud keys the
-  resulting app password on the *loginName* (the email), which differs from the
-  user's canonical UID (loginName != UID).
+  in with the **email address** of the account that Keycloak token resolves to.
+  Nextcloud keys the resulting app password on the *loginName* (the email), which
+  differs from the user's canonical UID (loginName != UID).
+
+The two legs must be the *same* Nextcloud account: since GHSA-84qv-22q6-x82r a
+grant completed by anyone other than the OAuth caller is refused and never
+stored. So the divergence comes from an email alias on the caller's own account,
+not from a second user (which is how this lane originally staged it).
 
 Getting these fixtures to provision at all is the regression guard for
 ``NEXTCLOUD_PUBLIC_URL``: in external-IdP mode the OAuth issuer URL is Keycloak,
@@ -35,6 +39,7 @@ unit tests.
 
 import json
 import logging
+import os
 import uuid
 from typing import Any, AsyncGenerator
 
@@ -93,49 +98,77 @@ KEYCLOAK_SUPPORTED_SCOPES = (
 )
 
 
+async def _nextcloud_uid_for_bearer(token: str) -> str | None:
+    """Canonical Nextcloud UID a Keycloak access token authenticates as.
+
+    The same question ``auth/grant_ownership.py`` asks, and the reason it has to
+    ask Nextcloud rather than read a claim: ``user_oidc`` is configured with
+    ``--unique-uid``, so the UID is a hash of the IdP ``sub``.
+    """
+    host = os.getenv("NEXTCLOUD_HOST")
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        response = await http.get(
+            f"{host.rstrip('/')}/ocs/v2.php/cloud/user",
+            headers={"Authorization": f"Bearer {token}", "OCS-APIRequest": "true"},
+            params={"format": "json"},
+        )
+    response.raise_for_status()
+    return response.json()["ocs"]["data"]["id"]
+
+
 @pytest.fixture(scope="session")
 async def divergent_email_user(
-    anyio_backend, nc_client: NextcloudClient
+    anyio_backend,
+    nc_client: NextcloudClient,
+    keycloak_service_oauth_token: str,
 ) -> AsyncGenerator[dict[str, str], Any]:
-    """Create a local Nextcloud user whose loginName (email) differs from its UID.
+    """The OAuth caller's own Nextcloud account, reachable under an email loginName.
 
-    Yields a dict with ``uid``, ``email``, ``password`` and ``display_name``.
-    The user is deleted on teardown. Nextcloud login-by-email is enabled by
-    default, so logging in with the email during Login Flow v2 produces an app
-    password whose stored loginName is the email — not the UID.
+    Yields a dict with ``uid``, ``email`` and ``password``. Nextcloud
+    login-by-email is enabled by default, so logging in with the email during
+    Login Flow v2 produces an app password whose stored loginName is the email —
+    not the UID (loginName != UID, the identity shape this lane exists to
+    exercise).
+
+    The account is the *caller's own*, not a second user: since
+    GHSA-84qv-22q6-x82r a Login Flow v2 grant completed by any account other than
+    the OAuth caller is refused and never stored, so a separate local user — what
+    this fixture used to create — can no longer provision at all. The divergence
+    therefore comes from the email alias alone.
 
     Session-scoped: the ``mcp-keycloak`` app-password store is keyed by the
     Keycloak OAuth identity (a single shared ``admin``), so all tests share one
-    provisioned app password. The divergent user must therefore stay alive for
-    the whole session — a per-test user would be deleted while its app password
-    is still cached server-side, turning the WebDAV reproduction into a spurious
-    401-on-deleted-user instead of the #980 wrong-path failure.
+    provisioned app password and the email alias must stay in place for the whole
+    session. It is restored on teardown.
     """
-    suffix = uuid.uuid4().hex[:8]
-    uid = f"divprincipal_{suffix}"
-    user = {
-        "uid": uid,
-        "email": f"{uid}@example.com",
-        "password": "DivergentPrincipalPass123!",  # NOSONAR(S2068) - ephemeral test user
-        "display_name": f"Divergent Principal {suffix}",
-    }
-
-    logger.info("Creating divergent-principal user uid=%s email=%s", uid, user["email"])
-    await nc_client.users.create_user(
-        userid=uid,
-        password=user["password"],
-        display_name=user["display_name"],
-        email=user["email"],
+    uid = await _nextcloud_uid_for_bearer(keycloak_service_oauth_token)
+    nc_username = os.getenv("NEXTCLOUD_USERNAME")
+    nc_password = os.getenv("NEXTCLOUD_PASSWORD")
+    assert nc_username and nc_password, (
+        "NEXTCLOUD_USERNAME/NEXTCLOUD_PASSWORD must be set for the keycloak lane"
+    )
+    assert uid == nc_username, (
+        f"Keycloak user {KEYCLOAK_OAUTH_USER!r} resolves to Nextcloud UID {uid!r}, "
+        f"but this lane can only complete Login Flow v2 as {nc_username!r} (the "
+        "only account whose password the tests know). Since GHSA-84qv-22q6-x82r "
+        "the grant must come from the caller's own account, so the OAuth leg and "
+        "the browser leg have to be the same user."
     )
 
+    original_email = (await nc_client.users.get_user_details(uid)).email
+    email = f"divprincipal_{uuid.uuid4().hex[:8]}@example.com"
+
+    logger.info("Giving caller uid=%s the email alias %s", uid, email)
+    await nc_client.users.update_user_field(uid, "email", email)
+
     try:
-        yield user
+        yield {"uid": uid, "email": email, "password": nc_password}
     finally:
         try:
-            await nc_client.users.delete_user(uid)
-            logger.info("Deleted divergent-principal user %s", uid)
+            await nc_client.users.update_user_field(uid, "email", original_email or "")
+            logger.info("Restored email of %s", uid)
         except Exception as e:  # noqa: BLE001 - best-effort cleanup
-            logger.warning("Failed to delete divergent-principal user %s: %s", uid, e)
+            logger.warning("Failed to restore email of %s: %s", uid, e)
 
 
 @pytest.fixture(scope="session")
@@ -182,7 +215,7 @@ async def keycloak_service_oauth_token(anyio_backend) -> str:
 async def _complete_login_flow_v2_with_email(
     browser, login_url: str, email: str, password: str
 ) -> None:
-    """Complete Nextcloud Login Flow v2 logging in as a local user via EMAIL.
+    """Complete Nextcloud Login Flow v2 logging in via EMAIL.
 
     Identical to the login_flow helper, but fills the Nextcloud login form's
     user field with the *email* address so the resulting app password's stored
@@ -275,8 +308,8 @@ async def nc_mcp_keycloak_email_client(
 
     1. Connects to mcp-keycloak (8002) with a Keycloak OAuth token.
     2. Calls ``nc_auth_provision_access`` to start Login Flow v2.
-    3. Completes the browser login as the local ``divergent_email_user`` **via
-       its email**, minting an app password whose loginName is the email.
+    3. Completes the browser login as the caller's own account **via its email
+       alias**, minting an app password whose loginName is the email.
     4. Polls ``nc_auth_check_status`` until provisioned, then yields the session.
     """
     email = divergent_email_user["email"]

--- a/tests/server/keycloak/test_keycloak_login_flow_webdav.py
+++ b/tests/server/keycloak/test_keycloak_login_flow_webdav.py
@@ -13,10 +13,13 @@ they are also the regression guard for ``NEXTCLOUD_PUBLIC_URL`` (in external-IdP
 mode the OAuth issuer URL is Keycloak, not Nextcloud; without the dedicated
 public-URL setting the login page 404s on Keycloak).
 
-The fixtures log into Nextcloud Login Flow v2 as a *local* user via its **email**,
-so the app password's stored ``loginName`` is the email while the canonical UID is
-``divprincipal_<suffix>`` (loginName != UID). This exercises the same
-identity-divergence shape as PR #980's client fix. Note: it does not reproduce
+The fixtures log into Nextcloud Login Flow v2 via an **email alias** on the
+account the Keycloak token resolves to, so the app password's stored
+``loginName`` is the email while the canonical UID is the account name
+(loginName != UID). This exercises the same identity-divergence shape as PR
+#980's client fix — and, because the granting account is the OAuth caller's own,
+it is also the end-to-end guard that GHSA-84qv-22q6-x82r's ownership check
+accepts a legitimate external-IdP grant. Note: it does not reproduce
 #980's wrong-path failure on the CI Nextcloud versions — Nextcloud resolves
 ``/remote.php/dav/files/<email>/`` to the user's real home, so the round-trip
 succeeds regardless of the client-side principal-discovery fix. #980's failure
@@ -74,7 +77,9 @@ async def test_webdav_round_trip_via_keycloak_login_flow(
     Login Flow v2 ``login_url`` were rewritten to the Keycloak origin again, the
     session fixture could not provision and this test would never run.
     """
-    suffix = divergent_email_user["uid"].split("_")[-1]
+    # Per-session suffix from the email alias, so a leftover directory from an
+    # earlier run cannot collide (the UID is now the fixed caller account).
+    suffix = divergent_email_user["email"].split("@")[0].split("_")[-1]
     dir_path = f"/KeycloakLoginFlowTest_{suffix}"
     file_path = f"{dir_path}/keycloak_login_flow.txt"
     content = f"webdav round-trip via keycloak service {suffix}"

--- a/tests/unit/test_grant_ownership.py
+++ b/tests/unit/test_grant_ownership.py
@@ -21,16 +21,12 @@ APP_PASSWORD = secrets.token_urlsafe(24)
 
 @pytest.fixture(autouse=True)
 def _settings(monkeypatch):
-    """Point the helper at a fixed Nextcloud host and clear the endpoint cache."""
+    """Point the helper at a fixed Nextcloud host."""
 
     class _S:
         nextcloud_host = "https://cloud.example.com"
-        oidc_discovery_url = None
 
     monkeypatch.setattr(go, "get_settings", lambda: _S())
-    go._userinfo_endpoints.clear()
-    yield
-    go._userinfo_endpoints.clear()
 
 
 def _patch_transport(monkeypatch, handler) -> list[httpx.Request]:
@@ -109,41 +105,52 @@ async def test_caller_identities_without_a_token_is_just_the_sub():
     assert await go.caller_identities("Alice") == {"alice"}
 
 
-async def test_caller_identities_adds_preferred_username_from_the_idp(monkeypatch):
-    """External IdP: ``sub`` is a UUID, the Nextcloud account is preferred_username."""
+async def test_caller_identities_adds_the_uid_nextcloud_resolves(monkeypatch):
+    """External IdP: the UID is a hash of the sub, so only Nextcloud knows it."""
+    uid = "9b2d9c7f2c12390ddabe33578c453daaa6a0e3618d606b84e995dcfa6c59145e"
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path.endswith("/.well-known/openid-configuration"):
-            return httpx.Response(
-                200, json={"userinfo_endpoint": "https://idp.example.com/userinfo"}
-            )
         assert request.headers["Authorization"] == "Bearer tok"
-        return httpx.Response(200, json={"sub": "uuid-1", "preferred_username": "Bob"})
+        return _ocs_user(uid)
 
     _patch_transport(monkeypatch, handler)
 
-    assert await go.caller_identities("uuid-1", "tok") == {"uuid-1", "bob"}
+    assert await go.caller_identities("uuid-1", "tok") == {"uuid-1", uid}
 
 
 async def test_external_idp_caller_owns_their_grant(monkeypatch):
-    """End to end for the Keycloak shape: UUID sub, Nextcloud UID from the IdP."""
+    """End to end for the Keycloak shape: UUID sub, hashed Nextcloud UID."""
+    uid = "9b2d9c7f2c12390ddabe33578c453daaa6a0e3618d606b84e995dcfa6c59145e"
+    _patch_transport(monkeypatch, lambda _r: _ocs_user(uid))
+
+    identities = await go.caller_identities("6f1c-uuid", "tok")
+    assert await go.grant_belongs_to_caller(identities, uid, APP_PASSWORD) is True
+
+
+async def test_caller_identities_ignores_idp_claims(monkeypatch):
+    """A ``preferred_username`` naming someone else's UID must not be honoured.
+
+    An IdP — or, where it lets users pick their own username, an attacker —
+    could otherwise claim the victim's Nextcloud UID and walk back into the
+    advisory. Only what Nextcloud says the bearer token authenticates as counts.
+    """
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path.endswith("/.well-known/openid-configuration"):
-            return httpx.Response(
-                200, json={"userinfo_endpoint": "https://idp.example.com/userinfo"}
-            )
-        if request.url.path.endswith("/userinfo"):
-            return httpx.Response(200, json={"preferred_username": "bob"})
-        return _ocs_user("bob")
+        # Nextcloud does not accept this IdP's bearer tokens; the app password
+        # the victim granted authenticates fine.
+        if request.headers.get("Authorization", "").startswith("Bearer "):
+            return httpx.Response(401)
+        return _ocs_user("victim")
 
     _patch_transport(monkeypatch, handler)
 
-    identities = await go.caller_identities("6f1c-uuid", "tok")
-    assert await go.grant_belongs_to_caller(identities, "bob", APP_PASSWORD) is True
+    identities = await go.caller_identities("attacker-uuid", "tok")
+
+    assert identities == {"attacker-uuid"}
+    assert await go.grant_belongs_to_caller(identities, "victim", APP_PASSWORD) is False
 
 
-async def test_caller_identities_survives_an_unreachable_idp(monkeypatch):
+async def test_caller_identities_survives_an_unreachable_nextcloud(monkeypatch):
     def handler(_request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("boom")
 


### PR DESCRIPTION
Follow-up to the GHSA-84qv-22q6-x82r fix in 0.185.1. The keycloak integration
lane has been red on every open PR since it landed; the cause turned out to be
two separate defects, one in the check and one in the lane.

## 1. The caller's Nextcloud identity cannot be read off the token

`caller_identities()` built the set of identities the OAuth caller may be from
claims: the `sub`, plus the IdP's `preferred_username`. That is wrong in both
directions.

**It refuses legitimate grants.** With `user_oidc --unique-uid` — the documented
external-IdP setup, and what this repo's own
`app-hooks/post-installation/15-setup-keycloak-provider.sh` configures — the
caller's Nextcloud UID is a *hash* of the IdP `sub`. No claim in the token equals
it, so a Login Flow v2 grant behind an external IdP never matches and every
provisioning is refused. Verified against the dev stack: a Keycloak token for
`test_read_only` authenticates to Nextcloud as
`9b2d9c7f2c12390ddabe33578c453daaa6a0e3618d606b84e995dcfa6c59145e`.

**It accepts grants it should not.** `preferred_username` is an IdP-controlled
claim; on an IdP that lets users pick their own username, an attacker can set it
to the victim's Nextcloud UID, and the advisory's attack works again.

The fix resolves the caller the same authoritative way the granter already is:
ask Nextcloud who the credential authenticates as (OCS `/cloud/user`), using the
caller's own bearer token. The OAuth `sub` stays accepted — it *is* the UID when
Nextcloud is the IdP — and `preferred_username`, along with the
userinfo/discovery lookup that fetched it, is dropped. Net effect on
`grant_ownership.py` is a smaller module, not a bigger one.

Consequence, documented in `docs/login-flow-v2.md`: external-IdP deployments need
Nextcloud to accept the IdP's bearer tokens (`user_oidc --check-bearer=1`), which
ADR-002 already requires. Without it the caller's UID cannot be established and
provisioning fails closed.

## 2. The keycloak lane was staging a cross-account grant

`tests/server/keycloak/` completed Login Flow v2 as a *separate* local Nextcloud
user while the OAuth caller was Keycloak `admin`. That is precisely the shape the
advisory forbids, so it is now correctly refused — the lane was encoding the
vulnerable behaviour to get its `loginName != UID` fixture.

It now grants as the caller's own account and gets the same divergence from an
email alias set on that account for the session (restored on teardown). Since the
granting account is the OAuth caller's, the lane doubles as the end-to-end guard
that the ownership check *accepts* a legitimate external-IdP grant, not just that
it rejects a foreign one. The fixture asserts the OAuth leg and the browser leg
resolve to the same Nextcloud account rather than assuming it.

## Test coverage

No API surface changes (no new/changed MCP tool, HTTP route, or cross-service
boundary), so no new contract tests are required.

- Unit (`tests/unit/test_grant_ownership.py`): the hashed-UID external-IdP shape
  is accepted; a `preferred_username` naming someone else's UID is not; an
  unreachable Nextcloud still fails closed.
- Integration: `integration (keycloak / nc32|nc33|nc34)` is the end-to-end
  coverage for this path and is what this PR turns green.

## For the renovate PRs

Nothing to merge in a particular order — rebase them onto `master` once this
merges and the keycloak lane passes.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYq6m5cXzLqMtt8dMBu8Rk
