### PR TITLE
feat(shopping_list): add Nextcloud Shopping List app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ For Kubernetes, see [cbcoutinho/helm-charts](https://github.com/cbcoutinho/helm-
 | **Mail** | 13 | Accounts, mailboxes, messages, attachments, send; flags (read/unread, star), tags, move, delete |
 | **Collectives** | 16 | Full CRUD on collectives, pages, and tags |
 | **Talk (spreed)** | 6 | List conversations, read/post messages, mark as read, list participants |
+| **Shopping List** | 12 | Lists and items — add a whole recipe's ingredients in one call, tick items off, clear checked |
 | **Semantic Search** | 2+ | Vector search for Notes, Files, News items, Deck cards, and Mail messages (experimental, opt-in, requires infrastructure) |
 
 Want to see another Nextcloud app supported? [Open an issue](https://github.com/cbcoutinho/nextcloud-mcp-server/issues) or contribute a pull request!

--- a/app-hooks/before-starting/26-configure-astrolabe-oauth.sh
+++ b/app-hooks/before-starting/26-configure-astrolabe-oauth.sh
@@ -45,7 +45,7 @@ REDIRECT_URI="${NC_EXTERNAL_URL}/apps/astrolabe/oauth/callback"
 # every tool call (not just for tool visibility) — so a scope omitted here
 # silently removes those tools. mail.* and talk.* were missing for exactly that
 # reason. Keep in sync with models/auth.py, not with a mental list of apps.
-ALLOWED_SCOPES="openid profile email offline_access notes.read notes.write calendar.read calendar.write todo.read todo.write contacts.read contacts.write cookbook.read cookbook.write deck.read deck.write tables.read tables.write files.read files.write sharing.read sharing.write news.read news.write collectives.read collectives.write mail.read mail.write mail.send talk.read talk.write semantic.read"
+ALLOWED_SCOPES="openid profile email offline_access notes.read notes.write calendar.read calendar.write todo.read todo.write contacts.read contacts.write cookbook.read cookbook.write deck.read deck.write tables.read tables.write files.read files.write sharing.read sharing.write news.read news.write collectives.read collectives.write shopping_list.read shopping_list.write mail.read mail.write mail.send talk.read talk.write semantic.read"
 
 # Create OAuth client
 CLIENT_JSON=$(php occ oidc:create "Astrolabe" \

--- a/app-hooks/post-installation/10-install-shopping_list-app.sh
+++ b/app-hooks/post-installation/10-install-shopping_list-app.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euox pipefail
+
+php /var/www/html/occ app:enable shopping_list

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1481,7 +1481,8 @@ account with Talk disabled sees no Talk tools while their colleague does.
 - Only apps that actually publish a capability block are gated: **Notes, Tables,
   Deck, Cookbook and Talk** (`spreed`). Calendar and Contacts tools speak
   CalDAV/CardDAV and keep working with those web apps uninstalled, so they are
-  never gated; Collectives, News and Mail publish nothing to gate on.
+  never gated; Collectives, News, Mail and Shopping List publish nothing to gate
+  on.
 - Version floors follow PEP 440, so a pre-release (`1.18.0-beta.3`) sorts
   *below* the release it precedes and stays gated out.
 

--- a/docs/login-flow-v2.md
+++ b/docs/login-flow-v2.md
@@ -320,6 +320,7 @@ Scopes are **per-app** and follow an `<app>.<read|write>` pattern. There is no `
 | `cookbook.read` / `cookbook.write` | Cookbook |
 | `todo.read` / `todo.write` | Tasks (VTODO outside Calendar) |
 | `collectives.read` / `collectives.write` | Collectives |
+| `shopping_list.read` / `shopping_list.write` | Shopping List |
 | `news.read` | News (read-only) |
 | `sharing.write` | Share-link / share-permission management |
 | `semantic.read` | Semantic search + RAG (when enabled) |

--- a/nextcloud_mcp_server/client/__init__.py
+++ b/nextcloud_mcp_server/client/__init__.py
@@ -25,6 +25,7 @@ from .news import NewsClient
 from .notes import NotesClient
 from .ocs import OCS_REQUEST_HEADERS
 from .sharing import SharingClient
+from .shopping_list import ShoppingListClient
 from .tables import TablesClient
 from .talk import TalkClient
 from .users import UsersClient
@@ -173,6 +174,7 @@ class NextcloudClient:
         self.users = UsersClient(self._client, username)
         self.groups = GroupsClient(self._client, username)
         self.sharing = SharingClient(self._client, username)
+        self.shopping_list = ShoppingListClient(self._client, username)
 
         # Initialize controllers
         self._notes_search = NotesSearchController()

--- a/nextcloud_mcp_server/client/shopping_list.py
+++ b/nextcloud_mcp_server/client/shopping_list.py
@@ -1,0 +1,150 @@
+"""Client for the Nextcloud Shopping List app (``shopping_list``).
+
+Covers the lists and items surface of the app's OCS API. Shop areas, tags,
+shares and the public-link API are deliberately not wrapped yet — nothing asks
+for them, and the item payload carries ``shopAreaId`` through untouched, so the
+app's own area auto-detection keeps working.
+
+See https://github.com/otherworld-dev/Shopping-List.
+"""
+
+import logging
+from typing import Any
+
+from .base import BaseNextcloudClient
+from .ocs import OCS_REQUEST_HEADERS
+
+logger = logging.getLogger(__name__)
+
+
+class ShoppingListClient(BaseNextcloudClient):
+    """Client for Nextcloud Shopping List app operations."""
+
+    app_name = "shopping_list"
+
+    API_BASE = "/ocs/v2.php/apps/shopping_list/api/v1"
+
+    # Own copy -- see the note in GroupsClient.
+    _OCS_HEADERS: dict[str, str] = dict(OCS_REQUEST_HEADERS)
+
+    async def _ocs(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Issue an OCS request and hand back ``ocs.data``.
+
+        Every route in this app answers with the same envelope, and
+        ``/ocs/v2.php`` mirrors the OCS code onto the HTTP status, which
+        ``_make_request`` already raises on — so unwrapping is all that is left
+        to do. The delete/clear routes answer 204 with an empty body, hence the
+        guard.
+        """
+        response = await self._make_request(
+            method, f"{self.API_BASE}{path}", headers=self._OCS_HEADERS, **kwargs
+        )
+        if not response.content:
+            return None
+        return response.json()["ocs"]["data"]
+
+    # --- Lists ---
+
+    async def get_lists(self) -> list[dict[str, Any]]:
+        """Get every list the user owns or has had shared with them."""
+        return await self._ocs("GET", "/lists")
+
+    async def get_list(self, list_id: int) -> dict[str, Any]:
+        """Get a single list.
+
+        Raises:
+            HTTPStatusError: 404 if the list does not exist or is not shared
+                with the user.
+        """
+        return await self._ocs("GET", f"/lists/{list_id}")
+
+    async def create_list(self, title: str) -> dict[str, Any]:
+        """Create a new list owned by the user."""
+        return await self._ocs("POST", "/lists", json={"title": title})
+
+    async def update_list(self, list_id: int, title: str) -> dict[str, Any]:
+        """Rename a list.
+
+        Raises:
+            HTTPStatusError: 404 if not found, 403 without write access.
+        """
+        return await self._ocs("PUT", f"/lists/{list_id}", json={"title": title})
+
+    async def delete_list(self, list_id: int) -> None:
+        """Delete a list and everything on it.
+
+        Raises:
+            HTTPStatusError: 404 if not found, 403 if the user is not the owner.
+        """
+        await self._ocs("DELETE", f"/lists/{list_id}")
+
+    # --- Items ---
+
+    async def get_items(self, list_id: int) -> list[dict[str, Any]]:
+        """Get every item on a list, checked ones included."""
+        return await self._ocs("GET", f"/lists/{list_id}/items")
+
+    async def add_item(
+        self,
+        list_id: int,
+        name: str,
+        quantity: str | None = None,
+        unit: str | None = None,
+        shop_area_id: int | None = None,
+        checked: bool = False,
+    ) -> dict[str, Any]:
+        """Add an item to a list.
+
+        Args:
+            list_id: List to add to.
+            name: Item name, e.g. "flour".
+            quantity: Free-text amount, e.g. "2". Defaults to "1" server-side.
+            unit: Free-text unit, e.g. "cups".
+            shop_area_id: Shop area to file the item under. Left unset, the app
+                assigns one from its keyword mappings.
+            checked: Add the item already ticked off.
+
+        Raises:
+            HTTPStatusError: 404 if the list is missing, 403 without write
+                access.
+        """
+        payload: dict[str, Any] = {"name": name, "checked": checked}
+        if quantity is not None:
+            payload["quantity"] = quantity
+        if unit is not None:
+            payload["unit"] = unit
+        if shop_area_id is not None:
+            payload["shopAreaId"] = shop_area_id
+        return await self._ocs("POST", f"/lists/{list_id}/items", json=payload)
+
+    async def update_item(
+        self, list_id: int, item_id: int, fields: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update an item's fields.
+
+        Args:
+            fields: Only the keys present are changed — the app reads the
+                request params rather than a full entity, so an omitted field
+                keeps its value while an explicit ``None`` clears it.
+        """
+        return await self._ocs("PUT", f"/lists/{list_id}/items/{item_id}", json=fields)
+
+    async def check_item(
+        self, list_id: int, item_id: int, checked: bool
+    ) -> dict[str, Any]:
+        """Tick an item off, or put it back on the list."""
+        return await self._ocs(
+            "PUT", f"/lists/{list_id}/items/{item_id}/check", json={"checked": checked}
+        )
+
+    async def delete_item(self, list_id: int, item_id: int) -> None:
+        """Delete a single item."""
+        await self._ocs("DELETE", f"/lists/{list_id}/items/{item_id}")
+
+    async def clear_checked_items(self, list_id: int) -> None:
+        """Delete every ticked-off item on a list."""
+        await self._ocs("DELETE", f"/lists/{list_id}/items/checked")
+
+    async def uncheck_all_items(self, list_id: int) -> None:
+        """Put every ticked-off item on a list back into the open section."""
+        await self._ocs("POST", f"/lists/{list_id}/items/uncheck-all")

--- a/nextcloud_mcp_server/models/auth.py
+++ b/nextcloud_mcp_server/models/auth.py
@@ -92,6 +92,8 @@ ALL_SUPPORTED_SCOPES: frozenset[str] = frozenset(
         "talk.write",
         "collectives.read",
         "collectives.write",
+        "shopping_list.read",
+        "shopping_list.write",
         # MCP-server-level rather than a Nextcloud app, but it gates tools the
         # same way, so it lives in the same vocabulary. Advertised in DCR only
         # when vector sync is enabled — see app.py.

--- a/nextcloud_mcp_server/models/shopping_list.py
+++ b/nextcloud_mcp_server/models/shopping_list.py
@@ -1,0 +1,110 @@
+"""Pydantic models for Shopping List app responses."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .base import BaseResponse, StatusResponse
+
+
+class ShoppingList(BaseModel):
+    """A shopping list."""
+
+    id: int = Field(description="List ID")
+    userId: str | None = Field(None, description="UID of the list owner")
+    title: str = Field(description="List title")
+    permission: int | None = Field(
+        None, description="Current user's permission level (0 = read, 1 = write)"
+    )
+    isOwner: bool | None = Field(None, description="Whether the user owns this list")
+    isPinned: bool | None = Field(
+        None, description="Whether the user pinned this list in the sidebar"
+    )
+    createdAt: str | None = Field(None, description="Creation timestamp (ISO 8601)")
+    updatedAt: str | None = Field(None, description="Last update timestamp (ISO 8601)")
+
+    # The app gained `isPinned` in 1.5 and may gain more; an unknown field
+    # should widen the model's output, not fail the tool.
+    model_config = ConfigDict(extra="allow")
+
+
+class ShoppingListItem(BaseModel):
+    """An item on a shopping list."""
+
+    id: int = Field(description="Item ID")
+    listId: int = Field(description="ID of the list the item belongs to")
+    name: str = Field(description="Item name")
+    quantity: str | None = Field(None, description="Free-text quantity, e.g. '2'")
+    unit: str | None = Field(None, description="Free-text unit, e.g. 'cups'")
+    shopAreaId: int | None = Field(
+        None, description="ID of the shop area the item is filed under"
+    )
+    checked: bool = Field(default=False, description="Whether the item is ticked off")
+    checkedBy: str | None = Field(
+        None, description="UID of the user who ticked the item off"
+    )
+    sortOrder: int | None = Field(None, description="Manual sort position")
+    tags: list[dict[str, Any]] = Field(
+        default_factory=list, description="Tags on the item"
+    )
+    createdAt: str | None = Field(None, description="Creation timestamp (ISO 8601)")
+    updatedAt: str | None = Field(None, description="Last update timestamp (ISO 8601)")
+
+    model_config = ConfigDict(extra="allow")
+
+
+# Response models for MCP tools
+
+
+class ListShoppingListsResponse(BaseResponse):
+    """Response model for listing shopping lists."""
+
+    lists: list[ShoppingList] = Field(description="The user's shopping lists")
+    total_count: int = Field(description="Number of lists returned")
+
+
+class ShoppingListResponse(BaseResponse):
+    """Response model for a single shopping list."""
+
+    list: ShoppingList = Field(description="The shopping list")
+
+
+class DeleteShoppingListResponse(StatusResponse):
+    """Response model for shopping list deletion."""
+
+    deleted_id: int = Field(description="ID of the deleted list")
+
+
+class ListShoppingListItemsResponse(BaseResponse):
+    """Response model for listing the items on a shopping list."""
+
+    items: list[ShoppingListItem] = Field(description="Items on the list")
+    list_id: int = Field(description="ID of the list the items belong to")
+    total_count: int = Field(description="Number of items returned")
+
+
+class ShoppingListItemResponse(BaseResponse):
+    """Response model for a single shopping list item."""
+
+    item: ShoppingListItem = Field(description="The item")
+
+
+class AddShoppingListItemsResponse(BaseResponse):
+    """Response model for adding several items to a list in one call."""
+
+    items: list[ShoppingListItem] = Field(description="The items that were added")
+    list_id: int = Field(description="ID of the list the items were added to")
+    added_count: int = Field(description="Number of items added")
+
+
+class DeleteShoppingListItemResponse(StatusResponse):
+    """Response model for item deletion."""
+
+    deleted_id: int = Field(description="ID of the deleted item")
+    list_id: int = Field(description="ID of the list the item was on")
+
+
+class BulkItemActionResponse(StatusResponse):
+    """Response model for the list-wide item actions (clear / uncheck all)."""
+
+    list_id: int = Field(description="ID of the list the action applied to")

--- a/nextcloud_mcp_server/models/shopping_list.py
+++ b/nextcloud_mcp_server/models/shopping_list.py
@@ -2,9 +2,59 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from .base import BaseResponse, StatusResponse
+
+
+class ShoppingListItemInput(BaseModel):
+    """One item as an MCP caller supplies it to ``nc_shopping_list_add_items``.
+
+    Separate from :class:`ShoppingListItem`, which is what the app hands back:
+    only ``name`` is required here, and the server-assigned fields (``id``,
+    ``listId``, ``checkedBy``, timestamps) have no place in a request.
+    """
+
+    name: str = Field(min_length=1, description="Item name, e.g. 'flour'")
+    quantity: str | None = Field(
+        None, description="Free-text quantity, e.g. '2'. The app defaults it to '1'"
+    )
+    unit: str | None = Field(None, description="Free-text unit, e.g. 'cups'")
+    shop_area_id: int | None = Field(
+        None,
+        # Both spellings are accepted, and the snake_case one is what the schema
+        # advertises: it matches the sibling tool `nc_shopping_list_update_item`
+        # and every other MCP parameter in this repo. `shopAreaId` stays valid
+        # because that is what the app's own API calls it, so a caller working
+        # from the Shopping List docs is not caught out either way.
+        validation_alias=AliasChoices("shop_area_id", "shopAreaId"),
+        description=(
+            "Shop area to file the item under. Leave it unset and the app picks "
+            "one from its own keyword mappings, which is usually what you want"
+        ),
+    )
+    checked: bool = Field(default=False, description="Add the item already ticked off")
+
+    # `extra="forbid"` turns a misspelled key into a validation error naming the
+    # offending index, rather than an ignored field and an item quietly missing
+    # its quantity.
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @field_validator("quantity", "unit", mode="before")
+    @classmethod
+    def coerce_to_str(cls, v: object) -> object:
+        """Accept a number where the app stores a free-text string.
+
+        ``{"name": "eggs", "quantity": 3}`` is the obvious thing for a model to
+        send, and the app's column is a nullable string either way — rejecting
+        it would be pedantry. Booleans are not numbers for this purpose.
+        """
+        if isinstance(v, bool):
+            msg = "boolean values are not valid for quantity or unit"
+            raise ValueError(msg)
+        if isinstance(v, (int, float)):
+            return str(v)
+        return v
 
 
 class ShoppingList(BaseModel):

--- a/nextcloud_mcp_server/server/__init__.py
+++ b/nextcloud_mcp_server/server/__init__.py
@@ -14,6 +14,7 @@ from .news import configure_news_tools
 from .notes import configure_notes_tools
 from .semantic import configure_semantic_tools
 from .sharing import configure_sharing_tools
+from .shopping_list import configure_shopping_list_tools
 from .tables import configure_tables_tools
 from .talk import configure_talk_tools
 from .webdav import configure_webdav_tools
@@ -35,6 +36,7 @@ AVAILABLE_APPS: dict[str, Callable[[MCPServer], None]] = {
     "news": configure_news_tools,
     "mail": configure_mail_tools,
     "talk": configure_talk_tools,
+    "shopping_list": configure_shopping_list_tools,
 }
 
 # App name → the key it publishes on /ocs/v2.php/cloud/capabilities, for apps
@@ -50,6 +52,8 @@ AVAILABLE_APPS: dict[str, Callable[[MCPServer], None]] = {
 #     `client_integration`) are deliberately absent: those tools speak
 #     CalDAV/CardDAV and keep working with the web app uninstalled
 #   collectives / news / mail        → publish no capability block at all
+#   shopping_list                    → likewise; gating it would hide working
+#                                      tools on every instance that has it
 #   webdav / sharing                 → core `files`/`files_sharing`, always there
 APP_CAPABILITY_KEY: dict[str, str] = {
     "notes": "notes",
@@ -92,6 +96,7 @@ __all__ = [
     "configure_notes_tools",
     "configure_semantic_tools",
     "configure_sharing_tools",
+    "configure_shopping_list_tools",
     "configure_tables_tools",
     "configure_talk_tools",
     "configure_webdav_tools",

--- a/nextcloud_mcp_server/server/shopping_list.py
+++ b/nextcloud_mcp_server/server/shopping_list.py
@@ -27,6 +27,7 @@ from nextcloud_mcp_server.models.shopping_list import (
     ListShoppingListsResponse,
     ShoppingList,
     ShoppingListItem,
+    ShoppingListItemInput,
     ShoppingListItemResponse,
     ShoppingListResponse,
 )
@@ -167,27 +168,21 @@ def configure_shopping_list_tools(mcp: MCPServer):
     @instrument_tool
     async def nc_shopping_list_add_items(
         list_id: int,
-        items: list[dict[str, Any]],
+        items: list[ShoppingListItemInput],
         ctx: Context,
     ) -> AddShoppingListItemsResponse:
         """Add one or more items to a shopping list.
 
-        Takes a list so a whole recipe's ingredients land in one call. Each entry
-        is an object with:
+        Takes a list so a whole recipe's ingredients land in one call, e.g.
+        ``[{"name": "flour", "quantity": "2", "unit": "cups"},
+        {"name": "eggs", "quantity": "3"}]``. See the ``items`` schema for the
+        fields each entry accepts — only ``name`` is required.
 
-        - ``name`` (required) — the item, e.g. "flour"
-        - ``quantity`` — free text, e.g. "2". The app defaults it to "1"
-        - ``unit`` — free text, e.g. "cups"
-        - ``shopAreaId`` — shop area to file it under. Leave it out and the app
-          picks one from its own keyword mappings, which is usually what you want
-        - ``checked`` — add the item already ticked off (default false)
-
-        e.g. ``[{"name": "flour", "quantity": "2", "unit": "cups"},
-        {"name": "eggs", "quantity": "3"}]``
-
-        Items are added one at a time — the app has no bulk endpoint — so a
-        failure partway through leaves the earlier items on the list. Adding a
-        name the list already carries merges the quantities rather than
+        The whole list is validated before anything is sent, so a malformed
+        entry adds nothing. Once sending starts the items go one at a time — the
+        app has no bulk endpoint — so a failure partway through leaves the
+        earlier items on the list, and the error says how many those were.
+        Adding a name the list already carries merges the quantities rather than
         duplicating the row.
         """
         if not items:
@@ -195,27 +190,18 @@ def configure_shopping_list_tools(mcp: MCPServer):
 
         client = await get_client(ctx)
         added: list[ShoppingListItem] = []
-        for index, item in enumerate(items):
-            name = item.get("name")
-            if not name:
-                raise MCPError(
-                    code=-1,
-                    message=(
-                        f"Item at position {index} has no 'name'. "
-                        f"{len(added)} item(s) were already added to list {list_id}."
-                    ),
-                )
+        for item in items:
             with _shopping_list_errors(
-                f"adding '{name}' to shopping list {list_id} "
+                f"adding '{item.name}' to shopping list {list_id} "
                 f"({len(added)} of {len(items)} item(s) already added)"
             ):
                 data = await client.shopping_list.add_item(
                     list_id,
-                    name=name,
-                    quantity=item.get("quantity"),
-                    unit=item.get("unit"),
-                    shop_area_id=item.get("shopAreaId"),
-                    checked=bool(item.get("checked", False)),
+                    name=item.name,
+                    quantity=item.quantity,
+                    unit=item.unit,
+                    shop_area_id=item.shop_area_id,
+                    checked=item.checked,
                 )
             added.append(ShoppingListItem(**data))
 
@@ -247,15 +233,15 @@ def configure_shopping_list_tools(mcp: MCPServer):
         Use ``nc_shopping_list_check_item`` to tick an item off — this tool does
         not touch the checked state.
         """
-        fields: dict[str, Any] = {}
-        if name is not None:
-            fields["name"] = name
-        if quantity is not None:
-            fields["quantity"] = quantity
-        if unit is not None:
-            fields["unit"] = unit
-        if shop_area_id is not None:
-            fields["shopAreaId"] = shop_area_id
+        # Only the keys present are sent: the app reads request params, so an
+        # absent key leaves that field alone.
+        given: dict[str, Any] = {
+            "name": name,
+            "quantity": quantity,
+            "unit": unit,
+            "shopAreaId": shop_area_id,
+        }
+        fields = {key: value for key, value in given.items() if value is not None}
         if not fields:
             raise MCPError(code=-1, message="No fields given to update")
 

--- a/nextcloud_mcp_server/server/shopping_list.py
+++ b/nextcloud_mcp_server/server/shopping_list.py
@@ -229,9 +229,11 @@ def configure_shopping_list_tools(mcp: MCPServer):
     ) -> ShoppingListItemResponse:
         """Update an item's name, quantity, unit or shop area.
 
-        Only the arguments given are changed. Omitted ones keep their value.
-        Use ``nc_shopping_list_check_item`` to tick an item off — this tool does
-        not touch the checked state.
+        Only the arguments given are changed. Omitted ones keep their value,
+        which also means this tool can set a field but not *clear* one back to
+        empty — pass a new value, or delete and re-add the item. Use
+        ``nc_shopping_list_check_item`` to tick an item off — this tool does not
+        touch the checked state.
         """
         # Only the keys present are sent: the app reads request params, so an
         # absent key leaves that field alone.

--- a/nextcloud_mcp_server/server/shopping_list.py
+++ b/nextcloud_mcp_server/server/shopping_list.py
@@ -182,8 +182,12 @@ def configure_shopping_list_tools(mcp: MCPServer):
         entry adds nothing. Once sending starts the items go one at a time — the
         app has no bulk endpoint — so a failure partway through leaves the
         earlier items on the list, and the error says how many those were.
-        Adding a name the list already carries merges the quantities rather than
-        duplicating the row.
+
+        A name already on the list is added again as a **second row**. The
+        quantity-merging the Shopping List web UI does is client-side, so the
+        API does not do it for you. To top up an existing item instead, read the
+        list with ``nc_shopping_list_get_items`` and use
+        ``nc_shopping_list_update_item``.
         """
         if not items:
             raise MCPError(code=-1, message="No items given to add")

--- a/nextcloud_mcp_server/server/shopping_list.py
+++ b/nextcloud_mcp_server/server/shopping_list.py
@@ -1,0 +1,339 @@
+"""MCP tools for the Nextcloud Shopping List app.
+
+The app answers every failure with the same three statuses — 404 for a missing
+list or item, 403 for one the user may read but not write, and anything else is
+a server fault — so the translation to ``MCPError`` lives in one context
+manager rather than a try/except per tool.
+"""
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from httpx import HTTPStatusError, RequestError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared.exceptions import MCPError
+from mcp.types import ToolAnnotations
+
+from nextcloud_mcp_server.auth import require_scopes
+from nextcloud_mcp_server.context import get_client
+from nextcloud_mcp_server.models.shopping_list import (
+    AddShoppingListItemsResponse,
+    BulkItemActionResponse,
+    DeleteShoppingListItemResponse,
+    DeleteShoppingListResponse,
+    ListShoppingListItemsResponse,
+    ListShoppingListsResponse,
+    ShoppingList,
+    ShoppingListItem,
+    ShoppingListItemResponse,
+    ShoppingListResponse,
+)
+from nextcloud_mcp_server.observability.metrics import instrument_tool
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _shopping_list_errors(action: str) -> Iterator[None]:
+    """Re-raise a Shopping List failure as the message the model should act on."""
+    try:
+        yield
+    except RequestError as e:
+        raise MCPError(code=-1, message=f"Network error {action}: {e}")
+    except HTTPStatusError as e:
+        status = e.response.status_code
+        if status == 404:
+            detail = "not found, or not shared with you"
+        elif status == 403:
+            detail = "you do not have write access to this list"
+        else:
+            detail = f"server error ({status})"
+        raise MCPError(code=-1, message=f"Failed {action}: {detail}")
+
+
+def configure_shopping_list_tools(mcp: MCPServer):
+    """Configure Shopping List app MCP tools."""
+
+    @mcp.tool(
+        title="List Shopping Lists",
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.read")
+    @instrument_tool
+    async def nc_shopping_list_get_lists(ctx: Context) -> ListShoppingListsResponse:
+        """List every shopping list the user owns or has had shared with them."""
+        client = await get_client(ctx)
+        with _shopping_list_errors("listing shopping lists"):
+            lists = [
+                ShoppingList(**item) for item in await client.shopping_list.get_lists()
+            ]
+        return ListShoppingListsResponse(lists=lists, total_count=len(lists))
+
+    @mcp.tool(
+        title="Get Shopping List",
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.read")
+    @instrument_tool
+    async def nc_shopping_list_get_list(
+        list_id: int, ctx: Context
+    ) -> ShoppingListResponse:
+        """Get a single shopping list by ID."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"getting shopping list {list_id}"):
+            data = await client.shopping_list.get_list(list_id)
+        return ShoppingListResponse(list=ShoppingList(**data))
+
+    @mcp.tool(
+        title="Create Shopping List",
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_create_list(
+        title: str, ctx: Context
+    ) -> ShoppingListResponse:
+        """Create a new shopping list.
+
+        Titles are not unique — calling this twice with the same title makes two
+        lists.
+        """
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"creating shopping list '{title}'"):
+            data = await client.shopping_list.create_list(title)
+        return ShoppingListResponse(list=ShoppingList(**data))
+
+    @mcp.tool(
+        title="Rename Shopping List",
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_update_list(
+        list_id: int, title: str, ctx: Context
+    ) -> ShoppingListResponse:
+        """Rename an existing shopping list."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"renaming shopping list {list_id}"):
+            data = await client.shopping_list.update_list(list_id, title)
+        return ShoppingListResponse(list=ShoppingList(**data))
+
+    @mcp.tool(
+        title="Delete Shopping List",
+        annotations=ToolAnnotations(
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
+        ),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_delete_list(
+        list_id: int, ctx: Context
+    ) -> DeleteShoppingListResponse:
+        """Delete a shopping list and every item on it. Only the owner may do this."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"deleting shopping list {list_id}"):
+            await client.shopping_list.delete_list(list_id)
+        return DeleteShoppingListResponse(
+            deleted_id=list_id, message=f"Deleted shopping list {list_id}"
+        )
+
+    @mcp.tool(
+        title="List Shopping List Items",
+        annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.read")
+    @instrument_tool
+    async def nc_shopping_list_get_items(
+        list_id: int, ctx: Context
+    ) -> ListShoppingListItemsResponse:
+        """Get every item on a shopping list, ticked-off ones included."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"listing items on shopping list {list_id}"):
+            items = [
+                ShoppingListItem(**item)
+                for item in await client.shopping_list.get_items(list_id)
+            ]
+        return ListShoppingListItemsResponse(
+            items=items, list_id=list_id, total_count=len(items)
+        )
+
+    @mcp.tool(
+        title="Add Shopping List Items",
+        annotations=ToolAnnotations(idempotent_hint=False, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_add_items(
+        list_id: int,
+        items: list[dict[str, Any]],
+        ctx: Context,
+    ) -> AddShoppingListItemsResponse:
+        """Add one or more items to a shopping list.
+
+        Takes a list so a whole recipe's ingredients land in one call. Each entry
+        is an object with:
+
+        - ``name`` (required) — the item, e.g. "flour"
+        - ``quantity`` — free text, e.g. "2". The app defaults it to "1"
+        - ``unit`` — free text, e.g. "cups"
+        - ``shopAreaId`` — shop area to file it under. Leave it out and the app
+          picks one from its own keyword mappings, which is usually what you want
+        - ``checked`` — add the item already ticked off (default false)
+
+        e.g. ``[{"name": "flour", "quantity": "2", "unit": "cups"},
+        {"name": "eggs", "quantity": "3"}]``
+
+        Items are added one at a time — the app has no bulk endpoint — so a
+        failure partway through leaves the earlier items on the list. Adding a
+        name the list already carries merges the quantities rather than
+        duplicating the row.
+        """
+        if not items:
+            raise MCPError(code=-1, message="No items given to add")
+
+        client = await get_client(ctx)
+        added: list[ShoppingListItem] = []
+        for index, item in enumerate(items):
+            name = item.get("name")
+            if not name:
+                raise MCPError(
+                    code=-1,
+                    message=(
+                        f"Item at position {index} has no 'name'. "
+                        f"{len(added)} item(s) were already added to list {list_id}."
+                    ),
+                )
+            with _shopping_list_errors(
+                f"adding '{name}' to shopping list {list_id} "
+                f"({len(added)} of {len(items)} item(s) already added)"
+            ):
+                data = await client.shopping_list.add_item(
+                    list_id,
+                    name=name,
+                    quantity=item.get("quantity"),
+                    unit=item.get("unit"),
+                    shop_area_id=item.get("shopAreaId"),
+                    checked=bool(item.get("checked", False)),
+                )
+            added.append(ShoppingListItem(**data))
+
+        return AddShoppingListItemsResponse(
+            items=added, list_id=list_id, added_count=len(added)
+        )
+
+    @mcp.tool(
+        title="Update Shopping List Item",
+        # Idempotent, unlike most update tools here: the app has no etag or
+        # version on an item, so ADR-017's "HTTP PUT without version control"
+        # case applies — the same fields twice leave the same end state.
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_update_item(
+        list_id: int,
+        item_id: int,
+        ctx: Context,
+        name: str | None = None,
+        quantity: str | None = None,
+        unit: str | None = None,
+        shop_area_id: int | None = None,
+    ) -> ShoppingListItemResponse:
+        """Update an item's name, quantity, unit or shop area.
+
+        Only the arguments given are changed. Omitted ones keep their value.
+        Use ``nc_shopping_list_check_item`` to tick an item off — this tool does
+        not touch the checked state.
+        """
+        fields: dict[str, Any] = {}
+        if name is not None:
+            fields["name"] = name
+        if quantity is not None:
+            fields["quantity"] = quantity
+        if unit is not None:
+            fields["unit"] = unit
+        if shop_area_id is not None:
+            fields["shopAreaId"] = shop_area_id
+        if not fields:
+            raise MCPError(code=-1, message="No fields given to update")
+
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"updating item {item_id} on list {list_id}"):
+            data = await client.shopping_list.update_item(list_id, item_id, fields)
+        return ShoppingListItemResponse(item=ShoppingListItem(**data))
+
+    @mcp.tool(
+        title="Check Shopping List Item",
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_check_item(
+        list_id: int, item_id: int, checked: bool, ctx: Context
+    ) -> ShoppingListItemResponse:
+        """Tick an item off the list, or put it back (``checked=false``)."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"checking item {item_id} on list {list_id}"):
+            data = await client.shopping_list.check_item(list_id, item_id, checked)
+        return ShoppingListItemResponse(item=ShoppingListItem(**data))
+
+    @mcp.tool(
+        title="Delete Shopping List Item",
+        annotations=ToolAnnotations(
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
+        ),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_delete_item(
+        list_id: int, item_id: int, ctx: Context
+    ) -> DeleteShoppingListItemResponse:
+        """Delete a single item from a shopping list."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"deleting item {item_id} on list {list_id}"):
+            await client.shopping_list.delete_item(list_id, item_id)
+        return DeleteShoppingListItemResponse(
+            deleted_id=item_id,
+            list_id=list_id,
+            message=f"Deleted item {item_id} from shopping list {list_id}",
+        )
+
+    @mcp.tool(
+        title="Clear Checked Shopping List Items",
+        annotations=ToolAnnotations(
+            destructive_hint=True, idempotent_hint=True, open_world_hint=True
+        ),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_clear_checked_items(
+        list_id: int, ctx: Context
+    ) -> BulkItemActionResponse:
+        """Delete every ticked-off item on a shopping list."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"clearing checked items on list {list_id}"):
+            await client.shopping_list.clear_checked_items(list_id)
+        return BulkItemActionResponse(
+            list_id=list_id,
+            message=f"Cleared checked items from shopping list {list_id}",
+        )
+
+    @mcp.tool(
+        title="Uncheck All Shopping List Items",
+        annotations=ToolAnnotations(idempotent_hint=True, open_world_hint=True),
+    )
+    @require_scopes("shopping_list.write")
+    @instrument_tool
+    async def nc_shopping_list_uncheck_all_items(
+        list_id: int, ctx: Context
+    ) -> BulkItemActionResponse:
+        """Put every ticked-off item on a shopping list back among the open items."""
+        client = await get_client(ctx)
+        with _shopping_list_errors(f"unchecking all items on list {list_id}"):
+            await client.shopping_list.uncheck_all_items(list_id)
+        return BulkItemActionResponse(
+            list_id=list_id,
+            message=f"Unchecked all items on shopping list {list_id}",
+        )

--- a/tests/client/shopping_list/test_shopping_list_api.py
+++ b/tests/client/shopping_list/test_shopping_list_api.py
@@ -1,0 +1,165 @@
+"""Mocked unit tests for the Shopping List client.
+
+What these pin down is the OCS-specific behaviour the rest of the codebase
+cannot see: that the envelope is unwrapped, that the ``OCS-APIRequest`` header
+goes out on every call (without it Nextcloud answers 997, not a 4xx), and that
+an empty 204 body does not blow up on ``.json()``.
+"""
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.client.shopping_list import ShoppingListClient
+from tests.client.conftest import create_mock_response
+
+pytestmark = pytest.mark.unit
+
+API = "/ocs/v2.php/apps/shopping_list/api/v1"
+
+
+def _ocs(data):
+    """Wrap *data* in the envelope the app's OCS routes answer with."""
+    return {
+        "ocs": {
+            "meta": {"status": "ok", "statuscode": 200, "message": "OK"},
+            "data": data,
+        }
+    }
+
+
+def _client(mocker, json_data=None, content=None):
+    """A client whose ``_make_request`` is patched, plus the patch itself."""
+    mock_response = create_mock_response(
+        status_code=200 if content is None else 204,
+        json_data=json_data,
+        content=content,
+    )
+    mock_make_request = mocker.patch.object(
+        ShoppingListClient, "_make_request", return_value=mock_response
+    )
+    client = ShoppingListClient(mocker.AsyncMock(spec=httpx.AsyncClient), "testuser")
+    return client, mock_make_request
+
+
+LIST_FIXTURE = {
+    "id": 3,
+    "userId": "testuser",
+    "title": "Groceries",
+    "permission": 1,
+    "isOwner": True,
+    "isPinned": None,
+    "createdAt": "2026-09-11T10:00:00+00:00",
+    "updatedAt": "2026-09-11T10:00:00+00:00",
+}
+
+ITEM_FIXTURE = {
+    "id": 42,
+    "listId": 3,
+    "name": "flour",
+    "quantity": "2",
+    "unit": "cups",
+    "shopAreaId": 7,
+    "checked": False,
+    "checkedBy": None,
+    "sortOrder": 0,
+    "tags": [],
+    "createdAt": "2026-09-11T10:00:00+00:00",
+    "updatedAt": "2026-09-11T10:00:00+00:00",
+}
+
+
+async def test_get_lists_unwraps_ocs_envelope(mocker):
+    client, make_request = _client(mocker, json_data=_ocs([LIST_FIXTURE]))
+
+    lists = await client.get_lists()
+
+    assert lists == [LIST_FIXTURE]
+    method, url = make_request.call_args.args
+    assert (method, url) == ("GET", f"{API}/lists")
+
+
+async def test_every_request_sends_the_ocs_header(mocker):
+    """Without ``OCS-APIRequest`` Nextcloud answers 997, not a 4xx."""
+    client, make_request = _client(mocker, json_data=_ocs(LIST_FIXTURE))
+
+    await client.get_list(3)
+
+    assert make_request.call_args.kwargs["headers"]["OCS-APIRequest"] == "true"
+
+
+async def test_create_list_posts_title(mocker):
+    client, make_request = _client(mocker, json_data=_ocs(LIST_FIXTURE))
+
+    result = await client.create_list("Groceries")
+
+    assert result["title"] == "Groceries"
+    assert make_request.call_args.args == ("POST", f"{API}/lists")
+    assert make_request.call_args.kwargs["json"] == {"title": "Groceries"}
+
+
+async def test_delete_list_tolerates_an_empty_204_body(mocker):
+    """DELETE answers 204 with no body — ``.json()`` on it would raise."""
+    client, make_request = _client(mocker, content=b"")
+
+    assert await client.delete_list(3) is None
+    assert make_request.call_args.args == ("DELETE", f"{API}/lists/3")
+
+
+async def test_add_item_omits_unset_optional_fields(mocker):
+    """An omitted ``shopAreaId`` is what lets the app auto-detect the area."""
+    client, make_request = _client(mocker, json_data=_ocs(ITEM_FIXTURE))
+
+    await client.add_item(3, name="flour")
+
+    assert make_request.call_args.kwargs["json"] == {"name": "flour", "checked": False}
+
+
+async def test_add_item_sends_the_fields_it_was_given(mocker):
+    client, make_request = _client(mocker, json_data=_ocs(ITEM_FIXTURE))
+
+    item = await client.add_item(
+        3, name="flour", quantity="2", unit="cups", shop_area_id=7, checked=True
+    )
+
+    assert item["id"] == 42
+    assert make_request.call_args.args == ("POST", f"{API}/lists/3/items")
+    assert make_request.call_args.kwargs["json"] == {
+        "name": "flour",
+        "checked": True,
+        "quantity": "2",
+        "unit": "cups",
+        "shopAreaId": 7,
+    }
+
+
+async def test_update_item_sends_only_the_given_fields(mocker):
+    """The app reads request params, so an absent key means "leave it alone"."""
+    client, make_request = _client(mocker, json_data=_ocs(ITEM_FIXTURE))
+
+    await client.update_item(3, 42, {"quantity": "3"})
+
+    assert make_request.call_args.args == ("PUT", f"{API}/lists/3/items/42")
+    assert make_request.call_args.kwargs["json"] == {"quantity": "3"}
+
+
+async def test_check_item_hits_the_check_route(mocker):
+    client, make_request = _client(
+        mocker, json_data=_ocs({**ITEM_FIXTURE, "checked": True})
+    )
+
+    item = await client.check_item(3, 42, True)
+
+    assert item["checked"] is True
+    assert make_request.call_args.args == ("PUT", f"{API}/lists/3/items/42/check")
+    assert make_request.call_args.kwargs["json"] == {"checked": True}
+
+
+async def test_clear_checked_and_uncheck_all_use_their_own_routes(mocker):
+    """The static routes must not be swallowed by ``/items/{id}``."""
+    client, make_request = _client(mocker, content=b"")
+
+    await client.clear_checked_items(3)
+    assert make_request.call_args.args == ("DELETE", f"{API}/lists/3/items/checked")
+
+    await client.uncheck_all_items(3)
+    assert make_request.call_args.args == ("POST", f"{API}/lists/3/items/uncheck-all")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ DEFAULT_FULL_SCOPES = (
     "sharing.read sharing.write "
     "news.read news.write "
     "collectives.read collectives.write "
+    "shopping_list.read shopping_list.write "
     "mail.read mail.write mail.send "
     "talk.read talk.write "
     "semantic.read"
@@ -72,6 +73,7 @@ DEFAULT_READ_SCOPES = (
     "sharing.read "
     "news.read "
     "collectives.read "
+    "shopping_list.read "
     "mail.read "
     "talk.read "
     "semantic.read"
@@ -91,6 +93,7 @@ DEFAULT_WRITE_SCOPES = (
     "sharing.write "
     "news.write "
     "collectives.write "
+    "shopping_list.write "
     "mail.write mail.send "
     "talk.write"
 )

--- a/tests/server/test_annotations.py
+++ b/tests/server/test_annotations.py
@@ -3,7 +3,32 @@
 import pytest
 from mcp import ClientSession
 
+from nextcloud_mcp_server.server import AVAILABLE_APPS
+
 pytestmark = pytest.mark.integration
+
+#: ``nc_<app>_`` for every registered app, longest first so ``nc_notes_`` can
+#: never shadow a longer prefix that starts with it.
+_APP_PREFIXES = tuple(
+    sorted((f"nc_{app}_" for app in AVAILABLE_APPS), key=len, reverse=True)
+)
+
+
+def _operation(tool_name: str) -> str:
+    """The verb part of a tool name, with its ``nc_<app>_`` prefix removed.
+
+    These tests classify a tool by looking for "list"/"get"/"delete"/... in its
+    name, which silently classifies by the *app* name too. Shopping List is the
+    first app whose own name contains one of those words: every
+    ``nc_shopping_list_*`` tool contains ``_list_``, so the raw name marked
+    ``nc_shopping_list_create_list`` as read-only. Matching on the verb alone
+    keeps the heuristic aimed at the operation, and leaves every other app's
+    classification unchanged.
+    """
+    for prefix in _APP_PREFIXES:
+        if tool_name.startswith(prefix):
+            return tool_name[len(prefix) :]
+    return tool_name
 
 
 async def test_all_tools_have_titles(nc_mcp_client: ClientSession):
@@ -40,8 +65,9 @@ async def test_read_only_tools_have_correct_annotations(nc_mcp_client: ClientSes
 
     for tool in tools.tools:
         # Check if tool name suggests it's read-only
-        is_likely_readonly = tool.name.startswith(tuple(read_only_prefixes)) or any(
-            pattern in tool.name for pattern in read_only_patterns
+        operation = _operation(tool.name)
+        is_likely_readonly = operation.startswith(tuple(read_only_prefixes)) or any(
+            pattern in operation for pattern in read_only_patterns
         )
 
         if is_likely_readonly:
@@ -64,7 +90,7 @@ async def test_destructive_tools_have_correct_annotations(nc_mcp_client: ClientS
 
     for tool in tools.tools:
         has_destructive_keyword = any(
-            keyword in tool.name.lower() for keyword in destructive_keywords
+            keyword in _operation(tool.name).lower() for keyword in destructive_keywords
         )
 
         if has_destructive_keyword:
@@ -89,7 +115,10 @@ async def test_delete_operations_are_idempotent(nc_mcp_client: ClientSession):
     non_idempotent_deletes = {"collectives_delete_collective", "nc_mail_delete_message"}
 
     for tool in tools.tools:
-        if "delete" in tool.name.lower() and tool.name not in non_idempotent_deletes:
+        if (
+            "delete" in _operation(tool.name).lower()
+            and tool.name not in non_idempotent_deletes
+        ):
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
             assert tool.annotations.idempotent_hint is True, (
                 f"Delete tool {tool.name} should be idempotent (same end state)"
@@ -113,7 +142,10 @@ async def test_create_operations_not_idempotent(nc_mcp_client: ClientSession):
     }
 
     for tool in tools.tools:
-        if "create" in tool.name.lower() and tool.name not in idempotent_exceptions:
+        if (
+            "create" in _operation(tool.name).lower()
+            and tool.name not in idempotent_exceptions
+        ):
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
             assert tool.annotations.idempotent_hint is not True, (
                 f"Create tool {tool.name} should not be idempotent (creates new resources)"
@@ -124,8 +156,21 @@ async def test_update_operations_not_idempotent(nc_mcp_client: ClientSession):
     """Verify update operations are marked as non-idempotent (due to etag requirements)."""
     tools = await nc_mcp_client.list_tools()
 
+    # Exceptions: updates on a resource carrying no etag or version, where
+    # ADR-017's "HTTP PUT without version control" case applies instead -- the
+    # same fields sent twice leave the same end state, because there is no
+    # version for the first call to have invalidated. The Shopping List app
+    # stores neither on a list or an item.
+    idempotent_exceptions = {
+        "nc_shopping_list_update_list",
+        "nc_shopping_list_update_item",
+    }
+
     for tool in tools.tools:
-        if "update" in tool.name.lower():
+        if (
+            "update" in _operation(tool.name).lower()
+            and tool.name not in idempotent_exceptions
+        ):
             assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
             # Most updates use etags which change each time, making them non-idempotent
             # Exception: calendar_update_event might be different
@@ -201,7 +246,7 @@ async def test_annotation_consistency(nc_mcp_client: ClientSession):
         read_ops = [
             t
             for t in category_tools
-            if any(op in t.name for op in ["list", "search", "get"])
+            if any(op in _operation(t.name) for op in ["list", "search", "get"])
         ]
         for tool in read_ops:
             assert tool.annotations.read_only_hint is True, (
@@ -209,7 +254,7 @@ async def test_annotation_consistency(nc_mcp_client: ClientSession):
             )
 
         # All delete operations should be destructive and idempotent
-        delete_ops = [t for t in category_tools if "delete" in t.name]
+        delete_ops = [t for t in category_tools if "delete" in _operation(t.name)]
         for tool in delete_ops:
             assert tool.annotations.destructive_hint is True, (
                 f"{tool.name} is a delete operation but not marked destructive"

--- a/tests/server/test_shopping_list_mcp.py
+++ b/tests/server/test_shopping_list_mcp.py
@@ -104,6 +104,46 @@ async def test_mcp_shopping_list_recipe_round_trip(
                 logger.warning("Failed to clean up shopping list %s: %s", list_id, e)
 
 
+async def test_mcp_shopping_list_duplicate_name_adds_a_second_row(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """Pin the fact the add_items docstring tells the model.
+
+    The app's quantity-merging lives in its Vue store, which matches an existing
+    item and issues an update — `ItemService::create` behind `POST /items`
+    inserts unconditionally. So the API duplicates, and a tool description
+    promising a merge would send a model down the wrong path.
+    """
+    title = f"MCP Dup Test {uuid.uuid4().hex[:8]}"
+    list_id = None
+
+    try:
+        created = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_create_list", {"title": title}
+            )
+        )
+        list_id = created["list"]["id"]
+
+        for _ in range(2):
+            _payload(
+                await nc_mcp_client.call_tool(
+                    "nc_shopping_list_add_items",
+                    {"list_id": list_id, "items": [{"name": "flour", "quantity": "1"}]},
+                )
+            )
+
+        items = await nc_client.shopping_list.get_items(list_id)
+        assert [item["name"] for item in items] == ["flour", "flour"]
+
+    finally:
+        if list_id is not None:
+            try:
+                await nc_client.shopping_list.delete_list(list_id)
+            except Exception as e:
+                logger.warning("Failed to clean up shopping list %s: %s", list_id, e)
+
+
 async def test_mcp_shopping_list_missing_list_is_a_clean_error(
     nc_mcp_client: ClientSession,
 ):

--- a/tests/server/test_shopping_list_mcp.py
+++ b/tests/server/test_shopping_list_mcp.py
@@ -1,0 +1,116 @@
+"""End-to-end coverage of the Shopping List MCP tools against a real stack.
+
+The round-trip mirrors GH #1461's use case: create a list, drop a recipe's
+ingredients on it in one call, shop it, tidy up.
+"""
+
+import json
+import logging
+import uuid
+
+import pytest
+from mcp import ClientSession
+
+from nextcloud_mcp_server.client import NextcloudClient
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.integration
+
+
+def _payload(result):
+    assert result.is_error is False, f"MCP tool call failed: {result.content}"
+    return json.loads(result.content[0].text)
+
+
+async def test_mcp_shopping_list_recipe_round_trip(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient
+):
+    """Create a list, add a recipe's ingredients, tick one off, clear it."""
+    title = f"MCP Test List {uuid.uuid4().hex[:8]}"
+    list_id = None
+
+    try:
+        created = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_create_list", {"title": title}
+            )
+        )
+        list_id = created["list"]["id"]
+        assert created["list"]["title"] == title
+
+        # Verify via the direct client, not only through the tool that made it.
+        assert (await nc_client.shopping_list.get_list(list_id))["title"] == title
+
+        # The whole point of #1461: a recipe's ingredients in one call.
+        added = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_add_items",
+                {
+                    "list_id": list_id,
+                    "items": [
+                        {"name": "flour", "quantity": "100", "unit": "g"},
+                        {"name": "eggs", "quantity": "2"},
+                        {"name": "milk", "quantity": "200", "unit": "ml"},
+                    ],
+                },
+            )
+        )
+        assert added["added_count"] == 3
+        assert [item["name"] for item in added["items"]] == ["flour", "eggs", "milk"]
+        egg_id = added["items"][1]["id"]
+
+        listed = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_get_items", {"list_id": list_id}
+            )
+        )
+        assert listed["total_count"] == 3
+        assert {item["name"] for item in listed["items"]} == {"flour", "eggs", "milk"}
+
+        updated = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_update_item",
+                {"list_id": list_id, "item_id": egg_id, "quantity": "3"},
+            )
+        )
+        assert updated["item"]["quantity"] == "3"
+
+        checked = _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_check_item",
+                {"list_id": list_id, "item_id": egg_id, "checked": True},
+            )
+        )
+        assert checked["item"]["checked"] is True
+
+        _payload(
+            await nc_mcp_client.call_tool(
+                "nc_shopping_list_clear_checked_items", {"list_id": list_id}
+            )
+        )
+        remaining = await nc_client.shopping_list.get_items(list_id)
+        assert {item["name"] for item in remaining} == {"flour", "milk"}
+
+        lists = _payload(
+            await nc_mcp_client.call_tool("nc_shopping_list_get_lists", {})
+        )
+        assert list_id in {entry["id"] for entry in lists["lists"]}
+
+    finally:
+        if list_id is not None:
+            try:
+                await nc_client.shopping_list.delete_list(list_id)
+            except Exception as e:
+                logger.warning("Failed to clean up shopping list %s: %s", list_id, e)
+
+
+async def test_mcp_shopping_list_missing_list_is_a_clean_error(
+    nc_mcp_client: ClientSession,
+):
+    """A 404 from the app must surface as an explained tool error, not a trace."""
+    result = await nc_mcp_client.call_tool(
+        "nc_shopping_list_get_items", {"list_id": 99999999}
+    )
+
+    assert result.is_error is True
+    assert "not found" in result.content[0].text.lower()

--- a/tests/unit/test_shopping_list_item_input.py
+++ b/tests/unit/test_shopping_list_item_input.py
@@ -1,0 +1,58 @@
+"""Validation rules for the ``nc_shopping_list_add_items`` item schema.
+
+These exist because the tool's ``items`` parameter is the one place in the
+Shopping List surface where a caller hands over free-form objects, so the model
+is what stops a typo from becoming a silently dropped field.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from nextcloud_mcp_server.models.shopping_list import ShoppingListItemInput
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("key", ["shop_area_id", "shopAreaId"])
+def test_both_shop_area_spellings_are_accepted(key):
+    """snake_case matches the sibling update tool, camelCase matches the app."""
+    assert ShoppingListItemInput(name="flour", **{key: 7}).shop_area_id == 7
+
+
+def test_a_misspelled_key_is_rejected_rather_than_dropped():
+    """A silently ignored key would add the item missing a field the caller set."""
+    with pytest.raises(ValidationError) as exc_info:
+        ShoppingListItemInput(name="flour", shoparea=7)
+
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"), [(3, "3"), (2.5, "2.5"), ("2", "2"), (None, None)]
+)
+def test_a_numeric_quantity_is_coerced_to_the_apps_string_column(value, expected):
+    """A model sending `"quantity": 3` is obvious enough to accept, not reject."""
+    assert ShoppingListItemInput(name="eggs", quantity=value).quantity == expected
+
+
+def test_a_boolean_quantity_is_not_treated_as_a_number():
+    """`True` is an int in Python — coercing it to "True" would be nonsense."""
+    with pytest.raises(ValidationError):
+        ShoppingListItemInput(name="eggs", quantity=True)
+
+
+def test_an_empty_name_is_rejected():
+    """The app would happily store a nameless row, which no caller wants."""
+    with pytest.raises(ValidationError):
+        ShoppingListItemInput(name="")
+
+
+def test_only_name_is_required():
+    item = ShoppingListItemInput(name="milk")
+
+    assert (item.quantity, item.unit, item.shop_area_id, item.checked) == (
+        None,
+        None,
+        None,
+        False,
+    )


### PR DESCRIPTION
Closes #1461 — support for the [Shopping List](https://github.com/otherworld-dev/Shopping-List)
app (`shopping_list`), so a cookbook recipe's ingredients can be turned into a
shopping list.

## What's here

A `ShoppingListClient` over the app's OCS API
(`/ocs/v2.php/apps/shopping_list/api/v1/...`) plus twelve MCP tools:

| Tool | |
|---|---|
| `nc_shopping_list_get_lists` / `_get_list` | read lists |
| `nc_shopping_list_create_list` / `_update_list` / `_delete_list` | manage lists |
| `nc_shopping_list_get_items` | read items |
| `nc_shopping_list_add_items` | add **one or more** items in a single call |
| `nc_shopping_list_update_item` / `_check_item` / `_delete_item` | manage items |
| `nc_shopping_list_clear_checked_items` / `_uncheck_all_items` | list-wide actions |

`nc_shopping_list_add_items` takes an array because the driving use case is a
whole recipe's ingredient list. Entries are validated as a batch before anything
is sent, so a malformed one adds nothing. The app has no bulk endpoint, so the
sending itself loops; if one item fails, the error names how many already landed
rather than leaving the caller guessing about the partial state.

Note that a duplicate name adds a **second row**: the app's quantity-merging
lives in its Vue store, not behind `POST /items`, so the docstring points at
`get_items` + `update_item` for that instead. An e2e case pins it.

## Decisions worth reviewing

- **Scope.** Shop areas, tags, shares and the public-link API are not wrapped.
  Nothing asks for them yet, and leaving `shopAreaId` unset on an add is exactly
  what lets the app's own keyword-based area detection assign the aisle.
- **No capability gating.** The app publishes no capability block, so per
  `CLAUDE.md` it must not be gated — absence of the key is what closes the gate,
  and gating here would hide working tools on every instance that has the app.
  It is called out in the `APP_CAPABILITY_KEY` comment alongside
  collectives/news/mail.
- **One `_ocs` helper** unwraps the envelope instead of per-method boilerplate,
  including the empty-204-body case the delete and clear routes return.
- **`idempotent_hint=True` on both update tools.** Neither endpoint has an etag
  or version, so ADR-017's "HTTP PUT without version control" case applies — the
  same fields twice leave the same end state. Noted in a comment so it doesn't
  read as an oversight.

## Test coverage

- **Unit** — `tests/client/shopping_list/test_shopping_list_api.py` pins the
  OCS-specific behaviour: envelope unwrapping, the `OCS-APIRequest` header on
  every call (without it Nextcloud answers 997, not a 4xx), the 204 empty-body
  guard, which fields an add omits, and that the static `/items/checked` and
  `/items/uncheck-all` routes are not swallowed by `/items/{id}`.
- **End-to-end** — `tests/server/test_shopping_list_mcp.py` runs the #1461
  round-trip against the real stack: create a list, add three ingredients in one
  call, list, update, tick one off, clear checked, verify through the direct
  client. Plus a 404 case asserting the failure surfaces as an explained tool
  error. `app-hooks/post-installation/10-install-shopping_list-app.sh` enables
  the app in the integration stack (published for NC 32/33/34 on the app store).
- **Contract (Pact)** — none added, and none is owed: this adds no `/api/v1/*`
  provider surface and no cross-service consumer boundary. The tools call
  Nextcloud directly, which is not a pact participant here — the same position
  as the existing News, Mail, Talk and Collectives integrations.

Scopes `shopping_list.read` / `shopping_list.write` are added to
`ALL_SUPPORTED_SCOPES`, the test scope constants, and the astrolabe OAuth
client's allowed-scope ceiling.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDXLaiUKTTw5z4PFJ3JG8Y
