### PR TITLE
feat(calendar): implement nc_calendar_find_availability

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -140,11 +140,24 @@ error rather than being quietly treated as free.
 
 **The window.** `date_range_start` defaults to now and is never allowed into the
 past; `date_range_end` defaults to a week later. The response reports the window
-that was actually searched. `timezone` (an IANA name) is the zone
-`business_hours_only` (09:00-17:00) and `preferred_times` are expressed in, and
-defaults to the server's local zone. `preferred_times`, when given, *replaces*
-business hours rather than narrowing them -- so `preferred_times="19:00-21:00"`
-finds evening slots without also having to unset `business_hours_only`.
+that was actually searched.
+
+`timezone` (an IANA name) is the zone `business_hours_only` (09:00-17:00) and
+`preferred_times` are expressed in. An unknown name is an **error**, not a
+fallback -- business hours in the wrong zone are a confidently wrong answer.
+Omitting it uses the server's current UTC offset, which is why a window that
+crosses a daylight-saving change is better served by naming the zone.
+
+`preferred_times`, when given, *replaces* business hours rather than narrowing
+them -- so `preferred_times="19:00-21:00"` finds evening slots without also
+having to unset `business_hours_only`. Overlapping ranges are merged (so the
+same free time is never returned twice), and a malformed range is logged and
+skipped rather than failing the whole query.
+
+**A calendar that cannot be read is an error too.** If one of your calendars
+fails to load during the search it is not skipped: it would contribute no busy
+time and its booked hours would be offered as free. The same holds for an
+attendee the server will not report free/busy for.
 
 ```python
 availability = await nc_calendar_find_availability(

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -12,7 +12,7 @@
 | `nc_calendar_delete_event` | Delete a calendar event |
 | `nc_calendar_create_meeting` | Quick meeting creation with smart defaults |
 | `nc_calendar_get_upcoming_events` | Get upcoming events in the next N days |
-| `nc_calendar_find_availability` | **New:** Intelligent availability finder - find free time slots for meetings with attendee conflict detection |
+| `nc_calendar_find_availability` | Find free time slots for meetings, from your own calendars plus any attendees' free/busy |
 | `nc_calendar_bulk_operations` | **New:** Bulk update, delete, or move events matching filter criteria |
 | `nc_calendar_manage_calendar` | **New:** Create, delete, and manage calendar properties |
 | `nc_calendar_complete_todo` | **New:** Mark a todo complete, setting `STATUS`, `PERCENT-COMPLETE` and `COMPLETED` together |
@@ -89,7 +89,8 @@ availability = await nc_calendar_find_availability(
     date_range_end="2025-08-04",
     business_hours_only=True,
     exclude_weekends=True,
-    preferred_times="09:00-12:00,14:00-17:00"
+    preferred_times="09:00-12:00,14:00-17:00",
+    timezone="Europe/Amsterdam",
 )
 
 # Bulk update all team meetings to new location
@@ -110,6 +111,57 @@ new_calendar = await nc_calendar_manage_calendar(
     description="Calendar for Project Alpha team",
     color="#FF5722"
 )
+```
+
+## Finding availability
+
+`nc_calendar_find_availability` subtracts busy time from the windows you are
+willing to meet in and returns what is left.
+
+**Slots are maximal free windows, not a grid.** A free morning comes back once
+as a single 09:00-12:00 slot of 180 minutes rather than as five overlapping
+60-minute candidates. Pick any sub-range of at least `duration_minutes` from a
+slot.
+
+**Not everything on a calendar consumes time.** Ignored as busy:
+
+- events marked free (`TRANSP:TRANSPARENT`);
+- events on a calendar set to "never show me as busy"
+  (`schedule-calendar-transp: transparent`, RFC 4791 5.2.9);
+- cancelled events;
+- all-day events, unless you pass `include_all_day=True`. Birthdays, name days
+  and subscribed school-holiday feeds are all-day and opaque, and honouring
+  them would blank out entire working days.
+
+**Attendees are looked up for real.** Each address in `attendees` is resolved
+through an RFC 6638 free/busy request to the scheduling outbox, and their busy
+time is merged with yours. An attendee the server will not report on raises an
+error rather than being quietly treated as free.
+
+**The window.** `date_range_start` defaults to now and is never allowed into the
+past; `date_range_end` defaults to a week later. The response reports the window
+that was actually searched. `timezone` (an IANA name) is the zone
+`business_hours_only` (09:00-17:00) and `preferred_times` are expressed in, and
+defaults to the server's local zone. `preferred_times`, when given, *replaces*
+business hours rather than narrowing them -- so `preferred_times="19:00-21:00"`
+finds evening slots without also having to unset `business_hours_only`.
+
+```python
+availability = await nc_calendar_find_availability(
+    duration_minutes=45,
+    date_range_start="2025-07-28",
+    date_range_end="2025-07-30",
+    timezone="Europe/Amsterdam",
+)
+# -> {"available_slots": [{"start": "2025-07-28T09:00:00+02:00",
+#                          "end":   "2025-07-28T11:00:00+02:00",
+#                          "duration_minutes": 120,
+#                          "date":  "2025-07-28"}, ...],
+#     "duration_requested": 45,
+#     "date_range_start": "2025-07-28T09:14:03+02:00",
+#     "date_range_end":   "2025-07-30T23:59:59+02:00",
+#     "attendees_checked": [],
+#     "business_hours_only": true}
 ```
 
 ## Completing a todo

