### PR TITLE
fix(ingest): refuse empty document payloads instead of dead-lettering them

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -237,10 +237,14 @@ success, so partial extractions and in-flight batch-OCR polls never inflate them
 - `astrolabe_document_bytes_processed_total` - Source bytes parsed
 - `astrolabe_document_parse_duration_seconds` - Parse latency per document
 - `astrolabe_document_parse_failed_total{reason}` - Hard failures
-  (`timeout` | `oom` | `error` | `oversize` | `unreadable` | `unsupported_type`).
+  (`timeout` | `oom` | `error` | `oversize` | `unreadable` | `unsupported_type` |
+  `empty_document`).
   `unsupported_type` means no registered processor claims the document's mime
   type — a property of what this deployment has enabled, not of the document, so
   it is answered by enabling a processor (or excluding the type), not by a retry.
+  `empty_document` means the document has no bytes: terminal, since no tier can
+  extract text from nothing. A file the scanner measured as non-empty that
+  *downloads* empty is not this — that is a bad response, and it is re-queued.
 
 Corpus shape, recorded before the oversize gate so the over-cap tail is visible:
 

--- a/nextcloud_mcp_server/document_processors/base.py
+++ b/nextcloud_mcp_server/document_processors/base.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:  # pragma: no cover - import cycle guard
 
 from pydantic import BaseModel
 
+#: ``parse_failed_reason`` for a document whose bytes are empty. Terminal: no
+#: tier can extract text from zero bytes, so escalating it would just walk the
+#: queues to fail three times. Lives here rather than in ``registry`` so
+#: ``ocr`` can use it without importing the registry that imports ``ocr``.
+EMPTY_DOCUMENT_REASON = "empty_document"
+
 
 class ProcessingResult(BaseModel):
     """Standardized result from any document processor."""

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -38,7 +38,12 @@ import httpx
 
 from nextcloud_mcp_server.config import Settings, get_settings
 
-from .base import DocumentProcessor, ProcessingResult, ProcessorError
+from .base import (
+    EMPTY_DOCUMENT_REASON,
+    DocumentProcessor,
+    ProcessingResult,
+    ProcessorError,
+)
 
 if TYPE_CHECKING:
     # Annotation-only imports (the runtime imports are lazy — inside
@@ -694,6 +699,25 @@ class OcrProcessor(DocumentProcessor):
             Callable[[float, float | None, str | None], Awaitable[None]] | None
         ) = None,
     ) -> ProcessingResult:
+        # An empty payload base64-encodes to "" and the gateway rejects the
+        # submission with 422 "document decodes to empty bytes" -- a permanent
+        # validation failure that dead-letters the document under the generic
+        # "error" reason, invisibly (card #1230). Refuse it locally under its own
+        # name instead, before any gateway round-trip. The ingest path also
+        # guards the download itself (``vector.processor.empty_download_result``);
+        # this is the backstop for every other caller of a processor.
+        if not content:
+            logger.warning(
+                "OCR skipped for %s: document has no bytes", filename or "<bytes>"
+            )
+            return ProcessingResult(
+                text="",
+                metadata={"parse_failed_reason": EMPTY_DOCUMENT_REASON},
+                processor=self.name,
+                success=False,
+                error="document is empty",
+            )
+
         settings = get_settings()
 
         # Batch mode (Deck #332): submit to the gateway's async Batch OCR job and

--- a/nextcloud_mcp_server/document_processors/ocr.py
+++ b/nextcloud_mcp_server/document_processors/ocr.py
@@ -55,6 +55,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Log stand-in for a document handed over as bare bytes, with no filename.
+_UNNAMED = "<bytes>"
+
 # Connect timeout for the OCR backend request. The overall (read) timeout is
 # configurable via DOCUMENT_OCR_TIMEOUT_SECONDS and resolved per call.
 _OCR_CONNECT_TIMEOUT_SECONDS = 10.0
