### PR TITLE
fix(processors): batch OCR is worker-only — stop the inline escalation loop

### DIFF
--- a/nextcloud_mcp_server/document_processors/registry.py
+++ b/nextcloud_mcp_server/document_processors/registry.py
@@ -566,6 +566,10 @@ class ProcessorRegistry:
     ) -> ProcessingResult:
         """Pay for OCR when the classifier says a text extractor cannot do better.
 
+        Only under ``document_ocr_mode=sync``. Batch OCR is worker-only, so on this
+        inline path ``batch`` makes ``structured`` the terminal tier (see the gate
+        below); ``sync`` is what grants inline requests access to OCR.
+
         Fires for a scanned / no-text-layer doc (recommended "ocr"), and also for
         an unresolved "structured" recommendation -- a glyph-corrupt doc whose
         structured rung wasn't registered -- so the inline path falls through to
@@ -603,6 +607,21 @@ class ProcessorRegistry:
         result.metadata["ocr_recommended_reason"] = reason
         if not settings.document_ocr_enabled:
             result.metadata["ocr_escalation_skipped"] = "disabled"
+            return result
+
+        # Batch OCR defers its poll across procrastinate retries, which only the
+        # external worker path can do -- the inline/memory pool threads no per-doc
+        # identity through ``options``, so ``_process_batch`` raises there by
+        # construction (see ocr.py ``_batch_identity``). Escalating anyway burns a
+        # full structured re-parse per attempt for an OCR call that CANNOT succeed,
+        # and because OCR failure is non-fatal ("an enhancement, not a gate") the
+        # document is never dead-lettered -- it is simply re-discovered and
+        # re-parsed on the next scan, indefinitely. That loop OOMKilled a tenant's
+        # API Pod (Deck #1226). Under batch, the inline ladder therefore stops at
+        # structured; OCR belongs to the document-processing pipeline alone.
+        # Under sync, both the external processors and inline requests may escalate.
+        if settings.document_ocr_mode == "batch":
+            result.metadata["ocr_escalation_skipped"] = "batch_worker_only"
             return result
 
         # Inline (memory pool) path: no queues to hop, so resolve the OCR tier

--- a/tests/unit/test_registry_tiering.py
+++ b/tests/unit/test_registry_tiering.py
@@ -82,6 +82,9 @@ class _Settings:
         # Guard off by default so existing tiering tests are unaffected; tests
         # that exercise the size guard pass an explicit cap.
         max_pdf_size_mb=0.0,
+        # Matches the real default (config.py). "batch" makes OCR worker-only,
+        # so the inline ladder stops at structured.
+        ocr_mode="sync",
     ):
         self.document_tier1_engine = engine
         self.document_classify_enabled = classify
@@ -95,6 +98,7 @@ class _Settings:
         self.document_ocr_detect_scanned = detect_scanned
         self.document_glyph_corruption_ratio = glyph_corruption_ratio
         self.document_max_pdf_size_mb = max_pdf_size_mb
+        self.document_ocr_mode = ocr_mode
 
 
 def _registry(*procs: tuple[DocumentProcessor, int]) -> ProcessorRegistry:
@@ -283,6 +287,63 @@ async def test_no_ocr_escalation_when_disabled(monkeypatch):
     res = await r.process(b"%PDF-1.7", "application/pdf")
     # Fast tier is terminal when OCR is disabled.
     assert res.processor == "fast"
+
+
+# --- batch OCR is worker-only: the inline ladder must stop at structured -----
+#
+# Batch mode defers its poll across procrastinate retries, which only the
+# external worker path can do. Escalating inline burns a structured re-parse for
+# an OCR call that cannot succeed, and since OCR failure is non-fatal the doc is
+# never dead-lettered -- it is re-parsed on every scan until the Pod OOMs.
+# (Deck #1226.)
+
+
+async def test_no_inline_ocr_escalation_under_batch_mode(monkeypatch):
+    monkeypatch.setattr(
+        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_mode="batch")
+    )
+    esc = MagicMock()
+    monkeypatch.setattr(reg_mod, "record_document_escalation", esc)
+    r = _registry(
+        (_Fake("fast", "fast", text=""), 20),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
+    )
+    res = await r.process(b"%PDF-1.7", "application/pdf")
+    # OCR is registered and enabled, but batch is worker-only -> never invoked.
+    assert res.processor == "fast"
+    assert res.metadata["ocr_escalation_skipped"] == "batch_worker_only"
+    esc.assert_not_called()
+
+
+async def test_inline_ocr_escalation_still_runs_under_sync_mode(monkeypatch):
+    # The counterpart: under sync, inline requests may escalate to OCR.
+    monkeypatch.setattr(
+        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_mode="sync")
+    )
+    monkeypatch.setattr(reg_mod, "record_document_escalation", MagicMock())
+    r = _registry(
+        (_Fake("fast", "fast", text=""), 20),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
+    )
+    res = await r.process(b"%PDF-1.7", "application/pdf")
+    assert res.processor == "ocr"
+    assert "ocr_escalation_skipped" not in res.metadata
+
+
+async def test_batch_mode_still_allows_structured_escalation(monkeypatch):
+    # Batch gates only the OCR rung. fast->structured is free and in-cluster, so
+    # it must still happen -- structured becomes the terminal tier, not fast.
+    monkeypatch.setattr(
+        reg_mod, "get_settings", lambda: _Settings(ocr=True, ocr_mode="batch")
+    )
+    monkeypatch.setattr(reg_mod, "record_document_escalation", MagicMock())
+    r = _registry(
+        (_Fake("fast", "fast", text=_GLYPH), 20),
+        (_Fake("structured", "structured", text="clean recovered prose text"), 10),
+        (_Fake("ocr", "ocr", text="ocr text"), 5),
+    )
+    res = await r.process(b"%PDF-1.7", "application/pdf")
+    assert res.processor == "structured"
 
 
 # --- glyph-corruption escalation + full-ladder parity ------------------------


### PR DESCRIPTION
## Problem

Under `DOCUMENT_OCR_MODE=batch` the **inline** (memory pool) path escalates
`fast -> structured -> ocr` like any other, but batch OCR can never succeed
there. It defers its poll across procrastinate retries, and the inline path
threads no per-doc identity through `options` — so `_process_batch` raises by
construction (`_batch_identity(options) is None`).

Two things compound that into an outage:

1. The failure is discovered **inside the OCR processor**, after the expensive
   structured re-parse has already run.
2. OCR failure is deliberately non-fatal — "an enhancement, not a gate" — so the
   document keeps its tier-1 result and is **never dead-lettered**. It is
   re-discovered on the next scan and the whole cascade runs again.

Indefinitely.

## Impact (observed on a dev tenant)

One 16-page PDF re-parsed every ~12s for 8+ minutes under a single trace, each
cycle re-running pymupdf over 48-64 embedded images (10.3s per pass). Pod RSS
climbed 350MB -> 883MB into its 1Gi limit and was **OOMKilled 4 times in 20
minutes** after 24h of zero restarts, 5xx-ing every in-flight request. Gateway
`envoy_cluster_upstream_rq_xx{class="5"}` tracked the restarts exactly.

## Fix

Move the decision to the escalation gate. Under `batch`, the inline ladder stops
at `structured`; OCR belongs to the external document-processing pipeline alone.

That is the point of batch mode: the OCR GPU is provisioned on demand and shut
down once the queue drains. Sync mode is what grants inline requests access to
OCR, and is unchanged — both external processors and inline requests may
escalate there.

Only the OCR rung is gated. `fast -> structured` still happens, so `structured`
becomes the terminal tier rather than `fast`.

```
ocr_mode=batch  ->  external pipeline only; inline stops at structured
ocr_mode=sync   ->  external pipeline AND inline requests
```

## Test coverage

Three unit tests in `tests/unit/test_registry_tiering.py`:

- `test_no_inline_ocr_escalation_under_batch_mode` — OCR registered and enabled,
  but batch is worker-only, so it is never invoked; `ocr_escalation_skipped` is
  stamped `batch_worker_only` and no escalation is recorded.
- `test_inline_ocr_escalation_still_runs_under_sync_mode` — the counterpart, so
  the gate cannot silently widen to sync.
- `test_batch_mode_still_allows_structured_escalation` — guards against
  over-gating: batch must not stop `fast -> structured`.

Verified the first fails without the fix (`assert 'ocr' == 'fast'`) rather than
passing vacuously.

No new API surface, so no e2e/contract tier applies — this changes an internal
escalation decision only.

Deck #1226

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep64me4M3NRJGkaVAw6MRF