--- a/nextcloud_mcp_server/client/availability.py
+++ b/nextcloud_mcp_server/client/availability.py
@@ -215,13 +215,18 @@ def daily_windows(
             continue
 
         if ranges:
-            day_spans = [
-                (
-                    dt.datetime.combine(day, from_time, tzinfo=tz),
-                    dt.datetime.combine(day, to_time, tzinfo=tz),
-                )
-                for from_time, to_time in ranges
-            ]
+            # Merged, because overlapping preferred ranges ("09:00-12:00,
+            # 11:00-14:00") would otherwise yield overlapping windows and hand
+            # the caller the same free time twice.
+            day_spans = merge_spans(
+                [
+                    (
+                        dt.datetime.combine(day, from_time, tzinfo=tz),
+                        dt.datetime.combine(day, to_time, tzinfo=tz),
+                    )
+                    for from_time, to_time in ranges
+                ]
+            )
         else:
             midnight = dt.datetime.combine(day, dt.time(0, 0), tzinfo=tz)
             day_spans = [(midnight, midnight + dt.timedelta(days=1))]

--- a/nextcloud_mcp_server/client/availability.py
+++ b/nextcloud_mcp_server/client/availability.py
@@ -155,21 +155,28 @@ def busy_spans_from_vfreebusy(data: str, tz: dt.tzinfo) -> list[Span]:
         if periods is None:
             continue
         for period in periods if isinstance(periods, list) else [periods]:
-            fbtype = str(period.params.get("FBTYPE", "BUSY")).upper()
-            if fbtype == _FREE_FBTYPE:
-                continue
-            start, end_or_duration = period.dt
-            end = (
-                start + end_or_duration
-                if isinstance(end_or_duration, dt.timedelta)
-                else end_or_duration
-            )
-            start = to_aware(start, tz)
-            end = to_aware(end, tz)
-            if start is None or end is None or end <= start:
-                continue
-            spans.append((start, end))
+            span = _period_to_span(period, tz)
+            if span is not None:
+                spans.append(span)
     return spans
+
+
+def _period_to_span(period: Any, tz: dt.tzinfo) -> Span | None:
+    """One FREEBUSY period as a busy span, or None if it consumes no time."""
+    if str(period.params.get("FBTYPE", "BUSY")).upper() == _FREE_FBTYPE:
+        return None
+
+    start, end_or_duration = period.dt
+    end = (
+        start + end_or_duration
+        if isinstance(end_or_duration, dt.timedelta)
+        else end_or_duration
+    )
+    start = to_aware(start, tz)
+    end = to_aware(end, tz)
+    if start is None or end is None or end <= start:
+        return None
+    return (start, end)
 
 
 def merge_spans(spans: list[Span]) -> list[Span]:
@@ -247,23 +254,28 @@ def free_slots(
 ) -> list[Span]:
     """Subtract busy spans from the candidate windows, keeping what is long enough."""
     busy = merge_spans(busy)
+    return [slot for window in windows for slot in _free_within(window, busy, minimum)]
+
+
+def _free_within(window: Span, busy: list[Span], minimum: dt.timedelta) -> list[Span]:
+    """The gaps of at least ``minimum`` left in one window. ``busy`` is merged."""
+    window_start, window_end = window
     slots: list[Span] = []
+    cursor = window_start
 
-    for window_start, window_end in windows:
-        cursor = window_start
-        for busy_start, busy_end in busy:
-            if busy_end <= cursor:
-                continue
-            if busy_start >= window_end:
-                break
-            if busy_start - cursor >= minimum:
-                slots.append((cursor, busy_start))
-            cursor = max(cursor, busy_end)
-            if cursor >= window_end:
-                break
-        if window_end - cursor >= minimum:
-            slots.append((cursor, window_end))
+    for busy_start, busy_end in busy:
+        if busy_end <= cursor:
+            continue
+        if busy_start >= window_end:
+            break
+        if busy_start - cursor >= minimum:
+            slots.append((cursor, busy_start))
+        cursor = max(cursor, busy_end)
+        if cursor >= window_end:
+            break
 
+    if window_end - cursor >= minimum:
+        slots.append((cursor, window_end))
     return slots
 
 

--- a/nextcloud_mcp_server/client/availability.py
+++ b/nextcloud_mcp_server/client/availability.py
@@ -1,0 +1,273 @@
+"""Interval arithmetic behind ``nc_calendar_find_availability``.
+
+Everything here is pure: it takes already-fetched event dicts (or an
+already-fetched VFREEBUSY blob) and returns time spans. The I/O lives in
+``CalendarClient.find_availability``, which is what makes this testable
+without a CalDAV server.
+
+The shape of the answer is *maximal free windows*, not a grid of candidate
+start times: a free 09:00-12:00 is returned once as a 180-minute slot rather
+than as five overlapping 60-minute ones. The caller wanted to know where the
+gaps are, and a grid multiplies the answer by an arbitrary granularity
+constant nobody asked for.
+"""
+
+import datetime as dt
+import logging
+from typing import Any
+
+from icalendar import Calendar
+
+logger = logging.getLogger(__name__)
+
+# A span is a half-open [start, end) interval of aware datetimes.
+Span = tuple[dt.datetime, dt.datetime]
+
+# "Business hours" in the sense the tool's parameter means it.
+BUSINESS_START = dt.time(9, 0)
+BUSINESS_END = dt.time(17, 0)
+
+# RFC 5545 3.2.9: FBTYPE=FREE marks a period that does *not* consume time.
+# Everything else (BUSY, BUSY-TENTATIVE, BUSY-UNAVAILABLE, absent) does.
+_FREE_FBTYPE = "FREE"
+
+
+def parse_time_ranges(value: str | list[str] | None) -> list[tuple[dt.time, dt.time]]:
+    """Parse ``"09:00-12:00,14:00-17:00"`` into time pairs.
+
+    Accepts the already-split list the MCP layer produces as well as the raw
+    comma-separated string. Malformed entries are logged and skipped rather
+    than raising: one typo in a preferred-times hint should not fail the whole
+    availability query.
+    """
+    if not value:
+        return []
+    parts = value.split(",") if isinstance(value, str) else list(value)
+
+    ranges: list[tuple[dt.time, dt.time]] = []
+    for part in parts:
+        text = part.strip()
+        if not text:
+            continue
+        start_text, _, end_text = text.partition("-")
+        try:
+            start = dt.time.fromisoformat(start_text.strip())
+            end = dt.time.fromisoformat(end_text.strip())
+        except ValueError:
+            logger.warning("Ignoring malformed preferred time range %r", text)
+            continue
+        if start >= end:
+            logger.warning("Ignoring inverted preferred time range %r", text)
+            continue
+        ranges.append((start, end))
+    return ranges
+
+
+def to_aware(value: Any, tz: dt.tzinfo) -> dt.datetime | None:
+    """Coerce an event's ISO datetime (or date) string into an aware datetime.
+
+    Naive values are floating local time in RFC 5545 terms, so they are read in
+    ``tz`` -- the same zone the daily windows are built in, which is what makes
+    "does this event overlap business hours" answerable at all.
+    """
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo else value.replace(tzinfo=tz)
+    if isinstance(value, dt.date):
+        return dt.datetime.combine(value, dt.time(0, 0), tzinfo=tz)
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Unparseable datetime %r", value)
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=tz)
+
+
+def event_is_busy(event: dict[str, Any], *, include_all_day: bool) -> bool:
+    """Whether an event should block time.
+
+    Four things make an event non-blocking, and all four matter on real
+    calendars:
+
+    * its calendar is marked "never show me as busy"
+      (``schedule-calendar-transp: transparent``, RFC 4791 5.2.9);
+    * the event itself is ``TRANSP:TRANSPARENT`` (RFC 5545 3.8.2.7);
+    * it is cancelled;
+    * it is all-day and the caller did not opt in. Birthdays, name days and
+      subscribed school-holiday feeds are all-day and OPAQUE, so honouring them
+      erases entire working days -- the exact complaint in issue #1394.
+    """
+    if event.get("calendar_transparent"):
+        return False
+    if str(event.get("transp") or "OPAQUE").upper() == "TRANSPARENT":
+        return False
+    if str(event.get("status") or "").upper() == "CANCELLED":
+        return False
+    if event.get("all_day") and not include_all_day:
+        return False
+    return True
+
+
+def busy_spans_from_events(
+    events: list[dict[str, Any]],
+    *,
+    tz: dt.tzinfo,
+    include_all_day: bool = False,
+) -> list[Span]:
+    """Busy spans for the events that actually consume time."""
+    spans: list[Span] = []
+    for event in events:
+        if not event_is_busy(event, include_all_day=include_all_day):
+            continue
+
+        start = to_aware(event.get("start_datetime"), tz)
+        if start is None:
+            continue
+
+        end = to_aware(event.get("end_datetime"), tz)
+        if end is None and event.get("all_day"):
+            # An all-day event with no DTEND covers its one day.
+            end = start + dt.timedelta(days=1)
+        if end is None or end <= start:
+            # Zero-length (and inverted) events mark an instant, not a block.
+            continue
+        spans.append((start, end))
+    return spans
+
+
+def busy_spans_from_vfreebusy(data: str, tz: dt.tzinfo) -> list[Span]:
+    """Busy spans from an RFC 6638 free/busy reply for one attendee.
+
+    Periods come back as ``start/end`` or ``start/duration``; icalendar hands
+    both back as a ``vPeriod`` whose ``.dt`` is a 2-tuple, with the FBTYPE
+    parameter attached per period rather than per FREEBUSY line.
+    """
+    try:
+        calendar = Calendar.from_ical(data)
+    except Exception as e:  # icalendar raises bare ValueError subclasses
+        logger.warning("Unparseable free/busy reply: %s", e)
+        return []
+
+    spans: list[Span] = []
+    for component in calendar.walk("VFREEBUSY"):
+        periods = component.get("freebusy")
+        if periods is None:
+            continue
+        for period in periods if isinstance(periods, list) else [periods]:
+            fbtype = str(period.params.get("FBTYPE", "BUSY")).upper()
+            if fbtype == _FREE_FBTYPE:
+                continue
+            start, end_or_duration = period.dt
+            end = (
+                start + end_or_duration
+                if isinstance(end_or_duration, dt.timedelta)
+                else end_or_duration
+            )
+            start = to_aware(start, tz)
+            end = to_aware(end, tz)
+            if start is None or end is None or end <= start:
+                continue
+            spans.append((start, end))
+    return spans
+
+
+def merge_spans(spans: list[Span]) -> list[Span]:
+    """Sort and coalesce overlapping/touching spans."""
+    merged: list[Span] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            if end > merged[-1][1]:
+                merged[-1] = (merged[-1][0], end)
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def daily_windows(
+    start: dt.datetime,
+    end: dt.datetime,
+    *,
+    tz: dt.tzinfo,
+    business_hours_only: bool = True,
+    exclude_weekends: bool = True,
+    preferred_times: list[tuple[dt.time, dt.time]] | None = None,
+) -> list[Span]:
+    """The spans the caller is willing to meet in, day by day, clipped to
+    ``[start, end)``.
+
+    ``preferred_times`` *replaces* business hours rather than intersecting with
+    them. Intersecting would make ``preferred_times="08:00-09:00"`` return
+    nothing at all under the default ``business_hours_only=True`` -- an empty
+    answer that looks like "you are fully booked", which is the failure mode
+    this whole tool is being fixed for.
+    """
+    windows: list[Span] = []
+    day = start.astimezone(tz).date()
+    last_day = end.astimezone(tz).date()
+    ranges = preferred_times or (
+        [(BUSINESS_START, BUSINESS_END)] if business_hours_only else []
+    )
+
+    while day <= last_day:
+        if exclude_weekends and day.weekday() >= 5:
+            day += dt.timedelta(days=1)
+            continue
+
+        if ranges:
+            day_spans = [
+                (
+                    dt.datetime.combine(day, from_time, tzinfo=tz),
+                    dt.datetime.combine(day, to_time, tzinfo=tz),
+                )
+                for from_time, to_time in ranges
+            ]
+        else:
+            midnight = dt.datetime.combine(day, dt.time(0, 0), tzinfo=tz)
+            day_spans = [(midnight, midnight + dt.timedelta(days=1))]
+
+        for window_start, window_end in day_spans:
+            clipped_start = max(window_start, start)
+            clipped_end = min(window_end, end)
+            if clipped_start < clipped_end:
+                windows.append((clipped_start, clipped_end))
+
+        day += dt.timedelta(days=1)
+
+    return sorted(windows)
+
+
+def free_slots(
+    windows: list[Span], busy: list[Span], minimum: dt.timedelta
+) -> list[Span]:
+    """Subtract busy spans from the candidate windows, keeping what is long enough."""
+    busy = merge_spans(busy)
+    slots: list[Span] = []
+
+    for window_start, window_end in windows:
+        cursor = window_start
+        for busy_start, busy_end in busy:
+            if busy_end <= cursor:
+                continue
+            if busy_start >= window_end:
+                break
+            if busy_start - cursor >= minimum:
+                slots.append((cursor, busy_start))
+            cursor = max(cursor, busy_end)
+            if cursor >= window_end:
+                break
+        if window_end - cursor >= minimum:
+            slots.append((cursor, window_end))
+
+    return slots
+
+
+def slot_to_dict(span: Span) -> dict[str, Any]:
+    """Render a span the way ``AvailabilitySlot`` expects it."""
+    start, end = span
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "duration_minutes": int((end - start).total_seconds() // 60),
+        "date": start.date().isoformat(),
+    }

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -1196,12 +1196,16 @@ class CalendarClient:
         slots: list[list[dict[str, Any]]],
         index: int,
         limit: int = 50,
+        failures: list[str] | None = None,
     ) -> None:
         """One calendar's events, annotated, written into its own slot.
 
         Failure is contained per calendar: a single unreachable or broken
         calendar is logged and skipped, exactly as in the previous serial
-        loop, rather than cancelling the whole task group.
+        loop, rather than cancelling the whole task group. ``failures``, when
+        given, collects what was skipped so a caller that cannot tolerate a
+        partial listing can say so -- an empty slot is indistinguishable from
+        a calendar that really had no events.
         """
         async with limiter:
             try:
@@ -1212,6 +1216,8 @@ class CalendarClient:
                 logger.warning(
                     "Error getting events from calendar %s: %s", calendar["name"], e
                 )
+                if failures is not None:
+                    failures.append(f"{calendar['name']} ({e})")
                 return
 
         # Apply filters if provided
@@ -1237,12 +1243,20 @@ class CalendarClient:
         end_datetime: dt.datetime | None = None,
         filters: dict[str, Any] | None = None,
         limit: int = 50,
