### PR TITLE
fix(deck): link card attachments and stop hiding Files-share ones

### DIFF
--- a/nextcloud_mcp_server/client/deck.py
+++ b/nextcloud_mcp_server/client/deck.py
@@ -286,9 +286,13 @@ class DeckClient(BaseNextcloudClient):
     # Cards
     async def get_card(self, board_id: int, stack_id: int, card_id: int) -> DeckCard:
         headers = self._get_deck_headers()
+        # v1.1 (Deck >= 1.3.0), not v1.0, for the sake of ``attachments``: on
+        # v1.0 CardService::find strips every attachment that is not a legacy
+        # ``deck_file``, so a card whose files were attached from the Files app
+        # comes back with attachmentCount > 0 and an empty attachments array.
         response = await self._make_request(
             "GET",
-            f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}",
+            f"/apps/deck/api/v1.1/boards/{board_id}/stacks/{stack_id}/cards/{card_id}",
             headers=headers,
         )
         return DeckCard(**response.json())
@@ -689,9 +693,10 @@ class DeckClient(BaseNextcloudClient):
     async def get_attachments(
         self, board_id: int, stack_id: int, card_id: int
     ) -> List[DeckAttachment]:
+        # v1.1 for the same reason as get_card: v1.0 returns only deck_file.
         response = await self._make_request(
             "GET",
-            f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments",
+            f"/apps/deck/api/v1.1/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments",
         )
         return [DeckAttachment(**attachment) for attachment in response.json()]
 
@@ -746,11 +751,19 @@ class DeckClient(BaseNextcloudClient):
         return DeckAttachment(**response.json())
 
     async def delete_attachment(
-        self, board_id: int, stack_id: int, card_id: int, attachment_id: int
+        self,
+        board_id: int,
+        stack_id: int,
+        card_id: int,
+        attachment_id: int,
+        file_type: str = "deck_file",
     ) -> None:
+        # The v1.0 route resolves the id against ``type`` (default deck_file),
+        # so a Files-share attachment needs type=file or Deck cannot find it.
         await self._make_request(
             "DELETE",
             f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments/{attachment_id}",
+            params={"type": file_type},
         )
 
     async def restore_attachment(

--- a/nextcloud_mcp_server/client/deck.py
+++ b/nextcloud_mcp_server/client/deck.py
@@ -701,12 +701,22 @@ class DeckClient(BaseNextcloudClient):
         return [DeckAttachment(**attachment) for attachment in response.json()]
 
     async def get_attachment_file(
-        self, board_id: int, stack_id: int, card_id: int, attachment_id: int
+        self,
+        board_id: int,
+        stack_id: int,
+        card_id: int,
+        attachment_id: int,
+        file_type: str = "deck_file",
     ) -> Any:
+        # Every route that addresses one attachment by id resolves that id
+        # against ``type`` (server-side default deck_file), so a Files-share
+        # attachment is only found with type=file. Applies equally to
+        # update/delete/restore below.
         # This endpoint returns the raw file, so we return the raw response content
         response = await self._make_request(
             "GET",
             f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments/{attachment_id}",
+            params={"type": file_type},
         )
         return response.content
 
@@ -758,8 +768,7 @@ class DeckClient(BaseNextcloudClient):
         attachment_id: int,
         file_type: str = "deck_file",
     ) -> None:
-        # The v1.0 route resolves the id against ``type`` (default deck_file),
-        # so a Files-share attachment needs type=file or Deck cannot find it.
+        # See get_attachment_file on why ``type`` has to be sent.
         await self._make_request(
             "DELETE",
             f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments/{attachment_id}",
@@ -767,11 +776,17 @@ class DeckClient(BaseNextcloudClient):
         )
 
     async def restore_attachment(
-        self, board_id: int, stack_id: int, card_id: int, attachment_id: int
+        self,
+        board_id: int,
+        stack_id: int,
+        card_id: int,
+        attachment_id: int,
+        file_type: str = "deck_file",
     ) -> None:
         await self._make_request(
             "PUT",
             f"/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}/attachments/{attachment_id}/restore",
+            params={"type": file_type},
         )
 
     # OCS API Endpoints (Config, Comments, Sessions)