@@ -708,7 +711,7 @@ class OcrProcessor(DocumentProcessor):
         # this is the backstop for every other caller of a processor.
         if not content:
             logger.warning(
-                "OCR skipped for %s: document has no bytes", filename or "<bytes>"
+                "OCR skipped for %s: document has no bytes", filename or _UNNAMED
             )
             return ProcessingResult(
                 text="",
@@ -750,7 +753,7 @@ class OcrProcessor(DocumentProcessor):
         if backend is None:
             logger.warning(
                 "OCR requested for %s but no backend is configured (provider=%s)",
-                filename or "<bytes>",
+                filename or _UNNAMED,
                 settings.document_ocr_provider,
             )
             return ProcessingResult(
@@ -773,7 +776,7 @@ class OcrProcessor(DocumentProcessor):
             # rather than being conflated with provider errors.
             timeout = settings.document_ocr_timeout_seconds
             logger.warning(
-                "OCR timed out for %s after %.1fs", filename or "<bytes>", timeout
+                "OCR timed out for %s after %.1fs", filename or _UNNAMED, timeout
             )
             return ProcessingResult(
                 text="",
@@ -783,7 +786,7 @@ class OcrProcessor(DocumentProcessor):
                 error=f"OCR timed out after {timeout:.1f}s",
             )
         except Exception as e:
-            logger.warning("OCR failed for %s: %s", filename or "<bytes>", e)
+            logger.warning("OCR failed for %s: %s", filename or _UNNAMED, e)
             return ProcessingResult(
                 text="",
                 metadata={"parse_failed_reason": "error"},

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -762,8 +762,10 @@ document_scan_truncated_total = Counter(
 
 document_download_truncated_total = Counter(
     "astrolabe_document_download_truncated_total",
-    "Times a WebDAV GET returned fewer bytes than Content-Length (truncated/"
-    "poisoned connection; raised as a retryable transport error, see #965)",
+    "Times a WebDAV GET returned fewer bytes than it should have -- short of "
+    "Content-Length (truncated/poisoned connection, #965) or empty for a file "
+    "the scanner measured as non-empty (card #1230). Raised as a retryable "
+    "transport error in both cases",
 )
 
 # =============================================================================
@@ -1784,7 +1786,7 @@ def record_document_ingest_size(doc_type: str, size_bytes: int) -> None:
 
 
 def record_document_ingest_rejected(doc_type: str, reason: str) -> None:
-    """Record a document rejected before parsing (currently ``oversize``).
+    """Record a document rejected before parsing (``oversize``, ``empty_document``).
 
     Paired with :func:`record_document_ingest_size` so "what fraction of this
     tenant's corpus is over cap" is a ratio of two metrics rather than an

--- a/nextcloud_mcp_server/observability/metrics.py
+++ b/nextcloud_mcp_server/observability/metrics.py
@@ -1788,9 +1788,10 @@ def record_document_ingest_size(doc_type: str, size_bytes: int) -> None:
 def record_document_ingest_rejected(doc_type: str, reason: str) -> None:
     """Record a document rejected before parsing (``oversize``, ``empty_document``).
 
-    Paired with :func:`record_document_ingest_size` so "what fraction of this
-    tenant's corpus is over cap" is a ratio of two metrics rather than an
-    investigation.
+    ``oversize`` is paired with :func:`record_document_ingest_size` so "what
+    fraction of this tenant's corpus is over cap" is a ratio of two metrics
+    rather than an investigation. ``empty_document`` has no such pairing —
+    there is no size to observe, which is the whole reason it was rejected.
     """
     document_ingest_rejected_total.labels(doc_type=doc_type, reason=reason).inc()
 

--- a/nextcloud_mcp_server/utils/document_parser.py
+++ b/nextcloud_mcp_server/utils/document_parser.py
@@ -26,6 +26,7 @@ from nextcloud_mcp_server.document_processors import (
     ProcessorError,
     get_registry,
 )
+from nextcloud_mcp_server.document_processors.base import EMPTY_DOCUMENT_REASON
 from nextcloud_mcp_server.document_processors.source import DocumentSource
 from nextcloud_mcp_server.models.webdav import ContentFormat, ParseStatus
 
@@ -122,6 +123,8 @@ def _failure_note(result: ProcessingResult, tier: str | None, settings: Any) -> 
             f"{settings.document_max_pdf_size_mb:g} MB parse cap "
             f"(DOCUMENT_MAX_PDF_SIZE_MB)."
         )
+    if reason == EMPTY_DOCUMENT_REASON:
+        return "The document was not parsed: it has no content (0 bytes)."
     where = f" in the '{tier}' tier" if tier else ""
     return f"Parsing failed ({reason}){where}; no text was extracted."
 

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -523,7 +523,7 @@ def empty_download_result(
         metadata={"parse_failed_reason": EMPTY_DOCUMENT_REASON},
         processor="empty_guard",
         success=False,
-        error="document is empty (0 bytes)",
+        error="document is empty",
     )
 
 

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -466,6 +466,60 @@ def preflight_oversize_result(
     return result
 
 
+def empty_download_result(
+    doc_task: Any, source: Any, file_path: str | None
+) -> "ProcessingResult | None":
+    """Reject a document that downloaded to zero bytes, before anything parses it.
+
+    Nothing downstream can use an empty document, and the OCR tier does worse
+    than nothing with one: it base64-encodes ``b""`` and the gateway rejects the
+    submission with 422 ``"document decodes to empty bytes"`` — a permanent
+    validation failure, so the document is dead-lettered under the generic
+    ``error`` reason and the loss is invisible (card #1230).
+
+    Which failure it is depends on what the scanner measured. Every tier is a
+    separate procrastinate job, so an escalated tier RE-DOWNLOADS the document;
+    a file the scanner saw as non-empty that comes back empty from *this*
+    request is a bad response, not a bad file, so it is raised as the same
+    short-read error the truncation guard raises (#965) and re-queued by the
+    next scan — bounded by the consecutive-failure counter, so a file that is
+    empty every time still parks eventually.
+
+    A file the scanner measured as empty (or never measured) really is empty:
+    returns the terminal ``empty_document`` failure, which names the cause
+    instead of surfacing as a generic OCR error.
+
+    Returns ``None`` — the overwhelmingly common case — when the download
+    produced bytes.
+    """
+    if source is None or source.size != 0:
+        return None
+    scanned_size = getattr(doc_task, "size_bytes", None)
+    if scanned_size:
+        logger.warning(
+            "Empty download for %s: scanner saw %d bytes, got 0; re-queueing",
+            file_path,
+            scanned_size,
+        )
+        raise httpx.RemoteProtocolError(
+            f"Empty download for {file_path!r}: scanner saw {scanned_size} bytes, got 0"
+        )
+    from nextcloud_mcp_server.document_processors.base import (  # noqa: PLC0415
+        EMPTY_DOCUMENT_REASON,
+        ProcessingResult,
+    )
+
+    logger.warning("Document %s has no bytes; failing as empty", file_path)
+    record_document_ingest_rejected(doc_task.doc_type, EMPTY_DOCUMENT_REASON)
+    return ProcessingResult(
+        text="",
+        metadata={"parse_failed_reason": EMPTY_DOCUMENT_REASON},
+        processor="empty_guard",
+        success=False,
+        error="document is empty (0 bytes)",
+    )
+
+
 def ingested_byte_size(source_size: int | None, content: str) -> int:
     """Bytes ingested for one document (card #401).
 
@@ -1171,10 +1225,11 @@ async def _index_document_inner(
         qdrant_client: Qdrant client instance
     """
     settings = get_settings()
-    # Set by the pre-flight size gate (files only) when a document is rejected
-    # from its scanned size; substituted for the parse result further down so the
-    # existing terminal/dead-letter handling is reached unchanged.
-    preflight_failure = None
+    # Set (files only) when a document is rejected before anything parses it —
+    # the pre-flight size gate, or an empty download; substituted for the parse
+    # result further down so the existing terminal/dead-letter handling is
+    # reached unchanged.
+    pre_parse_failure = None
     # The document handle for files; None for text doc types (note, deck card,
     # news item, mail message), which carry no binary.
     source: DocumentSource | None = None
@@ -1449,8 +1504,8 @@ async def _index_document_inner(
             # Pre-flight size gate: reject an over-cap document from the size the
             # scanner already captured, so the download is never paid for. Falls
             # through to the post-download guard when the size is unknown.
-            preflight_failure = preflight_oversize_result(doc_task, file_path, settings)
-            if preflight_failure is not None:
+            pre_parse_failure = preflight_oversize_result(doc_task, file_path, settings)
+            if pre_parse_failure is not None:
                 content_bytes, content_type = b"", PDF_MIME_TYPE
             elif settings.document_stream_download_enabled:
                 # Stream to a spool file: resident memory stays at one chunk
@@ -1483,6 +1538,11 @@ async def _index_document_inner(
                 # leaks one file per document, which is the very failure mode the
                 # streaming side's exit-stack scoping exists to prevent.
                 exit_stack.callback(source.cleanup)
+
+            # Downloaded nothing? Stop here, however the bytes were fetched.
+            pre_parse_failure = (
+                empty_download_result(doc_task, source, file_path) or pre_parse_failure
+            )
         else:
             raise ValueError(f"Unsupported doc_type: {doc_task.doc_type}")
 
@@ -1511,6 +1571,9 @@ async def _index_document_inner(
             from nextcloud_mcp_server.document_processors import (  # noqa: PLC0415
                 get_registry,
             )
+            from nextcloud_mcp_server.document_processors.base import (  # noqa: PLC0415
+                EMPTY_DOCUMENT_REASON,
+            )
             from nextcloud_mcp_server.document_processors.escalation import (  # noqa: PLC0415
                 TIER_LADDER,
                 BatchPending,
@@ -1529,13 +1592,13 @@ async def _index_document_inner(
                 # queue-hop to the next tier). Everything else -- non-PDF files,
                 # and the in-process/memory pool (tier is None) -- runs the inline
                 # tiered pipeline (fast -> OCR escalation in one call).
-                if preflight_failure is not None:
+                if pre_parse_failure is not None:
                     # Rejected from its scanned size before the download, so
                     # there is nothing to parse. Substituting the guard's result
                     # here (rather than returning early) keeps oversize handling
                     # on the single terminal/dead-letter path below, however the
                     # size became known.
-                    result = preflight_failure
+                    result = pre_parse_failure
                 elif tier is not None and _is_pdf(content_type):
                     # Narrowing: the download branch above always sets ``source``
                     # when it did not short-circuit on the pre-flight gate.
@@ -1581,10 +1644,13 @@ async def _index_document_inner(
                     # ``unsupported_type``: the tier ladder is PDF-only, so a mime
                     # type no processor claims cannot be parsed by a higher rung
                     # either -- escalating it would just walk the queues to burn
-                    # the same dispatch failure three times (Deck #1016).
+                    # the same dispatch failure three times (Deck #1016). And for
+                    # ``empty_document``: zero bytes yield no text at any tier
+                    # (card #1230).
                     next_avail = (
                         None
-                        if reason in ("oversize", UNSUPPORTED_TYPE_REASON)
+                        if reason
+                        in ("oversize", UNSUPPORTED_TYPE_REASON, EMPTY_DOCUMENT_REASON)
                         else registry.next_available_tier(failing_tier, settings)
                     )
                     # #399: a hard parse failure (an isolated-worker timeout/OOM on

--- a/nextcloud_mcp_server/vector/processor.py
+++ b/nextcloud_mcp_server/vector/processor.py
@@ -38,6 +38,7 @@ from nextcloud_mcp_server.document_processors.source import (
 )
 from nextcloud_mcp_server.models.deck import DeckCard
 from nextcloud_mcp_server.observability.metrics import (
+    document_download_truncated_total,
     estimate_vector_bytes,
     record_chunk_density,
     record_document_chunks,
@@ -496,6 +497,12 @@ def empty_download_result(
         return None
     scanned_size = getattr(doc_task, "size_bytes", None)
     if scanned_size:
+        # Same counter as the Content-Length short-read guard: both are "the
+        # server returned fewer bytes than it should have", and the only
+        # difference is which oracle caught it. Without this the retryable half
+        # of the guard would be the one thing here with no signal at all, which
+        # is the invisibility this whole change exists to end.
+        document_download_truncated_total.inc()
         logger.warning(
             "Empty download for %s: scanner saw %d bytes, got 0; re-queueing",
             file_path,

--- a/tests/unit/test_empty_document_guard.py
+++ b/tests/unit/test_empty_document_guard.py
@@ -1,0 +1,75 @@
+"""Regression guards for card #1230 — empty document payloads.
+
+A document that downloads to zero bytes used to travel all the way to the
+embedding gateway, which rejected the batch OCR submission with HTTP 422
+``"document decodes to empty bytes"``. 422 is permanent, so the document was
+dead-lettered under the generic ``error`` reason and the loss was invisible
+outside one dashboard panel.
+
+Two guards close it, and both are pinned here: the ingest path refuses an empty
+download before any tier parses it, and the OCR processor refuses an empty
+payload before any gateway round-trip — whichever caller handed it the bytes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from nextcloud_mcp_server.document_processors.base import EMPTY_DOCUMENT_REASON
+from nextcloud_mcp_server.document_processors.ocr import OcrProcessor
+from nextcloud_mcp_server.vector import processor as proc
+
+pytestmark = pytest.mark.unit
+
+
+def _task(size_bytes: int | None) -> SimpleNamespace:
+    return SimpleNamespace(doc_type="file", size_bytes=size_bytes)
+
+
+def _source(size: int) -> SimpleNamespace:
+    return SimpleNamespace(size=size)
+
+
+def test_non_empty_download_passes_through():
+    assert proc.empty_download_result(_task(1024), _source(1024), "/doc.pdf") is None
+
+
+def test_text_doc_types_have_no_source():
+    """Notes/deck cards carry no binary — the guard must not fire on them."""
+    assert proc.empty_download_result(_task(None), None, None) is None
+
+
+def test_empty_download_of_a_measured_file_is_retryable():
+    """The scanner saw bytes, so THIS response is wrong, not the file.
+
+    Each tier is a separate procrastinate job and re-downloads the document, so
+    an empty body here is transient. Raising re-queues it (bounded by the
+    consecutive-failure counter) instead of dead-lettering a healthy document.
+    """
+    with pytest.raises(httpx.RemoteProtocolError, match="scanner saw 4096 bytes"):
+        proc.empty_download_result(_task(4096), _source(0), "/doc.pdf")
+
+
+def test_genuinely_empty_file_fails_with_a_named_reason():
+    result = proc.empty_download_result(_task(0), _source(0), "/empty.pdf")
+
+    assert result is not None
+    assert result.success is False
+    assert result.metadata["parse_failed_reason"] == EMPTY_DOCUMENT_REASON
+
+
+async def test_ocr_refuses_an_empty_payload_without_calling_the_gateway(mocker):
+    """The backstop: no empty submission ever reaches the gateway's 422."""
+    processor = OcrProcessor()
+    submit = mocker.patch.object(
+        processor, "_get_batch_client", side_effect=AssertionError("submitted!")
+    )
+
+    result = await processor.process(b"", "application/pdf", "/empty.pdf")
+
+    assert result.success is False
+    assert result.metadata["parse_failed_reason"] == EMPTY_DOCUMENT_REASON
+    submit.assert_not_called()

--- a/tests/unit/test_empty_document_guard.py
+++ b/tests/unit/test_empty_document_guard.py
@@ -24,6 +24,8 @@ from nextcloud_mcp_server.vector import processor as proc
 
 pytestmark = pytest.mark.unit
 
+_TRUNCATED = "astrolabe_document_download_truncated_total"
+
 
 def _task(size_bytes: int | None) -> SimpleNamespace:
     return SimpleNamespace(doc_type="file", size_bytes=size_bytes)
@@ -42,15 +44,22 @@ def test_text_doc_types_have_no_source():
     assert proc.empty_download_result(_task(None), None, None) is None
 
 
-def test_empty_download_of_a_measured_file_is_retryable():
+def test_empty_download_of_a_measured_file_is_retryable(metric_sample):
     """The scanner saw bytes, so THIS response is wrong, not the file.
 
     Each tier is a separate procrastinate job and re-downloads the document, so
     an empty body here is transient. Raising re-queues it (bounded by the
     consecutive-failure counter) instead of dead-lettering a healthy document.
     """
+    before = metric_sample(_TRUNCATED, {})
+
     with pytest.raises(httpx.RemoteProtocolError, match="scanner saw 4096 bytes"):
         proc.empty_download_result(_task(4096), _source(0), "/doc.pdf")
+
+    # Counted on the same panel as the Content-Length short read: both are the
+    # server returning fewer bytes than it should have, and a retryable failure
+    # nothing counts is exactly the invisibility this change closes.
+    assert metric_sample(_TRUNCATED, {}) == before + 1
 
 
 def test_genuinely_empty_file_fails_with_a_named_reason():


### PR DESCRIPTION
## Problem

Board 7, card #1230. `embedding-gateway` was returning HTTP 422 on
`/v1/ocr/batch`:

```json
{"path":"/v1/ocr/batch","status":422,"detail":"document decodes to empty bytes"}
```

422 is a permanent validation failure, so those documents went straight to
dead-letter under the generic `error` reason (`Permanent parse failure ...
(reason=error); dead-lettered (terminal tier=ocr, no escalation)`) — silent
partial data loss, visible only as a non-zero series on one dashboard panel.

## Root cause

On the worker path each tier is a separate procrastinate job, so an escalated
tier **re-downloads** the document rather than inheriting the previous tier's
spool. That re-download can return zero bytes and nothing notices:
`_verify_content_length` returns early when `Content-Length` is absent, and a
`Content-Length: 0` response satisfies `received == expected`. `spooled_document`
has no `written > 0` check, so the OCR tier base64-encodes `b""` and submits it.

(A genuinely zero-byte PDF fails at the fast tier and is returned as-is without
escalating, so it never reaches OCR — which is why this is the download, not the
corpus. Not the #965 truncation bug either: `document_download_truncated_total`
is 0.)

## Change

One guard at the point every ingest tier routes through — right after the
download, covering both the streamed and buffered branches — that names the two
cases apart:

| scanner saw | download | behaviour |
|---|---|---|
| N > 0 bytes | 0 bytes | bad *response*: raise the same short-read error the #965 guard raises, so the next scan re-queues it (bounded by the existing consecutive-failure counter, so a file that is empty every time still parks) |
| 0 / unknown | 0 bytes | bad *file*: terminal `empty_document` failure, added to the terminal-reason set so it does not walk the escalation ladder |

`OcrProcessor.process` also refuses an empty payload up front — the backstop
that keeps an empty submission off the gateway whatever handed it the bytes.

Affected documents re-drive on their own: the dead-letter signature covers the
processor set, so the retryable case is simply re-queued by the next scan.

## Test coverage

`tests/unit/test_empty_document_guard.py` — pass-through, no-source (text doc
types), retryable-vs-terminal split, and that OCR never reaches the batch client
on an empty payload.

No API surface added or changed (no MCP tool, no `/api/v1/*` route, no new
cross-service boundary), so the e2e + contract gate does not apply here. The
gateway OCR consumer pact is unchanged — this stops a request being sent, it
does not alter the wire format.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6EFTLwkLQowN1UgAYMK4n