+        strict: bool = False,
     ) -> list[dict[str, Any]]:
         """Search events across all calendars with advanced filtering.
 
         ``limit`` is per calendar, and truncation is silent -- callers that
         need every event in the window (availability, above all) must raise it
         rather than accept a listing that merely looks complete.
+
+        ``strict`` decides what an unreadable calendar means. A listing can
+        reasonably show what it could reach, so the default keeps the
+        skip-and-warn behaviour. Availability cannot: a calendar that failed to
+        load contributes no busy time and therefore reads as free, which is the
+        confidently-wrong answer this whole path exists to avoid. Such a caller
+        passes ``strict=True`` and gets a ``ValueError`` naming the calendars.
 
         The per-calendar REPORTs are fanned out via ``anyio.create_task_group``
         instead of awaited one after another. The serial loop cost one full
@@ -1261,6 +1275,7 @@ class CalendarClient:
         depend on which REPORT happens to finish first.
         """
         await self._ensure_calendar_home()
+        failures: list[str] = []
         try:
             calendars = await self.list_calendars()
             slots: list[list[dict[str, Any]]] = [[] for _ in calendars]
@@ -1278,13 +1293,20 @@ class CalendarClient:
                         slots,
                         index,
                         limit,
+                        failures,
                     )
 
-            return [event for events in slots for event in events]
+            events = [event for events in slots for event in events]
 
         except Exception as e:
             logger.error("Error searching events across calendars: %s", e)
             raise
+
+        if strict and failures:
+            raise ValueError(
+                f"Could not read {len(failures)} calendar(s): {'; '.join(failures)}"
+            )
+        return events
 
     # ============= Todo/Task Operations (NEW) =============
 
@@ -3044,8 +3066,14 @@ class CalendarClient:
         if end <= start:
             raise ValueError("date_range_end must be after date_range_start")
 
+        # strict: a calendar that failed to load contributes no busy time, so a
+        # silent skip would offer its booked hours as free -- the same reason
+        # _attendee_busy_spans raises rather than shrugging off a missing reply.
         events = await self.search_events_across_calendars(
-            start_datetime=start, end_datetime=end, limit=AVAILABILITY_EVENT_LIMIT
+            start_datetime=start,
+            end_datetime=end,
+            limit=AVAILABILITY_EVENT_LIMIT,
+            strict=True,
         )
         busy = busy_spans_from_events(
             events,

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -49,6 +49,9 @@ CALENDAR_FANOUT = 8
 # listing into memory.
 AVAILABILITY_EVENT_LIMIT = 1000
 
+# The URI scheme RFC 6638 addresses attendees by.
+_MAILTO = "mailto:"
+
 
 async def _maybe_await(result: Any) -> Any:
     """Await a result if it's a coroutine, otherwise return it directly.
@@ -2969,6 +2972,32 @@ class CalendarClient:
             logger.error("Error in bulk update: %s", e)
             raise
 
+    @staticmethod
+    def _availability_timezone(name: Any) -> dt.tzinfo:
+        """Resolve the zone the windows are built in, refusing a bad name.
+
+        Deliberately not ``_resolve_timezone``, which falls back to floating
+        local time on an unknown name. That is right for storing an event --
+        the time was still given -- but wrong here: business hours and
+        preferred times mean nothing without the zone they are expressed in, so
+        ``timezone="America/New_Yrok"`` would answer confidently in the
+        server's zone and never say it had ignored the request.
+        """
+        text = str(name or "").strip()
+        if not text:
+            # The server's *current* UTC offset, not its IANA zone -- the
+            # stdlib cannot name the latter. A window that crosses a DST change
+            # is therefore built on today's offset, which is the reason to pass
+            # an explicit zone rather than rely on this.
+            return dt.datetime.now().astimezone().tzinfo or dt.UTC
+        try:
+            return ZoneInfo(text)
+        except (ZoneInfoNotFoundError, ValueError) as e:
+            raise ValueError(
+                f"Unknown timezone {text!r}; expected an IANA name such as "
+                "'Europe/Amsterdam'"
+            ) from e
+
     async def _attendee_busy_spans(
         self,
         attendees: list[str],
@@ -2992,7 +3021,7 @@ class CalendarClient:
         )
 
         recipients = [
-            address if address.lower().startswith("mailto:") else f"mailto:{address}"
+            address if address.lower().startswith(_MAILTO) else f"{_MAILTO}{address}"
             for address in attendees
         ]
         replies = await _maybe_await(principal.freebusy_request(start, end, recipients))
@@ -3000,18 +3029,18 @@ class CalendarClient:
         # Keys come back as the recipient URI the server echoes, whose case and
         # mailto: prefix need not match what we sent.
         by_address = {
-            key.lower().removeprefix("mailto:"): value
+            key.lower().removeprefix(_MAILTO): value
             for key, value in replies.items()
             if key != "errors"
         }
         error_by_address = {
-            key.lower().removeprefix("mailto:"): value
+            key.lower().removeprefix(_MAILTO): value
             for key, value in (replies.get("errors") or {}).items()
         }
 
         spans: list[Span] = []
         for recipient in recipients:
-            address = recipient.lower().removeprefix("mailto:")
+            address = recipient.lower().removeprefix(_MAILTO)
             if address in error_by_address:
                 raise ValueError(
                     f"Free/busy lookup for {address} failed: "
@@ -3042,7 +3071,10 @@ class CalendarClient:
         free spans, longest-possible rather than sliced onto a grid.
 
         ``constraints`` keys: ``business_hours_only``, ``exclude_weekends``,
-        ``preferred_times``, ``include_all_day``, ``timezone``.
+        ``preferred_times``, ``include_all_day``, ``timezone``. An unknown
+        ``timezone`` raises; a malformed entry in ``preferred_times`` is logged
+        and skipped, since one typo in a hint should not fail the query, and
+        overlapping entries are merged.
 
         Returns the slots together with the window they were computed over, so
         the caller can report what was actually searched rather than echoing a
@@ -3052,11 +3084,7 @@ class CalendarClient:
             raise ValueError("duration_minutes must be positive")
 
         constraints = constraints or {}
-        tz = (
-            self._resolve_timezone(str(constraints.get("timezone") or ""))
-            or dt.datetime.now().astimezone().tzinfo
-            or dt.UTC
-        )
+        tz = self._availability_timezone(constraints.get("timezone"))
 
         now = dt.datetime.now(tz)
         start = to_aware(start_datetime, tz) or now

--- a/nextcloud_mcp_server/client/calendar.py
+++ b/nextcloud_mcp_server/client/calendar.py
@@ -21,6 +21,16 @@ from icalendar import Todo as ICalTodo
 from lxml import etree  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 from ..config import get_nextcloud_ssl_verify
+from .availability import (
+    Span,
+    busy_spans_from_events,
+    busy_spans_from_vfreebusy,
+    daily_windows,
+    free_slots,
+    parse_time_ranges,
+    slot_to_dict,
+    to_aware,
+)
 from .dav_errors import DavPreconditionFailed, dav_error_from_response
 from .dav_urls import encode_dav_url
 
@@ -31,6 +41,13 @@ logger = logging.getLogger(__name__)
 # dozens of calendars would hammer the Nextcloud instance for no gain, since
 # the win is already had after a handful run in parallel.
 CALENDAR_FANOUT = 8
+
+# Per-calendar event cap when computing availability. The default listing cap
+# of 50 is fine for "show me what's on", but availability has to see *every*
+# busy event in the window: a dropped event becomes free time that is not free.
+# Bounded all the same, so one pathological calendar cannot pull an unlimited
+# listing into memory.
+AVAILABILITY_EVENT_LIMIT = 1000
 
 
 async def _maybe_await(result: Any) -> Any:
@@ -1178,6 +1195,7 @@ class CalendarClient:
         limiter: anyio.CapacityLimiter,
         slots: list[list[dict[str, Any]]],
         index: int,
+        limit: int = 50,
     ) -> None:
         """One calendar's events, annotated, written into its own slot.
 
@@ -1188,7 +1206,7 @@ class CalendarClient:
         async with limiter:
             try:
                 events = await self.get_calendar_events(
-                    calendar["name"], start_datetime, end_datetime
+                    calendar["name"], start_datetime, end_datetime, limit=limit
                 )
             except Exception as e:
                 logger.warning(
@@ -1206,6 +1224,10 @@ class CalendarClient:
             event["calendar_display_name"] = calendar.get(
                 "display_name", calendar["name"]
             )
+            # The calendar's own "never show me as busy" switch. Carried per
+            # event because availability works on a flat event list and would
+            # otherwise have to re-resolve which calendar each one came from.
+            event["calendar_transparent"] = calendar.get("transparent", False)
 
         slots[index] = events
 
@@ -1214,8 +1236,13 @@ class CalendarClient:
         start_datetime: dt.datetime | None = None,
         end_datetime: dt.datetime | None = None,
         filters: dict[str, Any] | None = None,
+        limit: int = 50,
     ) -> list[dict[str, Any]]:
         """Search events across all calendars with advanced filtering.
+
+        ``limit`` is per calendar, and truncation is silent -- callers that
+        need every event in the window (availability, above all) must raise it
+        rather than accept a listing that merely looks complete.
 
         The per-calendar REPORTs are fanned out via ``anyio.create_task_group``
         instead of awaited one after another. The serial loop cost one full
@@ -1250,6 +1277,7 @@ class CalendarClient:
                         limiter,
                         slots,
                         index,
+                        limit,
                     )
 
             return [event for events in slots for event in events]
@@ -1971,6 +1999,15 @@ class CalendarClient:
             tzid = dtend.params.get("TZID") if dtend.params else None
             if tzid:
                 event_data["end_tz"] = str(tzid)
+        elif dtstart is not None and component.get("duration") is not None:
+            # RFC 5545 3.6.1 lets an event carry DURATION instead of DTEND.
+            # Without this the event reads as zero-length, so anything working
+            # out how long it lasts -- availability above all -- silently
+            # treats it as not consuming any time.
+            duration = component.get("duration").dt
+            event_data["end_datetime"] = (dtstart.dt + duration).isoformat()
+            if "start_tz" in event_data:
+                event_data["end_tz"] = event_data["start_tz"]
 
         # Handle categories
         categories = component.get("categories")
@@ -2910,6 +2947,62 @@ class CalendarClient:
             logger.error("Error in bulk update: %s", e)
             raise
 
+    async def _attendee_busy_spans(
+        self,
+        attendees: list[str],
+        start: dt.datetime,
+        end: dt.datetime,
+        tz: dt.tzinfo,
+    ) -> list[Span]:
+        """Busy spans for other people, via the RFC 6638 scheduling outbox.
+
+        The organizer POSTs a VFREEBUSY REQUEST naming the attendees and the
+        server answers with one free/busy reply per recipient. This is the only
+        way to see time on a calendar we cannot read.
+
+        An attendee the server refuses to report on raises rather than being
+        skipped: treating "I could not check Bob" as "Bob is free" is exactly
+        the kind of confident-wrong answer issue #1394 is about.
+        """
+        get_principal = getattr(self._dav_client, "get_principal", None)
+        principal = await _maybe_await(
+            get_principal() if get_principal else self._dav_client.principal()
+        )
+
+        recipients = [
+            address if address.lower().startswith("mailto:") else f"mailto:{address}"
+            for address in attendees
+        ]
+        replies = await _maybe_await(principal.freebusy_request(start, end, recipients))
+
+        # Keys come back as the recipient URI the server echoes, whose case and
+        # mailto: prefix need not match what we sent.
+        by_address = {
+            key.lower().removeprefix("mailto:"): value
+            for key, value in replies.items()
+            if key != "errors"
+        }
+        error_by_address = {
+            key.lower().removeprefix("mailto:"): value
+            for key, value in (replies.get("errors") or {}).items()
+        }
+
+        spans: list[Span] = []
+        for recipient in recipients:
+            address = recipient.lower().removeprefix("mailto:")
+            if address in error_by_address:
+                raise ValueError(
+                    f"Free/busy lookup for {address} failed: "
+                    f"{error_by_address[address]}"
+                )
+            reply = by_address.get(address)
+            if reply is None or not reply.data:
+                raise ValueError(
+                    f"The server returned no free/busy information for {address}"
+                )
+            spans.extend(busy_spans_from_vfreebusy(reply.data, tz))
+        return spans
+
     async def find_availability(
         self,
         duration_minutes: int,
@@ -2917,11 +3010,74 @@ class CalendarClient:
         start_datetime: dt.datetime | None = None,
         end_datetime: dt.datetime | None = None,
         constraints: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
-        """Find available time slots for scheduling.
+    ) -> dict[str, Any]:
+        """Find free time slots of at least ``duration_minutes``.
 
-        Note: This is a simplified stub that returns empty list.
-        Full implementation would require complex free/busy analysis.
+        Busy time is every opaque, non-cancelled event in the user's own
+        calendars within the window, plus -- when ``attendees`` are given --
+        each attendee's free/busy as reported by the scheduling outbox. What is
+        left of the candidate windows (``constraints``) is returned as maximal
+        free spans, longest-possible rather than sliced onto a grid.
+
+        ``constraints`` keys: ``business_hours_only``, ``exclude_weekends``,
+        ``preferred_times``, ``include_all_day``, ``timezone``.
+
+        Returns the slots together with the window they were computed over, so
+        the caller can report what was actually searched rather than echoing a
+        request that may have left the range open.
         """