--- a/nextcloud_mcp_server/links.py
+++ b/nextcloud_mcp_server/links.py
@@ -28,6 +28,7 @@ from nextcloud_mcp_server.astrolabe_links import astrolabe_browser_base as brows
 from nextcloud_mcp_server.models.deck import (
     CardOperationResponse,
     CreateCardResponse,
+    DeckAttachment,
     DeckBoard,
     DeckCard,
     DeckCardSummary,
@@ -51,6 +52,7 @@ _NOTE_PATH = "/index.php/apps/notes/note/{note_id}"
 _FILE_PATH = "/index.php/f/{file_id}"
 _BOARD_PATH = "/index.php/apps/deck/board/{board_id}"
 _CARD_PATH = "/index.php/apps/deck/board/{board_id}/card/{card_id}"
+_DECK_FILE_PATH = "/index.php/apps/deck/cards/{card_id}/attachment/{attachment_id}"
 
 
 def _note_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
@@ -95,6 +97,15 @@ def _card_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
     return base + _CARD_PATH.format(board_id=board_id, card_id=item.id)
 
 
+def _attachment_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
+    # type="file" attachments are Files shares, so the file itself opens — this
+    # is what Deck's own AttachmentList.vue links to. type="deck_file" ones live
+    # in Deck's private storage and only have its download route.
+    return file_url(base, item.extendedData.fileid) or base + _DECK_FILE_PATH.format(
+        card_id=item.cardId, attachment_id=item.id
+    )
+
+
 def _card_operation_url(base: str, item: Any, ctx: dict[str, Any]) -> str | None:
     # This one carries both ids itself, so it never needs the walk context.
     return base + _CARD_PATH.format(board_id=item.board_id, card_id=item.card_id)
@@ -118,6 +129,7 @@ _URL_BUILDERS: dict[
     DeckBoard: _board_url,
     DeckStack: _stack_url,
     DeckCard: _card_url,
+    DeckAttachment: _attachment_url,
     DeckCardSummary: _card_url,
     CreateCardResponse: _card_url,
     CardOperationResponse: _card_operation_url,

--- a/nextcloud_mcp_server/models/deck.py
+++ b/nextcloud_mcp_server/models/deck.py
@@ -34,6 +34,14 @@ CARD_URL_DESCRIPTION = (
 )
 
 
+ATTACHMENT_URL_DESCRIPTION = (
+    "Link that opens this attachment. For type='file' attachments that is the "
+    "shared file in Nextcloud's Files UI; for type='deck_file' it is Deck's own "
+    "download route. None when the server has no browser-reachable Nextcloud "
+    "base URL configured."
+)
+
+
 class DeckLabel(BaseModel):
     id: int
     title: str
@@ -109,7 +117,7 @@ class DeckCard(BaseModel):
     labels: Optional[List[DeckLabel]] = None
     assignedUsers: Optional[List[Union[DeckUser, DeckAssignedUser]]] = None
     dependentCards: Optional[List[int]] = None  # IDs of cards this card depends on
-    attachments: Optional[List[Any]] = None  # Define a proper Attachment model later
+    attachments: Optional[List["DeckAttachment"]] = None
     attachmentCount: Optional[int] = None
     deletedAt: Optional[int] = None
     commentsUnread: Optional[int] = None
@@ -208,14 +216,23 @@ class DeckStack(BaseModel):
 
 
 class DeckAttachmentExtendedData(BaseModel):
-    filesize: int
-    mimetype: str
-    info: Dict[str, str]
+    # Every field is optional: Deck leaves extendedData empty when the
+    # underlying file is gone or unreadable (FileService/FilesAppService
+    # extendData bail out), which happens routinely for deleted attachments.
+    filesize: int | None = None
+    mimetype: str | None = None
+    info: Dict[str, str] = Field(default_factory=dict)
     # Populated for type="file" (Files share) attachments via FilesAppService.
     path: str | None = None
     fileid: int | None = None
     hasPreview: bool | None = None
     permissions: int | None = None
+
+    @field_validator("info", mode="before")
+    @classmethod
+    def validate_info(cls, v):
+        # PHP serialises an empty pathinfo() as [], not {}.
+        return v or {}
 
 
 class DeckAttachment(BaseModel):
@@ -227,7 +244,15 @@ class DeckAttachment(BaseModel):
     createdAt: int
     createdBy: str
     deletedAt: int
-    extendedData: DeckAttachmentExtendedData
+    extendedData: DeckAttachmentExtendedData = Field(
+        default_factory=DeckAttachmentExtendedData
+    )
+    url: str | None = Field(default=None, description=ATTACHMENT_URL_DESCRIPTION)
+
+    @field_validator("extendedData", mode="before")
+    @classmethod
+    def validate_extended_data(cls, v):
+        return v or {}
 
 
 class DeckComment(BaseModel):

--- a/nextcloud_mcp_server/server/deck.py
+++ b/nextcloud_mcp_server/server/deck.py
@@ -2011,6 +2011,7 @@ async def deck_attach_note(
 
 
 @require_scopes("deck.read")
+@with_links
 @instrument_tool
 async def deck_list_attachments(
     ctx: Context, board_id: int, stack_id: int, card_id: int
@@ -2019,7 +2020,9 @@ async def deck_list_attachments(
 
     Returns both shared-file attachments (``type="file"``, created via
     :func:`deck_attach_file` / :func:`deck_attach_note`) and uploaded
-    binary attachments (``type="deck_file"``).
+    binary attachments (``type="deck_file"``). Each carries a ``url`` that
+    opens it — the file in Files for ``type="file"``, Deck's download route
+    for ``type="deck_file"``.
 
     Args:
         board_id: The ID of the board
@@ -2039,6 +2042,7 @@ async def deck_delete_attachment(
     stack_id: int,
     card_id: int,
     attachment_id: int,
+    attachment_type: str = "deck_file",
 ) -> AttachmentOperationResponse:
     """Delete an attachment from a Nextcloud Deck card.
 
@@ -2052,9 +2056,15 @@ async def deck_delete_attachment(
         stack_id: The ID of the stack
         card_id: The ID of the card
         attachment_id: The ID of the attachment to delete
+        attachment_type: The attachment's ``type`` as reported by
+            :func:`deck_list_attachments` — ``"file"`` for a Files share,
+            ``"deck_file"`` for a blob uploaded into Deck. Deck resolves the
+            id against this type, so passing the wrong one 404s.
     """
     client = await get_client(ctx)
-    await client.deck.delete_attachment(board_id, stack_id, card_id, attachment_id)
+    await client.deck.delete_attachment(
+        board_id, stack_id, card_id, attachment_id, attachment_type
+    )
     return AttachmentOperationResponse(
         success=True,
         message="Attachment deleted successfully",

--- a/tests/client/deck/test_deck_api.py
+++ b/tests/client/deck/test_deck_api.py
@@ -335,6 +335,69 @@ async def test_deck_get_card(mocker):
     assert "/boards/123/stacks/456/cards/789" in mock_make_request.call_args[0][1]
 
 
+async def test_deck_get_card_uses_api_v11_so_attachments_are_not_filtered(mocker):
+    """On v1.0 CardService::find drops every attachment that is not a legacy
+    deck_file, so a card attached from Files reports attachmentCount > 0 with an
+    empty attachments array."""
+    mocker.patch.object(
+        DeckClient,
+        "_make_request",
+        return_value=create_mock_deck_card_response(
+            card_id=789, title="Test Card", stack_id=456
+        ),
+    )
+
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.get_card(board_id=123, stack_id=456, card_id=789)
+
+    assert "/apps/deck/api/v1.1/" in DeckClient._make_request.call_args[0][1]
+
+
+async def test_deck_get_attachments_uses_api_v11(mocker):
+    """Same filter as get_card: v1.0 returns only deck_file attachments."""
+    mocker.patch.object(
+        DeckClient, "_make_request", return_value=create_mock_response(json_data=[])
+    )
+
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    attachments = await client.get_attachments(board_id=123, stack_id=456, card_id=789)
+
+    assert attachments == []
+    assert (
+        "/apps/deck/api/v1.1/boards/123/stacks/456/cards/789/attachments"
+        in DeckClient._make_request.call_args[0][1]
+    )
+
+
+async def test_deck_delete_attachment_passes_the_type_through(mocker):
+    """Deck resolves the attachment id against ``type`` (default deck_file), so
+    a Files-share attachment is only found with type=file."""
+    mocker.patch.object(
+        DeckClient, "_make_request", return_value=create_mock_response(json_data={})
+    )
+
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.delete_attachment(
+        board_id=123, stack_id=456, card_id=789, attachment_id=1, file_type="file"
+    )
+
+    assert DeckClient._make_request.call_args.kwargs["params"] == {"type": "file"}
+
+
+async def test_deck_delete_attachment_defaults_to_deck_file(mocker):
+    """The default preserves the pre-existing behaviour for uploaded blobs."""
+    mocker.patch.object(
+        DeckClient, "_make_request", return_value=create_mock_response(json_data={})
+    )
+
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await client.delete_attachment(
+        board_id=123, stack_id=456, card_id=789, attachment_id=1
+    )
+
+    assert DeckClient._make_request.call_args.kwargs["params"] == {"type": "deck_file"}
+
+
 async def test_deck_assign_dependent_card(mocker):
     """Test that assign_dependent_card POSTs to the right route and parses the card."""
     mock_response = create_mock_deck_card_response(

--- a/tests/client/deck/test_deck_api.py
+++ b/tests/client/deck/test_deck_api.py
@@ -398,6 +398,26 @@ async def test_deck_delete_attachment_defaults_to_deck_file(mocker):
     assert DeckClient._make_request.call_args.kwargs["params"] == {"type": "deck_file"}
 
 
+@pytest.mark.parametrize(
+    "method", ["get_attachment_file", "restore_attachment", "delete_attachment"]
+)
+async def test_deck_attachment_routes_address_the_id_by_type(mocker, method):
+    """Every route that addresses one attachment by id resolves it against
+    ``type``, so all of them have to send it — not just delete."""
+    mocker.patch.object(
+        DeckClient,
+        "_make_request",
+        return_value=create_mock_response(json_data={}, content=b""),
+    )
+
+    client = DeckClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    await getattr(client, method)(
+        board_id=123, stack_id=456, card_id=789, attachment_id=1, file_type="file"
+    )
+
+    assert DeckClient._make_request.call_args.kwargs["params"] == {"type": "file"}
+
+
 async def test_deck_assign_dependent_card(mocker):
     """Test that assign_dependent_card POSTs to the right route and parses the card."""
     mock_response = create_mock_deck_card_response(

--- a/tests/unit/test_links.py
+++ b/tests/unit/test_links.py
@@ -21,6 +21,7 @@ from nextcloud_mcp_server.models.deck import (
     BoardOverviewResponse,
     CardOperationResponse,
     CreateCardResponse,
+    DeckAttachment,
     DeckCard,
     DeckCardSummary,
     DeckStack,
@@ -114,6 +115,61 @@ def test_stack_links_to_its_board():
     """Deck has no route that opens a single stack."""
     stack = DeckStack(id=3, title="S", boardId=7, order=0, deletedAt=0)
     assert _attach(stack).url == f"{BASE}/index.php/apps/deck/board/7"
+
+
+def _attachment(attachment_id: int = 5, **extended) -> DeckAttachment:
+    return DeckAttachment(
+        id=attachment_id,
+        cardId=42,
+        type="file" if extended else "deck_file",
+        data="a.pdf",
+        lastModified=0,
+        createdAt=0,
+        createdBy="alice",
+        deletedAt=0,
+        extendedData=extended,
+    )
+
+
+def test_file_attachment_links_to_the_shared_file():
+    """type="file" is a Files share, so the file itself opens — same link the
+    Deck UI builds in AttachmentList.vue."""
+    assert _attach(_attachment(fileid=99)).url == f"{BASE}/index.php/f/99"
+
+
+def test_deck_file_attachment_links_to_decks_download_route():
+    """type="deck_file" lives in Deck's private storage; there is no /f/ id."""
+    assert (
+        _attach(_attachment()).url
+        == f"{BASE}/index.php/apps/deck/cards/42/attachment/5"
+    )
+
+
+def test_card_attachments_are_linked_through_the_card():
+    card = _card(42)
+    card.attachments = [_attachment(fileid=99)]
+    _attach(card, {"board_id": 7})
+    assert card.attachments[0].url == f"{BASE}/index.php/f/99"
+
+
+def test_attachment_survives_an_empty_extended_data():
+    """Deck leaves extendedData [] when the underlying file is gone."""
+    attachment = DeckAttachment.model_validate(
+        {
+            "id": 5,
+            "cardId": 42,
+            "type": "deck_file",
+            "data": "a.pdf",
+            "lastModified": 0,
+            "createdAt": 0,
+            "createdBy": "alice",
+            "deletedAt": 0,
+            "extendedData": [],
+        }
+    )
+    assert (
+        _attach(attachment).url == f"{BASE}/index.php/apps/deck/cards/42/attachment/5"
+    )
 
 
 def test_card_operation_response_uses_the_ids_it_carries():


### PR DESCRIPTION
## Problem

`deck_get_card` reports `attachmentCount`, but its `attachments` array is unusable — for two independent reasons.

**1. No link.** Items were untyped raw dicts (`List[Any]`) carrying no way to open the attachment, while every other Deck model already gets a deep link from the `with_links` walker (ADR-035).

**2. The array is usually empty anyway.** The client asked for Deck **API v1.0**, where `CardService::find` and `AttachmentApiController::getAll` filter out every attachment that is not a legacy `deck_file`:

```php
// lib/Service/CardService.php
if ($this->request->getParam('apiVersion') === '1.0') {
    $attachments = array_filter($attachments, fn ($a) => $a->getType() === 'deck_file');
}
```

Our own `deck_attach_file` / `deck_attach_note` create `type="file"` shares, so a card attached through this server reported `attachmentCount: 1` with `attachments: []`.

## Changes

- `DeckAttachment` gains a `url`, populated by the existing walker: `/f/{fileid}` for `type="file"` (the same link Deck's `AttachmentList.vue` builds), Deck's `/apps/deck/cards/{card}/attachment/{id}` download route for `deck_file` blobs, which have no Files id.
- `DeckCard.attachments` is typed as `list[DeckAttachment]`; `deck_list_attachments` opts into `@with_links`.
- `get_card` and `get_attachments` use **API v1.1**. That version has been available since Deck 1.3.0 (2019), below any version this server supports, so it is not capability-gated.
- **`deck_delete_attachment` takes an `attachment_type`.** Deck resolves an attachment id against its `type`, and the client always sent the `deck_file` default — so deleting one of the now-visible `type="file"` shares would 404. Defaults to `deck_file`, i.e. existing calls are unchanged.
- `extendedData` tolerates the `[]` Deck emits when the underlying file is gone (`FileService::extendData` bails out) — routine for deleted attachments, and previously a hard validation error on the entire card.

Version-visible behaviour change, in the spirit of *"gate on versions, never on merge order"*: from this release `deck_get_card` returns `type="file"` attachments it previously omitted, and each attachment carries a `url`. Both are additive to the response; no field was removed or retyped in a way a consumer reading `attachments[i]["data"]` would notice.

## Test coverage

Unit (`uv run pytest -m unit`, 3766 passing):

- both URL shapes, plus attachments linked through a parent card (`tests/unit/test_links.py`)
- an attachment whose `extendedData` came back as `[]`
- the v1.1 routes on `get_card` / `get_attachments` — pinned so a future tidy-up back to v1.0 fails loudly rather than silently emptying the array
- `delete_attachment` passing `type` through, and defaulting to `deck_file`

**Gap, stated explicitly per CLAUDE.md's e2e + contract gate:** this changes MCP tool surface (`deck_list_attachments` response field, `deck_delete_attachment` parameter) and there is **no integration test** exercising it against a live Deck — the v1.1 switch and the `type=file` delete are verified against Deck's source, not against a running instance. Deck is not one of this repo's Pact boundaries, so no contract test applies. Tracked on Deck card #1221 (board 12).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzUa559nXtxHWTYuNpR2Wh
