### PR TITLE
chore: drop customer-identifying tenant slug from comments and docs

### DIFF
--- a/docs/ADR-033-per-user-paths-for-shared-documents.md
+++ b/docs/ADR-033-per-user-paths-for-shared-documents.md
@@ -29,7 +29,8 @@ Reconciled path for file_<id> after rename/move: '/A/doc.pdf' -> '/B/A/doc.pdf'
 Reconciled path for file_<id> after rename/move: '/B/A/doc.pdf' -> '/A/doc.pdf'
 ```
 
-Observed on blackbox-demo, 2026-07-20, service 0.142.0.
+Observed on a multi-user tenant with shared team folders, 2026-07-20, service
+0.142.0.
 
 ### Impact
 

--- a/nextcloud_mcp_server/vector/metrics_publisher.py
+++ b/nextcloud_mcp_server/vector/metrics_publisher.py
@@ -5,7 +5,7 @@ of ``mcp_vector_sync_queue_size`` only runs in the single-user consumer
 (``processor_task``). The multi-user consumer (``oauth_processor_task``) drains
 the same queue but never touched the gauge, so in multi-user deployments the
 gauge read 0 while the live anyio buffer held thousands of pending documents
-(observed on tenant-blackbox-demo: gauge 0 for 24h vs 2214 pending in the status
+(observed on a multi-user tenant: gauge 0 for 24h vs 2214 pending in the status
 endpoint). This task publishes the *same* ``get_ingest_pending()`` figure the
 ``/api/v1/vector-sync/status`` endpoint serves, on a fixed cadence, independent
 of which consumer drains the queue and of the queue backend (anyio buffer depth

--- a/nextcloud_mcp_server/vector/scanner.py
+++ b/nextcloud_mcp_server/vector/scanner.py
@@ -280,7 +280,7 @@ def _plan_file_deletions(
 
     A mode's discovery is *implausible* this cycle iff it was attempted, returned
     zero files, yet Qdrant still holds indexed points for it — the signature of a
-    flaky/empty tag read (issue: blackbox-demo re-index flap). While a mode's
+    flaky/empty tag read (issue: the observed re-index flap). While a mode's
     consecutive-empty streak is below ``empty_delete_threshold`` its deletions are
     suppressed and its grace timers are left untouched (neither started nor
     advanced), so a transient empty deletes nothing. Once the streak reaches the
@@ -434,7 +434,7 @@ def _indexed_files_scroll_filter(user_id: str) -> Filter:
     the original indexer, once they lost access, re-selected the shared points
     every scan (their discovery is now empty), re-issued a release, and — because
     the release only touches ``acl_principals`` — never shrank the set: a
-    perpetual no-op release loop (blackbox-demo team-folder removal, 2.7k
+    perpetual no-op release loop (observed on a team-folder removal, 2.7k
     releases/hr). Keying on the principal makes a release converge: once a user's
     principal is dropped, the next scan no longer selects the doc.
 
@@ -978,7 +978,7 @@ async def scan_user_documents(
         # Get this user's readable indexed file points from Qdrant (for deletion
         # tracking), keyed on acl_principals (the observed-access set) rather than
         # the immutable user_id indexer stamp — see _indexed_files_scroll_filter
-        # for why (blackbox-demo team-folder-removal release loop). Keying on the
+        # for why (the team-folder-removal release loop). Keying on the
         # principal makes a release converge and also tracks pure claimers, so a
         # reader who lost access releases its own principal on the next scan.
         indexed_by_mode: dict[str, set[str]] = {}

--- a/tests/integration/test_pdf_page_packing.py
+++ b/tests/integration/test_pdf_page_packing.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.integration
 def create_lean_multipage_pdf(n_pages: int = 12) -> bytes:
     """Create a born-digital PDF with many short (lean) pages.
 
-    Mimics the blackbox-demo density regime: one near-empty page each, so the
+    Mimics the observed low-density regime: one near-empty page each, so the
     per-page chunker floor would mint one dense vector per page (Deck #636).
     """
     doc = pymupdf.open()

--- a/tests/unit/vector/test_scanner_deletion_gate.py
+++ b/tests/unit/vector/test_scanner_deletion_gate.py
@@ -265,7 +265,7 @@ def test_bump_streak_evicts_oldest_when_bounded(monkeypatch):
 # ---------------------------------------------------------------------------
 # Deletion-tracking readback filter: keyed on acl_principals, not user_id, so a
 # removed original-indexer's release converges instead of looping forever
-# (blackbox-demo team-folder removal). Legacy points (no acl set) still tracked
+# (the team-folder removal case). Legacy points (no acl set) still tracked
 # by user_id.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

This repo is **public**. Seven comments/docstrings named a specific customer
tenant slug as the provenance of an observed behaviour.

Nothing in them depends on the identity — the *measurements* carry every
argument, the customer name carries none. So the slug is replaced with a neutral
descriptor and each number is kept verbatim:

| file | what is preserved |
|---|---|
| `vector/metrics_publisher.py` | gauge 0 for 24h vs 2214 pending |
| `vector/scanner.py` | 2.7k no-op releases/hr on a team-folder removal |
| `docs/ADR-033-…md` | 2,832 docs / ~288k chunks |
| `tests/integration/test_pdf_page_packing.py` | the near-empty-page density regime |
| `tests/unit/vector/test_scanner_deletion_gate.py` | the team-folder removal case |

## Audit result

Scanned the working tree **and full history** of both public repos (this one and
`helm-charts`) for corpus directory names, personal names, real filenames,
customer emails and customer hostnames.

- **`helm-charts`: completely clean** — no hits in tracked files or history. No
  change needed there.
- **This repo, high severity: zero.** No `TOR SCHOOL` / `BLACK BOX CLIENT` /
  `CONDUCT FILE` / `251 SAMPLE` / `Sample Files To AI` / `bbsd.co.uk` /
  `fileroom` / personal names — in tracked files or in any commit diff. A
  history sweep with `-S` per string returned nothing.

Because nothing high-severity was ever committed, **no history rewrite is
needed** — scrubbing the current tree is sufficient.

After this change, a case-insensitive search for the customer identifiers
returns nothing in tracked files.

## Scope note

The publication boundary is per-repo, not uniform: `astrolabe-cloud-gitops` is a
**private** repo, so the tenant detail in its comments is fine and is
deliberately not touched here.

Comments and docs only — no behaviour change, and no test changes beyond two
docstring/comment lines.

Deck #1228

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep64me4M3NRJGkaVAw6MRF