-        logger.warning("find_availability is not fully implemented with AsyncDavClient")
-        return []
+        if duration_minutes <= 0:
+            raise ValueError("duration_minutes must be positive")
+
+        constraints = constraints or {}
+        tz = (
+            self._resolve_timezone(str(constraints.get("timezone") or ""))
+            or dt.datetime.now().astimezone().tzinfo
+            or dt.UTC
+        )
+
+        now = dt.datetime.now(tz)
+        start = to_aware(start_datetime, tz) or now
+        # A slot in the past is not availability, whatever the caller asked for.
+        start = max(start, now)
+        end = to_aware(end_datetime, tz) or start + dt.timedelta(days=7)
+        if end <= start:
+            raise ValueError("date_range_end must be after date_range_start")
+
+        events = await self.search_events_across_calendars(
+            start_datetime=start, end_datetime=end, limit=AVAILABILITY_EVENT_LIMIT
+        )
+        busy = busy_spans_from_events(
+            events,
+            tz=tz,
+            include_all_day=bool(constraints.get("include_all_day")),
+        )
+
+        attendees = [address for address in (attendees or []) if address.strip()]
+        if attendees:
+            busy.extend(await self._attendee_busy_spans(attendees, start, end, tz))
+
+        windows = daily_windows(
+            start,
+            end,
+            tz=tz,
+            business_hours_only=bool(constraints.get("business_hours_only", True)),
+            exclude_weekends=bool(constraints.get("exclude_weekends", True)),
+            preferred_times=parse_time_ranges(constraints.get("preferred_times")),
+        )
+        slots = free_slots(windows, busy, dt.timedelta(minutes=duration_minutes))
+
+        logger.debug(
+            "Found %d free slot(s) of >=%d min between %s and %s (%d busy span(s))",
+            len(slots),
+            duration_minutes,
+            start,
+            end,
+            len(busy),
+        )
+        return {
+            "slots": [slot_to_dict(slot) for slot in slots],
+            "range_start": start.isoformat(),
+            "range_end": end.isoformat(),
+            "attendees_checked": attendees,
+        }

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -703,10 +703,12 @@ def configure_calendar_tools(mcp: MCPServer):
             exclude_weekends: Skip Saturdays and Sundays
             preferred_times: Preferred time ranges as "HH:MM-HH:MM"
                 (comma-separated). When given, these replace business hours
-                rather than narrowing them.
+                rather than narrowing them. Overlapping ranges are merged, and
+                a malformed one is skipped rather than failing the query.
             include_all_day: Treat all-day events as busy
             timezone: IANA timezone the business hours and preferred times are
-                expressed in (defaults to the server's local timezone)
+                expressed in, e.g. "Europe/Amsterdam". Defaults to the server's
+                local zone. An unknown name is an error, not a fallback.
 
         Returns:
             The available slots, plus the window that was actually searched

--- a/nextcloud_mcp_server/server/calendar.py
+++ b/nextcloud_mcp_server/server/calendar.py
@@ -10,11 +10,13 @@ from nextcloud_mcp_server.auth import require_scopes
 from nextcloud_mcp_server.client.dav_errors import DavPreconditionFailed
 from nextcloud_mcp_server.context import get_client
 from nextcloud_mcp_server.models.calendar import (
+    AvailabilitySlot,
     Calendar,
     CalendarEventSummary,
     CompleteTodoResponse,
     DeleteEventResponse,
     DeleteTodoResponse,
+    FindAvailabilityResponse,
     ListCalendarsResponse,
     ListEventsResponse,
     ListTodosResponse,
@@ -671,41 +673,49 @@ def configure_calendar_tools(mcp: MCPServer):
         business_hours_only: bool = True,
         exclude_weekends: bool = True,
         preferred_times: str = "",  # Comma-separated time ranges like "09:00-12:00,14:00-17:00"
-    ):
+        include_all_day: bool = False,
+        timezone: str = "",  # IANA name, e.g. "Europe/Amsterdam"
+    ) -> FindAvailabilityResponse:
         """Find available time slots for scheduling meetings.
 
-        This tool intelligently analyzes existing calendar events to find free time slots
-        that work for all specified attendees within the given constraints.
+        Analyses the events in your calendars (and, for any attendees given,
+        their free/busy as reported by the server) and returns the gaps that
+        are long enough. Slots are *maximal* free windows: a free morning comes
+        back once as a single long slot, not as a grid of candidate start
+        times, so pick any sub-range of at least duration_minutes from one.
+
+        Not everything on a calendar consumes time. Events marked free
+        (TRANSP:TRANSPARENT), cancelled events, and calendars set to "never
+        show me as busy" are ignored. All-day events are ignored too unless
+        include_all_day is set, because birthdays, name days and subscribed
+        holiday feeds would otherwise blank out whole working days.
 
         Args:
             duration_minutes: Required duration for the meeting in minutes
-            attendees: Comma-separated list of attendee email addresses to check availability for
-            date_range_start: Start date for availability search (YYYY-MM-DD)
-            date_range_end: End date for availability search (YYYY-MM-DD)
-            business_hours_only: Only suggest slots during business hours (9 AM - 5 PM)
-            exclude_weekends: Skip weekends when finding availability
-            preferred_times: Preferred time ranges as "HH:MM-HH:MM" (comma-separated)
+            attendees: Comma-separated attendee email addresses whose free/busy
+                should also be checked (RFC 6638, which requires a server that
+                answers scheduling requests for them)
+            date_range_start: Start date for availability search (YYYY-MM-DD),
+                defaulting to now. Never searches into the past.
+            date_range_end: End date for availability search (YYYY-MM-DD),
+                defaulting to a week after the start
+            business_hours_only: Only suggest slots between 09:00 and 17:00
+            exclude_weekends: Skip Saturdays and Sundays
+            preferred_times: Preferred time ranges as "HH:MM-HH:MM"
+                (comma-separated). When given, these replace business hours
+                rather than narrowing them.
+            include_all_day: Treat all-day events as busy
+            timezone: IANA timezone the business hours and preferred times are
+                expressed in (defaults to the server's local timezone)
 
         Returns:
-            List of available time slots with start/end times and duration
+            The available slots, plus the window that was actually searched
         """
         client = await get_client(ctx)
 
-        # Parse attendees
-        attendee_list = []
-        if attendees:
-            attendee_list = [
-                email.strip() for email in attendees.split(",") if email.strip()
-            ]
-
-        # Parse preferred times
-        preferred_time_list = []
-        if preferred_times:
-            preferred_time_list = [
-                time_range.strip()
-                for time_range in preferred_times.split(",")
-                if time_range.strip()
-            ]
+        attendee_list = [
+            email.strip() for email in attendees.split(",") if email.strip()
+        ]
 
         # Convert date strings to datetime objects
         start_datetime = None
@@ -714,30 +724,50 @@ def configure_calendar_tools(mcp: MCPServer):
         if date_range_start:
             try:
                 start_datetime = dt.datetime.strptime(date_range_start, "%Y-%m-%d")
-            except ValueError:
-                logger.warning("Invalid date_range_start format: %s", date_range_start)
+            except ValueError as e:
+                raise ToolError(
+                    f"Invalid date_range_start {date_range_start!r}; expected YYYY-MM-DD"
+                ) from e
 
         if date_range_end:
             try:
                 end_datetime = dt.datetime.strptime(date_range_end, "%Y-%m-%d").replace(
                     hour=23, minute=59, second=59
                 )
-            except ValueError:
-                logger.warning("Invalid date_range_end format: %s", date_range_end)
+            except ValueError as e:
+                raise ToolError(
+                    f"Invalid date_range_end {date_range_end!r}; expected YYYY-MM-DD"
+                ) from e
 
-        # Build constraints
         constraints = {
             "business_hours_only": business_hours_only,
             "exclude_weekends": exclude_weekends,
-            "preferred_times": preferred_time_list,
+            "preferred_times": preferred_times,
+            "include_all_day": include_all_day,
+            "timezone": timezone,
         }
 
-        return await client.calendar.find_availability(
-            duration_minutes=duration_minutes,
-            attendees=attendee_list,
-            start_datetime=start_datetime,
-            end_datetime=end_datetime,
-            constraints=constraints,
+        try:
+            result = await client.calendar.find_availability(
+                duration_minutes=duration_minutes,
+                attendees=attendee_list,
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
+                constraints=constraints,
+            )
+        except ValueError as e:
+            # Bad range, or an attendee the server would not report on. Either
+            # way the caller must see it: an empty slot list would read as
+            # "fully booked" (issue #1394).
+            raise ToolError(str(e)) from e
+
+        return FindAvailabilityResponse(
+            available_slots=[AvailabilitySlot(**slot) for slot in result["slots"]],
+            duration_requested=duration_minutes,
+            date_range_start=result["range_start"],
+            date_range_end=result["range_end"],
+            attendees_checked=result["attendees_checked"],
+            business_hours_only=business_hours_only,
         )
 
     @mcp.tool(

--- a/tests/server/test_calendar_availability_mcp.py
+++ b/tests/server/test_calendar_availability_mcp.py
@@ -1,0 +1,139 @@
+"""End-to-end availability against a live Nextcloud (issue #1394).
+
+The tool used to return an empty list while reporting success, so the thing
+worth proving against a real server is not that it responds -- it always did --
+but that real events on a real calendar move the answer.
+
+The window is pushed weeks out on purpose: availability spans *every* calendar
+the test user has, so a near-term range would pick up whatever other tests left
+behind.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+
+import pytest
+from mcp import ClientSession
+
+from nextcloud_mcp_server.client import NextcloudClient
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.integration
+
+
+def _quiet_monday() -> date:
+    """A Monday far enough out that no other test has booked anything on it."""
+    day = datetime.now().date() + timedelta(days=45)
+    while day.weekday() != 0:
+        day += timedelta(days=1)
+    return day
+
+
+async def _call(mcp_client: ClientSession, **arguments) -> dict:
+    result = await mcp_client.call_tool("nc_calendar_find_availability", arguments)
+    assert result.is_error is False, f"find_availability failed: {result.content}"
+    return json.loads(result.content[0].text)
+
+
+async def test_find_availability_reflects_real_events(
+    nc_mcp_client: ClientSession, nc_client: NextcloudClient, temporary_calendar: str
+):
+    """A booked hour splits the business day; an all-day event does not erase it."""
+    day = _quiet_monday()
+    created: list[str] = []
+
+    try:
+        meeting = await nc_client.calendar.create_event(
+            temporary_calendar,
+            {
+                "title": "Availability probe meeting",
+                "start_datetime": f"{day.isoformat()}T11:00:00",
+                "end_datetime": f"{day.isoformat()}T12:00:00",
+            },
+        )
+        created.append(meeting["uid"])
+
+        birthday = await nc_client.calendar.create_event(
+            temporary_calendar,
+            {
+                "title": "Availability probe birthday",
+                "start_datetime": day.isoformat(),
+                "end_datetime": (day + timedelta(days=1)).isoformat(),
+                "all_day": True,
+            },
+        )
+        created.append(birthday["uid"])
+
+        data = await _call(
+            nc_mcp_client,
+            duration_minutes=60,
+            date_range_start=day.isoformat(),
+            date_range_end=day.isoformat(),
+        )
+
+        assert data["success"] is True
+        assert data["duration_requested"] == 60
+        assert data["attendees_checked"] == []
+
+        slots = data["available_slots"]
+        # The all-day event must not have blanked the day out.
+        assert slots, "expected free time on an otherwise empty Monday"
+
+        by_start = {slot["start"][11:19]: slot for slot in slots}
+        assert "09:00:00" in by_start, f"morning slot missing from {slots}"
+        assert by_start["09:00:00"]["end"][11:19] == "11:00:00"
+        assert by_start["09:00:00"]["duration_minutes"] == 120
+        assert "12:00:00" in by_start, f"afternoon slot missing from {slots}"
+        assert by_start["12:00:00"]["end"][11:19] == "17:00:00"
+        assert all(slot["date"] == day.isoformat() for slot in slots)
+
+        # Opting in to all-day events books the whole day out.
+        with_all_day = await _call(
+            nc_mcp_client,
+            duration_minutes=60,
+            date_range_start=day.isoformat(),
+            date_range_end=day.isoformat(),
+            include_all_day=True,
+        )
+        assert with_all_day["available_slots"] == []
+
+    finally:
+        for uid in created:
+            try:
+                await nc_client.calendar.delete_event(temporary_calendar, uid)
+            except Exception as e:
+                logger.warning("Error deleting probe event %s: %s", uid, e)
+
+
+async def test_find_availability_honours_the_search_constraints(
+    nc_mcp_client: ClientSession,
+):
+    """Preferred times replace business hours; the window comes back as searched."""
+    day = _quiet_monday()
+
+    data = await _call(
+        nc_mcp_client,
+        duration_minutes=30,
+        date_range_start=day.isoformat(),
+        date_range_end=day.isoformat(),
+        preferred_times="19:00-21:00",
+    )
+
+    assert [
+        (slot["start"][11:19], slot["end"][11:19]) for slot in data["available_slots"]
+    ] == [("19:00:00", "21:00:00")]
+    assert data["date_range_start"].startswith(day.isoformat())
+    assert data["date_range_end"].startswith(day.isoformat())
+
+
+async def test_find_availability_rejects_an_impossible_request(
+    nc_mcp_client: ClientSession,
+):
+    """A refusal must surface as an error, not as "no slots" (issue #1394)."""
+    result = await nc_mcp_client.call_tool(
+        "nc_calendar_find_availability", {"duration_minutes": 0}
+    )
+
+    assert result.is_error is True
+    assert "duration_minutes" in result.content[0].text

--- a/tests/unit/client/test_availability.py
+++ b/tests/unit/client/test_availability.py
@@ -1,0 +1,335 @@
+"""Availability is interval arithmetic, so it is tested as interval arithmetic.
+
+``find_availability`` used to be a stub returning ``[]`` while reporting success
+(issue #1394), which is the failure these tests exist to keep from coming back:
+every case below asserts on *which* slots come out, never merely that something
+did.
+"""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from nextcloud_mcp_server.client.availability import (
+    busy_spans_from_events,
+    busy_spans_from_vfreebusy,
+    daily_windows,
+    free_slots,
+    merge_spans,
+    parse_time_ranges,
+    slot_to_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+TZ = ZoneInfo("Europe/Amsterdam")
+
+
+def at(day: str, time: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(f"{day}T{time}").replace(tzinfo=TZ)
+
+
+class TestParseTimeRanges:
+    def test_parses_comma_separated_string(self):
+        assert parse_time_ranges("09:00-12:00,14:00-17:30") == [
+            (dt.time(9), dt.time(12)),
+            (dt.time(14), dt.time(17, 30)),
+        ]
+
+    def test_accepts_an_already_split_list(self):
+        assert parse_time_ranges([" 09:00-12:00 "]) == [(dt.time(9), dt.time(12))]
+
+    def test_empty_input_is_no_constraint(self):
+        assert parse_time_ranges("") == []
+        assert parse_time_ranges(None) == []
+
+    @pytest.mark.parametrize("bad", ["09:00", "not-a-range", "25:00-26:00", "-"])
+    def test_malformed_ranges_are_skipped_not_raised(self, bad):
+        assert parse_time_ranges(f"{bad},09:00-10:00") == [(dt.time(9), dt.time(10))]
+
+    def test_inverted_range_is_skipped(self):
+        assert parse_time_ranges("17:00-09:00") == []
+
+
+class TestBusySpansFromEvents:
+    TIMED = {
+        "start_datetime": "2026-09-14T10:00:00+02:00",
+        "end_datetime": "2026-09-14T11:00:00+02:00",
+    }
+
+    def test_plain_event_is_busy(self):
+        assert busy_spans_from_events([self.TIMED], tz=TZ) == [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "11:00"))
+        ]
+
+    def test_transparent_event_does_not_block(self):
+        assert (
+            busy_spans_from_events([{**self.TIMED, "transp": "TRANSPARENT"}], tz=TZ)
+            == []
+        )
+
+    def test_event_on_a_transparent_calendar_does_not_block(self):
+        events = [{**self.TIMED, "calendar_transparent": True}]
+        assert busy_spans_from_events(events, tz=TZ) == []
+
+    def test_cancelled_event_does_not_block(self):
+        assert (
+            busy_spans_from_events([{**self.TIMED, "status": "CANCELLED"}], tz=TZ) == []
+        )
+
+    def test_all_day_event_is_ignored_by_default(self):
+        """Birthdays and holiday feeds must not blank out the working day."""
+        birthday = {
+            "start_datetime": "2026-09-14",
+            "end_datetime": "2026-09-15",
+            "all_day": True,
+        }
+        assert busy_spans_from_events([birthday], tz=TZ) == []
+
+    def test_all_day_event_blocks_when_opted_in(self):
+        vacation = {
+            "start_datetime": "2026-09-14",
+            "end_datetime": "2026-09-15",
+            "all_day": True,
+        }
+        assert busy_spans_from_events([vacation], tz=TZ, include_all_day=True) == [
+            (at("2026-09-14", "00:00"), at("2026-09-15", "00:00"))
+        ]
+
+    def test_all_day_event_without_end_covers_its_day(self):
+        event = {"start_datetime": "2026-09-14", "all_day": True}
+        assert busy_spans_from_events([event], tz=TZ, include_all_day=True) == [
+            (at("2026-09-14", "00:00"), at("2026-09-15", "00:00"))
+        ]
+
+    def test_floating_times_are_read_in_the_requested_zone(self):
+        event = {
+            "start_datetime": "2026-09-14T10:00:00",
+            "end_datetime": "2026-09-14T11:00:00",
+        }
+        assert busy_spans_from_events([event], tz=TZ) == [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "11:00"))
+        ]
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            {"end_datetime": "2026-09-14T11:00:00+02:00"},
+            {"start_datetime": "2026-09-14T11:00:00+02:00"},
+            {
+                "start_datetime": "2026-09-14T11:00:00+02:00",
+                "end_datetime": "2026-09-14T10:00:00+02:00",
+            },
+            {"start_datetime": "nonsense", "end_datetime": "also nonsense"},
+        ],
+        ids=["no-start", "zero-length", "inverted", "unparseable"],
+    )
+    def test_degenerate_events_are_skipped(self, event):
+        assert busy_spans_from_events([event], tz=TZ) == []
+
+
+class TestBusySpansFromVFreeBusy:
+    ICS = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//t//EN\r\n"
+        "BEGIN:VFREEBUSY\r\nUID:1\r\n"
+        "DTSTART:20260914T000000Z\r\nDTEND:20260915T000000Z\r\n"
+        "{body}"
+        "END:VFREEBUSY\r\nEND:VCALENDAR\r\n"
+    )
+
+    def test_busy_periods_are_read(self):
+        spans = busy_spans_from_vfreebusy(
+            self.ICS.format(
+                body="FREEBUSY;FBTYPE=BUSY:20260914T080000Z/20260914T090000Z\r\n"
+            ),
+            TZ,
+        )
+        assert spans == [(at("2026-09-14", "10:00"), at("2026-09-14", "11:00"))]
+
+    def test_period_given_as_a_duration_is_expanded(self):
+        spans = busy_spans_from_vfreebusy(
+            self.ICS.format(body="FREEBUSY:20260914T080000Z/PT90M\r\n"), TZ
+        )
+        assert spans == [(at("2026-09-14", "10:00"), at("2026-09-14", "11:30"))]
+
+    def test_free_periods_do_not_block(self):
+        spans = busy_spans_from_vfreebusy(
+            self.ICS.format(
+                body="FREEBUSY;FBTYPE=FREE:20260914T080000Z/20260914T090000Z\r\n"
+            ),
+            TZ,
+        )
+        assert spans == []
+
+    def test_tentative_and_unavailable_still_block(self):
+        spans = busy_spans_from_vfreebusy(
+            self.ICS.format(
+                body=(
+                    "FREEBUSY;FBTYPE=BUSY-TENTATIVE:20260914T080000Z/20260914T090000Z\r\n"
+                    "FREEBUSY;FBTYPE=BUSY-UNAVAILABLE:20260914T100000Z/20260914T110000Z\r\n"
+                )
+            ),
+            TZ,
+        )
+        assert len(spans) == 2
+
+    def test_reply_without_periods_is_empty_not_an_error(self):
+        assert busy_spans_from_vfreebusy(self.ICS.format(body=""), TZ) == []
+
+    def test_unparseable_reply_is_logged_and_ignored(self):
+        assert busy_spans_from_vfreebusy("not an icalendar object", TZ) == []
+
+
+class TestMergeSpans:
+    def test_overlapping_spans_collapse(self):
+        spans = [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "11:00")),
+            (at("2026-09-14", "10:30"), at("2026-09-14", "12:00")),
+        ]
+        assert merge_spans(spans) == [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "12:00"))
+        ]
+
+    def test_touching_spans_collapse(self):
+        spans = [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "11:00")),
+            (at("2026-09-14", "11:00"), at("2026-09-14", "12:00")),
+        ]
+        assert merge_spans(spans) == [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "12:00"))
+        ]
+
+    def test_a_span_swallowed_by_an_earlier_one_does_not_shorten_it(self):
+        spans = [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "17:00")),
+            (at("2026-09-14", "10:00"), at("2026-09-14", "11:00")),
+        ]
+        assert merge_spans(spans) == [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "17:00"))
+        ]
+
+    def test_disjoint_spans_are_returned_in_order(self):
+        later = (at("2026-09-14", "15:00"), at("2026-09-14", "16:00"))
+        earlier = (at("2026-09-14", "10:00"), at("2026-09-14", "11:00"))
+        assert merge_spans([later, earlier]) == [earlier, later]
+
+
+class TestDailyWindows:
+    # Monday 2026-09-14 .. Wednesday 2026-09-16
+    START = at("2026-09-14", "00:00")
+    END = at("2026-09-17", "00:00")
+
+    def test_business_hours_per_weekday(self):
+        windows = daily_windows(self.START, self.END, tz=TZ)
+        assert windows == [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "17:00")),
+            (at("2026-09-15", "09:00"), at("2026-09-15", "17:00")),
+            (at("2026-09-16", "09:00"), at("2026-09-16", "17:00")),
+        ]
+
+    def test_weekends_are_skipped(self):
+        # Friday .. Monday
+        windows = daily_windows(
+            at("2026-09-18", "00:00"), at("2026-09-22", "00:00"), tz=TZ
+        )
+        assert [window[0].date().isoformat() for window in windows] == [
+            "2026-09-18",
+            "2026-09-21",
+        ]
+
+    def test_weekends_are_kept_when_asked(self):
+        windows = daily_windows(
+            at("2026-09-18", "00:00"),
+            at("2026-09-22", "00:00"),
+            tz=TZ,
+            exclude_weekends=False,
+        )
+        assert len(windows) == 4
+
+    def test_whole_days_without_business_hours(self):
+        windows = daily_windows(
+            self.START, at("2026-09-15", "00:00"), tz=TZ, business_hours_only=False
+        )
+        assert windows == [(at("2026-09-14", "00:00"), at("2026-09-15", "00:00"))]
+
+    def test_preferred_times_replace_business_hours(self):
+        """Not intersect: 08:00-09:00 under the default would otherwise vanish."""
+        windows = daily_windows(
+            self.START,
+            at("2026-09-15", "00:00"),
+            tz=TZ,
+            preferred_times=[(dt.time(8), dt.time(9))],
+        )
+        assert windows == [(at("2026-09-14", "08:00"), at("2026-09-14", "09:00"))]
+
+    def test_windows_are_clipped_to_the_search_range(self):
+        windows = daily_windows(
+            at("2026-09-14", "10:30"), at("2026-09-14", "12:00"), tz=TZ
+        )
+        assert windows == [(at("2026-09-14", "10:30"), at("2026-09-14", "12:00"))]
+
+    def test_range_entirely_outside_business_hours_yields_nothing(self):
+        assert (
+            daily_windows(at("2026-09-14", "18:00"), at("2026-09-14", "20:00"), tz=TZ)
+            == []
+        )
+
+
+class TestFreeSlots:
+    WINDOW = [(at("2026-09-14", "09:00"), at("2026-09-14", "17:00"))]
+    HOUR = dt.timedelta(hours=1)
+
+    def test_no_busy_time_leaves_the_whole_window(self):
+        assert free_slots(self.WINDOW, [], self.HOUR) == self.WINDOW
+
+    def test_a_meeting_splits_the_window(self):
+        busy = [(at("2026-09-14", "11:00"), at("2026-09-14", "12:00"))]
+        assert free_slots(self.WINDOW, busy, self.HOUR) == [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "11:00")),
+            (at("2026-09-14", "12:00"), at("2026-09-14", "17:00")),
+        ]
+
+    def test_gaps_shorter_than_the_duration_are_dropped(self):
+        busy = [
+            (at("2026-09-14", "09:30"), at("2026-09-14", "12:00")),
+            (at("2026-09-14", "12:30"), at("2026-09-14", "17:00")),
+        ]
+        assert free_slots(self.WINDOW, busy, self.HOUR) == []
+
+    def test_overlapping_meetings_do_not_produce_phantom_gaps(self):
+        busy = [
+            (at("2026-09-14", "10:00"), at("2026-09-14", "13:00")),
+            (at("2026-09-14", "11:00"), at("2026-09-14", "12:00")),
+        ]
+        assert free_slots(self.WINDOW, busy, self.HOUR) == [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "10:00")),
+            (at("2026-09-14", "13:00"), at("2026-09-14", "17:00")),
+        ]
+
+    def test_busy_time_outside_the_window_is_irrelevant(self):
+        busy = [(at("2026-09-14", "06:00"), at("2026-09-14", "08:00"))]
+        assert free_slots(self.WINDOW, busy, self.HOUR) == self.WINDOW
+
+    def test_a_fully_booked_day_yields_nothing(self):
+        busy = [(at("2026-09-14", "08:00"), at("2026-09-14", "18:00"))]
+        assert free_slots(self.WINDOW, busy, self.HOUR) == []
+
+    def test_slots_are_found_across_several_windows(self):
+        windows = [
+            (at("2026-09-14", "09:00"), at("2026-09-14", "17:00")),
+            (at("2026-09-15", "09:00"), at("2026-09-15", "17:00")),
+        ]
+        busy = [(at("2026-09-14", "09:00"), at("2026-09-14", "17:00"))]
+        assert free_slots(windows, busy, self.HOUR) == [windows[1]]
+
+
+class TestSlotToDict:
+    def test_shape_matches_the_response_model(self):
+        slot = slot_to_dict((at("2026-09-14", "09:00"), at("2026-09-14", "10:30")))
+        assert slot == {
+            "start": "2026-09-14T09:00:00+02:00",
+            "end": "2026-09-14T10:30:00+02:00",
+            "duration_minutes": 90,
+            "date": "2026-09-14",
+        }

--- a/tests/unit/client/test_availability.py
+++ b/tests/unit/client/test_availability.py
@@ -263,6 +263,15 @@ class TestDailyWindows:
         )
         assert windows == [(at("2026-09-14", "08:00"), at("2026-09-14", "09:00"))]
 
+    def test_overlapping_preferred_ranges_do_not_duplicate_a_window(self):
+        windows = daily_windows(
+            self.START,
+            at("2026-09-15", "00:00"),
+            tz=TZ,
+            preferred_times=[(dt.time(9), dt.time(12)), (dt.time(11), dt.time(14))],
+        )
+        assert windows == [(at("2026-09-14", "09:00"), at("2026-09-14", "14:00"))]
+
     def test_windows_are_clipped_to_the_search_range(self):
         windows = daily_windows(
             at("2026-09-14", "10:30"), at("2026-09-14", "12:00"), tz=TZ

--- a/tests/unit/client/test_calendar.py
+++ b/tests/unit/client/test_calendar.py
@@ -1474,3 +1474,67 @@ def test_updating_a_timed_todo_with_a_bare_date_keeps_it_timed():
     )
 
     assert client._parse_ical_todo(merged)["due"] == "2026-08-09T00:00:00+00:00"
+
+
+class TestDurationWithoutDtend:
+    """RFC 5545 3.6.1 lets a VEVENT carry DURATION instead of DTEND.
+
+    Parsed with no end at all, such an event reads as zero-length -- so it
+    consumes no time and blocks nothing in availability, and every tool that
+    reports an end time reports none.
+    """
+
+    ICS = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//t//EN\r\n"
+        "BEGIN:VEVENT\r\nUID:dur-1\r\nSUMMARY:Workshop\r\n"
+        "{dtstart}"
+        "{extra}"
+        "END:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+
+    @staticmethod
+    def _parse(ics: str) -> dict:
+        return _pure_client()._extract_vevent_data(_vevent(ics))
+
+    def test_duration_becomes_an_end_datetime(self):
+        data = self._parse(
+            self.ICS.format(
+                dtstart="DTSTART:20260210T100000Z\r\n", extra="DURATION:PT90M\r\n"
+            )
+        )
+        assert data["start_datetime"] == "2026-02-10T10:00:00+00:00"
+        assert data["end_datetime"] == "2026-02-10T11:30:00+00:00"
+
+    def test_dtend_still_wins_over_duration(self):
+        data = self._parse(
+            self.ICS.format(
+                dtstart="DTSTART:20260210T100000Z\r\n",
+                extra="DTEND:20260210T103000Z\r\nDURATION:PT90M\r\n",
+            )
+        )
+        assert data["end_datetime"] == "2026-02-10T10:30:00+00:00"
+
+    def test_duration_inherits_the_start_timezone(self):
+        data = self._parse(
+            self.ICS.format(
+                dtstart="DTSTART;TZID=Europe/Amsterdam:20260210T100000\r\n",
+                extra="DURATION:PT1H\r\n",
+            )
+        )
+        assert data["end_datetime"].startswith("2026-02-10T11:00:00")
+        assert data["end_tz"] == "Europe/Amsterdam"
+
+    def test_all_day_duration_stays_a_date(self):
+        data = self._parse(
+            self.ICS.format(
+                dtstart="DTSTART;VALUE=DATE:20260210\r\n", extra="DURATION:P2D\r\n"
+            )
+        )
+        assert data["all_day"] is True
+        assert data["end_datetime"] == "2026-02-12"
+
+    def test_neither_dtend_nor_duration_leaves_no_end(self):
+        data = self._parse(
+            self.ICS.format(dtstart="DTSTART:20260210T100000Z\r\n", extra="")
+        )
+        assert "end_datetime" not in data

--- a/tests/unit/client/test_calendar_fanout.py
+++ b/tests/unit/client/test_calendar_fanout.py
@@ -89,6 +89,29 @@ async def test_one_broken_calendar_does_not_sink_the_rest(client, mocker):
     assert len(names) == len(CALENDARS) - 1
 
 
+async def test_strict_refuses_a_partial_listing(client, mocker):
+    """A skipped calendar contributes no events, which availability would read
+    as free time -- so a caller that cannot tolerate that asks for strict."""
+
+    async def events_for(name, *args, **kwargs):
+        if name == "cal2":
+            raise RuntimeError("calendar is on fire")
+        return [{"uid": f"{name}-1"}]
+
+    mocker.patch.object(client, "get_calendar_events", side_effect=events_for)
+
+    with pytest.raises(ValueError, match="cal2"):
+        await client.search_events_across_calendars(strict=True)
+
+
+async def test_strict_returns_normally_when_every_calendar_answers(client, mocker):
+    mocker.patch.object(client, "get_calendar_events", side_effect=_one)
+
+    events = await client.search_events_across_calendars(strict=True)
+
+    assert len(events) == len(CALENDARS)
+
+
 async def test_filters_are_applied_per_calendar(client, mocker):
     mocker.patch.object(client, "get_calendar_events", side_effect=_one)
     applied = mocker.patch.object(

--- a/tests/unit/client/test_calendar_find_availability.py
+++ b/tests/unit/client/test_calendar_find_availability.py
@@ -161,7 +161,7 @@ async def test_search_is_scoped_to_the_requested_window(mocker):
     )
 
     CalendarClient.search_events_across_calendars.assert_awaited_once_with(
-        start_datetime=start, end_datetime=end, limit=mocker.ANY
+        start_datetime=start, end_datetime=end, limit=mocker.ANY, strict=True
     )
 
 
@@ -308,6 +308,19 @@ class TestRefusals:
         with pytest.raises(ValueError, match="duration_minutes"):
             await client.find_availability(
                 duration, start_datetime=start, end_datetime=end
+            )
+
+    async def test_an_unreadable_calendar_raises(self, mocker):
+        """Skipping it would offer its booked hours as free (review round 1)."""
+        client = _client(mocker)
+        CalendarClient.search_events_across_calendars.side_effect = ValueError(
+            "Could not read 1 calendar(s): work (calendar is on fire)"
+        )
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="Could not read"):
+            await client.find_availability(
+                60, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
             )
 
     async def test_inverted_range_raises(self, mocker):

--- a/tests/unit/client/test_calendar_find_availability.py
+++ b/tests/unit/client/test_calendar_find_availability.py
@@ -323,6 +323,35 @@ class TestRefusals:
                 60, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
             )
 
+    async def test_an_unknown_timezone_raises(self, mocker):
+        """Falling back to the server's zone would answer the wrong question."""
+        client = _client(mocker)
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="America/New_Yrok"):
+            await client.find_availability(
+                60,
+                start_datetime=start,
+                end_datetime=end,
+                constraints={"timezone": "America/New_Yrok"},
+            )
+
+    async def test_no_timezone_falls_back_to_the_local_offset(self, mocker):
+        """A naive window is read in the server's zone when none is given."""
+        client = _client(mocker)
+        naive_start = dt.datetime.combine(MONDAY, dt.time(0, 0))
+
+        result = await client.find_availability(
+            60,
+            start_datetime=naive_start,
+            end_datetime=naive_start + dt.timedelta(days=1),
+        )
+
+        local = dt.datetime.now().astimezone().tzinfo
+        assert dt.datetime.fromisoformat(result["range_start"]).utcoffset() == (
+            naive_start.replace(tzinfo=local).utcoffset()
+        )
+
     async def test_inverted_range_raises(self, mocker):
         client = _client(mocker)
         start, end = _window()

--- a/tests/unit/client/test_calendar_find_availability.py
+++ b/tests/unit/client/test_calendar_find_availability.py
@@ -1,0 +1,318 @@
+"""``CalendarClient.find_availability`` wiring: events in, free slots out.
+
+The interval arithmetic itself is covered in ``test_availability.py``; what is
+pinned here is everything the client adds around it -- the search window it
+asks for, the attendee free/busy round trip, and the refusals that must not
+degrade into an empty (and therefore falsely reassuring) slot list.
+"""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from nextcloud_mcp_server.client.calendar import CalendarClient
+
+pytestmark = pytest.mark.unit
+
+TZ = "Europe/Amsterdam"
+ZONE = ZoneInfo(TZ)
+
+# A Monday, far enough out that "never suggest a slot in the past" never bites.
+MONDAY = (dt.datetime.now(ZONE) + dt.timedelta(days=30)).date()
+while MONDAY.weekday() != 0:
+    MONDAY += dt.timedelta(days=1)
+TUESDAY = MONDAY + dt.timedelta(days=1)
+
+
+def _client(mocker, events=None, principal=None):
+    client = CalendarClient.__new__(CalendarClient)
+    client._dav_client = _FakeDav(principal)
+    mocker.patch.object(
+        CalendarClient,
+        "search_events_across_calendars",
+        mocker.AsyncMock(return_value=list(events or [])),
+    )
+    return client
+
+
+class _FakeReply:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakePrincipal:
+    """Stands in for caldav's Principal; freebusy_request is sync here.
+
+    ``_maybe_await`` awaits only what is awaitable, so a plain return value
+    exercises the same code path as caldav's coroutine.
+    """
+
+    def __init__(self, replies):
+        self.replies = replies
+        self.calls = []
+
+    def freebusy_request(self, start, end, attendees):
+        self.calls.append((start, end, attendees))
+        return self.replies
+
+
+class _FakeDav:
+    def __init__(self, principal):
+        self._principal = principal
+
+    def get_principal(self):
+        return self._principal
+
+
+def _local(day, time_text):
+    """An aware datetime in ZONE -- never a hardcoded offset.
+
+    MONDAY moves with the clock, so a literal "+02:00" silently becomes an
+    hour wrong the first time the rolling window lands after the DST switch.
+    """
+    return dt.datetime.combine(day, dt.time.fromisoformat(time_text), tzinfo=ZONE)
+
+
+def _event(day, start, end, **extra):
+    return {
+        "start_datetime": _local(day, start).isoformat(),
+        "end_datetime": _local(day, end).isoformat(),
+        **extra,
+    }
+
+
+def _window(days=1):
+    start = dt.datetime.combine(MONDAY, dt.time(0, 0), tzinfo=ZONE)
+    return start, start + dt.timedelta(days=days)
+
+
+async def test_empty_calendar_offers_the_whole_business_day(mocker):
+    client = _client(mocker)
+    start, end = _window()
+
+    result = await client.find_availability(
+        60, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    assert [(slot["start"], slot["end"]) for slot in result["slots"]] == [
+        (
+            _local(MONDAY, "09:00").isoformat(),
+            _local(MONDAY, "17:00").isoformat(),
+        )
+    ]
+    assert result["attendees_checked"] == []
+
+
+async def test_a_meeting_splits_the_day(mocker):
+    client = _client(mocker, [_event(MONDAY, "11:00", "12:00")])
+    start, end = _window()
+
+    result = await client.find_availability(
+        60, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    assert [slot["duration_minutes"] for slot in result["slots"]] == [120, 300]
+
+
+async def test_free_and_all_day_events_do_not_consume_time(mocker):
+    """The three exclusions, through the real client path (issue #1394)."""
+    client = _client(
+        mocker,
+        [
+            _event(MONDAY, "09:00", "17:00", transp="TRANSPARENT"),
+            _event(MONDAY, "09:00", "17:00", calendar_transparent=True),
+            _event(MONDAY, "09:00", "17:00", status="CANCELLED"),
+            {
+                "start_datetime": MONDAY.isoformat(),
+                "end_datetime": TUESDAY.isoformat(),
+                "all_day": True,
+            },
+        ],
+    )
+    start, end = _window()
+
+    result = await client.find_availability(
+        60, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    assert len(result["slots"]) == 1
+    assert result["slots"][0]["duration_minutes"] == 480
+
+
+async def test_the_search_window_is_reported_back(mocker):
+    client = _client(mocker)
+    start, end = _window(days=2)
+
+    result = await client.find_availability(
+        30, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    assert result["range_start"] == start.isoformat()
+    assert result["range_end"] == end.isoformat()
+
+
+async def test_search_is_scoped_to_the_requested_window(mocker):
+    client = _client(mocker)
+    start, end = _window()
+
+    await client.find_availability(
+        30, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    CalendarClient.search_events_across_calendars.assert_awaited_once_with(
+        start_datetime=start, end_datetime=end, limit=mocker.ANY
+    )
+
+
+async def test_every_event_in_the_window_is_fetched(mocker):
+    """The default per-calendar listing cap would drop busy time silently."""
+    from nextcloud_mcp_server.client.calendar import AVAILABILITY_EVENT_LIMIT
+
+    client = _client(mocker)
+    start, end = _window()
+
+    await client.find_availability(
+        30, start_datetime=start, end_datetime=end, constraints={"timezone": TZ}
+    )
+
+    assert (
+        CalendarClient.search_events_across_calendars.await_args.kwargs["limit"]
+        == AVAILABILITY_EVENT_LIMIT
+    )
+
+
+async def test_the_past_is_never_searched(mocker):
+    """A range starting last week would otherwise offer slots already gone."""
+    client = _client(mocker)
+    now = dt.datetime.now(ZONE)
+
+    result = await client.find_availability(
+        30,
+        start_datetime=now - dt.timedelta(days=7),
+        end_datetime=now + dt.timedelta(days=1),
+        constraints={"timezone": TZ},
+    )
+
+    assert dt.datetime.fromisoformat(result["range_start"]) >= now
+
+
+class TestAttendees:
+    ICS = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//t//EN\r\n"
+        "BEGIN:VFREEBUSY\r\nUID:1\r\n"
+        "FREEBUSY;FBTYPE=BUSY:{start}/{end}\r\n"
+        "END:VFREEBUSY\r\nEND:VCALENDAR\r\n"
+    )
+
+    @staticmethod
+    def _utc(day, time_text):
+        return _local(day, time_text).astimezone(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+    def _busy_all_day_reply(self):
+        """Bob is busy for the whole local business day, expressed in UTC."""
+        return self.ICS.format(
+            start=self._utc(MONDAY, "09:00"), end=self._utc(MONDAY, "17:00")
+        )
+
+    async def test_attendee_busy_time_removes_slots(self, mocker):
+        principal = _FakePrincipal(
+            {"mailto:bob@example.org": _FakeReply(self._busy_all_day_reply())}
+        )
+        client = _client(mocker, principal=principal)
+        start, end = _window()
+
+        result = await client.find_availability(
+            60,
+            attendees=["bob@example.org"],
+            start_datetime=start,
+            end_datetime=end,
+            constraints={"timezone": TZ},
+        )
+
+        # Bob is busy 09:00-17:00 local; nothing is left of the business day.
+        assert result["slots"] == []
+        assert result["attendees_checked"] == ["bob@example.org"]
+        assert principal.calls[0][2] == ["mailto:bob@example.org"]
+
+    async def test_addresses_already_carrying_mailto_are_not_doubled(self, mocker):
+        principal = _FakePrincipal(
+            {"mailto:bob@example.org": _FakeReply(self._busy_all_day_reply())}
+        )
+        client = _client(mocker, principal=principal)
+        start, end = _window()
+
+        await client.find_availability(
+            60,
+            attendees=["MAILTO:bob@example.org"],
+            start_datetime=start,
+            end_datetime=end,
+            constraints={"timezone": TZ},
+        )
+
+        assert principal.calls[0][2] == ["MAILTO:bob@example.org"]
+
+    async def test_an_attendee_the_server_refuses_raises(self, mocker):
+        principal = _FakePrincipal(
+            {"errors": {"mailto:bob@example.org": "3.7;Invalid calendar user"}}
+        )
+        client = _client(mocker, principal=principal)
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="bob@example.org"):
+            await client.find_availability(
+                60,
+                attendees=["bob@example.org"],
+                start_datetime=start,
+                end_datetime=end,
+                constraints={"timezone": TZ},
+            )
+
+    async def test_a_missing_reply_raises_rather_than_reading_as_free(self, mocker):
+        """ "I could not check Bob" must never be reported as "Bob is free"."""
+        principal = _FakePrincipal({})
+        client = _client(mocker, principal=principal)
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="no free/busy information"):
+            await client.find_availability(
+                60,
+                attendees=["bob@example.org"],
+                start_datetime=start,
+                end_datetime=end,
+                constraints={"timezone": TZ},
+            )
+
+    async def test_no_attendees_means_no_scheduling_request(self, mocker):
+        principal = _FakePrincipal({})
+        client = _client(mocker, principal=principal)
+        start, end = _window()
+
+        await client.find_availability(
+            60,
+            attendees=["  "],
+            start_datetime=start,
+            end_datetime=end,
+            constraints={"timezone": TZ},
+        )
+
+        assert principal.calls == []
+
+
+class TestRefusals:
+    @pytest.mark.parametrize("duration", [0, -30])
+    async def test_non_positive_duration_raises(self, mocker, duration):
+        client = _client(mocker)
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="duration_minutes"):
+            await client.find_availability(
+                duration, start_datetime=start, end_datetime=end
+            )
+
+    async def test_inverted_range_raises(self, mocker):
+        client = _client(mocker)
+        start, end = _window()
+
+        with pytest.raises(ValueError, match="date_range_end"):
+            await client.find_availability(60, start_datetime=end, end_datetime=start)


### PR DESCRIPTION
Closes #1394.

`find_availability` was a stub: it logged `find_availability is not fully
implemented with AsyncDavClient`, returned `[]`, and the tool reported
success. A caller could not tell "no free slot exists" from "this tool does
nothing" — and, as the issue points out, that does not look like an error, it
looks like an answer.

Per the discussion on the issue this goes for option 3 (implement it) rather
than hiding or failing the tool.

## What it does now

Busy time is subtracted from the windows you are willing to meet in, and what
is left is returned:

- **Your own calendars** — every opaque, non-cancelled event in the window.
- **Attendees** — a real RFC 6638 free/busy request to the scheduling outbox
  (`Principal.freebusy_request`), merged into the same busy set. An attendee
  the server will not report on **raises**; "I could not check Bob" must never
  be rendered as "Bob is free".

What does *not* consume time, all four of which matter on real calendars:

- `TRANSP:TRANSPARENT` events;
- events on a calendar marked `schedule-calendar-transp: transparent`;
- cancelled events;
- all-day events, unless `include_all_day=True` — the reporter's point about
  birthdays, name days and subscribed school-holiday feeds erasing whole
  working days.

Slots are **maximal free windows**, not a grid of candidate start times: a
free morning is one 180-minute slot, not five overlapping 60-minute ones.

## API surface

The tool now returns the `FindAvailabilityResponse` model that already existed
but was never used — it previously returned a bare list, against this repo's
`BaseResponse` rule. Since the old return value was an empty list on every
call, no caller can have depended on the old shape.

Two new parameters:

- `include_all_day` (default `False`);
- `timezone` (IANA name, defaults to the server's local zone) — "business
  hours" cannot be evaluated without one.

Bad input now surfaces as a `ToolError` (unparseable dates, non-positive
duration, inverted range, an attendee the server refuses) instead of being
logged and quietly ignored.

## Two supporting fixes

Both would have made availability confidently wrong:

- `search_events_across_calendars` capped each calendar at 50 events and
  truncated **silently**; dropped events become free time that is not free.
  It now takes a `limit` (default unchanged) and the availability path asks
  for the whole window, bounded at 1000/calendar.
- An event carrying `DURATION` instead of `DTEND` was parsed with no end at
  all, so it read as zero-length and blocked nothing. `_extract_vevent_data`
  now derives the end — which also fixes the end time every other calendar
  tool reports for such events.

## Test coverage

- `tests/unit/client/test_availability.py` — 45 unit tests over the interval
  arithmetic: transparency, all-day, cancelled, floating vs zoned times,
  VFREEBUSY period/duration/FBTYPE parsing, span merging, window construction,
  subtraction.
- `tests/unit/client/test_calendar_find_availability.py` — the client wiring:
  search window, the attendee round trip, and every refusal path.
- `tests/server/test_calendar_availability_mcp.py` — e2e through MCP against a
  live Nextcloud: a booked hour splits the business day, an all-day event does
  not erase it, `include_all_day` books it out, preferred times replace
  business hours, and a bad request comes back as an error rather than an
  empty slot list.

Contract (Pact) coverage: this change adds no cross-service boundary — the
free/busy call is CalDAV to the same Nextcloud instance the rest of the
calendar client talks to, which is not a pacted provider — so no consumer pact
applies. Ran locally: `-m unit` (3861 passed) and the calendar integration
suite against the docker stack (50 passed, including the new e2e tests).

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvFYC7nvYWJ7nNv8bcMpg
